### PR TITLE
Check for 64-bit arch in setup.py

### DIFF
--- a/scripts/devSetup/bootstrap.sh
+++ b/scripts/devSetup/bootstrap.sh
@@ -58,13 +58,7 @@ checkDependencies deps[@] basicDependenciesErrorHandling
 if command -v node >/dev/null 2>&1; then
     checkNodeVersion
 fi
-
-#check if a git repository already exists here
-if [ -d .git ]; then
-  echo "A git repository already exists here!"
-else
-  #install git repository
-  git clone $repositoryUrl coco
-  #python ./coco/scripts/devSetup/setup.py
-  echo "Now copy and paste 'sudo python ./coco/scripts/devSetup/setup.py' into the terminal!"
-fi
+#install git repository
+git clone $repositoryUrl coco
+#python ./coco/scripts/devSetup/setup.py
+echo "Now copy and paste 'sudo python ./coco/scripts/devSetup/setup.py' into the terminal!"


### PR DESCRIPTION
This PR adds another check for 64-bit systems which fail to pass the `is64Bit = sys.maxsize/3 > 2**32` test.
Python sometimes defaults to using i386 on x86_64 systems causing it to use 32-bit python and shoots out this error:

```
sudo python ./coco/scripts/devSetup/setup.py
...
errors.NotSupportedError:
u"Your processor is determined to have a maxSize of2147483647,\n
which doesn't correspond with a 64-bit architecture.\n
Please contact CodeCombat support, and include this error in your message."
```

We can fix this by checking if the machine is x86_64 with `os.uname`. If it is we can safely assume the system is 64 bit and thus return 64.
I have only experienced this problem when trying to build on a macbook air with brew installed python. 
