### PR TITLE
Fix for #1795

### DIFF
--- a/app/styles/common/site-chrome.sass
+++ b/app/styles/common/site-chrome.sass
@@ -83,6 +83,7 @@
 
     .language-dropdown
       width: auto
+      padding: 0px 10px
       display: inline-block
       
     #site-nav-smooth-edge


### PR DESCRIPTION
Fixed padding on language-dropdown because it was annoying me too. The cause of the problem is padding: 6px 12px; in .form-control, and I guess the font is just too big.  Not sure if this is the best way to fix it, but it works. 
