### PR TITLE
Facebook friends patch

### DIFF
--- a/app/lib/services/facebook.coffee
+++ b/app/lib/services/facebook.coffee
@@ -1,7 +1,6 @@
 module.exports = initializeFacebook = ->
   # Additional JS functions here
   window.fbAsyncInit = ->
-    Backbone.Mediator.publish "fbapi-loaded"
     FB.init
       appId: (if document.location.origin is "http://localhost:3000" then "607435142676437" else "148832601965463") # App ID
       channelUrl: document.location.origin + "/channel.html" # Channel File
@@ -9,13 +8,14 @@ module.exports = initializeFacebook = ->
       cookie: true # enable cookies to allow the server to access the session
       xfbml: true # parse XFBML
 
-    
+    Backbone.Mediator.publish "fbapi-loaded"
+
     # This is fired for any auth related change, such as login, logout or session refresh.
     FB.Event.subscribe "auth.authResponseChange", (response) ->
-      
-      # Here we specify what we do with the response anytime this event occurs. 
+
+      # Here we specify what we do with the response anytime this event occurs.
       if response.status is "connected"
-        
+
         # They have logged in to the app.
         Backbone.Mediator.publish "facebook-logged-in",
           response: response
@@ -23,7 +23,7 @@ module.exports = initializeFacebook = ->
       else if response.status is "not_authorized"
         #
       else
-	      # 
+	      #
 
   # Load the SDK asynchronously
   ((d) ->
@@ -35,8 +35,8 @@ module.exports = initializeFacebook = ->
     js.id = id
     js.async = true
     js.src = "//connect.facebook.net/en_US/all.js"
-    
-    #js.src = "//connect.facebook.net/en_US/all/debug.js";
+
+    #js.src = "//connect.facebook.net/en_US/all/debug.js"
     ref.parentNode.insertBefore js, ref
     return
   ) document

--- a/app/views/play/ladder/ladder_tab.coffee
+++ b/app/views/play/ladder/ladder_tab.coffee
@@ -32,7 +32,6 @@ module.exports = class LadderTabView extends CocoView
     @leaderboards = {}
     @refreshLadder()
     @socialNetworkRes = @supermodel.addSomethingResource("social_network_apis", 0)
-    @checkFriends()
 
   checkFriends: ->
     return if @checked or (not window.FB) or (not window.gapi)
@@ -97,6 +96,9 @@ module.exports = class LadderTabView extends CocoView
       friend.otherTeam = if friend.team is 'humans' then 'ogres' else 'humans'
       friend.imageSource = "http://graph.facebook.com/#{friend.facebookID}/picture"
     @facebookFriendSessions = result
+    @getRenderData()
+    @render()
+
 
   # GOOGLE PLUS
 


### PR DESCRIPTION
This commit fixes a FB warning and decreases the FB friends session loading time by a bunch.

```
FB.getLoginStatus() called before calling FB.init(). 
```

I believe this warning was being thrown because `@checkFriends()` was being called in the constructor of the ladder_tab view before `FB.init()` had a chance. I don't think `@checkFriends()` is needed here? Removing it stops the chance of `FB.getLoginStatus()` getting called before `FB.init()`. Moving `Backbone.Mediator.publish "fbapi-loaded"` to after `FB.init()` also removes this chance.

In order to speed up the display of the friends playing list I added a call to render() immediately after FB is done getting their sessions. This greatly speeds up the loading time for my friends list. It was taking on average 20 seconds before the list was rendered but after this it usually pops in 5 seconds. I am not sure if there is a better/easier way to obtain this result other than a force calling of render()?

This might fix this issue https://github.com/codecombat/codecombat/issues/1056
