### PR TITLE
Fix #390

### DIFF
--- a/app/models/CocoModel.coffee
+++ b/app/models/CocoModel.coffee
@@ -86,7 +86,8 @@ class CocoModel extends Backbone.Model
     res
 
   markToRevert: ->
-    @_revertAttributes = _.cloneDeep @attributes
+    if @type() != 'ThangType'
+      @_revertAttributes = $.extend(true, {}, @attributes)
 
   revert: ->
     @set(@_revertAttributes, {silent: true}) if @_revertAttributes


### PR DESCRIPTION
The issue here was configSchema is an attribute within attributes and so revertAttributes and attributes get the same instance of it when clone is used. Later calls to _.equals fail when only configSchema has changed.
