### PR TITLE
Blur the music button after click so that subsequent space and enter keydown events do not trigger it.

### DIFF
--- a/app/views/play/level/playback_view.coffee
+++ b/app/views/play/level/playback_view.coffee
@@ -25,9 +25,7 @@ module.exports = class PlaybackView extends View
     'click #debug-toggle': 'onToggleDebug'
     'click #grid-toggle': 'onToggleGrid'
     'click #edit-wizard-settings': 'onEditWizardSettings'
-    'click #music-button': ->
-      me.set('music', not me.get('music'))
-      me.save()
+    'click #music-button': 'onToggleMusic'
     'click #zoom-in-button': -> Backbone.Mediator.publish('camera-zoom-in') unless @disabled
     'click #zoom-out-button': -> Backbone.Mediator.publish('camera-zoom-out') unless @disabled
     'click #volume-button': 'onToggleVolume'
@@ -204,6 +202,12 @@ module.exports = class PlaybackView extends View
       else if i is classes.length - 1  # no oldClass
         newI = 2
     Backbone.Mediator.publish 'level-set-volume', volume: volumes[newI]
+    $(document.activeElement).blur()
+
+  onToggleMusic: (e) ->
+    e?.preventDefault()
+    me.set('music', not me.get('music'))
+    me.save()
     $(document.activeElement).blur()
 
   destroy: ->


### PR DESCRIPTION
In the original code, there was no `$(document.activeElement).blur()` function fired after the music button was clicked (there was blur for the toggle play and toggle volume buttons). This caused the music button to remain in the focused state after the user clicks on it. Subsequent space and enter keydown events would toggle the state of the music button.

Moved the click event code for the music button into a new function and added a call to `$(document.activeElement).blur()` at the end of it.

This fixes issue #306. 
