### PR TITLE
Update hero-victory-modal.sass (Issue 1917)

### DIFF
--- a/app/styles/play/level/modal/hero-victory-modal.sass
+++ b/app/styles/play/level/modal/hero-victory-modal.sass
@@ -398,5 +398,6 @@ body.ipad
     .xp .pulse, .gems .pulse
       @include animation(none)
 
-body[lang='ru'] #hero-victory-modal #totals .total-wrapper .total-label
-  font-size: 12px
+body[lang='ru'], body[lang^='es-ES'], body[lang^='it'], body[lang^='hu'], body[lang^='mk-MK'], body[lang^='ja'], body[lang^='uk']
+  #hero-victory-modal #totals .total-wrapper .total-label
+    font-size: 12px


### PR DESCRIPTION
This fixes the issue #1917 for many languages such as Hungarian, Italian, Japanese, ...

The expression "Gems Gained" currently doesn't have translations in many languages so probably the issue #1917 will still be there for a while. 