### PR TITLE
Added test cases for fetching related by user slug instead of ID

### DIFF
--- a/server/commons/Handler.coffee
+++ b/server/commons/Handler.coffee
@@ -47,7 +47,7 @@ module.exports = class Handler
 
   # sending functions
   sendUnauthorizedError: (res) -> errors.forbidden(res) #TODO: rename sendUnauthorizedError to sendForbiddenError
-  sendNotFoundError: (res) -> errors.notFound(res)
+  sendNotFoundError: (res, message) -> errors.notFound(res, message)
   sendMethodNotAllowed: (res) -> errors.badMethod(res)
   sendBadInputError: (res, message) -> errors.badInput(res, message)
   sendDatabaseError: (res, err) ->

--- a/server/plugins/plugins.coffee
+++ b/server/plugins/plugins.coffee
@@ -31,8 +31,7 @@ module.exports.NamedPlugin = (schema) ->
   schema.index({'slug': 1}, {unique: true, sparse: true, name: 'slug index'})
 
   schema.statics.getBySlug = (slug, done) ->
-    @findOne {slug: slug}, (err, doc) ->
-      if err then done err else done doc
+    @findOne {slug: slug}, done
 
   schema.pre('save', (next) ->
     if schema.uses_coco_versions

--- a/test/server/functional/level_session.spec.coffee
+++ b/test/server/functional/level_session.spec.coffee
@@ -1,12 +1,64 @@
 require '../common'
 
-describe 'LevelFeedback', ->
+describe '/db/level.session', ->
 
-  url = getURL('/db/level.session')
+  url = getURL('/db/level.session/')
+  session =
+    permissions: simplePermissions
 
   it 'get schema', (done) ->
-    request.get {uri: url+'/schema'}, (err, res, body) ->
+    request.get {uri: url+'schema'}, (err, res, body) ->
       expect(res.statusCode).toBe(200)
       body = JSON.parse(body)
       expect(body.type).toBeDefined()
+      done()
+
+  it 'clears things first', (done) ->
+    clearModels [LevelSession], (err) ->
+      expect(err).toBeNull()
+      done()
+
+  # TODO Tried to mimic what happens on the site. Why is this even so hard to do.
+  # Right now it's even possible to create ownerless sessions through POST
+  xit 'allows users to create level sessions through PATCH', (done) ->
+    loginJoe (joe) ->
+      console.log url + mongoose.Types.ObjectId()
+      request {method: 'patch', uri: url + mongoose.Types.ObjectId(), json: session}, (err, res, body) ->
+        expect(err).toBeNull()
+        expect(res.statusCode).toBe 200
+        console.log body
+        expect(body.creator).toEqual joe.get('_id').toHexString()
+        done()
+
+  # Should remove this as soon as the PATCH test case above works
+  it 'create a level session', (done) ->
+    unittest.getNormalJoe (joe) ->
+      session.creator = joe.get('_id').toHexString()
+      session = new LevelSession session
+      session.save (err) ->
+        expect(err).toBeNull()
+        done()
+
+  it 'GET /db/user/<ID>/level.sessions gets a user\'s level sessions', (done) ->
+    unittest.getNormalJoe (joe) ->
+      request.get {uri: getURL "/db/user/#{joe.get '_id'}/level.sessions"}, (err, res, body) ->
+        expect(err).toBeNull()
+        expect(res.statusCode).toBe 200
+        sessions = JSON.parse body
+        expect(sessions.length).toBe 1
+        done()
+
+  it 'GET /db/user/<SLUG>/level.sessions gets a user\'s level sessions', (done) ->
+    unittest.getNormalJoe (joe) ->
+      request.get {uri: getURL "/db/user/#{joe.get 'slug'}/level.sessions"}, (err, res, body) ->
+        expect(err).toBeNull()
+        expect(res.statusCode).toBe 200
+        sessions = JSON.parse body
+        expect(sessions.length).toBe 1
+        done()
+
+  it 'GET /db/user/<IDorSLUG>/level.sessions returns 404 if user not found', (done) ->
+    request.get {uri: getURL "/db/user/misterschtroumpf/level.sessions"}, (err, res) ->
+      expect(err).toBeNull()
+      expect(res.statusCode).toBe 404
       done()


### PR DESCRIPTION
Feels like emptying a bathtub with a spoon. I'll leave the rest for the big database refactoring. Also apparently it's possible to create ownerless level sessions through POST requests (even when a creator is set). I tried mimicking the site's way of creating level sessions but didn't manage.

Anyway, tests for the PR from yesterday. Cleaned up some too.
