### PR TITLE
Vagrant node modules

### DIFF
--- a/scripts/vagrant/brunch.sh
+++ b/scripts/vagrant/brunch.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+vagrant ssh -c "sudo mount -o bind /node_modules /vagrant/node_modules"
 vagrant ssh -c "cd /vagrant && bin/coco-brunch"
 

--- a/scripts/vagrant/dev-server.sh
+++ b/scripts/vagrant/dev-server.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+vagrant ssh -c "sudo mount -o bind /node_modules /vagrant/node_modules"
 vagrant ssh -c "cd /vagrant && bin/coco-dev-server"
 

--- a/scripts/vagrant/provision.sh
+++ b/scripts/vagrant/provision.sh
@@ -5,12 +5,16 @@ sudo apt-get -y install python-software-properties git
 sudo add-apt-repository -y ppa:chris-lea/node.js
 sudo apt-get -y update
 sudo apt-get -y install nodejs
-sudo apt-get -y install g++ make coffeescript
+sudo apt-get -y install g++ make 
+sudo mkdir /node_modules
+sudo chown vagrant:vagrant /node_modules
+sudo mount -o bind /node_modules /vagrant/node_modules
 cd /vagrant
 sudo npm install
 sudo npm install -g bower
 sudo npm install -g brunch
 sudo npm install -g geoip-lite
+sudo npm install -g coffee-script
 bower install --allow-root
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list

--- a/scripts/vagrant/provision.sh
+++ b/scripts/vagrant/provision.sh
@@ -6,6 +6,7 @@ sudo add-apt-repository -y ppa:chris-lea/node.js
 sudo apt-get -y update
 sudo apt-get -y install nodejs
 sudo apt-get -y install g++ make 
+mkdir /vagrant/node_modules
 sudo mkdir /node_modules
 sudo chown vagrant:vagrant /node_modules
 sudo mount -o bind /node_modules /vagrant/node_modules


### PR DESCRIPTION
I think I've tracked down the issue that made Vagrant misbehave on Windows.

It appears that when there is a version mismatch between VirtualBox on the host and the VirtualBox Guest Additions inside the VM, symbolic links do not work for shared folders.

Guest additions is installed when the base box is built, so we can't easily control the version, and we don't want this cropping up every time someone upgrades VirtualBox. But npm needs symbolic links to work right. (Apart from this, npm likes long path names, which are also an issue within shared folders on Windows.)

I tossed around a few ideas and finally settled on making a directory within the VM and bind mounting it over top of `node_modules`. It works for me on Windows 7 with the latest VirtualBox.