### PR TITLE
Correctly parse multi-line error messages in the editor.

### DIFF
--- a/app/views/play/level/tome/problem_alert_view.coffee
+++ b/app/views/play/level/tome/problem_alert_view.coffee
@@ -17,7 +17,7 @@ module.exports = class ProblemAlertView extends View
 
   getRenderData: (context={}) ->
     context = super context
-    format = (s) -> s?.replace('<', '&lt;').replace('>', '&gt;').replace("\n", "<br>")
+    format = (s) -> s?.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, '<br>')
     context.message = format @problem.aetherProblem.message
     context.hint = format @problem.aetherProblem.hint
     context


### PR DESCRIPTION
Before, weirdly-formatted error message:

![before, weirdly-formatted error message](https://cloud.githubusercontent.com/assets/439616/2990209/51dbcfa0-dc6e-11e3-9b38-d43db40d4709.png)

After, pretty multi-line error message:

![multi-line error message](https://cloud.githubusercontent.com/assets/439616/2990211/553b515c-dc6e-11e3-9da9-2d96998c9f51.png)
