### PR TITLE
Eliminate brunch warnings about unjoined files

### DIFF
--- a/config.coffee
+++ b/config.coffee
@@ -4,7 +4,8 @@ startsWith = (string, substring) ->
 
 exports.config =
   paths:
-    'public': 'public'
+    public: 'public'
+    watched: ['app', 'vendor', 'test/app', 'test/demo']
   conventions:
     ignored: (path) -> startsWith(sysPath.basename(path), '_')
   sourceMaps: true


### PR DESCRIPTION
By specifying the directories that should be watched/built (i.e. exclude `test/server`)
