### PR TITLE
Add level to user profile page

### DIFF
--- a/app/templates/user/main-user-view.jade
+++ b/app/templates/user/main-user-view.jade
@@ -22,6 +22,10 @@ block append content
                 span(data-i18n="user.favorite_prefix") Favorite language is
                 strong.favorite-language= favoriteLanguage
                 span(data-i18n="user.favorite_postfix") .
+            if playerLevel
+              div.extra-info
+                span Level 
+                strong= playerLevel
         - var emails = user.getEnabledEmails()
         // TODO: fix this, use some other method for finding contributor classes other than email settings, since they're private... Maybe achievements?
         if emails

--- a/app/views/user/MainUserView.coffee
+++ b/app/views/user/MainUserView.coffee
@@ -46,9 +46,11 @@ module.exports = class MainUserView extends UserView
         if count > mostUsedCount
           mostUsedCount = count
           favoriteLanguage = language
+      playerLevel = @user.level()
       context.singlePlayerSessions = singlePlayerSessions
       context.multiPlayerSessions = multiPlayerSessions
       context.favoriteLanguage = favoriteLanguage
+      context.playerLevel = playerLevel
     if @earnedAchievements and @earnedAchievements.loaded
       context.earnedAchievements = @earnedAchievements
     if @clans and @clans.loaded


### PR DESCRIPTION
![Screenshot of a sample user Profile Page](https://cloud.githubusercontent.com/assets/6085092/11993447/03268cb6-aa57-11e5-84cc-c8160d62d591.png)

This should close #3141 

- [x] Add User's Level to Profile Page
- [x] Link to account page already present