### PR TITLE
Added Moment i18n support

### DIFF
--- a/app/initialize.coffee
+++ b/app/initialize.coffee
@@ -31,6 +31,7 @@ init = ->
   app.initialize()
   Backbone.history.start({ pushState: true })
   handleNormalUrls()
+  setUpMoment() # Set up i18n for moment
 
   treemaExt = require 'treema-ext'
   treemaExt.setup()
@@ -63,6 +64,12 @@ setUpChannels = ->
 setUpDefinitions = ->
   for definition of definitionSchemas
     Backbone.Mediator.addDefSchemas definitionSchemas[definition]
+
+setUpMoment = ->
+  {me} = require 'lib/auth'
+  moment.lang me.lang(), {}
+  me.on 'change', (me) ->
+    moment.lang me.lang(), {} if me._previousAttributes.preferredLanguage isnt me.get 'preferredLanguage'
 
 initializeServices = ->
   services = [


### PR DESCRIPTION
I've been doing some stuff with Moment (our Date library) lately, so I figured this would be a nice addition. Now, on load and whenever a user's preferred language changes, moment is reconfigured to use the new i18n. 
