### PR TITLE
Increased scoring task timeout to 10 minutes

### DIFF
--- a/server/queues/scoring.coffee
+++ b/server/queues/scoring.coffee
@@ -13,7 +13,7 @@ TaskLog = require './task/ScoringTask'
 bayes = new (require 'bayesian-battle')()
 
 scoringTaskQueue = undefined
-scoringTaskTimeoutInSeconds = 240
+scoringTaskTimeoutInSeconds = 600
 
 module.exports.setup = (app) -> connectToScoringQueue()
 


### PR DESCRIPTION
Temporary increase until we can increase it only for Brawlwood
