### PR TITLE
Change supermodel to general resource loader.

### DIFF
--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -59,14 +59,16 @@ module.exports = class LevelLoader extends CocoClass
 
     # Unless you specify cache:false, sometimes the browser will use a cached session
     # and players will 'lose' code
-    @session.fetch({cache:false})
     @listenToOnce(@session, 'sync', @onSessionLoaded)
+    session_res = @supermodel.addModelResource(@session, @session.url, {cache:false})
+    session_res.load()
 
     if @opponentSessionID
       @opponentSession = new LevelSession()
       @opponentSession.url = "/db/level_session/#{@opponentSessionID}"
-      @opponentSession.fetch()
       @listenToOnce(@opponentSession, 'sync', @onSessionLoaded)
+      opponentSession_res = @supermodel.addModelResource(@opponentSession, @opponentSession.url)
+      opponentSession_res.load()
 
   sessionsLoaded: ->
     return true if @headless
@@ -217,7 +219,7 @@ module.exports = class LevelLoader extends CocoClass
   progress: ->
     return 0 unless @level.loaded
     overallProgress = 0
-    supermodelProgress = @supermodel.progress()
+    supermodelProgress = @supermodel.getProgress()
     overallProgress += supermodelProgress * 0.7
     overallProgress += 0.1 if @sessionsLoaded()
     if @headless
@@ -226,6 +228,7 @@ module.exports = class LevelLoader extends CocoClass
       spriteMapProgress = if supermodelProgress is 1 then 0.2 else 0
       spriteMapProgress *= @spriteSheetsBuilt / @spriteSheetsToBuild if @spriteSheetsToBuild
     overallProgress += spriteMapProgress
+
     return overallProgress
 
   notifyProgress: ->

--- a/app/models/CocoModel.coffee
+++ b/app/models/CocoModel.coffee
@@ -4,7 +4,6 @@ class CocoSchema extends Backbone.Model
   constructor: (path, args...) ->
     super(args...)
     @urlRoot = path + '/schema'
-    console.debug 'gintau', 'schema-urlRoot', @urlRoot
 
 window.CocoSchema = CocoSchema
 

--- a/app/views/editor/level/edit.coffee
+++ b/app/views/editor/level/edit.coffee
@@ -58,7 +58,7 @@ module.exports = class EditorLevelView extends View
 
   onLevelLoaded: ->
     @files = new DocumentFiles(@level)
-    @files.fetch()
+    @supermodel.addModelResource(@files, @files.url).load()
 
   onAllLoaded: ->
     @level.unset('nextLevel') if _.isString(@level.get('nextLevel'))

--- a/app/views/editor/thang/edit.coffee
+++ b/app/views/editor/thang/edit.coffee
@@ -56,11 +56,11 @@ module.exports = class ThangTypeEditView extends View
         @insertSubView(new ErrorView())
     )
 
-    @addResourceToLoad(@thangType.schema(), 'thang_type_schema')
-    @addResourceToLoad(@thangType, 'thang_type')
+    thang_res = @supermodel.addModelResource(@thangType, 'thang_type')
+    thang_schema_res = @supermodel.addModelResource(@thangType.schema(), 'thang_type_schema')
+    thang_res.addDependency('thang_type_schema')
 
-    @thangType.fetch()
-    @thangType.loadSchema()
+    thang_res.load()
     @listenToOnce(@thangType.schema(), 'sync', @onThangTypeSync)
     @listenToOnce(@thangType, 'sync', @onThangTypeSync)
 
@@ -70,7 +70,7 @@ module.exports = class ThangTypeEditView extends View
     return unless @thangType.loaded and ThangType.hasSchema()
     @startsLoading = false
     @files = new DocumentFiles(@thangType)
-    @files.fetch()
+    @supermodel.addModelResource(@files, @files.url).load()
     @render()
 
   getRenderData: (context={}) ->

--- a/app/views/play/level/level_loading_view.coffee
+++ b/app/views/play/level/level_loading_view.coffee
@@ -15,6 +15,7 @@ module.exports = class LevelLoadingView extends View
     tip = _.sample(tips)
     $(tip).removeClass('to-remove')
     @$el.find('.to-remove').remove()
+    @hideLoading()
 
   onLevelLoaderProgressChanged: (e) ->
     @progress = e.progress
@@ -33,7 +34,7 @@ module.exports = class LevelLoadingView extends View
     _.delay @reallyUnveil, 1000
 
   reallyUnveil: =>
-    return if @destroyed
+    return if @destroyed or @progress < 1
     loadingDetails = @$el.find('.loading-details')
     duration = parseFloat loadingDetails.css 'transition-duration'
     loadingDetails.css 'top', -loadingDetails.outerHeight(true)

--- a/app/views/play/level_view.coffee
+++ b/app/views/play/level_view.coffee
@@ -86,6 +86,7 @@ module.exports = class PlayLevelView extends View
     @listenToOnce(@supermodel, 'error', @onLevelLoadError)
     @saveScreenshot = _.throttle @saveScreenshot, 30000
 
+    @insertSubView @loadingView = new LoadingView {}
     if @isEditorPreview
       f = =>
         @supermodel.shouldSaveBackups = (model) ->
@@ -361,11 +362,11 @@ module.exports = class PlayLevelView extends View
       .css('transform', "rotate(#{@pointerRotation}rad) translate(-3px, #{@pointerRadialDistance}px)")
       .css('top', target_top - 50)
       .css('left', target_left - 50)
-    setTimeout((=>
+    setTimeout(()=>
       @animatePointer()
       clearInterval(@pointerInterval)
       @pointerInterval = setInterval(@animatePointer, 1200)
-    ), 1)
+    , 1)
 
 
   animatePointer: ->


### PR DESCRIPTION
#784

I merge my ResourceManager with SuperModel to make it accepts all kinds of resources, and I reserve SuperModel's original functions so view should change as less as possible. If this new supermodel is good enough, I'd proceed to move logic of progress bar and retry block from CocoView to RootView. Currently sub-view's render() also influence that part, thus imposing unnecessary progress checking code in render().
