### PR TITLE
Added str to sys.maxsize

### DIFF
--- a/scripts/devSetup/systemConfiguration.py
+++ b/scripts/devSetup/systemConfiguration.py
@@ -33,7 +33,6 @@ class SystemConfiguration(object):
             return 64
         else:
             if self.operating_system == u"mac":
-                raise NotSupportedError(u"Your processor is determined to have a maxSize of" + sys.maxsize +
+                raise NotSupportedError(u"Your processor is determined to have a maxSize of" + str(sys.maxsize) +
                                         u",\n which doesn't correspond with a 64-bit architecture.")
             return 32
-


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "./coco/scripts/devSetup/setup.py", line 45, in <module>
    setup = factories.constructSetup()
  File "/Users/fergusleen/Documents/projects/codecombat/coco/scripts/devSetup/factories.py", line 16, in constructSetup
    config = configuration.Configuration()
  File "/Users/fergusleen/Documents/projects/codecombat/coco/scripts/devSetup/configuration.py", line 8, in __init__
    self.system = SystemConfiguration()
  File "/Users/fergusleen/Documents/projects/codecombat/coco/scripts/devSetup/systemConfiguration.py", line 11, in __init__
    self.virtual_memory_address_width = self.get_virtual_memory_address_width()
  File "/Users/fergusleen/Documents/projects/codecombat/coco/scripts/devSetup/systemConfiguration.py", line 36, in get_virtual_memory_address_width
    raise NotSupportedError(u"Your processor is determined to have a maxSize of" + sys.maxsize +
TypeError: coercing to Unicode: need string or buffer, int found
```

This error occurs if the system is not 64 bit and if the os is mac. It is suppose to throw the NotSupportedError but fails due to `sys.maxsize` giving an int in a string. 

We can fix this by simply having `str(sys.maxsize)`
