### PR TITLE
Fix achievements notifications animation

### DIFF
--- a/app/styles/achievements.sass
+++ b/app/styles/achievements.sass
@@ -218,7 +218,7 @@ $user-achievements-scale: 0.8
   cursor: pointer
 
 .popup
-  left: 600px
+  left: -600px
 
 .user-level
   background-image: url("/images/achievements/level-bg.png")

--- a/app/views/core/AchievementPopup.coffee
+++ b/app/views/core/AchievementPopup.coffee
@@ -65,7 +65,7 @@ module.exports = class AchievementPopup extends CocoView
     if @popup
       hide = =>
         return if @destroyed
-        @$el.animate {left: 600}, =>
+        @$el.animate {left: -600}, =>
           @$el.remove()
           @destroy()
       @$el.animate left: 0


### PR DESCRIPTION
This fixes #3243. Achievement notification animation now slides in from
off-screen left and then hides back to off-screen left.