### PR TITLE
use https when linking to wikipedia

### DIFF
--- a/app/templates/modal/signup.jade
+++ b/app/templates/modal/signup.jade
@@ -23,7 +23,7 @@ block modal-body-content
           label.control-label(for="signup-confirm-age") 
             input#signup-confirm-age(name="confirm-age", type="checkbox", checked='checked')
             span(data-i18n="signup.coppa") 13+ or non-USA 
-            a(href="http://en.wikipedia.org/wiki/Children's_Online_Privacy_Protection_Act", data-i18n="signup.coppa_why", target="_blank") (Why?)
+            a(href="https://en.wikipedia.org/wiki/Children's_Online_Privacy_Protection_Act", data-i18n="signup.coppa_why", target="_blank") (Why?)
 
 block modal-body-wait-content
   h3(data-i18n="signup.creating") Creating Account...


### PR DESCRIPTION
Wikipedia supports (but does not yet require) https. This will change in the future but it will not hurt to switch to https ourselves :) 

https://blog.wikimedia.org/2013/08/01/future-https-wikimedia-projects/ 

non-breaking change. should not break tests as far as I can tell 
