### PR TITLE
Fix the fullscreen-code button and beautiful-code button

### DIFF
--- a/app/templates/play/level/tome/spell_list_tab_entry.jade
+++ b/app/templates/play/level/tome/spell_list_tab_entry.jade
@@ -18,12 +18,12 @@ if includeSpellList
     .glyphicon.glyphicon-repeat
     span.spl(data-i18n="play_level.reload") Reload
   
-  if levelType !== 'hero' && levelType !== 'hero-ladder' && levelType !== 'hero-coop'
+  if me.level() >= 15
    .btn.btn-small.btn-illustrated.fullscreen-code(title=maximizeShortcutVerbose)
      .glyphicon.glyphicon-fullscreen
      .glyphicon.glyphicon-resize-small
       
-  if codeLanguage === 'javascript' && levelType !== 'hero' && levelType !== 'hero-ladder' && levelType !== 'hero-coop'
+  if codeLanguage === 'javascript' && me.level() >= 15
     .btn.btn-small.btn-illustrated.beautify-code(title=beautifyShortcutVerbose)
       .glyphicon.glyphicon-magnet
 


### PR DESCRIPTION
Fix the fullscreen-code button of issue #3400. 
Also fix the beautiful-code button for language “Javascript”. Both of the buttons’ appearance are now based on player’s level and the buttons start to show up at level 15 of player level. ^^