### PR TITLE
Made changes to reloadAllCode to reload only the team's code.

### DIFF
--- a/app/views/play/level/tome/tome_view.coffee
+++ b/app/views/play/level/tome/tome_view.coffee
@@ -213,7 +213,7 @@ module.exports = class TomeView extends View
       @spellPaletteView.toggleControls {}, spell.view.controlsEnabled   # TODO: know when palette should have been disabled but didn't exist
 
   reloadAllCode: ->
-    spell.view.reloadCode false for spellKey, spell of @spells
+    spell.view.reloadCode false for spellKey, spell of @spells when spell.team is me.team
     Backbone.Mediator.publish 'tome:cast-spells', spells: @spells
 
   destroy: ->


### PR DESCRIPTION
Fix for #558. In my comment, I was checking for brawlwood or dungeon arena to reload only team spells, but it would be better if it only reloaded team spells in every level anyway.
