### PR TITLE
Fix thangTypes filtering in serialize

### DIFF
--- a/app/models/Level.coffee
+++ b/app/models/Level.coffee
@@ -28,7 +28,13 @@ module.exports = class Level extends CocoModel
     # Figure out ThangTypes' Components
     tmap = {}
     tmap[t.thangType] = true for t in o.thangs ? []
-    o.thangTypes = (original: tt.get('original'), name: tt.get('name'), components: $.extend(true, [], tt.get('components')) for tt in supermodel.getModels ThangType when tmap[tt.get('original')] or (tt.get('components') and not tt.notInLevel))
+    heroSelected = session.get('heroConfig').thangType
+    o.thangTypes = []
+    for tt in supermodel.getModels ThangType
+      if tmap[tt.get('original')] or
+        (tt.get('kind') isnt 'Hero' and tt.get('kind')? and tt.get('components') and not tt.notInLevel) or
+        (tt.get('kind') is 'Hero' and tt.get('original') is heroSelected)
+          o.thangTypes.push (original: tt.get('original'), name: tt.get('name'), components: $.extend(true, [], tt.get('components')))
     @sortThangComponents o.thangTypes, o.levelComponents, 'ThangType'
     @fillInDefaultComponentConfiguration o.thangTypes, o.levelComponents
 


### PR DESCRIPTION
This fixes #3299. There seemed to be two cases causing the errors that I could find: Thangs that had no kind attribute and Heroes that weren't the player selected character. I filtered those cases out.

Is there a reason I shouldn't be relying on session? Is session.get('heroConfig') the best way to grab the currently selected character?

Anyway, when this fix breaks something else, let me know :wink: 