### PR TITLE
Regenerate lodash with new Math.random

### DIFF
--- a/app/assets/javascripts/workers/worker_world.js
+++ b/app/assets/javascripts/workers/worker_world.js
@@ -298,6 +298,7 @@ self.setupDebugWorldToRunUntilFrame = function (args) {
         }
         Math.random = self.debugWorld.rand.randf;  // so user code is predictable
         Aether.replaceBuiltin("Math", Math);
+        _ = _.runInContext(self);
     }
     self.debugWorld.totalFrames = args.frame; //hack to work around error checking
     self.currentDebugWorldFrame = args.frame;


### PR DESCRIPTION
According to jdalton, all we need to do to regenerate lodash from our changed environment is call `_.runInContext(self)`. I haven't tested it here (not sure how to log from this point in the code), but it does work in the REPL.

Issue #1210.
