### PR TITLE
vagrant brunch detect file changes made on host

### DIFF
--- a/config.coffee
+++ b/config.coffee
@@ -39,6 +39,9 @@ exports.config =
         # So we remove the ones that have public in them.
         exec = require('child_process').exec
         exec "perl -pi -e 's/\\/\\/# sourceMappingURL=public.*//g' public/javascripts/*.js"
+    vagrant:
+      watcher:
+        usePolling: true
 
   files:
     javascripts:

--- a/scripts/vagrant/brunch.sh
+++ b/scripts/vagrant/brunch.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 vagrant ssh -c "sudo mount -o bind /node_modules /vagrant/node_modules"
-vagrant ssh -c "cd /vagrant && bin/coco-brunch"
+vagrant ssh -c "cd /vagrant && BRUNCH_ENV=vagrant bin/coco-brunch"
 


### PR DESCRIPTION
While testing with Vagrant, I noticed that changes made on the host weren't automatically getting picked up by brunch, but changes on the VM were.

I created a config section for brunch that switches brunch over to watching files by polling and updated the script so it gets used when running via Vagrant.

I do see a CPU hit from this while brunch is running, but it seems worth it since otherwise it breaks a pretty important part of the development workflow.
