### PR TITLE
Renamed sendUnauthorizedUser to sendForbiddenError

### DIFF
--- a/server/achievements/achievement_handler.coffee
+++ b/server/achievements/achievement_handler.coffee
@@ -16,7 +16,7 @@ class AchievementHandler extends Handler
   get: (req, res) ->
     # /db/achievement?related=<ID>
     if req.query.related
-      return @sendUnauthorizedError(res) if not @hasAccess(req)
+      return @sendForbiddenError(res) if not @hasAccess(req)
       Achievement.find {related: req.query.related}, (err, docs) =>
         return @sendDatabaseError(res, err) if err
         docs = (@formatEntity(req, doc) for doc in docs)
@@ -25,7 +25,7 @@ class AchievementHandler extends Handler
       super req, res
 
   delete: (req, res, slugOrID) ->
-    return @sendUnauthorizedError res unless req.user?.isAdmin()
+    return @sendForbiddenError res unless req.user?.isAdmin()
     @getDocumentForIdOrSlug slugOrID, (err, document) => # Check first
       return @sendDatabaseError(res, err) if err
       return @sendNotFoundError(res) unless document?

--- a/server/levels/level_handler.coffee
+++ b/server/levels/level_handler.coffee
@@ -50,7 +50,7 @@ LevelHandler = class LevelHandler extends Handler
     @getDocumentForIdOrSlug id, (err, level) =>
       return @sendDatabaseError(res, err) if err
       return @sendNotFoundError(res) unless level?
-      return @sendUnauthorizedError(res) unless @hasAccessToDocument(req, level, 'get')
+      return @sendForbiddenError(res) unless @hasAccessToDocument(req, level, 'get')
       callback err, level
 
   getSession: (req, res, id) ->

--- a/server/levels/sessions/level_session_handler.coffee
+++ b/server/levels/sessions/level_session_handler.coffee
@@ -20,7 +20,7 @@ class LevelSessionHandler extends Handler
       return _.omit documentObject, @privateProperties
 
   getActiveSessions: (req, res) ->
-    return @sendUnauthorizedError(res) unless req.user.isAdmin()
+    return @sendForbiddenError(res) unless req.user.isAdmin()
     start = new Date()
     start = new Date(start.getTime() - TIMEOUT)
     query = @modelClass.find({'changed': {$gt: start}})

--- a/server/patches/patch_handler.coffee
+++ b/server/patches/patch_handler.coffee
@@ -42,13 +42,13 @@ PatchHandler = class PatchHandler extends Handler
       targetModel.findOne(query).sort(sort).exec (err, target) =>
         return @sendDatabaseError(res, err) if err
         return @sendNotFoundError(res) unless target?
-        return @sendUnauthorizedError(res) unless targetHandler.hasAccessToDocument(req, target, 'get')
+        return @sendForbiddenError(res) unless targetHandler.hasAccessToDocument(req, target, 'get')
 
         if newStatus in ['rejected', 'accepted']
-          return @sendUnauthorizedError(res) unless targetHandler.hasAccessToDocument(req, target, 'put')
+          return @sendForbiddenError(res) unless targetHandler.hasAccessToDocument(req, target, 'put')
 
         if newStatus is 'withdrawn'
-          return @sendUnauthorizedError(res) unless req.user.get('_id').equals patch.get('creator')
+          return @sendForbiddenError(res) unless req.user.get('_id').equals patch.get('creator')
 
         patch.set 'status', newStatus
 

--- a/server/users/user_handler.coffee
+++ b/server/users/user_handler.coffee
@@ -193,7 +193,7 @@ UserHandler = class UserHandler extends Handler
     super(arguments...)
 
   agreeToCLA: (req, res) ->
-    return @sendUnauthorizedError(res) unless req.user
+    return @sendForbiddenError(res) unless req.user
     doc =
       user: req.user._id+''
       email: req.user.get 'email'
@@ -224,7 +224,7 @@ UserHandler = class UserHandler extends Handler
       res.end()
 
   getLevelSessionsForEmployer: (req, res, userID) ->
-    return @sendUnauthorizedError(res) unless req.user._id+'' is userID or req.user.isAdmin() or ('employer' in (req.user.get('permissions') ? []))
+    return @sendForbiddenError(res) unless req.user._id+'' is userID or req.user.isAdmin() or ('employer' in (req.user.get('permissions') ? []))
     query = creator: userID, levelID: {$in: ['gridmancer', 'greed', 'dungeon-arena', 'brawlwood', 'gold-rush']}
     projection = 'levelName levelID team playtime codeLanguage submitted code totalScore teamSpells level'
     LevelSession.find(query).select(projection).exec (err, documents) =>
@@ -281,7 +281,7 @@ UserHandler = class UserHandler extends Handler
     isMe = userID is req.user._id + ''
     isAuthorized = isMe or req.user.isAdmin()
     isAuthorized ||= ('employer' in (req.user.get('permissions') ? [])) and (activityName in ['viewed_by_employer', 'contacted_by_employer'])
-    return @sendUnauthorizedError res unless isAuthorized
+    return @sendForbiddenError res unless isAuthorized
     updateUser = (user) =>
       activity = user.trackActivity activityName, increment
       user.update {activity: activity}, (err) =>
@@ -356,7 +356,7 @@ UserHandler = class UserHandler extends Handler
     true
 
   getEmployers: (req, res) ->
-    return @sendUnauthorizedError(res) unless req.user.isAdmin()
+    return @sendForbiddenError(res) unless req.user.isAdmin()
     query = {employerAt: {$exists: true, $ne: ''}}
     selection = 'name firstName lastName email activity signedEmployerAgreement photoURL employerAt'
     User.find(query).select(selection).lean().exec (err, documents) =>
@@ -379,7 +379,7 @@ UserHandler = class UserHandler extends Handler
     hash.digest('hex')
 
   getRemark: (req, res, userID) ->
-    return @sendUnauthorizedError(res) unless req.user.isAdmin()
+    return @sendForbiddenError(res) unless req.user.isAdmin()
     query = user: userID
     projection = null
     if req.query.project
@@ -392,7 +392,7 @@ UserHandler = class UserHandler extends Handler
 
   searchForUser: (req, res) ->
     # TODO: also somehow search the CLAs to find a match amongst those fields and to find GitHub ids
-    return @sendUnauthorizedError(res) unless req.user.isAdmin()
+    return @sendForbiddenError(res) unless req.user.isAdmin()
     search = req.body.search
     query = email: {$exists: true}, $or: [
       {emailLower: search}


### PR DESCRIPTION
There was a TODO in server/commons/Handler.coffee on line 58 to do this. Currently, sendUnauthorizedUser does the exact same thing as sendForbiddenError, so removing it and renaming all uses of it to sendForbiddenError should do no harm.
