### PR TITLE
Added i18n function, fixed issue #15

### DIFF
--- a/app/lib/scripts/SpriteScriptModule.coffee
+++ b/app/lib/scripts/SpriteScriptModule.coffee
@@ -1,5 +1,6 @@
 ScriptModule = require './ScriptModule'
 {me} = require 'lib/auth'
+util = require 'lib/utils'
 
 module.exports = class SpritesScriptModule extends ScriptModule
   @neededFor: (noteGroup) ->
@@ -36,9 +37,9 @@ module.exports = class SpritesScriptModule extends ScriptModule
     responses = [] unless script.skippable or responses
     for response in responses ? []
       response.text = response.i18n?[me.lang()]?.text ? response.text
-    text = sprite.say.i18n?[me.lang()]?.text or sprite.say.text
-    blurb = sprite.say.i18n?[me.lang()]?.blurb or sprite.say.blurb
-    sound = sprite.say.sound?[me.lang()]?.sound or sprite.say.sound
+    text = util.i18n(sprite.say, 'text')
+    blurb = util.i18n(sprite.say, 'blurb')
+    sound = sprite.say.sound # TODO support sound i18n
     note =
       channel: 'level-sprite-dialogue'
       event:

--- a/app/lib/utils.coffee
+++ b/app/lib/utils.coffee
@@ -65,5 +65,6 @@ module.exports.i18n = (say, target, language=me.lang(), fallback='en') ->
   return generalResult if generalResult?
   return fallforwardResult if fallforwardResult?
   return fallbackResult if fallbackResult?
+  return say[target] if target of say
   return say.text if 'text' of say
   null

--- a/test/app/lib/utils.spec.coffee
+++ b/test/app/lib/utils.spec.coffee
@@ -4,6 +4,7 @@ describe 'utils library', ->
   beforeEach ->
     this.fixture1 =
       "text": "G'day, Wizard! Come to practice? Well, let's get started..."
+      "blurb": "G'day"
       "i18n":
         "es-419":
           "text": "¡Buenas, Hechicero! ¿Vienes a practicar? Bueno, empecemos..."
@@ -37,6 +38,8 @@ describe 'utils library', ->
   it 'i18n falls back to the default text, even for other targets (like blurb)', ->
     delete this.fixture1.i18n['en']
     expect(util.i18n(this.fixture1, 'text', 'en')).toEqual(this.fixture1.text)
+    expect(util.i18n(this.fixture1, 'blurb', 'en')).toEqual(this.fixture1.blurb)
+    delete this.fixture1.blurb
     expect(util.i18n(this.fixture1, 'blurb', 'en')).toEqual(this.fixture1.text)
 
   it 'i18n can fall forward if a general language is not found', ->


### PR DESCRIPTION
Added a utility function in lib/utils, named 'i18n'. The signature is quite simple:
`i18n = (say, target, language=me.lang(), fallback='en')`

This now gets used twice in the existing code, like so:
`text = util.i18n(sprite.say, 'text')`

Advantages, as per issue #15:
- Falls back from specific to general locale, e.g. 'es-ES' -> 'es'
- Falls back to a default language or, if not available, a target object (like _blurb_) or if not available, a _text_ object
- Falls forward to a more specific locale if the general would not be available for some reason, e.g. 'es' -> 'es-ES'

Because loading a game takes too long to actually test something decently I wrote some Jasmine tests in test/app/utils.spec.coffee. All pass.
