### PR TITLE
Fix the headless simulator

### DIFF
--- a/headless_client.coffee
+++ b/headless_client.coffee
@@ -50,13 +50,14 @@ Worker::removeEventListener = (what) ->
   if what is 'message'
     @onmessage = -> #This webworker api has only one event listener at a time.
 GLOBAL.tv4 = require('tv4').tv4
-GLOBAL.TreemaUtils = require './bower_components/treema/treema-utils.js'
+GLOBAL.TreemaUtils = require bowerComponentsPath + 'treema/treema-utils'
 GLOBAL.marked = setOptions: ->
 store = {}
 GLOBAL.localStorage =
     getItem: (key) => store[key]
     setItem: (key, s) => store[key] = s
     removeItem: (key) => delete store[key]
+GLOBAL.lscache = require bowerComponentsPath + 'lscache/lscache'
 
 # Hook node.js require. See https://github.com/mfncooper/mockery/blob/master/mockery.js
 # The signature of this function *must* match that of Node's Module._load,

--- a/headless_client/worker_world.coffee
+++ b/headless_client/worker_world.coffee
@@ -2,7 +2,6 @@
 # This function needs to run inside an environment that has a 'self'.
 # This specific worker is targeted towards the node.js headless_client environment.
 
-JASON = require 'JASON'
 fs = require 'fs'
 GLOBAL.Aether = Aether = require 'aether'
 GLOBAL._ = _ = require 'lodash'
@@ -10,12 +9,12 @@ GLOBAL.CoffeeScript = require 'coffee-script'
 
 betterConsole = () ->
 
-  self.logLimit = 200;
-  self.logsLogged = 0;
+  self.logLimit = 200
+  self.logsLogged = 0
 
   self.transferableSupported = () -> true
 
-  self.console = log: ->
+  self.console = log: (args...) ->
     if self.logsLogged++ is self.logLimit
       self.postMessage
         type: 'console-log'
@@ -23,7 +22,6 @@ betterConsole = () ->
         id: self.workerID
 
     else if self.logsLogged < self.logLimit
-      args = [].slice.call(arguments)
       i = 0
 
       while i < args.length
@@ -111,7 +109,7 @@ work = () ->
     t1 = new Date()
     diff = t1 - self.t0
     if (self.world.headless)
-      return console.log("Headless simulation completed in #{diff}ms.");
+      return console.log("Headless simulation completed in #{diff}ms.")
 
     transferableSupported = self.transferableSupported()
     try
@@ -191,11 +189,11 @@ for codeFile in [
     'app/vendor/aether-lua.js'
     'app/vendor/aether-python.js'
   ]
-  codeFileContents.push fs.readFileSync("./public/javascripts/#{codeFile}", 'utf8')
+  codeFileContents.push fs.readFileSync(__dirname + "/../public/javascripts/#{codeFile}", 'utf8')
 
 #window.BOX2D_ENABLED = true;
 
-newConsole = "newConsole = #{}JASON.stringify newConsole}()";
+newConsole = "newConsole = #{}(newConsole.toString())}()"
 
 ret = """
 
@@ -204,7 +202,7 @@ ret = """
 
   self.workerID = 'Worker';
 
-  console = #{JASON.stringify betterConsole}();
+  console = (#{betterConsole.toString()})();
 
   try {
     // the world javascript file
@@ -215,7 +213,7 @@ ret = """
     self.native_fs_ = native_fs_ = null;
 
     // the actual function
-    #{JASON.stringify work}();
+    (#{work.toString()})();
   } catch (error) {
     self.postMessage({'type': 'console-log', args: ['An unhandled error occured: ', error.toString(), error.stack], id: -1});
   }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "multiplayer"
   ],
   "dependencies": {
-    "JASON": "~0.1.3",
     "JQDeferred": "~2.1.0",
     "aether": "~0.3.0",
     "async": "0.2.x",

--- a/server/queues/scoring.coffee
+++ b/server/queues/scoring.coffee
@@ -169,6 +169,7 @@ module.exports.getTwoGames = (req, res) ->
       sendResponseObject req, res, taskObject
   else
     #console.log "Directly simulating #{humansGameID} vs. #{ogresGameID}."
+    selection = 'team totalScore transpiledCode submittedCodeLanguage teamSpells levelID creatorName creator submitDate'
     LevelSession.findOne(_id: humansGameID).select(selection).lean().exec (err, humanSession) =>
       if err? then return errors.serverError(res, 'Couldn\'t find the human game')
       LevelSession.findOne(_id: ogresGameID).select(selection).lean().exec (err, ogreSession) =>


### PR DESCRIPTION
"Shims" `lscache`, support io.js < v3.0.0. Make simulating `one-game` possible.

Tested on Linux with Node.js v0.10.40 and v0.12.7; as well as io.js v2.5.0.

It still won't work with io.js v3.0.0 because `webworker-threads` doesn't compile properly, so that's another problem.

Hopefully nothing else changed (as in the actual simulation results).