### PR TITLE
Add cocodb/ to .gitignore for Windows setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ bin/mongo/
 
 # windows
 /SCOCODE.bat
+cocodb/
 
 # local settings
 login.coffee


### PR DESCRIPTION
Created by the Windows development environment setup script
