### PR TITLE
Add type (warrior/ranger/wizard)  to hero selector modal (Issue #2307)

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -442,6 +442,7 @@
     lua_blurb: "Game scripting language."
     io_blurb: "Simple but obscure."
     status: "Status"
+    hero_type: "Type"
     weapons: "Weapons"
     weapons_warrior: "Swords - Short Range, No Magic"
     weapons_ranger: "Crossbows, Guns - Long Range, No Magic"

--- a/app/styles/play/modal/play-heroes-modal.sass
+++ b/app/styles/play/modal/play-heroes-modal.sass
@@ -1,7 +1,7 @@
 @import "app/styles/mixins"
 @import "app/styles/bootstrap/variables"
 
-$heroCanvasHeight: 265px
+$heroCanvasHeight: 275px
 
 #play-heroes-modal
   @include user-select(none)
@@ -198,10 +198,10 @@ $heroCanvasHeight: 265px
           color: white
           
         .hero-description
-          margin-bottom: 10px
+          margin-bottom: 7px
         
         .hero-stat-row
-          margin: 5px 0
+          margin: 4px 0
           
           .stat-label
             float: left

--- a/app/templates/play/modal/play-heroes-modal.jade
+++ b/app/templates/play/modal/play-heroes-modal.jade
@@ -37,7 +37,11 @@
               .hero-stat-row
                 .stat-label(data-i18n='choose_hero.status')
                 .stat-value.hero-status-value(data-i18n=hero.restricted ? 'inventory.restricted_title' : (hero.purchasable ? 'play.purchasable' : (hero.locked ? 'play.locked' : 'play.available')))
-                
+              
+              .hero-stat-row
+                .stat-label(data-i18n='choose_hero.hero_type')  
+                .stat-value(data-i18n='general.' +hero.class)
+
               .hero-stat-row
                 .stat-label(data-i18n='choose_hero.weapons')
                 .stat-value(data-i18n='choose_hero.weapons_'+hero.class)


### PR DESCRIPTION
(Issue #2307) 

Now you can also see the type of a hero in the hero selector modal

![untitled](https://cloud.githubusercontent.com/assets/3805149/6215206/c71592d0-b641-11e4-941d-ef28ef66f8dd.png)
