### PR TITLE
Fix deltas referring to last system saved

### DIFF
--- a/app/views/editor/level/systems_tab_view.coffee
+++ b/app/views/editor/level/systems_tab_view.coffee
@@ -59,12 +59,7 @@ module.exports = class SystemsTabView extends View
     unless systems.length
       systems = @buildDefaultSystems()
       insertedDefaults = true
-
-    systemModels = @supermodel.getModels LevelSystem
-    systemModelMap = {}
-    systemModelMap[sys.get('original')] = sys.get('name') for sys in systemModels
-    systems = _.sortBy systems, (sys) -> systemModelMap[sys.original]
-
+    systems = @getSortedByName systems
     treemaOptions =
       # TODO: somehow get rid of the + button, or repurpose it to open the LevelSystemAddView instead
       supermodel: @supermodel
@@ -84,7 +79,14 @@ module.exports = class SystemsTabView extends View
     @onSystemsChanged() if insertedDefaults
 
   onSystemsChanged: (e) =>
-    @level.set 'systems', @systemsTreema.data
+    systems = @getSortedByName @systemsTreema.data
+    @level.set 'systems', systems
+
+  getSortedByName: (systems) =>
+    systemModels = @supermodel.getModels LevelSystem
+    systemModelMap = {}
+    systemModelMap[sys.get('original')] = sys.get('name') for sys in systemModels
+    _.sortBy systems, (sys) -> systemModelMap[sys.original]
 
   onSystemSelected: (e, selected) =>
     selected = if selected.length > 1 then selected[0].getLastSelectedTreema() else selected[0]


### PR DESCRIPTION
If a system is added, it is added to treema at the end of the list of systems. Treema then raises it's changed event resulting in this order being set on the level. The next time a system is added, the first system is in it's correct position and so the delta shows it as moving. This changes ensures we save the correct order in the first instance.

There is a wider issue of adding systems resulting in misleading deltas. I've submitted one-time fix to Michael  to reorder systems correctly on levels in the mongo database to avoid adding a system resulting in multiple deltas relating to pre-existing systems. The fix in this PR seems to fix the majority of this issue after the one-time fix is applied. I've got a further fix to how we configure the json differ that seems to be required in a couple of instances but I want to look at this again more thoroughly to understand what's going on.
