### PR TITLE
fix misaligned login

### DIFF
--- a/app/styles/core/loading-error.sass
+++ b/app/styles/core/loading-error.sass
@@ -5,7 +5,7 @@
     margin-top: 20px
   
   .login-btn
-    margin-right: 10px
+    margin-right: 0px
   
   #not-found-img
     max-width: 20%

--- a/app/styles/core/loading-error.sass
+++ b/app/styles/core/loading-error.sass
@@ -7,6 +7,9 @@
   .login-btn
     margin-right: 0px
   
+  #create-account-btn
+    margin-left: 10px
+  
   #not-found-img
     max-width: 20%
     margin: 20px 0


### PR DESCRIPTION
Fixed the issue #3456 
The 'Log In' sentence is now correctly centered in its place. 