### PR TITLE
Autocomplete Basic fix for issue #1381

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -44,7 +44,7 @@
     "bootstrap": "~3.1.1",
     "validated-backbone-mediator": "~0.1.3",
     "jquery.browser": "~0.0.6",
-    "zatanna": "~0.0.5",
+    "zatanna": "~0.0.6",
     "modernizr": "~2.8.3"
   },
   "overrides": {


### PR DESCRIPTION
This is only a basic fix that removes `this.`, `@` and `self.` from the snippets if already in place. More can be added by setting in the zatanna initialization in [SpellView.coffee#L101](https://github.com/codecombat/codecombat/blob/master/app/views/play/level/tome/SpellView.coffee#L101) the value of `languagePrefixes` similar to this:

``` coffee
@zatanna = new Zatanna @ace,
      languagePrefixes: 'this.,@,self.'
      liveCompletion: aceConfig.liveCompletion ? true
      completers:
        keywords: false
```
