### PR TITLE
Update SpellView.coffee

### DIFF
--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -417,7 +417,7 @@ module.exports = class SpellView extends CocoView
             meta: 'press enter'
             name: doc.name
             tabTrigger: doc.snippets[e.language].tab
-          if doc.name is 'findNearestEnemy'
+          if doc.name is 'findNearestEnemy' or doc.name is 'findNearest'
             # Remember if we have findNearestEnemy so attack snippet can be updated
             haveFindNearestEnemy = true
           if doc.name is 'attack'


### PR DESCRIPTION
Fixed issue #1950 so attack defaults to enemy if player has findNearest or findNearestEnemy
