### PR TITLE
Added pendingPatches to patchables to keep track

### DIFF
--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -83,6 +83,8 @@ module.exports = class LevelLoader extends CocoClass
       @listenToOnce @level, 'sync', @onLevelLoaded
 
   onLevelLoaded: ->
+    console.log @level
+    window.level = @level
     @populateLevel()
 
   populateLevel: ->

--- a/app/schemas/models/patch.coffee
+++ b/app/schemas/models/patch.coffee
@@ -20,6 +20,9 @@ PatchSchema = c.object({title:'Patch', required:['target', 'delta', 'commitMessa
         major: { type: 'number', minimum: 0 }
         minor: { type: 'number', minimum: 0 }
   })
+
+  # TODO try to get rid of it on the app side
+  _wasPending: type: 'boolean'
 })
 
 c.extendBasicProperties(PatchSchema, 'patch')

--- a/app/schemas/schemas.coffee
+++ b/app/schemas/schemas.coffee
@@ -62,6 +62,7 @@ patchableProps = ->
     _id: me.objectId(links: [{rel: "db", href: "/db/patch/{($)}"}], title: "Patch ID", description: "A reference to the patch.")
     status: { enum: ['pending', 'accepted', 'rejected', 'cancelled']}
   })
+  pendingPatches: { type: 'integer' }
   allowPatches: { type: 'boolean' }
   watchers: me.array({title:'Watchers'},
     me.objectId(links: [{rel: 'extra', href: "/db/user/{($)}"}]))

--- a/app/templates/editor/level/edit.jade
+++ b/app/templates/editor/level/edit.jade
@@ -30,9 +30,9 @@ block header
         li
           a(href="#editor-level-patches", data-toggle="tab")#patches-tab
             span(data-i18n="resources.patches").spr Patches
-            - var patches = level.get('patches')
-            if patches && patches.length
-              span.badge= patches.length
+            - var pending = level.get('pendingPatches')
+            if pending
+              span.badge= pending
       
       .navbar-header
         span.navbar-brand #{level.attributes.name}

--- a/server/patches/patch_handler.coffee
+++ b/server/patches/patch_handler.coffee
@@ -50,9 +50,10 @@ PatchHandler = class PatchHandler extends Handler
           return @sendUnauthorizedError(res) unless req.user.get('_id').equals patch.get('creator')
           
         # these require callbacks
-        patch.update {$set:{status:newStatus}}, {}, ->
-        target.update {$pull:{patches:patch.get('_id')}}, {}, ->
-        @sendSuccess(res, null)
+        patch.set 'status', newStatus # triggers middleware
+        patch.save (err) =>
+          target.update {$pull:{patches:patch.get('_id')}}, {}, ->
+          @sendSuccess(res, null)
 
   onPostSuccess: (req, doc) ->
     log.error "Error sending patch created: could not find the loaded target on the patch object." unless doc.targetLoaded


### PR DESCRIPTION
This isn't finished yet.. But I'm stuck with a problem so far and I figured this would be the best place to ask, it might even be related with the currently existing Patch problems.

I added some middleware that keeps track of the amount of pending patches. I tried lots of different approaches, this one seemed best. The current problem is that pendingPatches is set on the wrong document (the one the patch was for) instead of on the last level. I don't know what the best approach would be to have this value on the latest, always. I'm not very good with the versioned system either.

The reason I added this field was I felt the badge (notification-like) should only show the amount of patches that need a developer's attention, not the ones already dealt with. Hence _pendingPatches_.
