### PR TITLE
Yellow arrow shouldn't point to replayable levels

### DIFF
--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -302,7 +302,7 @@ module.exports = class CampaignView extends RootView
       unless foundNext
         for nextLevelOriginal in level.nextLevels
           nextLevel = _.find levels, original: nextLevelOriginal
-          if nextLevel and not nextLevel.locked and @levelStatusMap[nextLevel.slug] isnt 'complete' and nextLevel.slug isnt 'lost-viking' and (
+          if nextLevel and not nextLevel.locked and @levelStatusMap[nextLevel.slug] isnt 'complete' and nextLevel.slug isnt 'lost-viking' and not nextLevel.replayable and (
             me.isPremium() or
             not nextLevel.requiresSubscription or
             nextLevel.slug is 'apocalypse' or


### PR DESCRIPTION
Prevent the campaign map yellow arrow from pointing to replayable levels, so people don't think they're required for the campaign progression.