### PR TITLE
Autocomplete bug fix #2233 - method 2

### DIFF
--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -443,7 +443,7 @@ module.exports = class SpellView extends CocoView
     # window.snippetEntries = snippetEntries
     lang = SpellView.editModes[e.language].substr 'ace/mode/'.length
     @zatanna.addSnippets snippetEntries, lang
-    @newlang = lang
+    @editorLang = lang
 
   onMultiplayerChanged: ->
     if @session.get('multiplayer')
@@ -1092,7 +1092,7 @@ module.exports = class SpellView extends CocoView
     @destroyAceEditor(@ace)
     @debugView?.destroy()
     @toolbarView?.destroy()
-    @zatanna.addSnippets [], @newlang if @newlang?
+    @zatanna.addSnippets [], @editorLang if @editorLang?
     $(window).off 'resize', @onWindowResize
     super()
     

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -443,6 +443,7 @@ module.exports = class SpellView extends CocoView
     # window.snippetEntries = snippetEntries
     lang = SpellView.editModes[e.language].substr 'ace/mode/'.length
     @zatanna.addSnippets snippetEntries, lang
+    @newlang = lang
 
   onMultiplayerChanged: ->
     if @session.get('multiplayer')
@@ -1091,7 +1092,7 @@ module.exports = class SpellView extends CocoView
     @destroyAceEditor(@ace)
     @debugView?.destroy()
     @toolbarView?.destroy()
-    @zatanna.addSnippets [], @spell.language
+    @zatanna.addSnippets [], @newlang if @newlang?
     $(window).off 'resize', @onWindowResize
     super()
     

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -1091,6 +1091,7 @@ module.exports = class SpellView extends CocoView
     @destroyAceEditor(@ace)
     @debugView?.destroy()
     @toolbarView?.destroy()
+    @zatanna.addSnippets [], @spell.language
     $(window).off 'resize', @onWindowResize
     super()
     


### PR DESCRIPTION
fixed auto-complete bug #2233 

Zatanna's tracking doesn't seems to work and is somehow loosing references of oldsnippets. 
Calling  @zatanna.addSnippets [], lang in SpellView.destroy  destroys old snippets from ace snippetmanager