### PR TITLE
Fixed NaN in ladder in case a player has never played before

### DIFF
--- a/app/templates/play/ladder/ladder_tab.jade
+++ b/app/templates/play/ladder/ladder_tab.jade
@@ -27,7 +27,7 @@ div#columns.row
               a(href="/play/level/#{level.get('slug') || level.id}/?team=#{team.otherTeam}&opponent=#{session.id}")
                 span(data-i18n="ladder.fight") Fight!
                 
-        if !inTheTop && ! me.get('anonymous')
+        if !inTheTop && ! me.get('anonymous') && team.leaderboard.hasSubmitted()
           tr(class="active")
             td(colspan=4).ellipsis-row ...
           for session in team.leaderboard.nearbySessions()

--- a/app/views/play/ladder/ladder_tab.coffee
+++ b/app/views/play/ladder/ladder_tab.coffee
@@ -80,7 +80,10 @@ class LeaderboardData
   
   inTopSessions: ->
     return me.id in (session.attributes.creator for session in @topPlayers.models)
-    
+
+  hasSubmitted: =>
+    return 'totalScore' in @session
+
   nearbySessions: ->
     return unless @session
     l = []


### PR DESCRIPTION
Basically this gets fixed:

![](http://puu.sh/7HSAl.png)

It took my quite a while to find where the necessary info was missing from, but if a user now hasn't submitted any code, they will see only the top 10.
