### PR TITLE
Pause help videos when guide modal is not visible

### DIFF
--- a/app/views/play/menu/GuideView.coffee
+++ b/app/views/play/menu/GuideView.coffee
@@ -102,6 +102,9 @@ module.exports = class LevelGuideView extends CocoView
     Backbone.Mediator.publish 'level:docs-shown', {}
 
   onHidden: ->
+    if @vimeoListenerAttached
+      player = $('#help-video-player')[0]
+      player.contentWindow.postMessage JSON.stringify(method: 'pause'), '*'
     createjs?.Sound?.setVolume?(@volume ? ( me.get('volume') ? 1.0))
     Backbone.Mediator.publish 'level:docs-hidden', {}
 

--- a/app/views/play/menu/GuideView.coffee
+++ b/app/views/play/menu/GuideView.coffee
@@ -103,7 +103,7 @@ module.exports = class LevelGuideView extends CocoView
 
   onHidden: ->
     if @vimeoListenerAttached
-      player = $('#help-video-player')[0]
+      player = @$('#help-video-player')[0]
       player.contentWindow.postMessage JSON.stringify(method: 'pause'), '*'
     createjs?.Sound?.setVolume?(@volume ? ( me.get('volume') ? 1.0))
     Backbone.Mediator.publish 'level:docs-hidden', {}


### PR DESCRIPTION
Fixes #2159. Use the Vimeo postMessage API to pause the help video when the guide view is hidden.