### PR TITLE
Fix teacher sessionless play; uses default campaign levels

### DIFF
--- a/app/models/Classroom.coffee
+++ b/app/models/Classroom.coffee
@@ -82,6 +82,7 @@ module.exports = class Classroom extends CocoModel
     return stats
 
   fetchForCourseInstance: (courseInstanceID, options={}) ->
+    return unless courseInstanceID
     CourseInstance = require 'models/CourseInstance'
     courseInstance = if _.isString(courseInstanceID) then new CourseInstance({_id:courseInstanceID}) else courseInstanceID
     options = _.extend(options, {

--- a/app/models/Level.coffee
+++ b/app/models/Level.coffee
@@ -252,6 +252,9 @@ module.exports = class Level extends CocoModel
   isLadder: ->
     return @get('type')?.indexOf('ladder') > -1
 
-  fetchNextForCourse: (levelOriginalID, courseInstanceID, options={}) ->
-    options.url = "/db/course_instance/#{courseInstanceID}/levels/#{levelOriginalID}/next"
+  fetchNextForCourse: ({ levelOriginalID, courseInstanceID, courseID }, options={}) ->
+    if courseInstanceID
+      options.url = "/db/course_instance/#{courseInstanceID}/levels/#{levelOriginalID}/next"
+    else
+      options.url = "/db/course/#{courseID}/levels/#{levelOriginalID}/next"
     @fetch(options)

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -69,7 +69,7 @@ module.exports = class User extends CocoModel
   isSessionless: ->
     # TODO: Fix old users who got mis-tagged as teachers
     # TODO: Should this just be isTeacher, eventually?
-    me.isTeacher() and utils.getQueryVariable('course', false)
+    Boolean(me.isTeacher() and utils.getQueryVariable('course', false))
 
   setRole: (role, force=false) ->
     return if me.isAdmin()

--- a/app/views/play/level/modal/CourseVictoryModal.coffee
+++ b/app/views/play/level/modal/CourseVictoryModal.coffee
@@ -29,9 +29,9 @@ module.exports = class CourseVictoryModal extends ModalView
     @newItems = new ThangTypes()
     @newHeroes = new ThangTypes()
     
-    @classroom = new Classroom()
-    @supermodel.trackRequest(@classroom.fetchForCourseInstance(@courseInstanceID))
-
+    if @courseInstanceID
+      @classroom = new Classroom()
+      @supermodel.trackRequest(@classroom.fetchForCourseInstance(@courseInstanceID))
     @achievements = options.achievements
     if not @achievements
       @achievements = new Achievements()
@@ -43,7 +43,7 @@ module.exports = class CourseVictoryModal extends ModalView
 
     @playSound 'victory'
     @nextLevel = new Level()
-    @nextLevelRequest = @supermodel.trackRequest @nextLevel.fetchNextForCourse(@level.get('original'), @courseInstanceID)
+    @nextLevelRequest = @supermodel.trackRequest @nextLevel.fetchNextForCourse({ levelOriginalID: @level.get('original'), @courseInstanceID, @courseID })
 
     @course = options.course
     if @courseID and not @course

--- a/server/middleware/course-instances.coffee
+++ b/server/middleware/course-instances.coffee
@@ -96,7 +96,7 @@ module.exports =
       throw new errors.NotFound('Level original ObjectId not found in Classroom courses')
     
     if not nextLevelOriginal
-      throw new errors.NotFound('No more levels in that course')
+      res.status(200).send({})
       
     dbq = Level.findOne({original: mongoose.Types.ObjectId(nextLevelOriginal)})
     dbq.sort({ 'version.major': -1, 'version.minor': -1 })

--- a/server/middleware/courses.coffee
+++ b/server/middleware/courses.coffee
@@ -39,7 +39,7 @@ module.exports =
       throw new errors.NotFound('Level original ObjectId not found in that course')
     
     if not nextLevelOriginal
-      throw new errors.NotFound('No more levels in that course')
+      res.status(200).send({})
       
     dbq = Level.findOne({original: mongoose.Types.ObjectId(nextLevelOriginal)})
     

--- a/server/middleware/courses.coffee
+++ b/server/middleware/courses.coffee
@@ -1,0 +1,51 @@
+errors = require '../commons/errors'
+wrap = require 'co-express'
+database = require '../commons/database'
+mongoose = require 'mongoose'
+Campaign = require '../models/Campaign'
+CourseInstance = require '../models/CourseInstance'
+Classroom = require '../models/Classroom'
+Course = require '../models/Course'
+User = require '../models/User'
+Level = require '../models/Level'
+parse = require '../commons/parse'
+
+module.exports =
+  fetchNextLevel: wrap (req, res) ->
+    levelOriginal = req.params.levelOriginal
+    if not database.isID(levelOriginal)
+      throw new errors.UnprocessableEntity('Invalid level original ObjectId')
+    
+    course = yield database.getDocFromHandle(req, Course)
+    if not course
+      throw new errors.NotFound('Course Instance not found.')
+      
+    campaign = yield Campaign.findById course.get('campaignID')
+    if not campaign
+      throw new errors.NotFound('Campaign not found.')
+    
+    levels = _.values(campaign.get('levels'))
+    levels = _.sortBy(levels, 'campaignIndex')
+    
+    nextLevelOriginal = null
+    foundLevelOriginal = false
+    for level, index in levels
+      if level.original.toString() is levelOriginal
+        foundLevelOriginal = true
+        nextLevelOriginal = levels[index+1]?.original
+        break
+    
+    if not foundLevelOriginal
+      throw new errors.NotFound('Level original ObjectId not found in that course')
+    
+    if not nextLevelOriginal
+      throw new errors.NotFound('No more levels in that course')
+      
+    dbq = Level.findOne({original: mongoose.Types.ObjectId(nextLevelOriginal)})
+    
+    
+    dbq.sort({ 'version.major': -1, 'version.minor': -1 })
+    dbq.select(parse.getProjectFromReq(req))
+    level = yield dbq
+    level = level.toObject({req: req})
+    res.status(200).send(level)

--- a/server/middleware/index.coffee
+++ b/server/middleware/index.coffee
@@ -5,6 +5,7 @@ module.exports =
   campaigns: require './campaigns'
   codelogs: require './codelogs'
   courseInstances: require './course-instances'
+  courses: require './courses'
   files: require './files'
   named: require './named'
   patchable: require './patchable'

--- a/server/routes/index.coffee
+++ b/server/routes/index.coffee
@@ -59,6 +59,7 @@ module.exports.setup = (app) ->
   Course = require '../models/Course'
   app.get('/db/course', mw.rest.get(Course))
   app.get('/db/course/:handle', mw.rest.getByHandle(Course))
+  app.get('/db/course/:handle/levels/:levelOriginal/next', mw.courses.fetchNextLevel) # For playing in teacher mode, which doesn't have a courseInstance
   
   app.get('/db/course_instance/:handle/levels/:levelOriginal/next', mw.courseInstances.fetchNextLevel)
   app.post('/db/course_instance/:handle/members', mw.auth.checkLoggedIn(), mw.courseInstances.addMembers)

--- a/server/routes/index.coffee
+++ b/server/routes/index.coffee
@@ -59,7 +59,7 @@ module.exports.setup = (app) ->
   Course = require '../models/Course'
   app.get('/db/course', mw.rest.get(Course))
   app.get('/db/course/:handle', mw.rest.getByHandle(Course))
-  app.get('/db/course/:handle/levels/:levelOriginal/next', mw.courses.fetchNextLevel) # For playing in teacher mode, which doesn't have a courseInstance
+  app.get('/db/course/:handle/levels/:levelOriginal/next', mw.courses.fetchNextLevel)
   
   app.get('/db/course_instance/:handle/levels/:levelOriginal/next', mw.courseInstances.fetchNextLevel)
   app.post('/db/course_instance/:handle/members', mw.auth.checkLoggedIn(), mw.courseInstances.addMembers)

--- a/spec/server/functional/course_instance.spec.coffee
+++ b/spec/server/functional/course_instance.spec.coffee
@@ -315,9 +315,10 @@ describe 'GET /db/course_instance/:handle/levels/:levelOriginal/next', ->
     expect(res.body.original).toBe(@levelB.original.toString())
     done()
     
-  it 'returns 404 if the given level is the last level in its course', utils.wrap (done) ->
+  it 'returns empty object if the given level is the last level in its course', utils.wrap (done) ->
     [res, body] = yield request.getAsync { uri: utils.getURL("/db/course_instance/#{@courseInstanceA.id}/levels/#{@levelB.id}/next"), json: true }
-    expect(res.statusCode).toBe(404)
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({})
     done()
 
   it 'returns 404 if the given level is not in the course instance\'s course', utils.wrap (done) ->

--- a/spec/server/functional/courses.spec.coffee
+++ b/spec/server/functional/courses.spec.coffee
@@ -6,6 +6,17 @@ request = require '../request'
 requestAsync = Promise.promisify(request, {multiArgs: true})
 Course = require '../../../server/models/Course'
 User = require '../../../server/models/User'
+Classroom = require '../../../server/models/Classroom'
+Campaign = require '../../../server/models/Campaign'
+Level = require '../../../server/models/Level'
+
+courseFixture = {
+  name: 'Unnamed course'
+  campaignID: ObjectId("55b29efd1cd6abe8ce07db0d")
+  concepts: ['basic_syntax', 'arguments', 'while_loops', 'strings', 'variables']
+  description: "Learn basic syntax, while loops, and the CodeCombat environment."
+  screenshot: "/images/pages/courses/101_info.png"
+}
 
 describe 'GET /db/course', ->
   beforeEach utils.wrap (done) ->
@@ -44,5 +55,76 @@ describe 'GET /db/course/:handle', ->
 
   it 'returns not found if handle does not exist in the db', utils.wrap (done) ->
     [res, body] = yield request.getAsync {uri: getURL("/db/course/dne"), json: true}
+    expect(res.statusCode).toBe(404)
+    done()
+
+describe 'GET /db/course/:handle/levels/:levelOriginal/next', ->
+
+  beforeEach utils.wrap (done) ->
+    yield utils.clearModels [User, Classroom, Course, Level, Campaign]
+    admin = yield utils.initAdmin()
+    yield utils.loginUser(admin)
+
+    levelJSON = { name: 'A', permissions: [{access: 'owner', target: admin.id}], type: 'course' }
+    [res, body] = yield request.postAsync({uri: getURL('/db/level'), json: levelJSON})
+    expect(res.statusCode).toBe(200)
+    @levelA = yield Level.findById(res.body._id)
+    paredLevelA = _.pick(res.body, 'name', 'original', 'type')
+
+    levelJSON = { name: 'B', permissions: [{access: 'owner', target: admin.id}], type: 'course' }
+    [res, body] = yield request.postAsync({uri: getURL('/db/level'), json: levelJSON})
+    expect(res.statusCode).toBe(200)
+    @levelB = yield Level.findById(res.body._id)
+    paredLevelB = _.pick(res.body, 'name', 'original', 'type')
+
+    levelJSON = { name: 'C', permissions: [{access: 'owner', target: admin.id}], type: 'course' }
+    [res, body] = yield request.postAsync({uri: getURL('/db/level'), json: levelJSON})
+    expect(res.statusCode).toBe(200)
+    @levelC = yield Level.findById(res.body._id)
+    paredLevelC = _.pick(res.body, 'name', 'original', 'type')
+
+    campaignJSONA = { name: 'Campaign A', levels: {} }
+    campaignJSONA.levels[paredLevelA.original] = paredLevelA
+    campaignJSONA.levels[paredLevelB.original] = paredLevelB
+    [res, body] = yield request.postAsync({uri: getURL('/db/campaign'), json: campaignJSONA})
+    @campaignA = yield Campaign.findById(res.body._id)
+
+    campaignJSONB = { name: 'Campaign B', levels: {} }
+    campaignJSONB.levels[paredLevelC.original] = paredLevelC
+    [res, body] = yield request.postAsync({uri: getURL('/db/campaign'), json: campaignJSONB})
+    @campaignB = yield Campaign.findById(res.body._id)
+
+    @courseA = Course({name: 'Course A', campaignID: @campaignA._id})
+    yield @courseA.save()
+
+    @courseB = Course({name: 'Course B', campaignID: @campaignB._id})
+    yield @courseB.save()
+
+    teacher = yield utils.initUser({role: 'teacher'})
+    yield utils.loginUser(teacher)
+    data = { name: 'Classroom 1' }
+    classroomsURL = getURL('/db/classroom')
+    [res, body] = yield request.postAsync {uri: classroomsURL, json: data }
+    expect(res.statusCode).toBe(201)
+    @classroom = yield Classroom.findById(res.body._id)
+    
+    url = getURL('/db/course')
+    
+    done()
+
+  it 'returns the next level for the course in the linked classroom', utils.wrap (done) ->
+    [res, body] = yield request.getAsync { uri: utils.getURL("/db/course/#{@courseA.id}/levels/#{@levelA.id}/next"), json: true }
+    expect(res.statusCode).toBe(200)
+    expect(res.body.original).toBe(@levelB.original.toString())
+    done()
+    
+  it 'returns empty object if the given level is the last level in its course', utils.wrap (done) ->
+    [res, body] = yield request.getAsync { uri: utils.getURL("/db/course/#{@courseA.id}/levels/#{@levelB.id}/next"), json: true }
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({})
+    done()
+
+  it 'returns 404 if the given level is not in the course instance\'s course', utils.wrap (done) ->
+    [res, body] = yield request.getAsync { uri: utils.getURL("/db/course/#{@courseB.id}/levels/#{@levelA.id}/next"), json: true }
     expect(res.statusCode).toBe(404)
     done()


### PR DESCRIPTION
This works around some things that broke with course level versioning, so that teachers can play course content again.

Main thing that was breaking: Teachers don't have courseInstance URL parameters when playing, which was being used to load a classroom, and to fetch the next level. I added a backend route that fetches a next level using only a courseID, which just looks them up in the default campaign. I also worked around a few places where it would try to fetch things based on courseInstanceID.

This means that teachers will always get the most recent version of a level ordering, and not a version that their classes may have.

One thing I still have not figured out is _sometimes_ the CourseVictoryModal fails to finish loading for teachers, when on the last level. I haven't seen it happen for students. This is troubling, since I'm not sure if it will work consistently for non-teachers.