### PR TITLE
fixing language selection disappearance when showing cached home view

### DIFF
--- a/app/views/kinds/RootView.coffee
+++ b/app/views/kinds/RootView.coffee
@@ -15,12 +15,8 @@ filterKeyboardEvents = (allowedEvents, func) ->
 module.exports = class RootView extends CocoView
   events:
     "click #logout-button": "logoutAccount"
-    'change .language-dropdown': 'showDiplomatSuggestionModal'
+    'change .language-dropdown': 'onLanguageChanged'
     'click .toggle-fullscreen': 'toggleFullscreen'
-
-  afterRender: ->
-    super()
-    @buildLanguages()
 
   logoutAccount: ->
     logoutUser($('#login-email').val())
@@ -60,11 +56,12 @@ module.exports = class RootView extends CocoView
         $("<option></option>").val(code).text(localeInfo.nativeDescription))
     $select.val(preferred).fancySelect()
 
-  showDiplomatSuggestionModal: ->
+  onLanguageChanged: ->
     newLang = $(".language-dropdown").val()
     $.i18n.setLng(newLang, {})
     @saveLanguage(newLang)
     @render()
+    @buildLanguages()
     unless newLang.split('-')[0] is "en"
       @openModalView(application.router.getView("modal/diplomat_suggestion", "_modal"))
 


### PR DESCRIPTION
this should take care of issue #167 - the plugin has to be reinitialized after inserting the view, and some additional clean-up has to be done for it to work properly. I couldn't find a proper destroy method, but the author seems to be working on it (see https://github.com/octopuscreative/FancySelect/issues/25)

-jose
