### PR TITLE
Implement simulators leaderboard

### DIFF
--- a/app/collections/SimulatorsLeaderboardCollection.coffee
+++ b/app/collections/SimulatorsLeaderboardCollection.coffee
@@ -1,0 +1,11 @@
+CocoCollection = require 'models/CocoCollection'
+User = require 'models/User'
+
+module.exports = class SimulatorsLeaderboardCollection extends CocoCollection
+  url: ''
+  model: User
+
+  constructor: (options) ->
+    super()
+    options ?= {}
+    @url = "/db/user/me/simulatorLeaderboard?#{$.param(options)}"

--- a/app/styles/play/ladder.sass
+++ b/app/styles/play/ladder.sass
@@ -28,6 +28,9 @@
     
   .ellipsis-row
     text-align: center
+
+  .simulator-leaderboard-cell
+    text-align: center
     
   // friend column
 

--- a/app/templates/play/ladder.jade
+++ b/app/templates/play/ladder.jade
@@ -58,3 +58,31 @@ block content
         span(data-i18n="ladder.games_simulated_for") Games simulated for you:
         |  
         span#simulated-for-you= me.get('simulatedFor') || 0
+
+      table.table.table-bordered.table-condensed.table-hover
+        tr
+          th(data-i18n="general.name").name-col-cell Name
+          th(data-i18n="general.gamessimulated") Games simulated
+          th(data-i18n="general.gamesplayed") Games played
+          th(data-i18n="general.ratio") Ratio
+        - var topSimulators = simulatorsLeaderboardData.topSimulators.models;
+        - var showJustTop = simulatorsLeaderboardData.inTopSimulators() || me.get('anonymous');
+        - if(!showJustTop) topSimulators = topSimulators.slice(0, 10);
+        for user in topSimulators
+          - var myRow = user.id == me.id
+          tr(class=myRow ? "success" : "")
+            td.name-col-cell= user.get('name') || "Anonymous"
+            td.simulator-leaderboard-cell= user.get('simulatedBy')
+            td.simulator-leaderboard-cell= user.get('simulatedFor')
+            td.simulator-leaderboard-cell= Math.round((user.get('simulatedBy') / user.get('simulatedFor')) * 10) / 10
+                
+        if !showJustTop && simulatorsLeaderboardData.nearbySimulators().length
+          tr(class="active")
+            td(colspan=4).ellipsis-row ...
+          for user in simulatorsLeaderboardData.nearbySimulators()
+            - var myRow = user.id == me.id
+            tr(class=myRow ? "success" : "")
+              td.name-col-cell= user.get('name') || "Anonymous"
+              td.simulator-leaderboard-cell= user.get('simulatedBy')
+              td.simulator-leaderboard-cell= user.get('simulatedFor')
+              td.simulator-leaderboard-cell= Math.round((user.get('simulatedBy') / user.get('simulatedFor')) * 10) / 10

--- a/app/views/play/ladder_view.coffee
+++ b/app/views/play/ladder_view.coffee
@@ -10,6 +10,8 @@ application = require 'application'
 LadderTabView = require './ladder/ladder_tab'
 MyMatchesTabView = require './ladder/my_matches_tab'
 LadderPlayModal = require './ladder/play_modal'
+SimulatorsLeaderboardCollection = require 'collections/SimulatorsLeaderboardCollection'
+CocoClass = require 'lib/CocoClass'
 
 HIGHEST_SCORE = 1000000
 
@@ -42,6 +44,9 @@ module.exports = class LadderView extends RootView
     @sessions.fetch({})
     @addResourceToLoad(@sessions, 'your_sessions')
     @addResourceToLoad(@level, 'level')
+    @simulatorsLeaderboardData = new SimulatorsLeaderboardData(me)
+    @simulatorsLeaderboardData.fetch({})
+    @addResourceToLoad(@simulatorsLeaderboardData, 'top_simulators')
     @simulator = new Simulator()
     @listenTo(@simulator, 'statusUpdate', @updateSimulationStatus)
     @teams = []
@@ -58,6 +63,7 @@ module.exports = class LadderView extends RootView
     ctx.teams = @teams
     ctx.levelID = @levelID
     ctx.levelDescription = marked(@level.get('description')) if @level.get('description')
+    ctx.simulatorsLeaderboardData = @simulatorsLeaderboardData
     ctx
 
   afterRender: ->
@@ -156,3 +162,58 @@ module.exports = class LadderView extends RootView
     clearInterval @refreshInterval
     @simulator.destroy()
     super()
+
+class SimulatorsLeaderboardData extends CocoClass
+  ###
+  Consolidates what you need to load for a leaderboard into a single Backbone Model-like object.
+  ###
+  
+  constructor: (@me) ->
+    super()
+    @fetch()
+    
+  fetch: ->
+    @topSimulators = new SimulatorsLeaderboardCollection({order:-1, scoreOffset: -1, limit: 20})
+    promises = []
+    promises.push @topSimulators.fetch() 
+    if !@me.get('anonymous')
+      score = @me.get('simulatedBy') or 10
+      @playersAbove = new SimulatorsLeaderboardCollection({order:1, scoreOffset: score, limit: 4})
+      promises.push @playersAbove.fetch()
+      @playersBelow = new SimulatorsLeaderboardCollection({order:-1, scoreOffset: score, limit: 4})
+      promises.push @playersBelow.fetch()
+    @promise = $.when(promises...)
+    @promise.then @onLoad
+    @promise.fail @onFail
+    @promise
+
+  onLoad: =>
+    return if @destroyed
+    @loaded = true
+    @trigger 'sync', @
+  
+  onFail: (resource, jqxhr) =>
+    return if @destroyed
+    @trigger 'error', @, jqxhr
+
+  inTopSimulators: ->
+    return me.id in (user.id for user in @topSimulators.models)
+
+  nearbySimulators: ->
+    #return [] unless @session?.get('totalScore')
+    l = []
+    above = @playersAbove.models
+    above.reverse()
+    l = l.concat(above)
+    l.push @me
+    l = l.concat(@playersBelow.models)
+    ###
+    if @myRank
+      startRank = @myRank - 4
+      session.rank = startRank + i for session, i in l
+    ###
+    l
+
+  allResources: ->
+    resources = [@topSimulators, @playersAbove, @playersBelow]
+    return (r for r in resources when r)


### PR DESCRIPTION
This implements #703
This currently looks like this:
![topsimulatorstable](https://cloud.githubusercontent.com/assets/396538/2688538/229c0478-c2a9-11e3-8b7d-d1e81148e2fb.jpg)

I still need to figure out how to add my strings for internationalization. I'm also concerned I'm returning more of the user objects than needed: is this a problem?
