### PR TITLE
Added Function.Prototype.bind shim to world worker

### DIFF
--- a/app/assets/javascripts/workers/worker_world.js
+++ b/app/assets/javascripts/workers/worker_world.js
@@ -5,6 +5,32 @@
 if(typeof window !== 'undefined' || !self.importScripts)
   throw "Attempt to load worker_world into main window instead of web worker.";
 
+// Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
+// This is here for running simuations in enviroments lacking function.bind (PhantomJS mostly)
+if (!Function.prototype.bind) {
+  Function.prototype.bind = function (oThis) {
+    if (typeof this !== "function") {
+      // closest thing possible to the ECMAScript 5 internal IsCallable function
+      throw new TypeError("Function.prototype.bind (Shim) - target is not callable");
+    }
+
+    var aArgs = Array.prototype.slice.call(arguments, 1), 
+        fToBind = this, 
+        fNOP = function () {},
+        fBound = function () {
+          return fToBind.apply(this instanceof fNOP && oThis
+                                 ? this
+                                 : oThis,
+                               aArgs.concat(Array.prototype.slice.call(arguments)));
+        };
+
+    fNOP.prototype = this.prototype;
+    fBound.prototype = new fNOP();
+
+    return fBound;
+  };
+}
+
 // assign global window so that Brunch's require (in world.js) can go into it
 self.window = self;
 self.workerID = "Worker";


### PR DESCRIPTION
attempting to run the simulation tab on headless browsers to enable running games on a vps.
cant inject this locally due to web workers running in their own context.
