### PR TITLE
Add VMware support and fix ulimits

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,14 +6,22 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  
+
+  # A VMware compatible box is avaliable from:
+  # https://github.com/spkane/vagrant-boxes/releases/download/v1.0.0/trusty64_vmware.box
   config.vm.box = "ubuntu/trusty64"
-  
+
   config.vm.network "forwarded_port", guest: 3000, host: 3000
   config.vm.network "forwarded_port", guest: 9485, host: 9485
 
   config.vm.provision "shell", path: "scripts/vagrant/provision.sh"
+
   config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    v.cpus = 2
+  end
+
+  config.vm.provider "vmware_fusion" do |v|
     v.memory = 2048
     v.cpus = 2
   end

--- a/scripts/vagrant/provision.sh
+++ b/scripts/vagrant/provision.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 # Original content copyright (c) 2014 dpen2000 licensed under the MIT license
+
+# Set default ulimits
+cat <<- EOF > /tmp/limits.conf
+* soft nofile 10000
+* hard nofile 10000
+EOF
+sudo mv /tmp/limits.conf /etc/security/limits.conf
+sudo chown root:root /etc/security/limits.conf
+
+#Install required software
 sudo apt-get -y update
 sudo apt-get -y install python-software-properties git
 sudo add-apt-repository -y ppa:chris-lea/node.js
 sudo apt-get -y update
 sudo apt-get -y install nodejs
-sudo apt-get -y install g++ make 
+sudo apt-get -y install g++ make
 mkdir /vagrant/node_modules
 sudo mkdir /node_modules
 sudo chown vagrant:vagrant /node_modules


### PR DESCRIPTION
* This updates the vagrant provisioning script to correctly set the ulimits in Ubuntu, since the `bin/coco-brunch` file can't set them properly when run as the vagrant user.
* Added some basic support into the Vagrantfile for VMware providers and uploaded a VMware compatible vagrant box based on trusty64 to https://github.com/spkane/vagrant-boxes/releases/download/v1.0.0/trusty64_vmware.box, that folks can use.