### PR TITLE
Disable body scrolling in Thang List

### DIFF
--- a/app/views/editor/level/thangs_tab_view.coffee
+++ b/app/views/editor/level/thangs_tab_view.coffee
@@ -43,7 +43,7 @@ module.exports = class ThangsTabView extends View
     'sprite:mouse-up': 'onSpriteMouseUp'
     'sprite:double-clicked': 'onSpriteDoubleClicked'
     'surface:stage-mouse-down': 'onStageMouseDown'
-  
+
   shortcuts:
     'esc': -> @selectAddThang()
 
@@ -70,11 +70,16 @@ module.exports = class ThangsTabView extends View
     return if @startsLoading
     super()
     $('.tab-content').click @selectAddThang
+    $('#thangs-list').bind 'mousewheel', @preventBodyScrollingInThangList
     key 'left', _.bind @moveAddThangSelection, @, -1
     key 'right', _.bind @moveAddThangSelection, @, 1
     key 'delete, del, backspace', @deleteSelectedExtantThang
     key 'f', => Backbone.Mediator.publish('level-set-debug', debug: not @surface.debug)
     key 'g', => Backbone.Mediator.publish('level-set-grid', grid: not @surface.gridShowing())
+
+  preventBodyScrollingInThangList: (e) ->
+    @scrollTop += (if e.deltaY < 0 then 1 else -1) * 30
+    e.preventDefault()
 
   onLevelLoaded: (e) ->
     @level = e.level


### PR DESCRIPTION
This overwrites the native scrolling behavior for the
thangs-list div by manually setting the value of
@scrollTop. It's using the jquery-mousewheel plugin
to normalize the events 

Ref #163
