### PR TITLE
Fix "Simulating game between" line to only have one "and"

### DIFF
--- a/app/views/play/ladder_view.coffee
+++ b/app/views/play/ladder_view.coffee
@@ -114,7 +114,7 @@ module.exports = class LadderView extends RootView
         for index in [0...creatorNames.length]
           unless creatorNames[index]
             creatorNames[index] = "Anonymous"
-          @simulationStatus += " and " + creatorNames[index]
+          @simulationStatus += (if index != 0 then " and " else "") + creatorNames[index]
         @simulationStatus += "..."
     catch e
       console.log "There was a problem with the named simulation status: #{e}"


### PR DESCRIPTION
Currently when simulating text reads:
"Simulating game between and Nick00 Melee Rush and dpen2000..."
This fixes it to read:
"Simulating game between Nick00 Melee Rush and dpen2000..."
