### PR TITLE
Integrate Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ Thumbs.db
 node_modules/
 bower_components/
 
+# Vagrant
+.vagrant/
+
 # Some other random stuff
 always-ignore extensions
 *.diff

--- a/.npmignore
+++ b/.npmignore
@@ -59,6 +59,9 @@ Thumbs.db
 # NPM packages folder.
 node_modules/
 
+# Vagrant
+.vagrant/
+
 # Some other random stuff
 always-ignore extensions
 *.diff

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,19 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Original content copyright (c) 2014 dpen2000 licensed under the MIT license
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "hashicorp/precise64"
+
+  config.vm.network "forwarded_port", guest: 3000, host: 3000
+
+  config.vm.provision "shell", path: "scripts/vagrant/provision.sh"
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    v.cpus = 2
+  end
+
+end

--- a/scripts/vagrant/brunch.bat
+++ b/scripts/vagrant/brunch.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+vagrant ssh -c "cd /vagrant && bin/coco-brunch"  
+

--- a/scripts/vagrant/brunch.sh
+++ b/scripts/vagrant/brunch.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+vagrant ssh -c "cd /vagrant && bin/coco-brunch"
+

--- a/scripts/vagrant/dev-server.bat
+++ b/scripts/vagrant/dev-server.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+vagrant ssh -c "cd /vagrant && bin/coco-dev-server"
+

--- a/scripts/vagrant/dev-server.sh
+++ b/scripts/vagrant/dev-server.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+vagrant ssh -c "cd /vagrant && bin/coco-dev-server"
+

--- a/scripts/vagrant/fillMongo.sh
+++ b/scripts/vagrant/fillMongo.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Original content copyright (c) 2014 dpen2000 licensed under the MIT license
+mkdir -p /vagrant/temp
+cd /vagrant/temp
+rm -f dump.tar.gz
+rm -rf dump
+wget http://analytics.codecombat.com:8080/dump.tar.gz
+tar xzvf dump.tar.gz --no-same-owner
+mongorestore

--- a/scripts/vagrant/provision.sh
+++ b/scripts/vagrant/provision.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Original content copyright (c) 2014 dpen2000 licensed under the MIT license
+sudo apt-get -y update
+sudo apt-get -y install python-software-properties git
+sudo add-apt-repository -y ppa:chris-lea/node.js
+sudo apt-get -y update
+sudo apt-get -y install nodejs
+sudo apt-get -y install g++ make coffeescript
+cd /vagrant
+sudo npm install
+sudo npm install -g bower
+sudo npm install -g brunch
+sudo npm install -g geoip-lite
+bower install --allow-root
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+sudo apt-get -y update
+sudo apt-get -y install mongodb-org
+sudo apt-get -y install ruby1.9.1 ruby1.9.1-dev
+sudo gem install sass
+npm install mongoose
+bash /vagrant/scripts/vagrant/fillMongo.sh


### PR DESCRIPTION
Automatic setup of a CodeCombat development environment using Vagrant, VirtualBox, and Ubuntu.

Once integrated, I can update the wiki to reflect the new instructions:
1. `vagrant up` from the root directory
2. `scripts/vagrant/brunch.sh` from the root directory
3. `scripts/vagrant/dev-server.sh` from the root directory

Once Brunch indicates that it's done compiling, visit http://localhost:3000.

The Vagrantfile and provisioning scripts were originally developed by dpen2000 and are hosted on GitHub under an MIT license. I am contributing based on the permissions under the MIT license to use, copy, modify, merge, publish, distribute, and sublicense without limitation.
