### PR TITLE
Disable timeline in Letterbox mode

### DIFF
--- a/app/views/play/level/playback_view.coffee
+++ b/app/views/play/level/playback_view.coffee
@@ -57,8 +57,14 @@ module.exports = class PlaybackView extends View
     @$el.find('#music-button').toggleClass('music-on', me.get('music'))
 
   onSetLetterbox: (e) ->
-    buttons = @$el.find '#play-button, .scrubber-handle'
-    buttons.css 'visibility', if e.on then 'hidden' else 'visible'
+    if e.on
+      $('.scrubber .progress', @$el).slider('disable', true)
+      $('#play-button', @$el).addClass('disabled')
+      $('.scrubber-handle', @$el).css('visibility', 'hidden')
+    else
+      $('.scrubber .progress', @$el).slider('enable', true)
+      $('#play-button', @$el).removeClass('disabled')
+      $('.scrubber-handle', @$el).css('visibility', 'visible')
     @disabled = e.on
 
   onWindowResize: (s...) =>


### PR DESCRIPTION
As discussed on https://github.com/codecombat/codecombat/issues/506:
- Timeline is visibly and functionally disabled
- Play/Pause button is not hidden, but disabled
