### PR TITLE
Update es-419.coffee

### DIFF
--- a/app/locale/es-419.coffee
+++ b/app/locale/es-419.coffee
@@ -28,7 +28,7 @@ module.exports = nativeDescription: "español (América Latina)", englishDescrip
     home: "Inicio"
     contribute: "Contribuir"
     legal: "Legal"
-    about: "Sobre"
+    about: "Acerca"
     contact: "Contacto"
     twitter_follow: "Seguir"
     teachers: "Profesores"


### PR DESCRIPTION
In this context "About" is better translated as "Acerca" instead of "Sobre". (Line 31)
