### PR TITLE
Refactored showNotFound into notFoundView

### DIFF
--- a/app/lib/Router.coffee
+++ b/app/lib/Router.coffee
@@ -44,7 +44,7 @@ module.exports = class CocoRouter extends Backbone.Router
       return @openRoute(args.join('/'))
     view = new ViewClass({}, slugOrId)
     view.render()
-    if view then @openView(view) else @showNotFound()
+    @openView if view then view else @notFoundView()
 
   cache: {}
   openRoute: (route) ->
@@ -99,7 +99,7 @@ module.exports = class CocoRouter extends Backbone.Router
       return document.location.reload()
     path = "views/#{path}"
     ViewClass = @tryToLoadModule path
-    return @showNotFound() if not ViewClass
+    return @openView @notFoundView() if not ViewClass
     view = new ViewClass({}, args...)  # options, then any path fragment args
     view.render()
     @openView(view)
@@ -117,7 +117,7 @@ module.exports = class CocoRouter extends Backbone.Router
       break if ViewClass
       split -= 1
 
-    return @showNotFound() if not ViewClass
+    return @notFoundView() if not ViewClass
     args = pieces[split+1..]
     view = new ViewClass({}, args...)  # options, then any path fragment args
     view.render()
@@ -129,7 +129,7 @@ module.exports = class CocoRouter extends Backbone.Router
       if error.toString().search('Cannot find module "' + path + '" from') is -1
         throw error
 
-  showNotFound: ->
+  notFoundView: ->
     NotFoundView = require('views/not_found')
     view = new NotFoundView()
     view.render()


### PR DESCRIPTION
I'm working on the router! And I noticed some logic got confused. 

`showNotFound` returned a view that was yet to be opened. One bit of code did this, the other code that used the function assumed the view would be opened by `showNotFound` itself. The name does hint at it. That's why I changed the name to `notFoundView`, hinting at a view that is created but yet to be opened, and corrected the current uses of `notFoundView` (where originally no view would be opened at all).

The cleanest would be that only top functions would be allowed to `@openView`, since now responsibility does tend to get confusing. We're good for now though.
