### PR TITLE
More humane view of i18n-editor

### DIFF
--- a/app/templates/i18n/i18n-edit-model-view.jade
+++ b/app/templates/i18n/i18n-edit-model-view.jade
@@ -54,12 +54,14 @@ block outer_content
     
     select.form-control#language-select
 
-    table.table
-      for row in translationList
-        tr(data-format=row.format || '')
+    for row in translationList
+      table.table
+        tr
           th= row.title
+        tr(data-format=row.format || '')
           td.english-value-row
             div= row.enValue
+        tr(data-format=row.format || '')
           td.to-value-row
             if row.format === 'markdown'
               div(data-index=row.index.toString())= row.toValue

--- a/app/views/i18n/I18NEditModelView.coffee
+++ b/app/views/i18n/I18NEditModelView.coffee
@@ -55,13 +55,18 @@ module.exports = class I18NEditModelView extends RootView
     editors = []
 
     @$el.find('tr[data-format="markdown"]').each((index, el) =>
-      englishEditor = ace.edit(enEl=$(el).find('.english-value-row div')[0])
-      englishEditor.el = enEl
-      englishEditor.setReadOnly(true)
-      toEditor = ace.edit(toEl=$(el).find('.to-value-row div')[0])
-      toEditor.el = toEl
-      toEditor.on 'change', @onEditorChange
-      editors = editors.concat([englishEditor, toEditor])
+      foundEnEl = enEl=$(el).find('.english-value-row div')[0]
+      if foundEnEl?
+        englishEditor = ace.edit(foundEnEl)
+        englishEditor.el = enEl
+        englishEditor.setReadOnly(true)
+        editors.push englishEditor
+      foundToEl = toEl=$(el).find('.to-value-row div')[0]
+      if foundToEl?
+        toEditor = ace.edit(foundToEl)
+        toEditor.el = toEl
+        toEditor.on 'change', @onEditorChange
+        editors.push toEditor
     )
 
     for editor in editors


### PR DESCRIPTION
Fix for Issue https://github.com/codecombat/codecombat/issues/2455
Change the layout to
Description 1
en
non-en

Description 2
en
non-en

etc...

It looks like this
![default](https://cloud.githubusercontent.com/assets/1132840/6597502/2d45ff3a-c80e-11e4-8557-c069b0890d1a.PNG)