### PR TITLE
Fix poll keys when key is a number

### DIFF
--- a/app/views/play/modal/PollModal.coffee
+++ b/app/views/play/modal/PollModal.coffee
@@ -73,7 +73,7 @@ module.exports = class PollModal extends ModalView
   onClickAnswer: (e) ->
     $selectedAnswer = $(e.target).closest('.answer')
     pollVotes = @userPollsRecord.get('polls') ? {}
-    pollVotes[@poll.id] = $selectedAnswer.data('answer')
+    pollVotes[@poll.id] = $selectedAnswer.data('answer').toString()
     @userPollsRecord.set 'polls', pollVotes
     @updateAnswers true
     @userPollsRecord.save {polls: pollVotes}, {success: => @awardRandomGems?()}


### PR DESCRIPTION
jQuery converts data strings into a possible JavaScript value, so keys like '0' and '1' get converted into numbers, which fails the validation (it expects a string for a key).

fixes #2924 