### PR TITLE
Create account modal: don't open Facebook popup when pressing Enter in an input field, fixes #3729

### DIFF
--- a/app/templates/core/create-account-modal.jade
+++ b/app/templates/core/create-account-modal.jade
@@ -33,10 +33,10 @@
       .col-md-6
         .auth-network-logins.text-center
           strong(data-i18n="signup.or_sign_up_with")
-          button#facebook-signup-btn.btn.btn-primary.btn-lg.btn-illustrated.network-login(disabled=true)
+          button#facebook-signup-btn.btn.btn-primary.btn-lg.btn-illustrated.network-login(type="button", disabled=true)
             img.network-logo(src="/images/pages/community/logo_facebook.png", draggable="false")
             span.sign-in-blurb(data-i18n="login.sign_in_with_facebook")
-          button#gplus-signup-btn.btn.btn-danger.btn-lg.btn-illustrated.network-login(disabled=true)
+          button#gplus-signup-btn.btn.btn-danger.btn-lg.btn-illustrated.network-login(type="button", disabled=true)
             img.network-logo(src="/images/pages/community/logo_g+.png", draggable="false")
             span.sign-in-blurb(data-i18n="login.sign_in_with_gplus")
             .gplus-login-wrapper


### PR DESCRIPTION
Ref: #3729

`<button>`s are `type="submit"` by default.