### PR TITLE
Added non-mutating methods for Vectors in player code

### DIFF
--- a/test/app/lib/world/vector.spec.coffee
+++ b/test/app/lib/world/vector.spec.coffee
@@ -27,3 +27,57 @@ describe 'Vector', ->
     v2 = v.copy()
     v2.rotate -0.0000001 * Math.PI
     expect(v.distance v2).toBeCloseTo 0
+
+  it 'has class methods equivalent to the instance methods', ->
+    expectEquivalentMethods = (method, arg) ->
+      v = new Vector 7, 7
+      classResult = Vector[method](v, arg)
+      instanceResult = v[method](arg)
+      expect(classResult).toEqual instanceResult
+
+    expectEquivalentMethods 'add', new Vector 1, 1
+    expectEquivalentMethods 'subtract', new Vector 3, 3
+    expectEquivalentMethods 'multiply', 4
+    expectEquivalentMethods 'divide', 2
+    expectEquivalentMethods 'limit', 3
+    expectEquivalentMethods 'normalize'
+    expectEquivalentMethods 'rotate', 0.3
+    expectEquivalentMethods 'magnitude'
+    expectEquivalentMethods 'heading'
+    expectEquivalentMethods 'distance', new Vector 2, 2
+    expectEquivalentMethods 'distanceSquared', new Vector 4, 4
+    expectEquivalentMethods 'dot', new Vector 3, 3
+    expectEquivalentMethods 'equals', new Vector 7, 7
+    expectEquivalentMethods 'copy'
+
+  it "doesn't mutate when in player code", ->
+    expectNoMutation = (fn) ->
+      v = new Vector 5, 5
+      # player code detection hack depends on this property being != null
+      v.__aetherAPIValue = {}
+      v2 = fn v
+      expect(v.x).toEqual 5
+      expect(v).not.toBe v2
+
+    expectNoMutation (v) -> v.normalize()
+    expectNoMutation (v) -> v.limit 2
+    expectNoMutation (v) -> v.subtract new Vector 2, 2
+    expectNoMutation (v) -> v.add new Vector 2, 2
+    expectNoMutation (v) -> v.divide 2
+    expectNoMutation (v) -> v.multiply 2
+    expectNoMutation (v) -> v.rotate 0.5
+
+  it 'mutates when not in player code', ->
+    expectMutation = (fn) ->
+      v = new Vector 5, 5
+      v2 = fn v
+      expect(v.x).not.toEqual 5
+      expect(v).toBe v2
+
+    expectMutation (v) -> v.normalize()
+    expectMutation (v) -> v.limit 2
+    expectMutation (v) -> v.subtract new Vector 2, 2
+    expectMutation (v) -> v.add new Vector 2, 2
+    expectMutation (v) -> v.divide 2
+    expectMutation (v) -> v.multiply 2
+    expectMutation (v) -> v.rotate 0.5


### PR DESCRIPTION
Related to Issue #3110.

- Added hack to detect when it's in Aether-transpiled
- Made the instance methods available class methods
- Made the class methods available as instance methods that will not mutate in player code

I also added "...Self" methods to indicate that a method will mutate. Currently the regular methods will still mutate when called outside of Aether-transpiled code. My thinking is that it allows for refactoring engine code to the Self functions (.add -> .addSelf) to preserve performance (object re-use > object creation). If we go that route, we'll be able to remove the Aether check once everything is refactored, making Vector work the same in player code as it does in the engine.