### PR TITLE
Limit multiplayer leaderboard name width even more

### DIFF
--- a/app/styles/play/ladder/ladder-tab-view.sass
+++ b/app/styles/play/ladder/ladder-tab-view.sass
@@ -1,6 +1,6 @@
 #ladder-tab-view
   .name-col-cell
-    max-width: 150px
+    max-width: 100px
     white-space: nowrap
     overflow: hidden
     text-overflow: ellipsis

--- a/app/styles/play/ladder/ladder.sass
+++ b/app/styles/play/ladder/ladder.sass
@@ -75,7 +75,7 @@
       color: white
 
   .name-col-cell
-    max-width: 150px
+    max-width: 100px
     text-overflow: ellipsis
     white-space: nowrap
     overflow: hidden


### PR DESCRIPTION
adjusted max-width to 100px, fixes #2373 

![maybe-right](https://cloud.githubusercontent.com/assets/6857146/8255712/d328c464-1656-11e5-9ca7-da0ffcf2c069.png)
