### PR TITLE
Change play link to the latest level when saved in local storage

### DIFF
--- a/app/views/home_view.coffee
+++ b/app/views/home_view.coffee
@@ -34,6 +34,17 @@ module.exports = class HomeView extends View
     @wizardType.fetch()
     @wizardType.once 'sync', @initCanvas
 
+    # Try to find latest level and set "Play" link to go to that level
+    if localStorage?
+      lastLevel = localStorage["lastLevel"]
+      if lastLevel? and lastLevel isnt ""
+        playLink = @$el.find("#beginner-campaign")
+        if playLink?
+          href = playLink.attr("href").split("/")
+          href[href.length-1] = lastLevel if href.length isnt 0
+          href = href.join("/")
+          playLink.attr("href", href)
+
   initCanvas: =>
     @stage = new createjs.Stage($('#beginner-campaign canvas', @$el)[0])
     @createWizard()

--- a/app/views/play/level_view.coffee
+++ b/app/views/play/level_view.coffee
@@ -81,6 +81,10 @@ module.exports = class PlayLevelView extends View
 
     @load() unless @isEditorPreview
 
+    # Save latest level played in local storage
+    if localStorage?
+      localStorage["lastLevel"] = @levelID
+
   setLevel: (@level, @supermodel) ->
     @god?.level = @level.serialize @supermodel
     @load()


### PR DESCRIPTION
Changed the "Play" link on the home page to switch to the latest level played if the user has been there before.

This is a simple solution using localStorage, we can possibly make this more sophisticated later on.
