### PR TITLE
Fix sass error

### DIFF
--- a/app/styles/editor/level/edit.sass
+++ b/app/styles/editor/level/edit.sass
@@ -26,7 +26,8 @@
   .navbar
     min-height: 0px
     border-radius: 0
-  .navbar-right // not sure why bootstrap puts a big negative margin in, but this overrides it
+  // not sure why bootstrap puts a big negative margin in, but this overrides it
+  .navbar-right
     margin-right: 10px
     
   // custom navbar styling


### PR DESCRIPTION
While running coco-brunch, I get this error:
error: Compiling of 'app/styles/editor/level/edit.sass' failed. Syntax error: Properties are only allowed within rules, directives, mixin includes, or other properties.
        on line 30 of standard input
  Use --trace for backtrace.

It appears sass views a comment as the parent of the property in this line and thus invalid. I'll probably raise an issue with sass about this but for now, I've moved comment.
