### PR TITLE
Treema fix

### DIFF
--- a/app/treema-ext.coffee
+++ b/app/treema-ext.coffee
@@ -106,7 +106,7 @@ class SoundFileTreema extends TreemaNode.nodeMap.string
     if @data
       valEl.append(playButton)
       valEl.append(stopButton)
-    valEl.append(dropdown) if files.length
+    valEl.append(dropdown) if files.length and @canEdit()
     if @data
       path = @data.split('/')
       name = path[path.length-1]


### PR DESCRIPTION
I was out hunting Treema bugs.
Found just the one: one shouldn't be able to switch music files from a readOnly Treema.

Extra note: The Config Schema of a System as can be accessed from the Level Editor is editable while nothing else is. I wasn't sure whether this was a feature, a coding bug where readOnly wasn't set or a Treema extension bug. Could someone please get back to me on this?
