### PR TITLE
Change spell palette colors

### DIFF
--- a/app/styles/play/level/tome/spell_palette_entry.sass
+++ b/app/styles/play/level/tome/spell_palette_entry.sass
@@ -8,17 +8,17 @@
   font-size: 12px
   border: 1px solid transparent
   cursor: pointer
-  @include user-select(all)
+  @user-select(none)
 
   &:hover
-    border: 1px solid #BFF
+    border: 1px solid #000000
 
   &.pinned
-    background-color: darken(#BFF, 20%)
+    background-color: darken(#FFFFFF, 25%)
 
   // Pulling these colors from the most relevant textmate-theme classes
   &.function
-    color: #0000A2
+    color: #0066FF
   &.object
     color: rgb(6, 150, 14)
   &.string


### PR DESCRIPTION
Currently, it looked quite bad when you clicked on a method.  This changes some basic colors to make it more pleasant when you click on a method
