### PR TITLE
Fixed all server-sided tests, with server-test TODO

### DIFF
--- a/server/achievements/Achievement.coffee
+++ b/server/achievements/Achievement.coffee
@@ -1,5 +1,4 @@
 mongoose = require('mongoose')
-plugins = require('../plugins/plugins')
 jsonschema = require('../../app/schemas/models/achievement')
 log = require 'winston'
 
@@ -29,7 +28,9 @@ AchievementSchema.pre('save', (next) ->
   next()
 )
 
+module.exports = Achievement = mongoose.model('Achievement', AchievementSchema)
+
+plugins = require('../plugins/plugins')
+
 AchievementSchema.plugin(plugins.NamedPlugin)
 AchievementSchema.plugin(plugins.SearchablePlugin, {searchable: ['name']})
-
-module.exports = Achievement = mongoose.model('Achievement', AchievementSchema)

--- a/server/levels/components/level_component_handler.coffee
+++ b/server/levels/components/level_component_handler.coffee
@@ -9,7 +9,7 @@ LevelComponentHandler = class LevelComponentHandler extends Handler
     'description'
     'code'
     'js'
-    'language'
+    'codeLanguage'
     'dependencies'
     'propertyDocumentation'
     'configSchema'

--- a/server/levels/systems/level_system_handler.coffee
+++ b/server/levels/systems/level_system_handler.coffee
@@ -7,7 +7,7 @@ LevelSystemHandler = class LevelSystemHandler extends Handler
     'description'
     'code'
     'js'
-    'language'
+    'codeLanguage'
     'dependencies'
     'propertyDocumentation'
     'configSchema'

--- a/server/plugins/achievements.coffee
+++ b/server/plugins/achievements.coffee
@@ -1,7 +1,6 @@
 mongoose = require('mongoose')
 Achievement = require('../achievements/Achievement')
 EarnedAchievement = require '../achievements/EarnedAchievement'
-User = require '../users/User'
 LocalMongo = require '../../app/lib/LocalMongo'
 util = require '../../app/lib/utils'
 log = require 'winston'
@@ -19,6 +18,8 @@ loadAchievements = ->
 loadAchievements()
 
 module.exports = AchievablePlugin = (schema, options) ->
+  User = require '../users/User'
+
   checkForAchievement = (doc) ->
     collectionName = doc.constructor.modelName
 

--- a/server/plugins/plugins.coffee
+++ b/server/plugins/plugins.coffee
@@ -1,5 +1,4 @@
 mongoose = require('mongoose')
-User = require('../users/User')
 textSearch = require('mongoose-text-search')
 
 module.exports.MigrationPlugin = (schema, migrations) ->

--- a/test/server/functional/file.spec.coffee
+++ b/test/server/functional/file.spec.coffee
@@ -6,7 +6,8 @@ describe '/file', ->
   options = {
     uri:url
     json: {
-      url: 'http://scotterickson.info/images/where-are-you.jpg'
+      # url: 'http://scotterickson.info/images/where-are-you.jpg'
+      url: 'http://fc07.deviantart.net/fs37/f/2008/283/5/1/Chu_Chu_Pikachu_by_angelishi.gif'
       filename: 'where-are-you.jpg'
       mimetype: 'image/jpeg'
       description: 'None!'
@@ -20,7 +21,8 @@ describe '/file', ->
     filename: 'ittybitty.data'
     mimetype: 'application/octet-stream'
     description: 'rando-info'
-    my_buffer_url: 'http://scotterickson.info/images/where-are-you.jpg'
+    # my_buffer_url: 'http://scotterickson.info/images/where-are-you.jpg'
+    my_buffer_url: 'http://fc07.deviantart.net/fs37/f/2008/283/5/1/Chu_Chu_Pikachu_by_angelishi.gif'
   }
 
   it 'preparing test : deletes all the files first', (done) ->


### PR DESCRIPTION
I wanted to start on some server-sided achievement tests but soon ran into trouble. I fixed three scenarios, the third one of which is the gravest and needs a follow-up.
- First of all I had to resolve yet another mutual inclusion case between Achievements and Users. This took quite some time but I luckily managed since this prevented any tests from running.
- Secondly, scotterickson.info is down but some tests in `file.spec.coffee` needed a working URL. It didn't only fail the tests but instead crashed the whole suite. I substituted a tiny Pikachu gif but left the old link in comments, in case the merger would like to update this URL.
- Last of all, and most annoyingly, Mongo text search broke our Level Component and System schemas. `language` has become a reserved Mongo field while we use it to denote programming language. As a _temporary_ fix I un-required the field in the schemas and removed the field from all tests. All instances involved can be found with `grep -r "TODO server-test [app|server]".

For reference, here's an example Mongo error that helped me find the cause. 

`{ name : 'MongoError', code : 17262, err : 'insertDocument :: caused by :: 17262 language override unsupported: javascript' }`

I also tried using Mongo's `language_override` field so it would ignore `language` but it didn't.

All 146 tests now run successfully but we still need to rename the `language` field in components and systems I'm afraid.
