### PR TITLE
Noty errors don't show up on user save fails anymore

### DIFF
--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -6,6 +6,7 @@ module.exports = class User extends CocoModel
   @className: 'User'
   @schema: require 'schemas/models/user'
   urlRoot: '/db/user'
+  notyErrors: false
 
   initialize: ->
     super()


### PR DESCRIPTION
More of a proposition really: I didn't like how Noty errors popped up when I tried to generate user name conflicts on the account settings page. Users don't need it because a fancy error shows up next to the offending field. There might be other cases where you think it IS desirable for users, but I couldn't find any.

![](http://puu.sh/a4SNz/c31ce74651.png)
