### PR TITLE
Fixing error on empty else.

### DIFF
--- a/scripts/devSetup/factories.py
+++ b/scripts/devSetup/factories.py
@@ -120,6 +120,7 @@ class LinuxSetup(SetupFactory):
                     else:
                         exit(1)
                 else:
+                    pass
                     #try:
                         #print("Enabling and starting MongoDB in systemd.")
                         #subprocess.check_call(["systemctl", "enable",


### PR DESCRIPTION
Fixing the following error.
```
Traceback (most recent call last):
  File "setup.py", line 26, in <module>
    import factories
  File "/home/divyanshu/codes/codecombat/scripts/devSetup/factories.py", line 133
    if distro == "ubuntu":
    ^
IndentationError: expected an indented block
```
When you try to install Dev enviroment following this guide: https://github.com/codecombat/codecombat/wiki/Dev-Setup:-Linux The error above will raise.