### PR TITLE
First step towards fetching related by slug

### DIFF
--- a/server/plugins/plugins.coffee
+++ b/server/plugins/plugins.coffee
@@ -30,6 +30,10 @@ module.exports.NamedPlugin = (schema) ->
   schema.add({name: String, slug: String})
   schema.index({'slug': 1}, {unique: true, sparse: true, name: 'slug index'})
 
+  schema.statics.getBySlug = (slug, done) ->
+    @findOne {slug: slug}, (err, doc) ->
+      if err then done err else done doc
+
   schema.pre('save', (next) ->
     if schema.uses_coco_versions
       v = @get('version')


### PR DESCRIPTION
I can now do the following: GET `http://localhost:3000/db/user/abraham-lincoln/level.sessions`.

The key was introducing `getBySlug` for all named schemas. I already did `level.sessions` and `earned.achievements`. Still needs to be a little bit more robust because I don't handle errors that very well. How do you check whether something is an Error? Didn't have time to check.

Anyway I'll leave this here. It's safe to pull. Will do some others tomorrow. All I need to do is throw `IDify` in there.
