### PR TITLE
Fix players above the current player coming out in wrong order

### DIFF
--- a/app/views/play/ladder/ladder_tab.coffee
+++ b/app/views/play/ladder/ladder_tab.coffee
@@ -309,8 +309,8 @@ class LeaderboardData extends CocoClass
     return [] unless @session?.get('totalScore')
     l = []
     above = @playersAbove.models
-    above.reverse()
     l = l.concat(above)
+    l.reverse()
     l.push @session
     l = l.concat(@playersBelow.models)
     if @myRank

--- a/app/views/play/ladder/simulate_tab.coffee
+++ b/app/views/play/ladder/simulate_tab.coffee
@@ -116,8 +116,8 @@ class SimulatorsLeaderboardData extends CocoClass
   nearbySimulators: ->
     l = []
     above = @playersAbove.models
-    above.reverse()
     l = l.concat(above)
+    l.reverse()
     l.push @me
     l = l.concat(@playersBelow.models) if @playersBelow
     if @myRank


### PR DESCRIPTION
Players above the current player are currently coming out in the wrong order. See:
![issueinleaderboard](https://cloud.githubusercontent.com/assets/396538/2726093/a71d57a6-c5b5-11e3-841a-37213178ac91.jpg)
and:
![issueinsimulatorleaderboard](https://cloud.githubusercontent.com/assets/396538/2726101/b02400ac-c5b5-11e3-9731-1aeb2c65a69a.jpg)
Note the scores of the players above me increase going down, instead of decreasing.

This is because the nearbySessions and nearbySimulator functions get called twice after the leaderboards load. The reverse was previously being done to the global copy and this was resulting in the reversal being reversed; switching to doing the reverse on the local copy of the array fixes this.
