### PR TITLE
Fix Syntax error in ruby.py

### DIFF
--- a/scripts/devSetup/ruby.py
+++ b/scripts/devSetup/ruby.py
@@ -34,7 +34,7 @@ class Ruby(dependency.Dependency):
         elif operating_system == u"mac":
             raise errors.CoCoError(u"Ruby should be installed with Mac OSX machines. Please install Ruby.")
         elif operating_system == u"linux":
-            raise errors.CoCoError(u"Please install Ruby (try 'sudo apt-get install ruby').\nIf you are not using Ubuntu then please see your Linux Distribution's documentation for help installing ruby."")
+            raise errors.CoCoError(u"Please install Ruby (try 'sudo apt-get install ruby').\nIf you are not using Ubuntu then please see your Linux Distribution's documentation for help installing ruby.")
     def install_ruby_on_windows(self):
         raise NotImplementedError
 


### PR DESCRIPTION
Fix error "SyntaxError: EOL while scanning string literal" when running setup.py script
