### PR TITLE
Remove iframe borders using CSS instead of DOM

### DIFF
--- a/app/styles/common/common.sass
+++ b/app/styles/common/common.sass
@@ -14,6 +14,9 @@ h1, h2, h3, h4, h5, h6
 a
   cursor: pointer
 
+iframe
+  border: none
+
 .error
   left: 8px
 

--- a/app/views/play/menu/GuideView.coffee
+++ b/app/views/play/menu/GuideView.coffee
@@ -121,7 +121,6 @@ module.exports = class LevelGuideView extends CocoView
     tag.src = helpVideoURL + "?api=1&badge=0&byline=0&portrait=0&title=0"
     tag.height = @helpVideoHeight
     tag.width = @helpVideoWidth
-    tag.frameborder = '0'
     tag.allowFullscreen = true
     @$el.find('#help-video-player').replaceWith(tag)
 


### PR DESCRIPTION
This patch makes iframe borders render identically in all supported browsers (i.e. no border).

Although Chrome does not displays borders around iframes by default, Firefox and Edge (IE) had visible iframe borders prior to this patch. This is because, as [previously mentioned](https://github.com/codecombat/codecombat/pull/3122#discussion_r42338590), the DOM property was mistyped as `frameborder` when it should be `frameBorder`.

As this is presentational issue, it feels more appropriate to fix it using CSS. Therefore, I've removed the buggy JS code and added a generic CSS solution to reset iframes' border styling.