### PR TITLE
Improved `updateLevelRequiredItems` logic regarding rings, fixes #2740

### DIFF
--- a/app/views/play/menu/InventoryModal.coffee
+++ b/app/views/play/menu/InventoryModal.coffee
@@ -430,10 +430,20 @@ module.exports = class InventoryModal extends ModalView
   updateLevelRequiredItems: (equipment) ->
     return unless requiredGear = @options.level.get 'requiredGear'
     return unless heroClass = @selectedHero?.get 'heroClass'
+
+    ringSlots = ['left-ring', 'right-ring']
+
     for slot, items of requiredGear when items.length
-      equipped = equipment[slot]
-      continue if equipped in items
-      continue if equipped  # Actually, just let them play if they have equipped anything in that slot (and we haven't unequipped it due to restrictions).
+      if slot in ringSlots
+        validSlots = ringSlots
+      else
+        validSlots = [slot]
+
+      continue if validSlots.some (slot) ->
+        equipped = equipment[slot]
+        equipped in items
+
+      continue if equipment[slot]  # Actually, just let them play if they have equipped anything in that slot (and we haven't unequipped it due to restrictions).
       items = (item for item in items when heroClass in (@items.findWhere(original: item)?.classes ? []))
       continue unless items.length  # If the required items are for another class, then let's not be finicky.
 


### PR DESCRIPTION
This fixes the main issue of #2740, allowing the player to play the level if the required ring is equipped on either ring slot.

There's still a small problem: if the player already had a ring equipped in the `right-ring` slot, the Ring of flowers will not display as required due to this [line](https://github.com/codecombat/codecombat/blob/0df6da7efa3df9ff6cd0e65133ff31923a9a0ee8/app/views/play/menu/InventoryModal.coffee#L436). This seems to be a different issue though, probably related to the `unequipLevelRestrictedItems` logic.