### PR TITLE
Bootstrappified Wizard Settings modal

### DIFF
--- a/app/styles/modal/wizard_settings.sass
+++ b/app/styles/modal/wizard_settings.sass
@@ -9,9 +9,9 @@
     display: block
     float: none
     background: white
-    
-  .wizard-name-line
+
+  #wizard-settings-name-wrapper
+    padding-left: 0px !important
+
+  .help-block
     text-align: center
-    margin-bottom: 10px
-    label
-      margin-right: 10px

--- a/app/templates/modal/wizard_settings.jade
+++ b/app/templates/modal/wizard_settings.jade
@@ -4,10 +4,13 @@ block modal-header-content
   h3(data-i18n="wizard_settings.title2") Customize Your Character
 
 block modal-body-content
-  div.wizard-name-line.form-group
-    label.control-label(for="name")
-      | Your Wizardly Name:
-    input#wizard-settings-name(name="name", type="text", value="#{me.get('name')||''}")
+  form.form-horizontal
+    div.form-group
+      .row
+        label.control-label.col-sm-6(for="name")
+          | Your Wizardly Name:
+        #wizard-settings-name-wrapper.col-sm-4
+          input#wizard-settings-name.form-control.input-sm(name="name", type="text", value="#{me.get('name')||''}")
 
   #wizard-settings-view
 


### PR DESCRIPTION
I developed this on top of my `nameable_users2` branch that implements a cooler wizard settings modal, so that's where the screenshots come from. For cleanliness purposes I rebased it on coco's master so if my other branch hasn't been merged in yet you won't be able to check the results for yourself. Luckily I brought screenshots :).

This is purely a matter of preference, but now we get the nice glow provided by Bootstrap etc.

Before:
![](http://puu.sh/a9IRa/ced2054042.png)

After:
![](http://puu.sh/a9ITW/71988b8134.png)
