### PR TITLE
Improved team name display on ladder view

### DIFF
--- a/app/templates/play/ladder/my_matches_tab.jade
+++ b/app/templates/play/ladder/my_matches_tab.jade
@@ -53,7 +53,7 @@ div#columns.row
             td.name-cell= match.opponentName || "Anonymous"
             td.time-cell= match.when
             td.battle-cell
-              - var text = match.state === 'win' ? 'Watch your victory' : 'Defeat the ' + team.otherTeam
+              - var text = match.state === 'win' ? 'Watch your victory' : 'Defeat the ' + (team.otherTeam === 'theogres' ? "Ogres" : "Humans")
               a(href="/play/level/#{levelID}?team=#{team.id}&opponent=#{match.sessionID}")= text
 
         if !team.matches.length


### PR DESCRIPTION
Format was a little annoying 

Before: 
Defeat theogres
After: 
Defeat the Ogres
![screenshot 2014-03-20 13 13 05](https://f.cloud.github.com/assets/569929/2472144/be464f44-b031-11e3-852a-6eae4ab04fa1.png)
![screenshot 2014-03-20 13 15 23](https://f.cloud.github.com/assets/569929/2472145/be5d57e8-b031-11e3-8b55-0892df955304.png)
