### PR TITLE
subscribe modal: interpolate feature values for all languages

### DIFF
--- a/app/locale/ar.coffee
+++ b/app/locale/ar.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "العربية", englishDescription: "Arabi
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/bg.coffee
+++ b/app/locale/bg.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "български език", englishDescri
 
   subscribe:
     comparison_blurb: "Изостри уменията си в CodeCombat с абонамент!"
-    feature1: "110+ основни нива в 4 свята" # {change}
-    feature2: "10 силни <strong>нови герои</strong> с уникални умения!"
-    feature3: "70+ бонус нива" # {change}
+    feature1: "$t(data.levelsCount)+ основни нива в $t(data.worldsCount) свята"
+    feature2: "$t(data.heroesCount) силни <strong>нови герои</strong> с уникални умения!"
+    feature3: "$t(data.bonusLevelsCount)+ бонус нива"
     feature4: "<strong>{{gems}} скъпоценни камъни бонус</strong> всеки месец!"
     feature5: "Видео уроци"
     feature6: "Премиум email поддръжка"

--- a/app/locale/ca.coffee
+++ b/app/locale/ca.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Català", englishDescription: "Catalan", tr
 
   subscribe:
     comparison_blurb: "Afina les teves habilitats amb una subscripció a CodeCombat!"
-    feature1: "Més de 60 nivells bàsics a traves de 4 móns" # {change}
-    feature2: "10 <strong>nous herois</strong> poderosos amb habilitats úniques!"
-    feature3: "Més de 80 nivells bonus" # {change}
+    feature1: "Més de $t(data.levelsCount) nivells bàsics a traves de $t(data.worldsCount) móns"
+    feature2: "$t(data.heroesCount) <strong>nous herois</strong> poderosos amb habilitats úniques!"
+    feature3: "Més de $t(data.bonusLevelsCount) nivells bonus"
     feature4: "<strong>{{gems}} gemmes bonus</strong> cada mes!"
     feature5: "Vídeo tutorials"
     feature6: "Suport Premium per correu electrònic"

--- a/app/locale/cs.coffee
+++ b/app/locale/cs.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "čeština", englishDescription: "Czech", tr
 
   subscribe:
     comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-    feature1: "60+ základních úrovní napříč 4 světy" # {change}
-    feature2: "7 silných <strong>nových hrdinů</strong> s jedinečnými dovednostmi!" # {change}
-    feature3: "30+ bonusových úrovní" # {change}
+    feature1: "$t(data.levelsCount)+ základních úrovní napříč $t(data.worldsCount) světy"
+    feature2: "$t(data.heroesCount) silných <strong>nových hrdinů</strong> s jedinečnými dovednostmi!"
+    feature3: "$t(data.bonusLevelsCount)+ bonusových úrovní"
     feature4: "<strong>{{gems}} bonusových drahokamů</strong> každý měsíc!"
     feature5: "Video tutoriály"
     feature6: "Premiová e-mailová podpora"

--- a/app/locale/da.coffee
+++ b/app/locale/da.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "dansk", englishDescription: "Danish", trans
 
   subscribe:
     comparison_blurb: "Skærp dine færdigheder med et CodeCombat abonnement!"
-    feature1: "110+ grundlæggende baner på tværs af 4 verdener"
-    feature2: "10 magtfulde <strong> nye helte </strong> med unikke færdigheder!"
-    feature3: "80+ bonus baner"
+    feature1: "$t(data.levelsCount)+ grundlæggende baner på tværs af $t(data.worldsCount) verdener"
+    feature2: "$t(data.heroesCount) magtfulde <strong> nye helte </strong> med unikke færdigheder!"
+    feature3: "$t(data.bonusLevelsCount)+ bonus baner"
     feature4: "<strong>{{gems}} bonus ædelstene</strong> every month!"
     feature5: "Video tutorials"
     feature6: "Premium e-mail support"

--- a/app/locale/de-AT.coffee
+++ b/app/locale/de-AT.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Deutsch (Österreich)", englishDescription:
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/de-CH.coffee
+++ b/app/locale/de-CH.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Dütsch (Schwiiz)", englishDescription: "Ge
 
   subscribe:
     comparison_blurb: "Verschärf dins Chönne midme CodeCombat Abonement."
-    feature1: "80+ basis levels in 4 Weltete!" # {change}
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-    feature3: "50+ bonus levels" # {change}
+    feature1: "$t(data.levelsCount)+ basis levels in $t(data.worldsCount) Weltete!"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
     feature5: "Video Aleitige"
     feature6: "Premium Email Hilf"

--- a/app/locale/de-DE.coffee
+++ b/app/locale/de-DE.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Deutsch (Deutschland)", englishDescription:
 
   subscribe:
     comparison_blurb: "Verbessere deine Fähigkeiten mit einem CodeCombat Abonnement"
-    feature1: "60+ Basislevel in 4 Gebieten" # {change}
-    feature2: "7 mächtige <strong>neue Helden</strong> mit einzigartigen Fertigkeiten" # {change}
-    feature3: "30+ Bonuslevel" # {change}
+    feature1: "$t(data.levelsCount)+ Basislevel in $t(data.worldsCount) Gebieten"
+    feature2: "$t(data.heroesCount) mächtige <strong>neue Helden</strong> mit einzigartigen Fertigkeiten"
+    feature3: "$t(data.bonusLevelsCount)+ Bonuslevel"
     feature4: "<strong>{{gems}} Bonusedelsteine</strong> jeden Monat!"
     feature5: "Videoanleitungen"
     feature6: "Premium Emailsupport"

--- a/app/locale/el.coffee
+++ b/app/locale/el.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Ελληνικά", englishDescription: "Gre
 
   subscribe:
     comparison_blurb: "Ακόνησε τις ικανότητές σου με μια συνδρομή στο CodeCombat!"
-    feature1: "110+ βασικά επίπεδα που εκτείνονται σε 4 κόσμους" # {change}
-    feature2: "10 παντοδύναμοι <strong>νέοι ήρωες</strong> με μοναδικές ικανότητες!"
-    feature3: "80+ επίπεδα δώρο" # {change}
+    feature1: "$t(data.levelsCount)+ βασικά επίπεδα που εκτείνονται σε $t(data.worldsCount) κόσμους"
+    feature2: "$t(data.heroesCount) παντοδύναμοι <strong>νέοι ήρωες</strong> με μοναδικές ικανότητες!"
+    feature3: "$t(data.bonusLevelsCount)+ επίπεδα δώρο"
     feature4: "<strong>{{gems}} πετράδια δώρο</strong> κάθε μήνα!"
     feature5: "Βίντεο Βοηθήματα"
     feature6: "Προνομιακή υποστήριξη μέσω ηλεκτρονικού ταχυδρομείου"

--- a/app/locale/en-GB.coffee
+++ b/app/locale/en-GB.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "English (UK)", englishDescription: "English
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/en-US.coffee
+++ b/app/locale/en-US.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "English (US)", englishDescription: "English
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1,4 +1,12 @@
 ﻿module.exports = nativeDescription: "English", englishDescription: "English", translation:
+  # Don't translate this block nor copy it to other locale files.
+  # This is just raw data that is automatically shared across all locales.
+  data:
+    levelsCount: "125"
+    bonusLevelsCount: "85"
+    heroesCount: "10"
+    worldsCount: "4"
+
   home:
     slogan: "Learn to Code by Playing a Game"
     no_ie: "CodeCombat does not run in Internet Explorer 8 or older. Sorry!"  # Warning that only shows up in IE8 and older
@@ -532,9 +540,9 @@
 
   subscribe:
     comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-    feature1: "125+ basic levels across 4 worlds"
-    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-    feature3: "85+ bonus levels"
+    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
     feature4: "<strong>{{gems}} bonus gems</strong> every month!"
     feature5: "Video tutorials"
     feature6: "Premium email support"
@@ -1319,7 +1327,7 @@
     how_to_enroll_blurb_3: "Once a student is enrolled, they will have access to all of the course content."
     bulk_pricing_blurb: "Purchasing for more than 15 students? Get in touch with us for bulk pricing quotes."
     total_unenrolled: "Total unenrolled"
-    
+
   classes:
     archmage_title: "Archmage"
     archmage_title_description: "(Coder)"

--- a/app/locale/eo.coffee
+++ b/app/locale/eo.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Esperanto", englishDescription: "Esperanto"
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/es-419.coffee
+++ b/app/locale/es-419.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Español (América Latina)", englishDescrip
 
   subscribe:
     comparison_blurb: "Agudiza tus habilidades con la suscripción a CodeCombat!"
-    feature1: "Más de 110 niveles basicos a lo largo de 4 mundos" # {change}
-    feature2: "10 poderosos <strong>nuevos heroés</strong> con habilidades unicas!"
-    feature3: "+80 niveles extras" # {change}
+    feature1: "Más de $t(data.levelsCount) niveles basicos a lo largo de $t(data.worldsCount) mundos"
+    feature2: "$t(data.heroesCount) poderosos <strong>nuevos heroés</strong> con habilidades unicas!"
+    feature3: "Más de $t(data.bonusLevelsCount) niveles extras"
     feature4: "<strong>{{gems}} gemas de bono</strong> cada mes!"
     feature5: "Video tutoriales"
     feature6: "Soporte Premium vía email"

--- a/app/locale/es-ES.coffee
+++ b/app/locale/es-ES.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "español (ES)", englishDescription: "Spanis
 
   subscribe:
     comparison_blurb: "¡Mejora tus habilidades con una suscripción a CodeCombat!"
-    feature1: "Más de 110 niveles básicos pasando por 4 mundos" # {change}
-    feature2: "¡10 <strong>héroes nuevos</strong> con poderes únicos!"
-    feature3: "Más de 70 niveles extra" # {change}
+    feature1: "Más de $t(data.levelsCount) niveles básicos pasando por $t(data.worldsCount) mundos"
+    feature2: "¡$t(data.heroesCount) <strong>héroes nuevos</strong> con poderes únicos!"
+    feature3: "Más de $t(data.bonusLevelsCount) niveles extra"
     feature4: "¡<strong>{{gems}} gemas extra</strong> cada mes!"
     feature5: "Vídeo tutoriales"
     feature6: "Soporte electrónico Premium"

--- a/app/locale/et.coffee
+++ b/app/locale/et.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Eesti", englishDescription: "Estonian", tra
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/fa.coffee
+++ b/app/locale/fa.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "فارسی", englishDescription: "Persian",
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/fi.coffee
+++ b/app/locale/fi.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "suomi", englishDescription: "Finnish", tran
 
   subscribe:
     comparison_blurb: "Teroita kykyjäsi CodeCombat kuukausitilauksella!"
-    feature1: "110+ perustasoa 4:ssä maailmassa" # {change}
-    feature2: "10 mahtavaa <strong>uutta sankaria</strong> erilaisine kykyineen!"
-    feature3: "70+ lisätasoa" # {change}
+    feature1: "$t(data.levelsCount)+ perustasoa $t(data.worldsCount):ssä maailmassa"
+    feature2: "$t(data.heroesCount) mahtavaa <strong>uutta sankaria</strong> erilaisine kykyineen!"
+    feature3: "$t(data.bonusLevelsCount)+ lisätasoa"
     feature4: "<strong>{{gems}} jalokiveä</strong> joka kuukausi!"
     feature5: "Video-oppaat"
     feature6: "Premium sähköpostituki"

--- a/app/locale/fr.coffee
+++ b/app/locale/fr.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "français", englishDescription: "French", t
 
   subscribe:
     comparison_blurb: "Aiguisez vos compétences avec un abonnement CodeCombat !"
-    feature1: "Plus de 60 niveaux au travers de 4 mondes" # {change}
-    feature2: "7 puissants <strong>nouveaux héros</strong> avec des compétences uniques !" # {change}
-    feature3: "Plus de 30 niveaux bonus" # {change}
+    feature1: "Plus de $t(data.levelsCount) niveaux au travers de $t(data.worldsCount) mondes"
+    feature2: "$t(data.heroesCount) puissants <strong>nouveaux héros</strong> avec des compétences uniques !"
+    feature3: "Plus de $t(data.bonusLevelsCount) niveaux bonus"
     feature4: "<strong>{{gems}} gemmes bonus</strong> tous les mois !"
     feature5: "Tutoriels vidéo"
     feature6: "Assitance par e-mail dédiée"

--- a/app/locale/gl.coffee
+++ b/app/locale/gl.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Galego", englishDescription: "Galician", tr
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/he.coffee
+++ b/app/locale/he.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "עברית", englishDescription: "Hebrew", 
 
   subscribe:
     comparison_blurb: ".CodeCombatחדד את כישוריך עם מנוי ל"
-    feature1: "60+ שלבים בסיסיים ב 4 עולמות שונים." # {change}
-    feature2: "!עם כישורים מיוחדים <strong>גיבורים עוצמתיים חדשים</strong> 7" # {change}
-    feature3: "30+ שלבי בונוס" # {change}
+    feature1: "$t(data.levelsCount)+ שלבים בסיסיים ב $t(data.worldsCount) עולמות שונים."
+    feature2: "!עם כישורים מיוחדים <strong>גיבורים עוצמתיים חדשים</strong> $t(data.heroesCount)"
+    feature3: "$t(data.bonusLevelsCount)+ שלבי בונוס"
     feature4: "!בחינם כל חודש <strong>{{gems}} אבני חן</strong>"
     feature5: "הדרכות וידאו"
     feature6: "תמיכת מייל בעדיפות ראשונה"

--- a/app/locale/hi.coffee
+++ b/app/locale/hi.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "मानक हिन्दी", englishDe
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/hu.coffee
+++ b/app/locale/hu.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "magyar", englishDescription: "Hungarian", t
 
   subscribe:
     comparison_blurb: "Élesítsd képességeid CodeCombat feliratkozással!"
-    feature1: "60+ alap pálya, 4 világon át" # {change}
-    feature2: "7 erőteljes <strong>új hős</strong> egyedi képességekkel!" # {change}
-    feature3: "30+ bónusz pálya" # {change}
+    feature1: "$t(data.levelsCount)+ alap pálya, $t(data.worldsCount) világon át"
+    feature2: "$t(data.heroesCount) erőteljes <strong>új hős</strong> egyedi képességekkel!"
+    feature3: "$t(data.bonusLevelsCount)+ bónusz pálya"
     feature4: "<strong>{{gems}} bónusz drágakő</strong> minden hónapban!"
     feature5: "Videó oktatóanyagok"
     feature6: "Prémium e-mail támogatás"

--- a/app/locale/id.coffee
+++ b/app/locale/id.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Bahasa Indonesia", englishDescription: "Ind
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/it.coffee
+++ b/app/locale/it.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Italiano", englishDescription: "Italian", t
 
   subscribe:
     comparison_blurb: "Aumenta le tue competenze con un abbonamento a CodeCombat!"
-    feature1: "80+ livelli base in 4 mondi" # {change}
-    feature2: "7 potenti <strong>nuovi eroi</strong> con capacità uniche!" # {change}
-    feature3: "50+ livelli bonus" # {change}
+    feature1: "$t(data.levelsCount)+ livelli base in $t(data.worldsCount) mondi"
+    feature2: "$t(data.heroesCount) potenti <strong>nuovi eroi</strong> con capacità uniche!"
+    feature3: "$t(data.bonusLevelsCount)+ livelli bonus"
     feature4: "<strong>{{gems}} gemme bonus</strong> ogni mese!"
     feature5: "Video tutorial"
     feature6: "Supporto via email premium"

--- a/app/locale/ja.coffee
+++ b/app/locale/ja.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "日本語", englishDescription: "Japanese",
 
   subscribe:
     comparison_blurb: "CodeCombatへ課金してスキルを磨きましょう！"
-    feature1: "110以上の基本レベルが４つの世界に" # {change}
-    feature2: "10人のパワフルな <strong>ニューヒーロー</strong> とユニークなスキル!" # {change}
-    feature3: "70以上のボーナスレベル" # {change}
+    feature1: "$t(data.levelsCount)以上の基本レベルが$t(data.worldsCount)つの世界に"
+    feature2: "$t(data.heroesCount)人のパワフルな <strong>ニューヒーロー</strong> とユニークなスキル!"
+    feature3: "$t(data.bonusLevelsCount)以上のボーナスレベル"
     feature4: "<strong>{{gems}}のジェム</strong>が毎月ボーナス!"
     feature5: "ビデオチュートリアル"
     feature6: "プレミアムメールサポート"

--- a/app/locale/ko.coffee
+++ b/app/locale/ko.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "한국어", englishDescription: "Korean", t
 
   subscribe:
     comparison_blurb: "코드컴뱃을 구독하셔서 당신의 스킬을 날카롭게하십시오!"
-    feature1: "110+개의 기초 레벨들은 4개의 세계에 있습니다" # {change}
-    feature2: "힘쌘 10 <strong>새로운 영웅들</strong>은 희기한 스킬과 함께!"
-    feature3: "80+ 보너스 레벨들" # {change}
+    feature1: "$t(data.levelsCount)+개의 기초 레벨들은 $t(data.worldsCount)개의 세계에 있습니다"
+    feature2: "힘쌘 $t(data.heroesCount) <strong>새로운 영웅들</strong>은 희기한 스킬과 함께!"
+    feature3: "$t(data.bonusLevelsCount)+ 보너스 레벨들"
     feature4: "매 달마다<strong>{{gems}} 보너스 잼</strong>!"
     feature5: "영상 튜토리얼"
     feature6: "프리미엄 이메일 지원"

--- a/app/locale/lt.coffee
+++ b/app/locale/lt.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "lietuvių kalba", englishDescription: "Lith
 
   subscribe:
     comparison_blurb: "Pagerink savo įgudžius su CodeCombat prenumerata!"
-    feature1: "110+ įprastų lygių per 4 pasaulius" # {change}
-    feature2: "10 galingų <strong>naujų herojų</strong> su unikaliais įgudžiais!"
-    feature3: "80+ papildomų lygių" # {change}
+    feature1: "$t(data.levelsCount)+ įprastų lygių per $t(data.worldsCount) pasaulius"
+    feature2: "$t(data.heroesCount) galingų <strong>naujų herojų</strong> su unikaliais įgudžiais!"
+    feature3: "$t(data.bonusLevelsCount)+ papildomų lygių"
     feature4: "<strong>{{gems}} papildomi krystalai</strong> kiekvieną mėnesį!"
     feature5: "Video pamokos"
     feature6: "Papildomas el.pašto palaikymas"

--- a/app/locale/mk-MK.coffee
+++ b/app/locale/mk-MK.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Македонски", englishDescription: 
 
   subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/ms.coffee
+++ b/app/locale/ms.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Bahasa Melayu", englishDescription: "Bahasa
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/my.coffee
+++ b/app/locale/my.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "မြန်မာစကား", englishDes
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/nb.coffee
+++ b/app/locale/nb.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Norsk Bokmål", englishDescription: "Norweg
 
   subscribe:
     comparison_blurb: "Spiss dine kunnskaper med et CodeCombat abonnement!"
-    feature1: "60+ grunnleggende brett fordelt på 4 verdener" # {change}
-    feature2: "7 kraftfulle <strong>nye helter</strong> med unike ferdigheter!" # {change}
-    feature3: "30+ bonusbrett" # {change}
+    feature1: "$t(data.levelsCount)+ grunnleggende brett fordelt på $t(data.worldsCount) verdener"
+    feature2: "$t(data.heroesCount) kraftfulle <strong>nye helter</strong> med unike ferdigheter!"
+    feature3: "$t(data.bonusLevelsCount)+ bonusbrett"
     feature4: "<strong>{{gems}} bonusjuveler</strong> hver måned!"
     feature5: "Videoveiledninger"
     feature6: "Premium e-poststøtte"

--- a/app/locale/nl-BE.coffee
+++ b/app/locale/nl-BE.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Nederlands (België)", englishDescription: 
 
   subscribe:
     comparison_blurb: "Verbeter je vaardigheden met een abonement op CodeCombat!"
-    feature1: "meer dan 110+ basislevels over 4 werelden" # {change}
-    feature2: "10 sterke <strong>nieuwe helden</strong> met unieke vaardigheden!"
-    feature3: "70+ bonuslevels" # {change}
+    feature1: "Meer dan $t(data.levelsCount) basislevels over $t(data.worldsCount) werelden"
+    feature2: "$t(data.heroesCount) sterke <strong>nieuwe helden</strong> met unieke vaardigheden!"
+    feature3: "Meer dan $t(data.bonusLevelsCount) bonuslevels"
     feature4: "<strong>{{gems}} bonus edelstenen</strong> elke maand!"
     feature5: "Video cursussen"
     feature6: "Hoogwaardige e-mail ondersteuning"

--- a/app/locale/nl-NL.coffee
+++ b/app/locale/nl-NL.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Nederlands (Nederland)", englishDescription
 
   subscribe:
     comparison_blurb: "Verbeter je vaardigheden met een abonement op CodeCombat!"
-    feature1: "meer dan 125+ basislevels over 4 werelden" # {change}
-    feature2: "10 sterke <strong>nieuwe helden</strong> met unieke vaardigheden!"
-    feature3: "85+ bonuslevels" # {change}
+    feature1: "Meer dan $t(data.levelsCount) basislevels over $t(data.worldsCount) werelden"
+    feature2: "$t(data.heroesCount) sterke <strong>nieuwe helden</strong> met unieke vaardigheden!"
+    feature3: "Meer dan $t(data.bonusLevelsCount) bonuslevels"
     feature4: "<strong>{{gems}} bonus edelstenen</strong> elke maand!"
     feature5: "Video cursussen"
     feature6: "Hoogwaardige e-mail ondersteuning"

--- a/app/locale/nn.coffee
+++ b/app/locale/nn.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Norsk Nynorsk", englishDescription: "Norweg
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/pl.coffee
+++ b/app/locale/pl.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "polski", englishDescription: "Polish", tran
 
   subscribe:
     comparison_blurb: "Popraw swoje umiejętności z subskrypcją CodeCombat!"
-    feature1: "110+ poziomów w 4 różnych światach" # {change}
-    feature2: "10 potężnych, <strong>nowych bohaterów</strong> z unikalnymi umiejętnościami!"
-    feature3: "80+ bonusowych poziomów" # {change}
+    feature1: "$t(data.levelsCount)+ poziomów w $t(data.worldsCount) różnych światach"
+    feature2: "$t(data.heroesCount) potężnych, <strong>nowych bohaterów</strong> z unikalnymi umiejętnościami!"
+    feature3: "$t(data.bonusLevelsCount)+ bonusowych poziomów"
     feature4: "<strong>{{gems}} klejnotów</strong> co miesiąc!"
     feature5: "Poradniki wideo"
     feature6: "Priorytetowe wsparcie przez e-mail"

--- a/app/locale/pt-BR.coffee
+++ b/app/locale/pt-BR.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Português do Brasil", englishDescription: 
 
   subscribe:
     comparison_blurb: "Afine suas habilidades com uma assinatura CodeCombat!"
-    feature1: "Mais de 60 níveis básicos entre 4 mundos" # {change}
-    feature2: "7 poderosos <strong>novos heróis</strong> com habilidades únicas!" # {change}
-    feature3: "Mais de 30 níveis bônus" # {change}
+    feature1: "Mais de $t(data.levelsCount) níveis básicos entre $t(data.worldsCount) mundos"
+    feature2: "$t(data.heroesCount) poderosos <strong>novos heróis</strong> com habilidades únicas!"
+    feature3: "Mais de $t(data.bonusLevelsCount) níveis bônus"
     feature4: "<strong>{{gems}} gemas bônus</strong> todo mês!"
     feature5: "Vídeo tutorials"
     feature6: "Suporte via e-mail Premium"

--- a/app/locale/pt-PT.coffee
+++ b/app/locale/pt-PT.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Português (Portugal)", englishDescription:
 
   subscribe:
     comparison_blurb: "Aperfeiçoa as tuas habilidades com uma subscrição do CodeCombat!"
-    feature1: "125+ níveis básicos dispersos por 4 mundos"
-    feature2: "10 <strong>heróis novos</strong> e poderosos com habilidades únicas!"
-    feature3: "85+ níveis de bónus"
+    feature1: "$t(data.levelsCount)+ níveis básicos dispersos por $t(data.worldsCount) mundos"
+    feature2: "$t(data.heroesCount) <strong>heróis novos</strong> e poderosos com habilidades únicas!"
+    feature3: "$t(data.bonusLevelsCount)+ níveis de bónus"
     feature4: "<strong>{{gems}} gemas de bónus</strong> por mês!"
     feature5: "Tutoriais em vídeo"
     feature6: "Apoio por e-mail prioritário"

--- a/app/locale/ro.coffee
+++ b/app/locale/ro.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "limba română", englishDescription: "Roman
 
   subscribe:
     comparison_blurb: "Îmbunătățeșteți abilitățile cu abonamentul CodeCombat"
-    feature1: "80+ de nivele de bază în 4 lumi diferite!" # {change}
-    feature2: "7 <strong>Eroi Noi</strong> puternici, cu skilluri unice!" # {change}
-    feature3: "60+ nivele bonus" # {change}
+    feature1: "$t(data.levelsCount)+ de nivele de bază în $t(data.worldsCount) lumi diferite!"
+    feature2: "$t(data.heroesCount) <strong>Eroi Noi</strong> puternici, cu skilluri unice!"
+    feature3: "$t(data.bonusLevelsCount)+ nivele bonus"
     feature4: "<strong>{{gems}} de Pietre Prețioase bonus</strong> în fiecare lună!"
     feature5: "Tutoriale Video"
     feature6: "Suport e-mail premium"

--- a/app/locale/ru.coffee
+++ b/app/locale/ru.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "русский", englishDescription: "Russi
 
   subscribe:
     comparison_blurb: "Отточите свое мастерство благодаря подписке на CodeCombat!"
-    feature1: "80+ основных уровней на просторах 4-х миров" # {change}
-    feature2: "7 могущественных <strong>новых героев</strong> с уникальными способностями!" # {change}
-    feature3: "60+ дополнительных уровней" # {change}
+    feature1: "$t(data.levelsCount)+ основных уровней на просторах $t(data.worldsCount)-х миров"
+    feature2: "$t(data.heroesCount) могущественных <strong>новых героев</strong> с уникальными способностями!"
+    feature3: "$t(data.bonusLevelsCount)+ дополнительных уровней"
     feature4: "<strong>{{gems}} бонусных самоцветов</strong> каждый месяц!"
     feature5: "Обучающие видеоролики"
     feature6: "Эксклюзивная поддержка по электронной почте"

--- a/app/locale/sk.coffee
+++ b/app/locale/sk.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "slovenčina", englishDescription: "Slovak",
 
   subscribe:
     comparison_blurb: "Uč sa dôkladnejšie vďaka predplatnému !"
-    feature1: "60+ základných úrovní v štyroch svetoch" # {change}
-    feature2: "7 mocných <strong>new hrdinov</strong> s jedinečnými schopnosťami!" # {change}
-    feature3: "30+ bonusových úrovní" # {change}
+    feature1: "$t(data.levelsCount)+ základných úrovní v $t(data.worldsCount) svetoch"
+    feature2: "$t(data.heroesCount) mocných <strong>new hrdinov</strong> s jedinečnými schopnosťami!"
+    feature3: "$t(data.bonusLevelsCount)+ bonusových úrovní"
     feature4: "<strong>{{gems}} bonusových diamantov</strong> každý mesiac !"
     feature5: "Video tutoriály"
     feature6: "Prémiová emailová podpora"

--- a/app/locale/sl.coffee
+++ b/app/locale/sl.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "slovenščina", englishDescription: "Sloven
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/sr.coffee
+++ b/app/locale/sr.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "српски", englishDescription: "Serbian
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/sv.coffee
+++ b/app/locale/sv.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Svenska", englishDescription: "Swedish", tr
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/th.coffee
+++ b/app/locale/th.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "ไทย", englishDescription: "Thai", tra
 
   subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/tr.coffee
+++ b/app/locale/tr.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Türkçe", englishDescription: "Turkish", t
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/uk.coffee
+++ b/app/locale/uk.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Українська", englishDescription: 
 
   subscribe:
     comparison_blurb: "Відточіть свої навички завдяки підписці на CodeCombat!"
-    feature1: "Більше 110 основних рівней на просторах 4 світів" # {change}
-    feature2: "10 могутніх <strong>нових героїв</strong> з унікальними здібностями!"
-    feature3: "Більше 80-ти бонусних рівнів" # {change}
+    feature1: "Більше $t(data.levelsCount) основних рівней на просторах $t(data.worldsCount) світів"
+    feature2: "$t(data.heroesCount) могутніх <strong>нових героїв</strong> з унікальними здібностями!"
+    feature3: "Більше $t(data.bonusLevelsCount)-ти бонусних рівнів"
     feature4: "<strong>{{gems}} бонусних самоцвітів</strong> кожного місяця!"
     feature5: "Навчальні відеоролики"
     feature6: "Екслюзивна підтримка по електронній пошті"

--- a/app/locale/ur.coffee
+++ b/app/locale/ur.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "اُردُو", englishDescription: "Urdu", 
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/uz.coffee
+++ b/app/locale/uz.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "O'zbekcha", englishDescription: "Uzbek", tr
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/vi.coffee
+++ b/app/locale/vi.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "Tiếng Việt", englishDescription: "Vietn
 
   subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-    feature1: "110+ level căn bản qua 4 thế giới" # {change}
-    feature2: "7 <strong>nhât vật mới</strong> mạnh mẽ với những kĩ năng đặc biệt!" # {change}
-    feature3: "80+ bonus levels" # {change}
+    feature1: "$t(data.levelsCount)+ level căn bản qua $t(data.worldsCount) thế giới"
+    feature2: "$t(data.heroesCount) <strong>nhât vật mới</strong> mạnh mẽ với những kĩ năng đặc biệt!"
+    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
     feature4: "<strong>Được thưởng thêm {{gems}} ngọc</strong> mỗi tháng!"
     feature5: "Những video hướng dẫn qua bàn"
     feature6: "Sự hỗ trợ tận tình qua email"

--- a/app/locale/zh-HANS.coffee
+++ b/app/locale/zh-HANS.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "简体中文", englishDescription: "Chinese
 
   subscribe:
     comparison_blurb: "亲，订阅CodeCombat，大力的提升您的技能！"
-    feature1: "110+ 基本关卡（4个世界）" # {change}
-    feature2: "10 个强大 <strong>英雄</strong>以及各式非凡技能!"
-    feature3: "80+ 奖励关卡" # {change}
+    feature1: "$t(data.levelsCount)+ 基本关卡（$t(data.worldsCount)个世界）"
+    feature2: "$t(data.heroesCount) 个强大 <strong>英雄</strong>以及各式非凡技能!"
+    feature3: "$t(data.bonusLevelsCount)+ 奖励关卡"
     feature4: "每月享有{{gems}}额外宝石"
     feature5: "视频教学"
     feature6: "专业邮件支援"

--- a/app/locale/zh-HANT.coffee
+++ b/app/locale/zh-HANT.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "繁體中文", englishDescription: "Chinese
 
   subscribe:
     comparison_blurb: "訂閱 CodeCombat 來磨練您的技巧！"
-    feature1: "110 個以上的基本關卡散佈在4張地圖中" # {change}
-    feature2: "10 個強壯的<strong>新英雄</strong>並每位都有不同技巧！"
-    feature3: "80 個以上的額外關卡" # {change}
+    feature1: "$t(data.levelsCount) 個以上的基本關卡散佈在$t(data.worldsCount)張地圖中"
+    feature2: "$t(data.heroesCount) 個強壯的<strong>新英雄</strong>並每位都有不同技巧！"
+    feature3: "$t(data.bonusLevelsCount) 個以上的額外關卡"
     feature4: "每個月<strong>{{gems}}顆額外寶石</strong>！"
     feature5: "影片教學"
     feature6: "頂級信箱支援"

--- a/app/locale/zh-WUU-HANS.coffee
+++ b/app/locale/zh-WUU-HANS.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "吴语", englishDescription: "Wuu (Simplifi
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"

--- a/app/locale/zh-WUU-HANT.coffee
+++ b/app/locale/zh-WUU-HANT.coffee
@@ -532,9 +532,9 @@ module.exports = nativeDescription: "吳語", englishDescription: "Wuu (Traditio
 
 #  subscribe:
 #    comparison_blurb: "Sharpen your skills with a CodeCombat subscription!"
-#    feature1: "125+ basic levels across 4 worlds"
-#    feature2: "10 powerful <strong>new heroes</strong> with unique skills!"
-#    feature3: "85+ bonus levels"
+#    feature1: "$t(data.levelsCount)+ basic levels across $t(data.worldsCount) worlds"
+#    feature2: "$t(data.heroesCount) powerful <strong>new heroes</strong> with unique skills!"
+#    feature3: "$t(data.bonusLevelsCount)+ bonus levels"
 #    feature4: "<strong>{{gems}} bonus gems</strong> every month!"
 #    feature5: "Video tutorials"
 #    feature6: "Premium email support"


### PR DESCRIPTION
With this change, all locales pull the levels and heroes numbers from `en.coffee`. This removes the maintenance burden of having to update these numbers across all locales.

I've made use of i18next's [nesting feature](http://i18next.com/translate/nesting/) coupled with the fallback mechanic—i.e. when a given key doesn't exist in the selected language, i18next will look it up in the fallback locale (`en.coffee`).

Let me know if I've overlooked something.