### PR TITLE
Deduplicated bootstrap include

### DIFF
--- a/app/styles/bootstrap.scss
+++ b/app/styles/bootstrap.scss
@@ -1,1 +1,0 @@
-@import "bootstrap/bootstrap";

--- a/config.coffee
+++ b/config.coffee
@@ -64,7 +64,7 @@ exports.config =
         'stylesheets/app.css': /^(app|vendor|bower_components)/
       order:
         before: [
-          'app/styles/bootstrap.scss'
+          'app/styles/bootstrap/*'
           'vendor/styles/nanoscroller.scss'
         ]
     templates:


### PR DESCRIPTION
My styles and effects were running a tad bit slower from time to time. Investigated, took some time, then found out we included Bootstrap twice. The cleanest way is to use bootstrap's master file, instead of creating our own that imports bootstrap's master file, effectively compiling bootstrap twice.

This also saves us about 350KB on the app.css file, so yay :).
