### PR TITLE
Fix ReferenceError: setupLodash is not defined

### DIFF
--- a/headless_client.coffee
+++ b/headless_client.coffee
@@ -157,7 +157,7 @@ $.isPlainObject = (object) ->
   _.isPlainObject object
 
 
-do (setupLodash = this) ->
+do (@setupLodash = this) ->
   GLOBAL._ = require 'lodash'
   _.str = require 'underscore.string'
   _.string = _.str


### PR DESCRIPTION
I get:
`ReferenceError: setupLodash is not defined  
    at Object.<anonymous> (/coco/headless_client.coffee:207:6)  
    at Object.<anonymous> (/coco/headless_client.coffee:254:4)  
    at Module._compile (module.js:456:26)  
    at Object.exports.run (/usr/lib/coffee-script/lib/coffee-script/coffee-scrip
t.js:68:25)  
    at compileScript (/usr/lib/coffee-script/lib/coffee-script/command.js:135:29
)  
    at /usr/lib/coffee-script/lib/coffee-script/command.js:110:18  
    at fs.js:266:14  
    at Object.oncomplete (fs.js:107:15)`
when running coffee ./headless_client.coffee without this change. Presuming others don't have the problem.
cc @domenukk
