### PR TITLE
add user backup / restore for Vagrant

### DIFF
--- a/scripts/vagrant/backup.bat
+++ b/scripts/vagrant/backup.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+vagrant ssh -c "cd /vagrant/scripts/vagrant && bash backupMongo.sh"
+

--- a/scripts/vagrant/backup.sh
+++ b/scripts/vagrant/backup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+vagrant ssh -c "cd /vagrant/scripts/vagrant && bash backupMongo.sh"
+

--- a/scripts/vagrant/backupMongo.sh
+++ b/scripts/vagrant/backupMongo.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+mkdir -p /vagrant/temp
+cd /vagrant/temp
+rm -fr backup
+mkdir backup
+cd backup
+mongodump -db coco --collection users 
+mongodump -db coco --collection earnedachievements

--- a/scripts/vagrant/fillMongo.sh
+++ b/scripts/vagrant/fillMongo.sh
@@ -6,4 +6,9 @@ rm -f dump.tar.gz
 rm -rf dump
 wget http://analytics.codecombat.com:8080/dump.tar.gz
 tar xzvf dump.tar.gz --no-same-owner
-mongorestore
+mongorestore --drop
+if [ -d /vagrant/temp/backup ]
+then
+  cd /vagrant/temp/backup
+  mongorestore
+fi

--- a/scripts/vagrant/update.bat
+++ b/scripts/vagrant/update.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+vagrant ssh -c "cd /vagrant/scripts/vagrant && bash fillMongo.sh"
+

--- a/scripts/vagrant/update.sh
+++ b/scripts/vagrant/update.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+vagrant ssh -c "cd /vagrant/scripts/vagrant && bash fillMongo.sh"
+


### PR DESCRIPTION
Adds a script that can be used to backup the `users` and `earnedachievements` collections.

Designed to allow rebuilding the Vagrant VM (with `destroy` and `up`) without losing created users.
