### PR TITLE
Did UX changes, added an error and fixed a job profile editing bug

### DIFF
--- a/app/locale/en-US.coffee
+++ b/app/locale/en-US.coffee
@@ -186,6 +186,7 @@ module.exports = nativeDescription: "English (US)", englishDescription: "English
 #    error_saving: "Error Saving"
 #    saved: "Changes Saved"
 #    password_mismatch: "Password does not match."
+#    password_repeat: "Please repeat your password."
 #    job_profile: "Job Profile"
 #    job_profile_approved: "Your job profile has been approved by CodeCombat. Employers will be able to see it until you either mark it inactive or it has not been changed for four weeks."
 #    job_profile_explanation: "Hi! Fill this out, and we will get in touch about finding you a software developer job."


### PR DESCRIPTION
- Added an error in case the second password field is empty. Otherwise simply nothing would happen upon saving. I was confused myself so at least someone will appreciate the feedback.
- Improved saving of email settings.
- Tackled a bug that's been bugging me for a while: the jobProfile would keep getting patched even though it wasn't changed. Sometimes it'd be the only thing getting saved, wrongly giving me (the user) the impression that another field got saved
