### PR TITLE
corrected sass-brunch release requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "javascript-brunch": "> 1.0 < 1.8",
     "coffee-script-brunch": "> 1.0 < 1.8",
     "coffeelint-brunch": "> 1.0 < 1.8",
-    "sass-brunch": "> 1.0 < 1.8",
+    "sass-brunch": "1.7.0",
     "css-brunch": "> 1.0 < 1.8",
     "jade-brunch": "> 1.0 < 1.8",
     "uglify-js-brunch": "~1.7.4",


### PR DESCRIPTION
Windows users should now be able to install the codecombat requirements without the extra step to fix sass-brunch. Version 1.7.0 of brunch repo tested as working.
