### PR TITLE
Issue #2082: Campaign editor login fixed

### DIFF
--- a/app/views/editor/campaign/CampaignEditorView.coffee
+++ b/app/views/editor/campaign/CampaignEditorView.coffee
@@ -255,6 +255,9 @@ module.exports = class CampaignEditorView extends RootView
       if achievement.hasLocalChanges()
         @toSave.add achievement
 
+  onClickLoginButton: ->
+    # Do Nothing 
+    # This is a override method to RootView, so that only CampaignView is listenting to login button click
 
 class LevelsNode extends TreemaObjectNode
   valueClass: 'treema-levels'


### PR DESCRIPTION
Override  RootView's onClickLoginButton method in CampaignEditorView with a blank method so that only CampaignView is listening to this method.