### PR TITLE
Autocomplete bug fix #2233

### DIFF
--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -443,6 +443,7 @@ module.exports = class SpellView extends CocoView
     # window.snippetEntries = snippetEntries
     lang = SpellView.editModes[e.language].substr 'ace/mode/'.length
     @zatanna.addSnippets snippetEntries, lang
+    @snippetEntries = snippetEntries
 
   onMultiplayerChanged: ->
     if @session.get('multiplayer')
@@ -1091,6 +1092,8 @@ module.exports = class SpellView extends CocoView
     @destroyAceEditor(@ace)
     @debugView?.destroy()
     @toolbarView?.destroy()
+    snippetManager = ace.require('ace/snippets').snippetManager
+    snippetManager.unregister @snippetEntries if @snippetEntries?
     $(window).off 'resize', @onWindowResize
     super()
     


### PR DESCRIPTION
fixed auto-complete bug https://github.com/codecombat/codecombat/issues/2233

On changing game language function addZatannaSnippets  was adding new snippets without removing previous snippets from ace editor.
keep a reference of old snippet in SpellView and destroy manually on exit.