### PR TITLE
Save autocastDelay as a setting on User re #627

### DIFF
--- a/app/views/play/level/tome/cast_button_view.coffee
+++ b/app/views/play/level/tome/cast_button_view.coffee
@@ -32,8 +32,7 @@ module.exports = class CastButtonView extends View
     @castOptions = $('.autocast-delays', @$el)
     @castButton.on 'click', @onCastButtonClick
     @castOptions.find('a').on 'click', @onCastOptionsClick
-    # TODO: use a User setting instead of localStorage
-    delay = localStorage.getItem 'autocastDelay'
+    delay = me.get('autocastDelay')
     delay ?= 5000
     if @levelID in ['brawlwood', 'brawlwood-tutorial', 'dungeon-arena', 'dungeon-arena-tutorial']
       delay = 90019001
@@ -88,7 +87,8 @@ module.exports = class CastButtonView extends View
     #console.log "Set autocast delay to", delay
     return unless delay
     @autocastDelay = delay = parseInt delay
-    localStorage.setItem 'autocastDelay', delay
+    me.set('autocastDelay', delay)
+    me.save()
     spell.view.setAutocastDelay delay for spellKey, spell of @spells
     @castOptions.find('a').each ->
       $(@).toggleClass('selected', parseInt($(@).attr('data-delay')) is delay)

--- a/server/users/user_handler.coffee
+++ b/server/users/user_handler.coffee
@@ -18,7 +18,7 @@ UserHandler = class UserHandler extends Handler
     'name', 'photoURL', 'password', 'anonymous', 'wizardColor1', 'volume',
     'firstName', 'lastName', 'gender', 'facebookID', 'emailSubscriptions',
     'testGroupNumber', 'music', 'hourOfCode', 'hourOfCodeComplete', 'preferredLanguage',
-    'wizard', 'aceConfig', 'simulatedBy', 'simulatedFor'
+    'wizard', 'aceConfig', 'simulatedBy', 'simulatedFor', 'autocastDelay'
   ]
 
   jsonSchema: schema

--- a/server/users/user_schema.coffee
+++ b/server/users/user_schema.coffee
@@ -17,7 +17,7 @@ UserSchema = c.object {},
   wizardColor1: c.pct({title: 'Wizard Clothes Color'})
   volume: c.pct({title: 'Volume'})
   music: {type: 'boolean', default: true}
-  #autocastDelay, or more complex autocast options? I guess I'll see what I need when trying to hook up Scott's suggested autocast behavior
+  autocastDelay: {type: 'integer', 'default': 5000 }
 
   emailSubscriptions: c.array {uniqueItems: true, 'default': ['announcement', 'notification']}, {'enum': emailSubscriptions}
 


### PR DESCRIPTION
This works but:
1. Currently defaults for this are set in client https://github.com/codecombat/codecombat/blob/master/app/views/play/level/tome/cast_button_view.coffee#L37-40. Should this continue to be the case? Or should a default be set in the schema?
2. Should I be handling the possibility of the save calling failing in some way? I've seen this elsewhere, just not sure what the appropriate action would be here.
