### PR TITLE
Fix "Contact" link in footer not properly changing cursor to pointer

### DIFF
--- a/app/styles/base.sass
+++ b/app/styles/base.sass
@@ -99,6 +99,7 @@ h1 h2 h3 h4
   font-size: 25px
   letter-spacing: 1px
   color: #ffffff
+  cursor: pointer
 
 a[data-toggle="modal"]
   cursor: pointer


### PR DESCRIPTION
The new "Contact" link uses the text cursor instead of the pointer cursor. I made all the footer links display the pointer cursor.
