### PR TITLE
Use spl (space left) util instead of trailing space for spacing

### DIFF
--- a/app/templates/community.jade
+++ b/app/templates/community.jade
@@ -1,7 +1,7 @@
 extends /templates/base
 
 block content
-  
+
   h1(data-i18n="community.main_title") CodeCombat Community
 
   p There are dozens of ways you can get involved with CodeCombat. Check out the resources we've built, decide what sounds the most fun, and we look forward to working with you!
@@ -15,13 +15,13 @@ block content
       p We have built several tools that enable users to get not only edit, but also build new game content!
 
         ul
-          li 
+          li
             a(href="/editor/level", data-i18n="community.level_editor")
             | : fork, edit, or build your own CodeCombat levels. New levels can be kept private or published to the community.
-          li 
+          li
             a(href="/editor/thang", data-i18n="editor.thang_title")
             | : modify or import new art assets for the game using our powerful editor.
-          li 
+          li
             a(href="/editor/article", data-i18n="editor.article_title")
             | : edit or create documentation used in CodeCombat levels.
 
@@ -35,51 +35,51 @@ block content
 
         ul
 
-          li We write about our progress and current projects on our 
-            a(href="http://blog.codecombat.com", data-i18n="nav.blog")
+          li We write about our progress and current projects on our
+            a.spl(href="http://blog.codecombat.com", data-i18n="nav.blog")
             | .
-          li Participate in our active user community by checking out our 
-            a(href="http://discourse.codecombat.com", data-i18n="nav.forum") 
+          li Participate in our active user community by checking out our
+            a.spl(href="http://discourse.codecombat.com", data-i18n="nav.forum")
             | .
-          li For regular news about learning to code, games, and education, check out our 
-            a(href="https://www.facebook.com/codecombat", data-i18n="community.facebook") 
+          li For regular news about learning to code, games, and education, check out our
+            a.spl(href="https://www.facebook.com/codecombat", data-i18n="community.facebook")
             | .
-          li For realtime status or to have a quick chat, follow us on 
-            a(href="https://twitter.com/CodeCombat", data-i18n="community.twitter") 
+          li For realtime status or to have a quick chat, follow us on
+            a.spl(href="https://twitter.com/CodeCombat", data-i18n="community.twitter")
             | .
-          li Don't like Facebook? We're on 
-            a(href="https://plus.google.com/115285980638641924488/posts", data-i18n="community.gplus") 
+          li Don't like Facebook? We're on
+            a.spl(href="https://plus.google.com/115285980638641924488/posts", data-i18n="community.gplus")
             | .
-          li You can also find us in our 
-            a(href="http://www.hipchat.com/g3plnOKqa", data-i18n="editor.hipchat_url")
+          li You can also find us in our
+            a.spl(href="http://www.hipchat.com/g3plnOKqa", data-i18n="editor.hipchat_url")
 
     .community_columns
 
       h2 Contribute
 
-      p Put your skills to use helping us teach the world to code. We have a lot of roles you can consider, and if we don't have a role for you, let us know: 
+      p Put your skills to use helping us teach the world to code. We have a lot of roles you can consider, and if we don't have a role for you, let us know:
 
         ul
 
-          li 
-            a(href="/contribute#archmage", data-i18n="classes.archmage_title") 
+          li
+            a(href="/contribute#archmage", data-i18n="classes.archmage_title")
             | : contribute by writing code.
-          li 
-            a(href="/contribute#artisan", data-i18n="classes.artisan_title") 
+          li
+            a(href="/contribute#artisan", data-i18n="classes.artisan_title")
             | : build new game levels.
-          li 
-            a(href="/contribute#adventurer", data-i18n="classes.adventurer_title") 
+          li
+            a(href="/contribute#adventurer", data-i18n="classes.adventurer_title")
             | : test new game levels.
-          li 
-            a(href="/contribute#scribe", data-i18n="classes.scribe_title") 
+          li
+            a(href="/contribute#scribe", data-i18n="classes.scribe_title")
             | : write educational documentation.
-          li 
-            a(href="/contribute#diplomat", data-i18n="classes.diplomat_title") 
+          li
+            a(href="/contribute#diplomat", data-i18n="classes.diplomat_title")
             | : translate site content.
-          li 
-            a(href="/contribute#ambassador", data-i18n="classes.ambassador_title") 
+          li
+            a(href="/contribute#ambassador", data-i18n="classes.ambassador_title")
             | : support our community of educators and coders.
 
-        | Check out the 
-        a(href="/contribute", data-i18n="nav.contribute") 
+        | Check out the
+        a.spl(href="/contribute", data-i18n="nav.contribute")
         |  page to find out more about the roles and how you can get started.


### PR DESCRIPTION
Replace trailing space with [Sass util class for spacing](https://github.com/codecombat/codecombat/blob/843ed97643bd1bb78a9482e6e04d0c6125e77370/app/styles/base.sass#L280-L283). 

Related issue [#1303](https://github.com/codecombat/codecombat/pull/1303#issuecomment-48848067).

![screen shot 2014-07-14 at 3 53 08 pm](https://cloud.githubusercontent.com/assets/2450760/3568269/29778b2e-0b2d-11e4-8947-6134a6ed8440.png)
