### PR TITLE
Fix for "Type str doesn't support the buffer API"

### DIFF
--- a/scripts/devSetup/factories.py
+++ b/scripts/devSetup/factories.py
@@ -36,6 +36,7 @@ class SetupFactory(object):
         mongo_version_string = ""
         try:
             mongo_version_string = subprocess.check_output("mongod --version",shell=True)
+	    mongo_version_string = mongo_version_string.decode(encoding='UTF-8')
         except:
             print("Mongod not found.")
         if "v2.5.4" not in mongo_version_string:


### PR DESCRIPTION
subprocess.check_output("mongod --version",shell=True) returns a byte
string so to convert it to a regular string we should do this :
mongo_version_string = subprocess.check_output("mongod
--version",shell=True)
mongo_version_string = mongo_version_string.decode(encoding='UTF-8')
