### PR TITLE
Fix issue #1558

### DIFF
--- a/server/levels/level_handler.coffee
+++ b/server/levels/level_handler.coffee
@@ -308,5 +308,8 @@ LevelHandler = class LevelHandler extends Handler
       @playCountCache[cacheKey] = data
       @sendSuccess res, data
 
+  hasAccessToDocument: (req, document, method=null) ->
+    return true if method == null or method == 'get'
+    super(req, document, method)
 
 module.exports = new LevelHandler()


### PR DESCRIPTION
This allows anyone to view any level, regardless of permissions. The issue could also be fixed by changing the permissions that are assigned when a level is created, but that would require updating the database for all of the older levels.

The commit message has a typo: This fixes issue #1558, not #8.
