### PR TITLE
Update de-DE.coffee

### DIFF
--- a/app/locale/de-DE.coffee
+++ b/app/locale/de-DE.coffee
@@ -415,7 +415,7 @@ module.exports = nativeDescription: "Deutsch (Deutschland)", englishDescription:
     feature6: "Premium Emailsupport"
 #    feature7: "Private <strong>Clans</strong>"
     free: "Kostenlos"
-    month: "Monate"
+    month: "Monat"
     subscribe_title: "Abonnieren"
     unsubscribe: "Abmelden"
     confirm_unsubscribe: "Abmeldung bestätigen"


### PR DESCRIPTION
Beim Dialog Abonnieren steht "$9.99/Monate". Es sollte aber "$9.99/Monat" heißen. Dev-tools sagen, dass der Text von subscribe.month stammt, wo "Monate" steht.