### PR TITLE
Repaired TestView by only loading js files once

### DIFF
--- a/app/views/TestView.coffee
+++ b/app/views/TestView.coffee
@@ -9,6 +9,7 @@ module.exports = TestView = class TestView extends CocoView
   id: 'test-view'
   template: template
   reloadOnClose: true
+  loadedFileIDs: []
 
   # INITIALIZE
 
@@ -18,13 +19,19 @@ module.exports = TestView = class TestView extends CocoView
     @loadTestingLibs()
 
   loadTestingLibs: ->
-    @queue = new createjs.LoadQueue()
+    @queue = new createjs.LoadQueue() unless @queue
     @queue.on('complete', @scriptsLoaded, @)
+    @queue.on('fileload', @onFileLoad, @)
     for f in ['jasmine', 'jasmine-html', 'boot', 'mock-ajax', 'test-app']
-      @queue.loadFile({
-        src: "/javascripts/#{f}.js"
-        type: createjs.LoadQueue.JAVASCRIPT
-      })
+      if f not in @loadedFileIDs
+        @queue.loadFile({
+          id: f
+          src: "/javascripts/#{f}.js"
+          type: createjs.LoadQueue.JAVASCRIPT
+        })
+
+  onFileLoad: (e) ->
+    @loadedFileIDs.push e.item.id if e.item.id
 
   scriptsLoaded: ->
     @initSpecFiles()


### PR DESCRIPTION
App tests were broken? Couldn't navigate around because it'd try to load the same JS files again. Still not sure why the `Illegal invocation` error though. Anyway, it should only load once now. 

P.S. @sderickson might want to have a look at this
