### PR TITLE
Update GoalManager.coffee

### DIFF
--- a/app/lib/world/GoalManager.coffee
+++ b/app/lib/world/GoalManager.coffee
@@ -235,7 +235,7 @@ module.exports = class GoalManager extends CocoClass
       numNeeded = goal.howMany ? Math.max(1, _.size stateThangs)
     else
       # saveThangs: by default we would want to save all the Thangs, which means that we would want none of them to be "done"
-      numNeeded = _.size(stateThangs) - Math.min((goal.howMany ? 1), _.size stateThangs) + 1
+      numNeeded = _.size(stateThangs) - Math.max((goal.howMany ? 1), _.size stateThangs) + 1
     numDone = _.filter(stateThangs).length
     console.log "needed", numNeeded, "done", numDone, "of total", _.size(stateThangs), "with how many", goal.howMany, "and stateThangs", stateThangs
     return unless numDone >= numNeeded


### PR DESCRIPTION
Justification:

For a negative goal like saveThangs, let's say you have 5 thangs on the save list.  As things stand, if you don't have a HowMany defined, then the number of needed deaths to fail is 

numNeeded = _.size(stateThangs) - Math.min((goal.howMany ? 1), _.size stateThangs) + 1
numNeeded = 5 - Math.min(1, 5) + 1
numNeeded = 5

So you would only fail the goal if all 5 thangs you were supposed to save died.  This is contrary to the comment right above this line:

saveThangs: by default we would want to save all the Thangs, which means that we would want none of them to be "done"

Therefore, I think it should be Math.max rather than Math.min.

numNeeded = _.size(stateThangs) - Math.max((goal.howMany ? 1), _.size stateThangs) + 1
numNeeded = 5 - Math.max(1, 5) + 1
numNeeded = 1

So any of the Thangs on the save list dying is enough to fail the goal.

As a double check, what if the level designer designated a HowMany of 5?

numNeeded = _.size(stateThangs) - Math.max((goal.howMany ? 1), _.size stateThangs) + 1
numNeeded = 5 - Math.max(5, 5) + 1
numNeeded = 1

So this is consistent.
