### PR TITLE
Minor bugfix for freezing editor due to out of bounds frame index

### DIFF
--- a/app/lib/surface/Surface.coffee
+++ b/app/lib/surface/Surface.coffee
@@ -502,6 +502,7 @@ module.exports = Surface = class Surface extends CocoClass
       # Skip some frame updates unless we're playing and not at end (or we haven't drawn much yet)
       frameAdvanced = (@playing and @currentFrame < @world.totalFrames) or @totalFramesDrawn < 2
       @currentFrame += @world.frameRate / @options.frameRate if frameAdvanced and @playing
+      @currentFrame = Math.min(@currentFrame, @world.totalFrames - 1)
       newWorldFrame = Math.floor @currentFrame
       worldFrameAdvanced = newWorldFrame isnt oldWorldFrame
       if worldFrameAdvanced


### PR DESCRIPTION
Resubmission for pull request #472. 
Bug fix for out of bounds index in @frames in tick listener. Possibly related to #438
