### PR TITLE
Make G+ button same size as other buttons

### DIFF
--- a/app/lib/Router.coffee
+++ b/app/lib/Router.coffee
@@ -73,8 +73,7 @@ module.exports = class CocoRouter extends Backbone.Router
         clientid:gplusClientID,
         cookiepolicy:"single_host_origin",
         scope:"https://www.googleapis.com/auth/plus.login https://www.googleapis.com/auth/userinfo.email",
-        height:"short",
-        width:"standard",
+        size:"medium",
       }
       if gapi.signin
         gapi.signin.render(gplusButton, params)

--- a/app/lib/world/docs.coffee
+++ b/app/lib/world/docs.coffee
@@ -174,7 +174,7 @@ module.exports.Level = class Level
     """
     buttons += """
     <div class="share-buttons">
-      <div class="g-plusone" data-href="http://codecombat.com"></div>
+      <div class="g-plusone" data-href="http://codecombat.com" data-size="medium"></div>
       <div class="fb-like" data-href="http://codecombat.com" data-send="false" data-layout="button_count" data-width="350" data-show-faces="true"></div>
       </div>
     """

--- a/app/templates/base.jade
+++ b/app/templates/base.jade
@@ -4,9 +4,9 @@ body
     .navbar.navbar-fixed-top
       .navbar-inner
         .content.clearfix
-          a.brand(href='/') 
+          a.brand(href='/')
             img(src="/images/pages/base/logo.png", title="CodeCombat", alt="CodeCombat")
- 
+
           select.language-dropdown
 
           if me.get('anonymous')
@@ -15,7 +15,7 @@ body
           else
             button.btn.btn-primary.navbuttontext#logout-button(data-i18n="nav.log_out") Logout
             a.btn.btn-primary.navbuttontext(href="/account/profile/#{me.id}")
-              | #{me.displayName()} 
+              | #{me.displayName()}
               i.icon-cog.icon-white.big
 
           ul(class='navbar-link-text').nav.pull-right
@@ -43,18 +43,18 @@ body
       .content
         p(class='footer-link-text')
           a(href='/', title='Home', tabindex=-1, data-i18n="nav.home") Home
-          |  | 
+          |  |
           a(href='/contribute', title='Contribute', tabindex=-1, data-i18n="nav.contribute") Contribute
-          |  | 
+          |  |
           a(href='/legal', title='Legal', tabindex=-1, data-i18n="nav.legal") Legal
-          |  | 
+          |  |
           a(href='/about', title='About', tabindex=-1, data-i18n="nav.about") About
-          |  | 
+          |  |
           a(title='Contact', tabindex=-1, data-toggle="coco-modal", data-target="modal/contact", data-i18n="nav.contact") Contact
 
-          
+
       .share-buttons
-        .g-plusone(data-href="http://codecombat.com")
+        .g-plusone(data-href="http://codecombat.com", data-size="medium")
         .fb-like(data-href="https://www.facebook.com/codecombat", data-send="false", data-layout="button_count", data-width="350", data-show-faces="true", data-ref="coco_footer_#{fbRef}")
         a.twitter-follow-button(href="https://twitter.com/CodeCombat", data-show-count="true", data-show-screen-name="false", data-dnt="true", data-align="right", data-i18n="nav.twitter_follow") Follow
         //iframe(src="https://www.lendyour.net/embed/lendbutton?account_id=6&campaign_id=7", frameBorder="0")

--- a/app/templates/play/level/modal/victory.jade
+++ b/app/templates/play/level/modal/victory.jade
@@ -15,7 +15,7 @@
       span(data-i18n="play_level.victory_sign_up_poke") Want to save your code? Create a free account!
   else
     div.rating.hide
-      span(data-i18n="play_level.victory_rate_the_level") Rate the level: 
+      span(data-i18n="play_level.victory_rate_the_level") Rate the level:
       i.icon-star-empty
       i.icon-star-empty
       i.icon-star-empty
@@ -34,7 +34,7 @@
       br
       textarea
   div.share-buttons
-    .g-plusone(data-href="http://codecombat.com")
+    .g-plusone(data-href="http://codecombat.com", data-size="medium")
     .fb-like(data-href="https://www.facebook.com/codecombat", data-send="false", data-layout="button_count", data-width="350", data-show-faces="true", data-ref="coco_victory_#{fbRef}")
     a.twitter-follow-button(href="https://twitter.com/CodeCombat", data-show-count="true", data-show-screen-name="false", data-dnt="true", data-align="right", data-i18n="nav.twitter_follow") Follow
 
@@ -42,5 +42,5 @@ if showHourOfCodeDoneButton
   .modal-footer
     h3.pull-left(data-i18n="play_level.victory_hour_of_code_done") Are You Done?
     a(href="http://code.org/api/hour/finish")
-      strong(data-i18n="play_level.victory_hour_of_code_done_yes") Yes, I'm finished with my Hour of Code! 
+      strong(data-i18n="play_level.victory_hour_of_code_done_yes") Yes, I'm finished with my Hour of Code!
       img(src="/images/level/csedweek-logo-final-small.jpg", alt="CS Ed Week Hour of Code", title="I'm finished with my Hour of Code", width=80)


### PR DESCRIPTION
The default G+ button size is slightly larger than the Facebook and Twitter buttons.  Use the "medium" size to make the size even.

I've taken screenshots with the modification- if you check the live site, the G+ button is currently slightly bigger.

![screen shot 2014-01-08 at 2 15 10 am](https://f.cloud.github.com/assets/933422/1867385/f876320e-784d-11e3-92a3-871a0806fc3a.png)
![screen shot 2014-01-08 at 2 14 52 am](https://f.cloud.github.com/assets/933422/1867386/f876589c-784d-11e3-92b3-28ac4bcc28e9.png)
