### PR TITLE
Add clear interval timers for the home page

### DIFF
--- a/app/views/home_view.coffee
+++ b/app/views/home_view.coffee
@@ -37,10 +37,17 @@ module.exports = class HomeView extends View
   initCanvas: =>
     @stage = new createjs.Stage($('#beginner-campaign canvas', @$el)[0])
     @createWizard -10, 2, 2.6
-    @turnOnStageUpdates()
 
   turnOnStageUpdates: ->
     @interval = setInterval(@updateStage, 40) unless @interval
+
+  turnOffStageUpdates: ->
+    turnOffFunc = =>
+      clearInterval @interval
+      clearInterval @turnOff
+      @interval = null
+      @turnOff = null
+    @turnOff = setInterval turnOffFunc, 2000
 
   createWizard: (x=0, y=0, scale=1.0) ->
     spriteOptions = thangID: "Beginner Wizard", resolutionFactor: scale
@@ -54,9 +61,11 @@ module.exports = class HomeView extends View
     @stage.update()
 
   onMouseOverButton: ->
+    @turnOnStageUpdates()
     @wizardSprite?.queueAction 'cast'
 
   onMouseOutButton: ->
+    @turnOffStageUpdates()
     @wizardSprite?.queueAction 'idle'
 
   updateStage: =>
@@ -70,3 +79,4 @@ module.exports = class HomeView extends View
   didReappear: ->
     super()
     @turnOnStageUpdates()
+


### PR DESCRIPTION
Remove the initial timer and add on/off timers to keep the canvas from drawing 100% of the time on the home page.
