### PR TITLE
Fix level list highlighted levels

### DIFF
--- a/app/styles/kinds/search.sass
+++ b/app/styles/kinds/search.sass
@@ -18,9 +18,20 @@
     .name-row
       @extend .body-row
       max-width: 300px
+    .description-row
+      @extend .body-row
+      max-width: 520px
     .small-name-row
       @extend .body-row
       max-width: 200px
+    .watch-row
+      @extend .body-row
+      max-width: 80px
+      text-align: center
+      &.watching
+        opacity: 1.0
+      &.not-watching
+        opacity: 0.5
 
     tr.mine
       background-color: #f8ecaa

--- a/app/templates/editor/level/table.jade
+++ b/app/templates/editor/level/table.jade
@@ -1,1 +1,35 @@
 extends /templates/common/table
+
+block tableResultsHeader
+  tr
+    th(colspan=4)
+      span(data-i18n="general.results")
+        | Results
+      span
+        |: #{documents.length}
+
+block tableHeader
+  tr
+    th(data-i18n="general.name") Name
+    th(data-i18n="general.description") Description
+    th(data-i18n="general.version") Version
+    th(data-i18n="common.watch") Watch
+
+block tableBody
+  for document in documents
+    - var data = document.attributes;
+    tr(class=document.get('creator') == me.id ? 'mine' : '')
+      td(title=data.name).name-row
+        a(href="/editor/#{page}/#{data.slug || data._id}")
+          | #{data.name}
+      td(title=data.description).description-row
+        | #{data.description}
+      td #{data.version.major}.#{data.version.minor}
+      if document.watching()
+        td.watch-row.watching
+          span(aria-hidden="true").glyphicon.glyphicon-eye-open
+          span(data-i18n="common.watch").sr-only Watch
+      else
+        td.watch-row.not-watching
+          span(aria-hidden="true").glyphicon.glyphicon-eye-close
+          span(data-i18n="common.unwatch").sr-only Unwatch

--- a/app/views/editor/level/LevelSearchView.coffee
+++ b/app/views/editor/level/LevelSearchView.coffee
@@ -6,6 +6,7 @@ module.exports = class LevelSearchView extends SearchView
   model: require 'models/Level'
   modelURL: '/db/level'
   tableTemplate: require 'templates/editor/level/table'
+  projection: ['slug', 'name', 'description', 'version', 'watchers', 'creator']
   page: 'level'
 
   getRenderData: ->


### PR DESCRIPTION
This fixes #2732. The Level Editor level list now highlights the rows in which you are the person who last saved the level. The level list now also displays glyphicons to indicate watched/unwatched levels.

Since the levels list was hitting the base Handler, I added "watchers" and "creators" to the default PROJECTions there. Let me know if you'd prefer it handled differently.

![screen shot 2016-01-14 at 4 28 52 pm](https://cloud.githubusercontent.com/assets/276924/12342423/0ffb76a2-badf-11e5-9079-96a5a8400b19.png)