### PR TITLE
Adding {change} to files when propagination.

### DIFF
--- a/scripts/copy-i18n-tags.coffee
+++ b/scripts/copy-i18n-tags.coffee
@@ -25,6 +25,7 @@ for section in splitByCategories
 
 dir = fs.readdirSync 'app/locale'
 for file in dir when not (file in ['locale.coffee', 'en.coffee'])
+  fileSource = fs.readFileSync 'app/locale/' + file, encoding='utf8'
   contents = require('../app/locale/' + file)
   categories = contents.translation
   lines = ["module.exports = nativeDescription: \"#{contents.nativeDescription}\", englishDescription: \"#{contents.englishDescription}\", translation:"]
@@ -44,6 +45,13 @@ for file in dir when not (file in ['locale.coffee', 'en.coffee'])
       if commentsMap[enCat]? and commentsMap[enCat][enTag]?
         comment = " \##{commentsMap[enCat][enTag]}"
 
+      if fileSource.search(new RegExp("#?    #{enTag}: \"#{tag}\".*\{change\}.*")) >= 0 and comment.search(/.*\{change\}/) < 0
+        comment = " \#" + comment if comment is "" 
+        comment = comment + " {change}"
+
       lines.push "#{if tagMissing then '#' else ''}    #{enTag}: \"#{tag}\"#{comment}"
   newContents = lines.join('\n') + '\n'
   fs.writeFileSync 'app/locale/' + file, newContents
+
+enSource = enSource.replace /\s?(#\s)?\{change\}/g, ""
+fs.writeFileSync 'app/locale/en.coffee', enSource


### PR DESCRIPTION
Fix Issue #2428

So, how it works.
Dev change some line in en.coffee. 
If he add {change} in comment of this line:
* this {change} will be added to all non-en files for this line
* {change} will be removed from en.coffee

If there is no comment in non-eu - " # {change}" will be added to line
If there is {change} in non-eu already - no doubles of {change}

Old mechanism of syncing comments from en also isn't broken - if there is a change in comment in eu and {change} in non-eu then new_comment + {change} will be added to non-eu

Totals: what is needed from dev? add {change} to en.coffee when dev change line. thats all.

If it will be merged to master, @popey456963 or @nwinter could you update devs guide for this? and some anounce would be great.
Also @Imperadeiro98 please participate in the discussion :)