### PR TITLE
Clarified level indicator for #2351

### DIFF
--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -376,7 +376,7 @@ $gameControlMargin: 30px
         height: 32px
         color: white
 
-      .gem, .player-level-icon, .player-hero-icon
+      .gem, .level-indicator .player-level-icon, .player-hero-icon
         position: absolute
         top: 1px
 
@@ -384,7 +384,7 @@ $gameControlMargin: 30px
         margin-left: 40px
 
       .player-level
-        margin-left: 34px
+        margin-left: 5px
 
       .player-name
         margin-left: 45px
@@ -399,6 +399,12 @@ $gameControlMargin: 30px
         width: 30px
         height: 30px
         margin: 0px 2px
+
+      .level-indicator
+        margin-left: 15px
+        color: #E5C100
+        display: inline-block
+        margin: 0p 2px
 
       .player-hero-icon
         margin-left: 10px

--- a/app/templates/play/campaign-view.jade
+++ b/app/templates/play/campaign-view.jade
@@ -93,7 +93,7 @@ else
   .user-status-line
     span.gem.gem-30
     span#gems-count.spr= me.gems()
-    span.level-indicator Level
+    span.level-indicator(data-i18n="general.player_level")
     span.player-level.spr= me.level()
     span.player-hero-icon
     if me.get('anonymous')

--- a/app/templates/play/campaign-view.jade
+++ b/app/templates/play/campaign-view.jade
@@ -93,7 +93,7 @@ else
   .user-status-line
     span.gem.gem-30
     span#gems-count.spr= me.gems()
-    span.player-level-icon
+    span.level-indicator Level
     span.player-level.spr= me.level()
     span.player-hero-icon
     if me.get('anonymous')


### PR DESCRIPTION
There was a level indicator in campaign view, but it said XP and was confusing.
![selection_009](https://cloud.githubusercontent.com/assets/10272301/6312908/a25eaef0-b95b-11e4-9058-21778cc19632.png)

I changed it to say 'Level' for clarity.

![selection_010](https://cloud.githubusercontent.com/assets/10272301/6312909/cfb8392a-b95b-11e4-811d-2a5c01cf345c.png)

