### PR TITLE
Vector.toString precision parameter

### DIFF
--- a/app/lib/world/vector.coffee
+++ b/app/lib/world/vector.coffee
@@ -111,10 +111,9 @@ class Vector
   invalid: () ->
     return (@x is Infinity) || isNaN(@x) || @y is Infinity || isNaN(@y) || @z is Infinity || isNaN(@z)
 
-  toString: (useZ) ->
-    useZ = true
-    return "{x: #{@x.toFixed(0)}, y: #{@y.toFixed(0)}, z: #{@z.toFixed(0)}}" if useZ
-    return "{x: #{@x.toFixed(0)}, y: #{@y.toFixed(0)}}"
+  toString: (precision = 2) ->
+    return "{x: #{@x.toFixed(precision)}, y: #{@y.toFixed(precision)}, z: #{@z.toFixed(precision)}}"
+
 
   serialize: ->
     {CN: @constructor.className, x: @x, y: @y, z: @z}


### PR DESCRIPTION
Vector.toString changed to accept precision parameter, defaulted to 2. Allows more natural display of small or normalized vectors. removed non-functional useZ parameter.