### PR TITLE
Block Ctrl-S while playing

### DIFF
--- a/app/application.coffee
+++ b/app/application.coffee
@@ -11,6 +11,11 @@ preventBackspace = (event) ->
   else if (key.ctrl or key.command) and not key.alt and event.keyCode in [219, 221]  # prevent Ctrl/Cmd + [ / ]
     event.preventDefault()
 
+preventControlS = (event) ->
+  if event.ctrlKey || event.metaKey
+    if String.fromCharCode(event.which).toLowerCase() == "s"
+      event.preventDefault()
+
 elementAcceptsKeystrokes = (el) ->
   # http://stackoverflow.com/questions/1495219/how-can-i-prevent-the-backspace-key-from-navigating-back
   el ?= document.activeElement
@@ -31,6 +36,7 @@ Application = initialize: ->
   new FacebookHandler()
   new GPlusHandler()
   $(document).bind 'keydown', preventBackspace
+  $(document).bind 'keydown', preventControlS
 
   preload(COMMON_FILES)
   $.i18n.init {


### PR DESCRIPTION
It was stated in [this thread](http://discourse.codecombat.com/t/capture-ctrl-s-might-make-the-experience-better-for-new-players/126) that we should block Ctrl-S to make the experience better for new players.  This code does that in a way that is easy and workers across Firefox, Chrome, and IE.
