### PR TITLE
Changed final_score to match coding style.

### DIFF
--- a/vendor/scripts/string_score.js
+++ b/vendor/scripts/string_score.js
@@ -124,7 +124,7 @@
       //final_score = (word_score + abbreviation_score) / 2;
       final_score = ((abbreviation_score * (abbreviation_length / string_length)) + abbreviation_score) / 2;
       
-      final_score = final_score / fuzzies;
+      final_score /= fuzzies;
       
       if (start_of_string_bonus && (final_score + 0.15 < 1)) {
         final_score += 0.15;


### PR DESCRIPTION
Extremely insignificant change, I just noticed that final_score was set as:

final_score = final_score / fuzzies;

compared to: "final_score /= fuzzies;" which is how the rest of your syntax is written. 
(Ex: "+=" and "-=")
