### PR TITLE
Express now removes all trailing slashes.

### DIFF
--- a/server_setup.coffee
+++ b/server_setup.coffee
@@ -70,11 +70,17 @@ setupMiddlewareToSendOldBrowserWarningWhenPlayersViewLevelDirectly = (app) ->
     return next() if req.query['try-old-browser-anyway'] or not isOldBrowser req
     res.sendfile(path.join(__dirname, 'public', 'index_old_browser.html'))
 
+setupTrailingSlashRemovingMiddleware = (app) ->
+  app.use (req, res, next) ->
+    return res.redirect 301, req.url[...-1] if req.url.length > 1 and req.url.slice(-1) is '/'
+    next()
+
 exports.setupMiddleware = (app) ->
   setupMiddlewareToSendOldBrowserWarningWhenPlayersViewLevelDirectly app
   setupExpressMiddleware app
   setupPassportMiddleware app
   setupOneSecondDelayMiddleware app
+  setupTrailingSlashRemovingMiddleware app
 
 ###Routing function implementations###
 


### PR DESCRIPTION
I didn't like how some URLs with a trailing `/` just ended up somewhere else entirely. At first I wanted to change the Backbone router, but apparently this wouldn't be the correct approach since multiple differing URLs would identify the same page (I lost the SO thread).

It's now done through Express middleware, as described [here](http://stackoverflow.com/questions/13442377/redirect-all-trailing-slashes-gloablly-in-express).
