### PR TITLE
Allow embedded help videos to go fullscreen

### DIFF
--- a/app/views/play/menu/GuideView.coffee
+++ b/app/views/play/menu/GuideView.coffee
@@ -122,6 +122,7 @@ module.exports = class LevelGuideView extends CocoView
     tag.height = @helpVideoHeight
     tag.width = @helpVideoWidth
     tag.frameborder = '0'
+    tag.allowFullscreen = true
     @$el.find('#help-video-player').replaceWith(tag)
 
     @onMessageReceived = (e) =>


### PR DESCRIPTION
Original bug report: http://discourse.codecombat.com/t/embedded-video-in-hint-section/5309