### PR TITLE
Fix/improve Class Code handling in signup form

### DIFF
--- a/app/views/core/CreateAccountModal.coffee
+++ b/app/views/core/CreateAccountModal.coffee
@@ -146,10 +146,11 @@ module.exports = class CreateAccountModal extends ModalView
       window.tracker?.trackEvent 'Finished Signup', category: "Signup", label: 'CodeCombat'
     if @classCode
       url = "/courses?_cc="+@classCode
-      application.router.navigate(url)
-    window.location.reload()
-    
-  
+      location.href = url
+    else
+      window.location.reload()
+
+
   # Google Plus
 
   onClickGPlusSignupButton: ->

--- a/app/views/courses/CoursesView.coffee
+++ b/app/views/courses/CoursesView.coffee
@@ -69,7 +69,7 @@ module.exports = class CoursesView extends RootView
     application.tracker?.trackEvent 'Started Student Login', category: 'Courses'
 
   openSignUpModal: ->
-    modal = new CreateAccountModal()
+    modal = new CreateAccountModal({ initialValues: { classCode: utils.getQueryVariable('_cc', "") } })
     @openModalView(modal)
     application.tracker?.trackEvent 'Started Student Signup', category: 'Courses'
 


### PR DESCRIPTION
This does two things:
- Fix a regression where signing up from /courses with a class code would not really join the class, because application.router.navigate doesn't work if the path is the same but the query parameter is different.
- Autofill the class code in the signup form if you get there from a classroom join link (`/courses?_cc=...`)