### PR TITLE
Remove unicode from url regex pattern

### DIFF
--- a/app/schemas/schemas.coffee
+++ b/app/schemas/schemas.coffee
@@ -8,7 +8,7 @@ combine = (base, ext) ->
   return base unless ext?
   return _.extend(base, ext)
 
-urlPattern = '^(ht|f)tp(s?)\:\/\/[0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*(:(0-9)*)*(\/?)([a-zA-Z0-9\-‌​\.\?\,\'\/\\\+&%\$#_=]*)?$'
+urlPattern = '^(ht|f)tp(s?)\:\/\/[0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*(:(0-9)*)*(\/?)([a-zA-Z0-9\-\.\?\,\'\/\\\+&%\$#_=]*)?$'
 
 # Common schema properties
 me.object = (ext, props) -> combine {type: 'object', additionalProperties: false, properties: props or {}}, ext


### PR DESCRIPTION
Remove unicodes `<U+200C><U+200B>` that appear in VIM editor.
Those unicodes are [zero-width non-joiner (U+200C)](http://en.wikipedia.org/wiki/Zero-width_non-joiner) and [zero-width space (U+200B)](http://en.wikipedia.org/wiki/Zero-width_space).

![screen shot 2014-06-13 at 10 34 37 am 1](https://cloud.githubusercontent.com/assets/2450760/3266077/55e735a8-f2a3-11e3-8fe1-dfdcb7c06905.png)
