### PR TITLE
Bootstrap.sh check for git repository before cloning

### DIFF
--- a/scripts/devSetup/bootstrap.sh
+++ b/scripts/devSetup/bootstrap.sh
@@ -58,7 +58,13 @@ checkDependencies deps[@] basicDependenciesErrorHandling
 if command -v node >/dev/null 2>&1; then
     checkNodeVersion
 fi
-#install git repository
-git clone $repositoryUrl coco
-#python ./coco/scripts/devSetup/setup.py
-echo "Now copy and paste 'sudo python ./coco/scripts/devSetup/setup.py' into the terminal!"
+
+#check if a git repository already exists here
+if [ -d .git ]; then
+  echo "A git repository already exists here!"
+else
+  #install git repository
+  git clone $repositoryUrl coco
+  #python ./coco/scripts/devSetup/setup.py
+  echo "Now copy and paste 'sudo python ./coco/scripts/devSetup/setup.py' into the terminal!"
+fi


### PR DESCRIPTION
This commit simply checks the directory for a `.git` folder before cloning the git repository. 

This stops people like me who forked and cloned the repo before running

```
curl https://raw.githubusercontent.com/codecombat/codecombat/master/scripts/devSetup/bootstrap.sh | bash -s your_repository_url
```

 from ending up with two copies of the code in the same directory.
