### PR TITLE
A small fix to the PR #2313

### DIFF
--- a/app/views/play/level/modal/HeroVictoryModal.coffee
+++ b/app/views/play/level/modal/HeroVictoryModal.coffee
@@ -268,6 +268,7 @@ module.exports = class HeroVictoryModal extends ModalView
 
   updateXPBars: (achievedXP) ->
     previousXP = @previousXP
+    previousXP = previousXP + 1000000 if me.isInGodMode() 
     previousLevel = @previousLevel
 
     currentXP = previousXP + achievedXP


### PR DESCRIPTION
A small fix to the PR #2313. 

This is just a small fix for making the victory dialog displays correctly when you are in the "god mode". Everything with the "god mode" should be ok now.  