### PR TITLE
Distro-specific devSetup for Arch Linux and Ubuntu

### DIFF
--- a/scripts/devSetup/factories.py
+++ b/scripts/devSetup/factories.py
@@ -142,8 +142,9 @@ class LinuxSetup(SetupFactory):
                                            "--recv", "7F0CEB10"])
                     subprocess.check_call(["add-apt-repository",
                                            "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen"])
-                    subprocess.check_call(["add-apt-repository",
-                                           "ppa:chris-lea/node.js"])
+                    subprocess.check_call(["curl", "-sL",
+                                           "https://deb.nodesource.com/setup",
+                                           "|", "bash"], shell=True)
                     subprocess.check_call(["apt-get", "update"])
                 except subprocess.CalledProcessError as err:
                     print("Adding repositories failed. Retry, Install without"

--- a/scripts/devSetup/factories.py
+++ b/scripts/devSetup/factories.py
@@ -142,9 +142,9 @@ class LinuxSetup(SetupFactory):
                                            "--recv", "7F0CEB10"])
                     subprocess.check_call(["add-apt-repository",
                                            "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen"])
-                    subprocess.check_call(["curl", "-sL",
-                                           "https://deb.nodesource.com/setup",
-                                           "|", "bash"], shell=True)
+                    subprocess.check_call("curl -sL "
+                                           "https://deb.nodesource.com/setup"
+                                           " | bash", shell=True)
                     subprocess.check_call(["apt-get", "update"])
                 except subprocess.CalledProcessError as err:
                     print("Adding repositories failed. Retry, Install without"

--- a/scripts/devSetup/factories.py
+++ b/scripts/devSetup/factories.py
@@ -104,7 +104,7 @@ class LinuxSetup(SetupFactory):
         if distro == "arch":
             print("Arch Linux detected. Would you like to install \n"
                   "NodeJS and MongoDB via pacman? [y/N]")
-            if input().lower() in ["y", "yes"]:
+            if raw_input().lower() in ["y", "yes"]:
                 try:
                     subprocess.check_call(["pacman", "-S",
                                            "nodejs", "mongodb",
@@ -112,7 +112,7 @@ class LinuxSetup(SetupFactory):
                 except subprocess.CalledProcessError as err:
                     print("Installation failed. Retry, Continue, or "
                           "Abort? [r/c/A]")
-                    answer = input().lower()
+                    answer = raw_input().lower()
                     if answer in ["r", "retry"]:
                         return(self.distroSetup())
                     elif answer in ["c", "continue"]:
@@ -133,7 +133,7 @@ class LinuxSetup(SetupFactory):
         if distro == "ubuntu":
             print("Ubuntu installation detected. Would you like to install \n"
                   "NodeJS and MongoDB via apt-get? [y/N]")
-            if input().lower() in ["y", "yes"]:
+            if raw_input().lower() in ["y", "yes"]:
                 print("Adding repositories for MongoDB and NodeJS...")
                 try:
                     subprocess.check_call(["apt-key", "adv",
@@ -149,7 +149,7 @@ class LinuxSetup(SetupFactory):
                     print("Adding repositories failed. Retry, Install without"
                           "adding \nrepositories, Skip apt-get installation, "
                           "or Abort? [r/i/s/A]")
-                    answer = input().lower()
+                    answer = raw_input().lower()
                     if answer in ["r", "retry"]:
                         return(self.distroSetup())
                     elif answer in ["i", "install"]:
@@ -166,7 +166,7 @@ class LinuxSetup(SetupFactory):
                     except subprocess.CalledProcessError as err:
                         print("Installation via apt-get failed. \nContinue "
                               "with manual installation, or Abort? [c/A]")
-                        if input().lower() in ["c", "continue"]:
+                        if raw_input().lower() in ["c", "continue"]:
                             return()
                         else:
                             exit(1)

--- a/scripts/devSetup/factories.py
+++ b/scripts/devSetup/factories.py
@@ -174,8 +174,8 @@ class LinuxSetup(SetupFactory):
                     else:
                         print("NodeJS and MongoDB installed successfully. "
                               "Staring MongoDB.")
-                        try:
-                            subprocess.check_call(["service", "mongod", "start"])
-                        except subprocess.CalledProcessError as err:
-                            print("Mongo failed to start. Aborting.")
-                            exit(1)
+                        #try:
+                            #subprocess.check_call(["service", "mongod", "start"])
+                        #except subprocess.CalledProcessError as err:
+                            #print("Mongo failed to start. Aborting.")
+                            #exit(1)

--- a/scripts/devSetup/factories.py
+++ b/scripts/devSetup/factories.py
@@ -163,7 +163,8 @@ class LinuxSetup(SetupFactory):
                     try:
                         print("Repositories added successfully. Installing NodeJS and MongoDB.")
                         subprocess.check_call(["apt-get", "install",
-                                               "nodejs", "mongodb-org", "-y"])
+                                               "nodejs", "mongodb-org",
+                                               "build-essential", "-y"])
                     except subprocess.CalledProcessError as err:
                         print("Installation via apt-get failed. \nContinue "
                               "with manual installation, or Abort? [c/A]")

--- a/scripts/devSetup/factories.py
+++ b/scripts/devSetup/factories.py
@@ -170,3 +170,11 @@ class LinuxSetup(SetupFactory):
                             return()
                         else:
                             exit(1)
+                    else:
+                        print("NodeJS and MongoDB installed successfully. "
+                              "Staring MongoDB.")
+                        try:
+                            subprocess.check_call(["service", "mongod", "start"])
+                        except subprocess.CalledProcessError as err:
+                            print("Mongo failed to start. Aborting.")
+                            exit(1)

--- a/scripts/devSetup/factories.py
+++ b/scripts/devSetup/factories.py
@@ -120,16 +120,16 @@ class LinuxSetup(SetupFactory):
                     else:
                         exit(1)
                 else:
-                    try:
-                        print("Enabling and starting MongoDB in systemd.")
-                        subprocess.check_call(["systemctl", "enable",
-                                               "mongodb.service"])
-                        subprocess.check_call(["systemctl", "start",
-                                               "mongodb.service"])
-                        print("Node and Mongo installed. Continuing.")
-                    except subprocess.CalledProcessError as err:
-                        print("Mongo failed to start. Aborting")
-                        exit(1)
+                    #try:
+                        #print("Enabling and starting MongoDB in systemd.")
+                        #subprocess.check_call(["systemctl", "enable",
+                        #                       "mongodb.service"])
+                        #subprocess.check_call(["systemctl", "start",
+                        #                       "mongodb.service"])
+                        #print("Node and Mongo installed. Continuing.")
+                    #except subprocess.CalledProcessError as err:
+                        #print("Mongo failed to start. Aborting")
+                        #exit(1)
         if distro == "ubuntu":
             print("Ubuntu installation detected. Would you like to install \n"
                   "NodeJS and MongoDB via apt-get? [y/N]")

--- a/scripts/devSetup/factories.py
+++ b/scripts/devSetup/factories.py
@@ -80,9 +80,93 @@ class SetupFactory(object):
 class MacSetup(SetupFactory):
     def setup(self):
         super(self.__class__, self).setup()
+
 class WinSetup(SetupFactory):
     def setup(self):
         super(self.__class__, self).setup()
+
 class LinuxSetup(SetupFactory):
     def setup(self):
+        self.distroSetup()
         super(self.__class__, self).setup()
+
+    def detectDistro(self):
+        distro_checks = {
+            "arch": "/etc/arch-release",
+            "ubuntu": "/etc/lsb-release"
+            }
+        for distro, path in distro_checks.items():
+            if os.path.exists(path):
+                return(distro)
+
+    def distroSetup(self):
+        distro = self.detectDistro()
+        if distro == "arch":
+            print("Arch Linux detected. Would you like to install \n"
+                  "NodeJS and MongoDB via pacman? [y/N]")
+            if input().lower() in ["y", "yes"]:
+                try:
+                    subprocess.check_call(["pacman", "-S",
+                                           "nodejs", "mongodb",
+                                           "--noconfirm"])
+                except subprocess.CalledProcessError as err:
+                    print("Installation failed. Retry, Continue, or "
+                          "Abort? [r/c/A]")
+                    answer = input().lower()
+                    if answer in ["r", "retry"]:
+                        return(self.distroSetup())
+                    elif answer in ["c", "continue"]:
+                        return()
+                    else:
+                        exit(1)
+                else:
+                    try:
+                        print("Enabling and starting MongoDB in systemd.")
+                        subprocess.check_call(["systemctl", "enable",
+                                               "mongodb.service"])
+                        subprocess.check_call(["systemctl", "start",
+                                               "mongodb.service"])
+                        print("Node and Mongo installed. Continuing.")
+                    except subprocess.CalledProcessError as err:
+                        print("Mongo failed to start. Aborting")
+                        exit(1)
+        if distro == "ubuntu":
+            print("Ubuntu installation detected. Would you like to install \n"
+                  "NodeJS and MongoDB via apt-get? [y/N]")
+            if input().lower() in ["y", "yes"]:
+                print("Adding repositories for MongoDB and NodeJS...")
+                try:
+                    subprocess.check_call(["apt-key", "adv",
+                                           "--keyserver",
+                                           "hkp://keyserver.ubuntu.com:80",
+                                           "--recv", "7F0CEB10"])
+                    subprocess.check_call(["add-apt-repository",
+                                           "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen"])
+                    subprocess.check_call(["add-apt-repository",
+                                           "ppa:chris-lea/node.js"])
+                    subprocess.check_call(["apt-get", "update"])
+                except subprocess.CalledProcessError as err:
+                    print("Adding repositories failed. Retry, Install without"
+                          "adding \nrepositories, Skip apt-get installation, "
+                          "or Abort? [r/i/s/A]")
+                    answer = input().lower()
+                    if answer in ["r", "retry"]:
+                        return(self.distroSetup())
+                    elif answer in ["i", "install"]:
+                        pass
+                    elif answer in ["s", "skip"]:
+                        return()
+                    else:
+                        exit(1)
+                else:
+                    try:
+                        print("Repositories added successfully. Installing NodeJS and MongoDB.")
+                        subprocess.check_call(["apt-get", "install",
+                                               "nodejs", "mongodb-org", "-y"])
+                    except subprocess.CalledProcessError as err:
+                        print("Installation via apt-get failed. \nContinue "
+                              "with manual installation, or Abort? [c/A]")
+                        if input().lower() in ["c", "continue"]:
+                            return()
+                        else:
+                            exit(1)

--- a/scripts/devSetup/repositoryInstaller.py
+++ b/scripts/devSetup/repositoryInstaller.py
@@ -64,7 +64,14 @@ class RepositoryInstaller():
         #TODO: "Replace npm with more robust package
         #npm_location = self.config.directory.bin_directory + os.sep + "node" + os.sep + "bin" + os.sep + "npm"
         npm_location = u"npm"
-        return_code = subprocess.call([npm_location,u"install"],cwd=self.config.directory.root_dir + os.sep + u"coco")
+        if sys.version_info[0] == 2:
+            py_cmd = "python"
+        else:
+            py_cmd = subprocess.check_output(['which', 'python2'])
+        return_code = subprocess.call([npm_location, u"install",
+                                       "--python=" + py_cmd],
+                                      cwd=self.config.directory.root_dir +
+                                      os.sep + u"coco")
         if return_code:
             raise errors.CoCoError(u"Failed to install node packages")
         else:

--- a/scripts/devSetup/repositoryInstaller.py
+++ b/scripts/devSetup/repositoryInstaller.py
@@ -4,6 +4,7 @@ import configuration
 import errors
 import subprocess
 import os
+import sys
 from which import which
 #git clone https://github.com/nwinter/codecombat.git coco
 class RepositoryInstaller():


### PR DESCRIPTION
There's no good reason to leave mongo and node out in the cold in terms of distro-provided updates. This ensures that Arch and Ubuntu get those. I'll add more distros as requested, or anyone else can. They're pretty easy. 