### PR TITLE
Fixed #2729 (bug in the article preview button)

### DIFF
--- a/app/views/editor/article/ArticleEditView.coffee
+++ b/app/views/editor/article/ArticleEditView.coffee
@@ -54,8 +54,12 @@ module.exports = class ArticleEditView extends RootView
     return unless @treema and @preview
     m = marked(@treema.data.body)
     b = $(@preview.document.body)
-    b.find('#insert').html(m)
-    b.find('#title').text(@treema.data.name)
+    onLoadHandler = =>
+      if b.find('#insert').length == 1
+        b.find('#insert').html(m)
+        b.find('#title').text(@treema.data.name)
+        clearInterval(id)
+    id = setInterval(onLoadHandler, 100)
 
   getRenderData: (context={}) ->
     context = super(context)
@@ -71,7 +75,8 @@ module.exports = class ArticleEditView extends RootView
     @patchesView.load()
 
   openPreview: ->
-    @preview = window.open('/editor/article/preview', 'preview', 'height=800,width=600')
+    if not @preview or @preview.closed
+      @preview = window.open('/editor/article/preview', 'preview', 'height=800,width=600')
     @preview.focus() if window.focus
     @preview.onload = => @pushChangesToPreview()
     return false


### PR DESCRIPTION
This commit is for issue #2729. Probably the bug occurred because it takes a moment for the preview page to get loaded in the new window. Now the button works as intended.
![workspace 1_004](https://cloud.githubusercontent.com/assets/3805149/9281968/104bf684-4304-11e5-9462-c15a6d7e3370.png)