### PR TITLE
Block Ctrl-S while playing

### DIFF
--- a/app/views/play/level_view.coffee
+++ b/app/views/play/level_view.coffee
@@ -64,6 +64,9 @@ module.exports = class PlayLevelView extends View
   events:
     'click #level-done-button': 'onDonePressed'
 
+  shortcuts:
+    'ctrl+s': 'onCtrlS'
+
   constructor: (options, @levelID) ->
     console.profile?() if PROFILE_ME
     super options
@@ -188,6 +191,9 @@ module.exports = class PlayLevelView extends View
 #    @showWizardSettingsModal() if not me.get('name')
 
   # callbacks
+
+  onCtrlS: (e) ->
+    e.preventDefault()
 
   onLevelReloadFromData: (e) ->
     isReload = Boolean @world


### PR DESCRIPTION
It was stated in [this thread](http://discourse.codecombat.com/t/capture-ctrl-s-might-make-the-experience-better-for-new-players/126) that we should block Ctrl-S to make the experience better for new players.  This code does that in a way that is easy and workers across Firefox, Chrome, and IE
