### PR TITLE
Updated URL for DB backup

### DIFF
--- a/scripts/windows/coco-dev-setup/batch/config/config.coco
+++ b/scripts/windows/coco-dev-setup/batch/config/config.coco
@@ -2,8 +2,8 @@
 <variables>
     <version>3.5</version>
     <author>GlenDC</author>
-    <copyright>CodeCombat.com © 2013-2014</copyright>
+    <copyright>CodeCombat.com Â© 2013-2014</copyright>
     <github_url>https://github.com/codecombat/codecombat.git</github_url>
     <github_ssh>git@github.com:codecombat/codecombat.git</github_ssh>
-    <database_backup>http://23.21.59.137/dump.tar.gz</database_backup>
+    <database_backup>http://54.91.159.37/dump.tar.gz</database_backup>
 </variables>


### PR DESCRIPTION
The old url seems to not exist anymore. Found the correct url in the dev-wiki.
