### PR TITLE
Change dev server to watch app/schemas

### DIFF
--- a/bin/coco-dev-server
+++ b/bin/coco-dev-server
@@ -8,5 +8,5 @@ current_directory = os.path.dirname(os.path.realpath(sys.argv[0]))
 coco_path = os.getenv("COCO_DIR",os.path.join(current_directory,os.pardir))
 nodemon_path = coco_path + os.sep + "node_modules" + os.sep + ".bin" + os.sep + "nodemon"
 
-call(nodemon_path + " . --ext \".coffee|.js\" --watch server --watch app.js --watch server_config.js --watch server_setup.coffee",shell=True,cwd=coco_path)
+call(nodemon_path + " . --ext \".coffee|.js\" --watch server --watch server_config.js --watch server_setup.coffee --watch app" + os.sep + "schemas",shell=True,cwd=coco_path)
 


### PR DESCRIPTION
The previous app.js watch wasn't working (as far as I can see) and we probably only need to see changes in schemas because : 1. The server code relating to schemas depend on these
2. We don't want to change status quo and have it compile server code for all client code changes (it might get annoying)
