### PR TITLE
Adds search bar for adding thangs in level editor

### DIFF
--- a/app/styles/editor/level/thangs_tab.sass
+++ b/app/styles/editor/level/thangs_tab.sass
@@ -79,7 +79,7 @@
     #thangs-list
       position: absolute
       right: 0
-      top: 40px
+      top: 60px
       bottom: 0
       overflow: scroll
 

--- a/app/templates/editor/level/add_thangs.jade
+++ b/app/templates/editor/level/add_thangs.jade
@@ -1,0 +1,10 @@
+h3(data-i18n="editor.level_tab_thangs_add") Add Thangs
+input(type="text", id="thang-search")
+#thangs-list
+  for group in groups
+    h4= group.name
+    for thangType in group.thangs
+      div.add-thang-palette-icon(data-thang-type=thangType.name)
+        - path = '/file/db/thang.type/'+thangType.original+'/portrait.png'
+        img(title="Add " + thangType.name, src=path, alt="")
+    div.clearfix

--- a/app/templates/editor/level/thangs_tab.jade
+++ b/app/templates/editor/level/thangs_tab.jade
@@ -21,14 +21,5 @@
     #canvas-left-gradient.gradient
     #canvas-top-gradient.gradient
 
-.add-thangs-palette.thangs-column
-  h3(data-i18n="editor.level_tab_thangs_add") Add Thangs
-  #thangs-list
-    for group in groups
-      h4= group.name
-      for thangType in group.thangs
-        div.add-thang-palette-icon(data-thang-type=thangType.name)
-          - path = '/file/db/thang.type/'+thangType.original+'/portrait.png'
-          img(title="Add " + thangType.name, src=path, alt="")
-      div.clearfix
+.add-thangs-palette.thangs-column#add-thangs-column
 #editor-level-thang-edit.secret

--- a/app/views/editor/level/add_thangs_view.coffee
+++ b/app/views/editor/level/add_thangs_view.coffee
@@ -1,0 +1,81 @@
+View = require 'views/kinds/CocoView'
+add_thangs_template = require 'templates/editor/level/add_thangs'
+ThangType = require 'models/ThangType'
+CocoCollection = require 'models/CocoCollection'
+
+class ThangTypeSearchCollection extends CocoCollection
+  url: '/db/thang.type/search?project=true'
+  model: ThangType
+
+  addTerm: (term) ->
+    @url += "&term=#{term}" if term
+
+module.exports = class AddThangsView extends View
+  id: "add-thangs-column"
+  className: 'add-thangs-palette thangs-column'
+  template: add_thangs_template
+  startsLoading: false
+
+  events:
+    'keyup input#thang-search': 'runSearch'
+
+  constructor: (options) ->
+    super options
+    @world = options.world
+    @thangTypes = @supermodel.getCollection new ThangTypeSearchCollection()  # should load depended-on Components, too
+    @thangTypes.once 'sync', @onThangTypesLoaded
+    @thangTypes.fetch()
+
+  onThangTypesLoaded: =>
+    return if @destroyed
+    @render()  # do it again but without the loading screen
+
+  getRenderData: (context={}) ->
+    context = super(context)
+    if @searchModels
+      models = @searchModels
+    else
+      models = @supermodel.getModels(ThangType)
+
+    thangTypes = (thangType.attributes for thangType in models)
+    thangTypes = _.uniq thangTypes, false, 'original'
+    thangTypes = _.reject thangTypes, kind: 'Mark'
+    groupMap = {}
+    for thangType in thangTypes
+      groupMap[thangType.kind] ?= []
+      groupMap[thangType.kind].push thangType
+
+    groups = []
+    for groupName in Object.keys(groupMap).sort()
+      someThangTypes = groupMap[groupName]
+      someThangTypes = _.sortBy someThangTypes, 'name'
+      group =
+        name: groupName
+        thangs: someThangTypes
+      groups.push group
+
+    context.thangTypes = thangTypes
+    context.groups = groups
+    context
+
+  afterRender: ->
+    return if @startsLoading
+    super()
+
+  runSearch: (e) =>
+    if e?.which is 27
+      @onEscapePressed()
+    term = @$el.find('input#thang-search').val()
+    return unless term isnt @lastSearch
+
+    @searchModels = @thangTypes.filter (model) ->
+      return true unless term
+      regExp = new RegExp term, 'i'
+      return model.get('name').match regExp
+    @render()
+    @$el.find('input#thang-search').focus().val(term)
+    @lastSearch = term
+
+  onEscapePressed: ->
+    @$el.find('input#thang-search').val("")
+    @runSearch

--- a/app/views/editor/level/thangs_tab_view.coffee
+++ b/app/views/editor/level/thangs_tab_view.coffee
@@ -1,4 +1,5 @@
 View = require 'views/kinds/CocoView'
+AddThangsView = require './add_thangs_view'
 thangs_template = require 'templates/editor/level/thangs_tab'
 Level = require 'models/Level'
 ThangType = require 'models/ThangType'
@@ -110,6 +111,7 @@ module.exports = class ThangsTabView extends View
     $('.tab-content').click @selectAddThang
     $('#thangs-list').bind 'mousewheel', @preventBodyScrollingInThangList
     @$el.find('#extant-thangs-filter button:first').button('toggle')
+    @addThangsView = @insertSubView new AddThangsView world: @world, supermodel: @supermodel
 
   onFilterExtantThangs: (e) ->
     @$el.find('#extant-thangs-filter button.active').button('toggle')


### PR DESCRIPTION
Right now, while creating/editing levels, adding new thangs is a little painful, especially when you aren't familiar with the images for thangs, which is true for most new users. So, I've added a little search bar in the Add Thangs column on the right.

I had to create a subview for the Add Thangs column, since partially updating a view in Backbone is a little tricky, without re-rendering the complete view. I'm mostly new to Backbone, so I'm a little unsure about this.
