### PR TITLE
fixed attempt to add scrolling to help pane

### DIFF
--- a/app/styles/play/level/tome/spell_palette.sass
+++ b/app/styles/play/level/tome/spell_palette.sass
@@ -70,6 +70,9 @@
     @include flex-wrap()
     @include flex-column()
     @include flex-align-content-start()
+    width: 500px;
+    height: 230px;
+    overflow: auto;
 
     .property-entry-item-group
       display: inline-block


### PR DESCRIPTION
previous attempt had width and height pixels swapped. no idea if this is in the right place, but this sure worked under chrome inspector: `<div class="properties" style="width: 500px; height: 230px; overflow: auto;">`