### PR TITLE
Fix bug: cannot upload profile picture

### DIFF
--- a/app/views/account/AccountSettingsView.coffee
+++ b/app/views/account/AccountSettingsView.coffee
@@ -69,7 +69,7 @@ module.exports = class AccountSettingsView extends CocoView
       photoContainer.addClass('saving')
     onSaved = (uploadingPath) =>
       @$el.find('#photoURL').val(uploadingPath)
-      @onInputChanged({target: @$el.find('#photoURL')}) # cause for some reason editing the value doesn't trigger the jquery event
+      @$el.find('#photoURL').trigger('change') # cause for some reason editing the value doesn't trigger the jquery event
       me.set('photoURL', uploadingPath)
       photoContainer.removeClass('saving').attr('src', me.getPhotoURL(photoContainer.width()))
     filepicker.pick {mimetypes: 'image/*'}, @onImageChosen(onSaving, onSaved)

--- a/app/views/account/AccountSettingsView.coffee
+++ b/app/views/account/AccountSettingsView.coffee
@@ -69,7 +69,7 @@ module.exports = class AccountSettingsView extends CocoView
       photoContainer.addClass('saving')
     onSaved = (uploadingPath) =>
       @$el.find('#photoURL').val(uploadingPath)
-      @onInputChanged() # cause for some reason editing the value doesn't trigger the jquery event
+      @onInputChanged({target: @$el.find('#photoURL')}) # cause for some reason editing the value doesn't trigger the jquery event
       me.set('photoURL', uploadingPath)
       photoContainer.removeClass('saving').attr('src', me.getPhotoURL(photoContainer.width()))
     filepicker.pick {mimetypes: 'image/*'}, @onImageChosen(onSaving, onSaved)


### PR DESCRIPTION
In the code before, onInputChanged function was called manually, but the parameter was not passed. I think it's better to trigger the event, than calling the callback function of the event.