### PR TITLE
Fix console.warning bug that prevents page from loading

### DIFF
--- a/app/lib/storage.coffee
+++ b/app/lib/storage.coffee
@@ -5,7 +5,7 @@ module.exports.load = (key) ->
     value = JSON.parse(s)
     return value
   catch SyntaxError
-    console.warning('error loading from storage', key)
+    console.warn('error loading from storage', key)
     return null
 
 module.exports.save = (key, value) ->


### PR DESCRIPTION
Currently if something fails to load from localStorage, the whole page is prevented from loading, since the function console.warning doesn't exist.

I've changed the call to console.warn which fixes this.
