### PR TITLE
Redirect to level editor only after modal hidden event is triggered. Fixes #438 and #439.

### DIFF
--- a/app/views/kinds/SearchView.coffee
+++ b/app/views/kinds/SearchView.coffee
@@ -24,6 +24,7 @@ module.exports = class ThangTypeHomeView extends View
     'click button.new-model-submit': 'makeNewModel'
     'submit form': 'makeNewModel'
     'shown.bs.modal #new-model-modal': 'focusOnName'
+    'hidden.bs.modal #new-model-modal': 'onModalHidden'
 
   getRenderData: ->
     c = super()
@@ -85,16 +86,21 @@ module.exports = class ThangTypeHomeView extends View
     res = model.save()
     return unless res
 
-    modal = @$el.find('.modal')
+    modal = @$el.find('#new-model-modal')
     forms.clearFormAlerts(modal)
     @showLoading(modal.find('.modal-body'))
     res.error =>
       @hideLoading()
       forms.applyErrorsToForm(modal, JSON.parse(res.responseText))
+    that = @
     res.success ->
-      modal.modal('hide')
-      base = document.location.pathname[1..] + '/'
-      app.router.navigate(base + (model.get('slug') or model.id), {trigger:true})
+      that.model = model
+      modal.modal('hide')      
+
+  onModalHidden: ->
+    # Can only redirect after the modal hidden event has triggered
+    base = document.location.pathname[1..] + '/'
+    app.router.navigate(base + (@model.get('slug') or @model.id), {trigger:true})
 
   focusOnName: ->
     @$el.find('#name').focus()


### PR DESCRIPTION
The `modal('hide')` function does not wait until the modal is fully hidden before the Backbone's `router.navigate` is triggered. Hence there was a transparent modal backdrop `<div class="modal-backdrop fade in"></div>` that remains and was covering the whole page, causing the whole page to be unresponsive.

To fix this, a event listener for the modal hidden event was added and the redirecting to the editor page only happens when the `hidden.bs.modal` event was triggered.

Fixes issues #438 and #439.
