### PR TITLE
Replaced git for https in clone URL.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "lodash": "~2.4.1",
     "backbone": "1.1.0",
     "jquery-mousewheel": "~3.1.9",
-    "i18next": "git://github.com/nwinter/i18next.git",
+    "i18next": "https://github.com/nwinter/i18next.git",
     "firepad": "~0.1.2",
     "marked": "~0.3.0",
     "moment": "~2.5.0",


### PR DESCRIPTION
If the user did not have access to SSH towards git, the installation would fail:  This was causing problems such as ![this](https://s3.amazonaws.com/uploads.hipchat.com/60497/1761100/RNGJU5a6mMMyI53/Error.png)