### PR TITLE
proofed the SearchView's runSearch

### DIFF
--- a/app/views/kinds/SearchView.coffee
+++ b/app/views/kinds/SearchView.coffee
@@ -46,6 +46,7 @@ module.exports = class SearchView extends View
     searchInput.focus()
 
   runSearch: =>
+    return if @destroyed
     term = @$el.find('input#search').val()
     return if @sameSearch(term)
     @removeOldSearch()


### PR DESCRIPTION
That one line prevents errors from popping up in the console when a debounced search occurs right after you change view, probably by clicking on a result from the search. 
