### PR TITLE
Select dependents when a extant component is selected.

### DIFF
--- a/app/styles/editor/components/main.sass
+++ b/app/styles/editor/components/main.sass
@@ -14,6 +14,9 @@
     h3
       margin: 5px 0
 
+  .treema-dependent > .treema-row 
+    background-color: #FFC671
+
   #extant-components-column
     left: 0
     width: 20%

--- a/app/views/editor/components/main.coffee
+++ b/app/views/editor/components/main.coffee
@@ -97,6 +97,34 @@ module.exports = class ThangComponentEditView extends CocoView
     @alreadySaving = false
 
     return unless selected.length
+
+    # select dependencies.
+    node = selected[0]
+    original = node.data.original
+
+    toRemoveTreema = []
+    dependent_class = 'treema-dependent'
+    try     
+      for index, child of @extantComponentsTreema.childrenTreemas
+        $(child.$el).removeClass(dependent_class)
+
+      for index, child of @extantComponentsTreema.childrenTreemas
+        if child.data.original == original # Here we assume that the treemas are sorted by their dependency.
+          break
+
+        dep_originals = (d.original for d in child.component.attributes.dependencies)
+        for dep_original in dep_originals
+          if original == dep_original
+            toRemoveTreema.push child
+
+      for dep_treema in toRemoveTreema
+        dep_treema.toggleSelect()
+        $(dep_treema.$el).addClass(dependent_class)
+
+    catch error
+      console.error error
+
+    return unless selected.length
     row = selected[0]
     @selectedRow = row
     component = row.component?.attributes or row.data


### PR DESCRIPTION
The original pull request is #630. I clean some files and create a new branch. 

When a extant component is selected, all its dependents are highlighted by different color. If it's deleted, the dependents are also deleted.

Fixes #507
