### PR TITLE
Templates

### DIFF
--- a/app/templates/play/level/modal/docs.jade
+++ b/app/templates/play/level/modal/docs.jade
@@ -1,13 +1,13 @@
 extends /templates/modal/modal_base
 
-block model-header-content
+block modal-header-content
   h3(data-i18n="play_level.guide_title") Guide
   
 block modal-body-content
-  ul.nav.nav-tabs
-    for doc in docs
-      li
-        a(data-target="#docs_tab_#{doc.slug}", data-toggle="tab") #{doc.name}
-  div.tab-content
-    for doc in docs
+   ul.nav.nav-tabs
+     for doc in docs
+       li
+         a(data-target="#docs_tab_#{doc.slug}", data-toggle="tab") #{doc.name}
+   div.tab-content
+     for doc in docs
       div.tab-pane(id="docs_tab_#{doc.slug}")!= doc.html

--- a/app/templates/play/level/modal/reload.jade
+++ b/app/templates/play/level/modal/reload.jade
@@ -1,11 +1,12 @@
-.modal-dialog
-  .modal-header
-    button(type='button', data-dismiss="modal", aria-hidden="true").close &times;
-    h3(data-i18n="play_level.reload_title") Reload All Code?
+extends /templates/modal/modal_base
+
+block modal-header-content
+  h3(data-i18n="play_level.reload_title") Reload All Code?
   
-  .modal-body
+block modal-body
+  block modal-body-content
     p(data-i18n="play_level.reload_really") Are you sure you want to reload this level back to the beginning?
   
-  .modal-footer
-    a(href='#', data-dismiss="modal", aria-hidden="true", data-i18n="modal.close").btn Close
-    a(href='#', data-dismiss="modal", aria-hidden="true", data-i18n="play_level.reload_confirm").btn.btn-primary#restart-level-confirm-button Reload All
+block modal-footer-content
+  a(href='#', data-dismiss="modal", aria-hidden="true", data-i18n="modal.close").btn Close
+  a(href='#', data-dismiss="modal", aria-hidden="true", data-i18n="play_level.reload_confirm").btn.btn-primary#restart-level-confirm-button Reload All


### PR DESCRIPTION
The only difference between the "close" button in the base template and the current ones is that it they are titled "Okay" versus "Close". So the guide dialog (docs.jade) now says "Okay" while the reload level dialog says "Close".

Fixes issue #546 partly
