### PR TITLE
JS beautifier: fix loop construct, fixes #3510

### DIFF
--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -1193,7 +1193,7 @@ module.exports = class SpellView extends CocoView
   onSpellBeautify: (e) ->
     return unless @spellThang and (@ace.isFocused() or e.spell is @spell)
     ugly = @getSource()
-    pretty = @spellThang.aether.beautify ugly
+    pretty = @spellThang.aether.beautify(ugly.replace /\bloop\b/g, 'while (__COCO_LOOP_CONSTRUCT__)').replace /while \(__COCO_LOOP_CONSTRUCT__\)/g, 'loop'
     @ace.setValue pretty
 
   onMaximizeToggled: (e) ->


### PR DESCRIPTION
Fixes #3510.

As JavaScript is the only language supported by the beautifier, and [CodeCombat is in the process of converting things to while (true)](https://github.com/codecombat/codecombat/issues/3510#issuecomment-201965310), I guess adding this quick hack to the view's code should suffice for now. Hopefully, the non-standard `loop` construct will be removed from other languages before they receive beautifier support.

If this doesn't seem good, I can move  this hack to `aether.beautify`, where it is possible to perform this substitution in a language-aware way (i.e. inside Aether's JavaScript implementation's [`beautify` method](https://github.com/codecombat/aether/blob/418ccf2414c87fa23bf1edcc838266097a2df559/src/languages/javascript.coffee#L137)). Seeing as the `loop` construct is specific to CodeCombat, I'm not sure if that would be a good idea. Passing an options object with a flag to support the `loop` construct seems a bit overkill.

Let me know what works best for you.