### PR TITLE
Campaign view: fix level titles getting cut off

### DIFF
--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -182,7 +182,7 @@ $gameControlMargin: 30px
         border-radius: $levelClickRadius
 
     .tooltip
-      z-index: 2
+      z-index: 3
       pointer-events: none
 
       .tooltip-arrow
@@ -402,7 +402,7 @@ $gameControlMargin: 30px
 
       .player-name
         margin-left: 45px
-        
+
       a
         color: white
 
@@ -624,4 +624,3 @@ body.ipad #campaign-view
 
 body[lang='ru'] .portals h2
   font-size: 26px
-


### PR DESCRIPTION
E.g.:

![Forest - level titles cut off](http://i.imgur.com/cfIbyXv.png)