### PR TITLE
Fixed wrong I18n suffix in Thang Editor section on Community page.

### DIFF
--- a/app/templates/community.jade
+++ b/app/templates/community.jade
@@ -26,7 +26,7 @@ block content
       p
         span(data-i18n="community.thang_editor_prefix") We call units within the game 'thangs'. Use the
         a.spl.spr(href="/editor/thang", data-i18n="editor.thang_title")
-        span(data-i18n="community.level_editor_suffix") to modify the CodeCombat source artwork. Allow units to throw projectiles, alter the direction of an animation, change a unit's hit points, or upload your own vector sprites.
+        span(data-i18n="community.thang_editor_suffix") to modify the CodeCombat source artwork. Allow units to throw projectiles, alter the direction of an animation, change a unit's hit points, or upload your own vector sprites.
 
     .community-columns
       a(href="/editor/article")


### PR DESCRIPTION
The Thang blurb was using community.level_editor_suffix instead of community.thang_editor_suffix
