### PR TITLE
Fix teacher quote page having lots of blank space at the bottom (after submitting the form)

### DIFF
--- a/app/views/RequestQuoteView.coffee
+++ b/app/views/RequestQuoteView.coffee
@@ -114,6 +114,7 @@ module.exports = class RequestQuoteView extends RootView
 
   onTrialRequestSubmit: ->
     @$('form, #form-submit-success').toggleClass('hide')
+    $('#flying-focus').css({top: 0, left: 0}) # Hack copied from Router.coffee#187. Ideally we'd swap out the view and have view-swapping logic handle this
     window.tracker?.trackEvent 'Submit Trial Request', category: 'Teachers', label: 'Trial Request', ['Mixpanel']
 
   onClickLoginButton: ->


### PR DESCRIPTION
This is due to `#flying-focus` taking up space at the bottom of the page. This solution is a bandaid. Ideally we have view-swapping logic that contains this type of thing and we just swap out views using one function. But since it just shows/hides some divs, we have to fix `#flying-focus` manually.