### PR TITLE
include iDeal offer for Dutch (nl) users

### DIFF
--- a/app/styles/new-home-view.sass
+++ b/app/styles/new-home-view.sass
@@ -40,6 +40,8 @@
           margin-top: 10px
         #learn-to-code-header
           margin-top: 80px
+        &#ideal-tickets-well
+          margin-top: 20px
         @media (max-width: $screen-md-min)
           margin-top: 320px
 

--- a/app/styles/style-flat.sass
+++ b/app/styles/style-flat.sass
@@ -184,7 +184,16 @@ $forest: #20572B
     background-color: white
     border: 1px solid $gold
     color: $gold
-  
+
+  .btn-purple
+    background-color: $purple
+    color: white
+
+  .btn-gold-alt
+    background-color: white
+    border: 1px solid $purple
+    color: $purple
+
   .btn-lg
     font-size: 18px
     

--- a/app/templates/base-flat.jade
+++ b/app/templates/base-flat.jade
@@ -140,5 +140,8 @@
         img(src="/images/pages/base/logo.png" alt="CodeCombat")
         br.hidden-lg.hidden-md
         span.spr Need help? Email
-        a(href="mailto:team@codecombat.com") team@codecombat.com
+        if (me.get('preferredLanguage', true) || 'en-US').split('-')[0] == 'nl'
+          a(href="mailto:klantenservice@codecombat.nl") klantenservice@codecombat.nl
+        else
+          a(href="mailto:team@codecombat.com") team@codecombat.com
         span.spl and we'll get in touch!

--- a/app/templates/new-home-view.jade
+++ b/app/templates/new-home-view.jade
@@ -21,6 +21,10 @@ block content
                 a.btn.btn-forest.btn-lg.btn-block(href="/courses", data-i18n="new_home.student")
               .col-xs-4
                 a.btn.btn-gold.btn-lg.btn-block(href=view.playURL, data-i18n="new_home.play_now")
+            if (me.get('preferredLanguage', true) || 'en-US').split('-')[0] == 'nl'
+              .row
+                .col-xs-12
+                  a.btn.btn-purple.btn-lg.btn-block(href="https://the-codecombat-ideal-page.com") Koop prepaid codes (iDeal)
 
           .well.text-center.hidden-xs.hidden-sm
             h6#classroom-edition-header(data-i18n="new_home.classroom_edition")
@@ -31,6 +35,12 @@ block content
 
             h6#learn-to-code-header(data-i18n="new_home.learn_to_code")
             a.btn.btn-gold.btn-lg.btn-block(href=view.playURL, data-i18n="new_home.play_now")
+
+          if (me.get('preferredLanguage', true) || 'en-US').split('-')[0] == 'nl'
+            .well#ideal-tickets-well.text-center.hidden-xs.hidden-sm
+              h6 Thuis versie:
+              a.btn.btn-purple.btn-lg.btn-block(href="https://the-codecombat-ideal-page.com") Prepaid codes (iDeal)
+
       .row#learn-more-row
         .col-xs-12.text-center
           a#learn-more-link


### PR DESCRIPTION
For users from Belgium and The Netherlands, a special button is included on the home page (new-home-view) to allow them to buy codes through iDeal, through a dedicated web site.
Also, the email address in the footer is changed to this dedicated domain.