### PR TITLE
add websocket port forward for Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "hashicorp/precise64"
 
   config.vm.network "forwarded_port", guest: 3000, host: 3000
+  config.vm.network "forwarded_port", guest: 9485, host: 9485
 
   config.vm.provision "shell", path: "scripts/vagrant/provision.sh"
   config.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
Forward the websocket port out of the virtual machine so the browser can connect to it