### PR TITLE
Moved 'skip tutorial' text to locales and 'Skip (esc)' next to Continue button

### DIFF
--- a/app/locale/ar.coffee
+++ b/app/locale/ar.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "العربية", englishDescription: "Arabi
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/bg.coffee
+++ b/app/locale/bg.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "български език", englishDescri
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/cs.coffee
+++ b/app/locale/cs.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "čeština", englishDescription: "Czech", tr
     tome_available_spells: "Dostupná kouzla"
     hud_continue: "Pokračovat (stiskněte shift-mezera)"
     spell_saved: "Kouzlo uloženo"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
   admin:
     av_title: "Administrátorský pohled"

--- a/app/locale/da.coffee
+++ b/app/locale/da.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "dansk", englishDescription: "Danish", trans
     tome_available_spells: "Tilgængelige trylleformularer"
     hud_continue: "Fortsæt (tryk skift-mellemrum)"
     spell_saved: "Trylleformularen er gemt"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
   admin:
 #    av_title: "Admin Views"

--- a/app/locale/de.coffee
+++ b/app/locale/de.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "Deutsch", englishDescription: "German", tra
     tome_available_spells: "Verfügbare Zauber"
     hud_continue: "Weiter (drücke Shift + Leertaste)"
     spell_saved: "Zauber gespeichert"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
   admin:
     av_title: "Administrator Übersicht"

--- a/app/locale/el.coffee
+++ b/app/locale/el.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "ελληνικά", englishDescription: "Gre
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/en-AU.coffee
+++ b/app/locale/en-AU.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "English (AU)", englishDescription: "English
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/en-GB.coffee
+++ b/app/locale/en-GB.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "English (UK)", englishDescription: "English
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/en-US.coffee
+++ b/app/locale/en-US.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "English (US)", englishDescription: "English
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -199,9 +199,9 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     tome_select_spell: "Select a Spell"
     tome_select_a_thang: "Select Someone for "
     tome_available_spells: "Available Spells"
-    hud_continue: "Continue (press shift-space)"
+    hud_continue: "Continue (shift+space)"
     spell_saved: "Spell Saved"
-    skip_tutorial: "skip: esc"
+    skip_tutorial: "Skip (esc)"
 
   admin:
     av_title: "Admin Views"

--- a/app/locale/es-419.coffee
+++ b/app/locale/es-419.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "español (América Latina)", englishDescrip
     tome_available_spells: "Hechizos Disponibles"
     hud_continue: "Continuar (presionar shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/es-ES.coffee
+++ b/app/locale/es-ES.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "español (ES)", englishDescription: "Spanis
     tome_available_spells: "Hechizos disponibles"
     hud_continue: "Continuar (pulsa Shift+Space)"
     spell_saved: "Hechizo guardado"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/es.coffee
+++ b/app/locale/es.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "español", englishDescription: "Spanish", t
     tome_available_spells: "Hechizos Disponibles"
     hud_continue: "Continuar (presionar shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/fa.coffee
+++ b/app/locale/fa.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "فارسی", englishDescription: "Persian",
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/fi.coffee
+++ b/app/locale/fi.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "suomi", englishDescription: "Finnish", tran
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/fr.coffee
+++ b/app/locale/fr.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "français", englishDescription: "French", t
     tome_available_spells: "Sorts diponibles"
     hud_continue: "Continuer (appuie sur shift ou espace)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
   admin:
     av_title: "Vues d'administrateurs"

--- a/app/locale/he.coffee
+++ b/app/locale/he.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "עברית", englishDescription: "Hebrew", 
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/hi.coffee
+++ b/app/locale/hi.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "मानक हिन्दी", englishDe
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/hu.coffee
+++ b/app/locale/hu.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "magyar", englishDescription: "Hungarian", t
     tome_available_spells: "Elérhető varázslatok"
     hud_continue: "Folytatás (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/id.coffee
+++ b/app/locale/id.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "Bahasa Indonesia", englishDescription: "Ind
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/it.coffee
+++ b/app/locale/it.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "italiano", englishDescription: "Italian", t
     tome_available_spells: "Incantesimi disponibili"
     hud_continue: "Continua (premi Maiusc-Spazio)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
   admin:
     av_title: "Vista amministratore"

--- a/app/locale/ja.coffee
+++ b/app/locale/ja.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "日本語", englishDescription: "Japanese",
     tome_available_spells: "利用できる呪文"
     hud_continue: "続く　（Shift+Spaceキー）"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
   admin:
     av_title: "管理画面"

--- a/app/locale/ko.coffee
+++ b/app/locale/ko.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "한국어", englishDescription: "Korean", t
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/lt.coffee
+++ b/app/locale/lt.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "lietuvių kalba", englishDescription: "Lith
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/ms-BA.coffee
+++ b/app/locale/ms-BA.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "Bahasa Melayu", englishDescription: "Bahasa
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/nb.coffee
+++ b/app/locale/nb.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "Norsk Bokmål", englishDescription: "Norweg
     tome_available_spells: "Tilgjenglige Trylleformularer"
     hud_continue: "Fortsett (trykk shift-mellomrom)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/nl.coffee
+++ b/app/locale/nl.coffee
@@ -201,7 +201,7 @@ module.exports = nativeDescription: "Nederlands", englishDescription: "Dutch", t
     tome_available_spells: "Beschikbare spreuken"
     hud_continue: "Ga verder (druk shift-space)"
     spell_saved: "Spreuk Opgeslagen"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
   admin:
     av_title: "Administrator panels"

--- a/app/locale/nn.coffee
+++ b/app/locale/nn.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "Norwegian Nynorsk", englishDescription: "No
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/no.coffee
+++ b/app/locale/no.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "Norsk", englishDescription: "Norwegian", tr
     tome_available_spells: "Tilgjenglige Trylleformularer"
     hud_continue: "Fortsett (trykk shift-mellomrom)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/pl.coffee
+++ b/app/locale/pl.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "język polski", englishDescription: "Polish
     tome_available_spells: "Dostępne czary"
     hud_continue: "Kontynuuj (naciśnij enter)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/pt-BR.coffee
+++ b/app/locale/pt-BR.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "português do Brasil", englishDescription: 
     tome_available_spells: "Feitiços Disponíveis"
     hud_continue: "Continue (tecle Shift+Space)"
     spell_saved: "Feitiço Salvo"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
   admin:
     av_title: "Visualização de Administrador"

--- a/app/locale/pt-PT.coffee
+++ b/app/locale/pt-PT.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "Português europeu", englishDescription: "P
     tome_available_spells: "Feitiços disponíveis"
     hud_continue: "Continuar (pressiona shift-space)"
     spell_saved: "Feitiço Guardado"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
   admin:
     av_title: "Visualizações de Admin"

--- a/app/locale/pt.coffee
+++ b/app/locale/pt.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "português", englishDescription: "Portugues
     tome_available_spells: "Feitiços Disponíveis"
     hud_continue: "Continue (tecle Shift+Space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/ro.coffee
+++ b/app/locale/ro.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "limba română", englishDescription: "Roman
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/ru.coffee
+++ b/app/locale/ru.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "русский", englishDescription: "Russi
     tome_available_spells: "Доступные заклинания"
     hud_continue: "Продолжить (нажмите Shift+Пробел)"
     spell_saved: "Заклинание сохранено"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
   admin:
     av_title: "Админ панель"

--- a/app/locale/sk.coffee
+++ b/app/locale/sk.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "slovenčina", englishDescription: "Slovak",
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/sl.coffee
+++ b/app/locale/sl.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "slovenščina", englishDescription: "Sloven
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/sr.coffee
+++ b/app/locale/sr.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "српски", englishDescription: "Serbian
     tome_available_spells: "Доступне чини"
     hud_continue: "Настави (притисни ентер)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/sv.coffee
+++ b/app/locale/sv.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "Svenska", englishDescription: "Swedish", tr
     tome_select_spell: "Välj en Förmåga"
     tome_select_a_thang: "Välj Någon för "
     tome_available_spells: "Tillgängliga Förmågor"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/th.coffee
+++ b/app/locale/th.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "ไทย", englishDescription: "Thai", tra
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/tr.coffee
+++ b/app/locale/tr.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "Türkçe", englishDescription: "Turkish", t
     tome_available_spells: "Kullanılabilir Büyüler"
     hud_continue: "Devam (ÜstKarakter+Boşluk)"
     spell_saved: "Büyü Kaydedildi"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
   admin:
     av_title: "Yönetici Görünümleri"

--- a/app/locale/uk.coffee
+++ b/app/locale/uk.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "українська мова", englishDesc
     tome_available_spells: "Доступні закляття"
     hud_continue: "Продовжити (натисніть shift-space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/ur.coffee
+++ b/app/locale/ur.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "اُردُو", englishDescription: "Urdu", 
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/vi.coffee
+++ b/app/locale/vi.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "Tiếng Việt", englishDescription: "Vietn
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/zh-HANS.coffee
+++ b/app/locale/zh-HANS.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "简体中文", englishDescription: "Chinese
     tome_available_spells: "可用的法术"
     hud_continue: "继续（按 Shift-空格）"
     spell_saved: "咒语已保存"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
   admin:
     av_title: "管理员视图"

--- a/app/locale/zh-HANT.coffee
+++ b/app/locale/zh-HANT.coffee
@@ -200,7 +200,7 @@ module.exports = nativeDescription: "繁体中文", englishDescription: "Chinese
     tome_available_spells: "可用的法術"
     hud_continue: "繼續 (按 shift-空格)"
     spell_saved: "咒語已儲存"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/locale/zh.coffee
+++ b/app/locale/zh.coffee
@@ -198,9 +198,9 @@ module.exports = nativeDescription: "中文", englishDescription: "Chinese", tra
 #    tome_select_spell: "Select a Spell"
 #    tome_select_a_thang: "Select Someone for "
 #    tome_available_spells: "Available Spells"
-#    hud_continue: "Continue (press shift-space)"
+#    hud_continue: "Continue (shift+space)"
 #    spell_saved: "Spell Saved"
-#    skip_tutorial: "skip: esc"
+#    skip_tutorial: "Skip (esc)"
 
 #  admin:
 #    av_title: "Admin Views"

--- a/app/styles/play/level/hud.sass
+++ b/app/styles/play/level/hud.sass
@@ -230,10 +230,7 @@
 
         .hud-hint
           font-weight: normal
-          color: #aaa
-          position: absolute
-          top: 0
-          right: 4px
+          color: #999
 
         .enter
           position: absolute

--- a/app/views/play/level/hud_view.coffee
+++ b/app/views/play/level/hud_view.coffee
@@ -175,10 +175,10 @@ module.exports = class HUDView extends View
         group.append(button)
         response.button = $('button:last', group)
     else
-      s = $.i18n.t('play_level.hud_continue', defaultValue: "Continue (press shift-space)")
+      s = $.i18n.t('play_level.hud_continue', defaultValue: "Continue (shift+space)")
       sk = $.i18n.t('play_level.skip_tutorial', defaultValue: "skip: esc")
-      if @shiftSpacePressed > 4 and not @escapePressed
-        @bubble.append('<span class="hud-hint">' + sk + '</span>')
+      if not @escapePressed
+        group.append('<span class="hud-hint">' + sk + '</span>')
       group.append($('<button class="btn btn-small banner with-dot">' + s + ' <div class="dot"></div></button>'))
       @lastResponses = null
     @bubble.append($("<h3>#{@speaker ? 'Captain Anya'}</h3>"))


### PR DESCRIPTION
As being discussed on https://github.com/codecombat/codecombat/issues/410, the help text for skipping the tutorial might change in the future. So, it makes sense to move this to locale files.
