### PR TITLE
Make components' patches tab look like Systems' patches tab

### DIFF
--- a/app/styles/editor/level/component/edit.sass
+++ b/app/styles/editor/level/component/edit.sass
@@ -5,7 +5,10 @@
   #component-patches
     padding: 0 10px 10px
     background: white
-  
+
+  .patches-view
+    padding: 10px 20px 10px 0px
+
   .navbar-text
     float: left
     

--- a/app/styles/editor/level/system/edit.sass
+++ b/app/styles/editor/level/system/edit.sass
@@ -1,4 +1,14 @@
 #editor-level-system-edit-view
+  nav
+    margin-bottom: 0
+    
+  #system-patches
+    padding: 0 10px 10px
+    background: white
+
+  .patches-view
+    padding: 10px 20px 10px 0px
+
   .navbar-text
     float: left
 


### PR DESCRIPTION
This changes components' patches tab from this:
![componentspatches](https://cloud.githubusercontent.com/assets/396538/2886189/29abbacc-d4df-11e3-9427-41d518513831.png)

to:
![componentspatchesafter](https://cloud.githubusercontent.com/assets/396538/2886187/2081c374-d4df-11e3-88a6-ec2aa526e646.png)

Which looks cleaner and is consistent with how systems' patches tab is laid out:
![systemspatches](https://cloud.githubusercontent.com/assets/396538/2886186/10f2f46e-d4df-11e3-9a2d-fa43fe4318ec.jpg)
