### PR TITLE
Fix bug: can't upload profile photo

### DIFF
--- a/app/views/account/AccountSettingsView.coffee
+++ b/app/views/account/AccountSettingsView.coffee
@@ -69,7 +69,7 @@ module.exports = class AccountSettingsView extends CocoView
       photoContainer.addClass('saving')
     onSaved = (uploadingPath) =>
       @$el.find('#photoURL').val(uploadingPath)
-      @onInputChanged() # cause for some reason editing the value doesn't trigger the jquery event
+      @onInputChanged({target: @$el.find('#photoURL')}) # cause for some reason editing the value doesn't trigger the jquery event
       me.set('photoURL', uploadingPath)
       photoContainer.removeClass('saving').attr('src', me.getPhotoURL(photoContainer.width()))
     filepicker.pick {mimetypes: 'image/*'}, @onImageChosen(onSaving, onSaved)


### PR DESCRIPTION
The onInputChanged callback is using the event parameter to get the target DOM element. On #L72 the callback function was called manually, but no parameter was passed. I pass in an object that has a target attribute(the DOM element), so it can get it.