### PR TITLE
Refactored getRenderData from SearchView to children

### DIFF
--- a/app/views/editor/article/home.coffee
+++ b/app/views/editor/article/home.coffee
@@ -6,3 +6,12 @@ module.exports = class ThangTypeHomeView extends SearchView
   model: require 'models/Article'
   modelURL: '/db/article'
   tableTemplate: require 'templates/editor/article/table'
+
+  getRenderData: ->
+    context = super()
+    context.currentEditor = 'editor.article_title'
+    context.currentNew = 'editor.new_article_title'
+    context.currentNewSignup = 'editor.new_article_title_login'
+    context.currentSearch = 'editor.article_search_title'
+    @$el.i18n()
+    context

--- a/app/views/editor/level/home.coffee
+++ b/app/views/editor/level/home.coffee
@@ -6,3 +6,12 @@ module.exports = class EditorSearchView extends SearchView
   model: require 'models/Level'
   modelURL: '/db/level'
   tableTemplate: require 'templates/editor/level/table'
+
+  getRenderData: ->
+    context = super()
+    context.currentEditor = 'editor.level_title'
+    context.currentNew = 'editor.new_level_title'
+    context.currentNewSignup = 'editor.new_level_title_login'
+    context.currentSearch = 'editor.level_search_title'
+    @$el.i18n()
+    context

--- a/app/views/editor/thang/home.coffee
+++ b/app/views/editor/thang/home.coffee
@@ -5,7 +5,16 @@ module.exports = class ThangTypeHomeView extends SearchView
   modelLabel: 'Thang Type'
   model: require 'models/ThangType'
   modelURL: '/db/thang.type'
-  tableTemplate: require 'templates/editor/thang/table' 
+  tableTemplate: require 'templates/editor/thang/table'
+
+  getRenderData: ->
+    context = super()
+    context.currentEditor = 'editor.thang_title'
+    context.currentNew = 'editor.new_thang_title'
+    context.currentNewSignup = 'editor.new_thang_title_login'
+    context.currentSearch = 'editor.thang_search_title'
+    @$el.i18n()
+    context
 
   onSearchChange: =>
     super()

--- a/app/views/kinds/SearchView.coffee
+++ b/app/views/kinds/SearchView.coffee
@@ -26,27 +26,6 @@ module.exports = class SearchView extends View
     'shown.bs.modal #new-model-modal': 'focusOnName'
     'hidden.bs.modal #new-model-modal': 'onModalHidden'
 
-  getRenderData: ->
-    context = super()
-    switch @modelLabel
-      when 'Level'
-        context.currentEditor = 'editor.level_title'
-        context.currentNew = 'editor.new_level_title'
-        context.currentNewSignup = 'editor.new_level_title_login'
-        context.currentSearch = 'editor.level_search_title'
-      when 'Thang Type'
-        context.currentEditor = 'editor.thang_title'
-        context.currentNew = 'editor.new_thang_title'
-        context.currentNewSignup = 'editor.new_thang_title_login'
-        context.currentSearch = 'editor.thang_search_title'
-      when 'Article'
-        context.currentEditor = 'editor.article_title'
-        context.currentNew = 'editor.new_article_title'
-        context.currentNewSignup = 'editor.new_article_title_login'
-        context.currentSearch = 'editor.article_search_title'
-    @$el.i18n()
-    context
-
   constructor: (options) ->
     @runSearch = _.debounce(@runSearch, 500)
     super options


### PR DESCRIPTION
It's a silly PR but I wanted rid of getRenderData in SearchView while I was building the Achievement search view. It makes more sense to have it in the children, even though that makes them slightly fatter.
