### PR TITLE
Achievement updates

### DIFF
--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -368,6 +368,11 @@ module.exports = class User extends CocoModel
     options.url = _.result(@, 'url') + '/deteacher'
     options.type = 'POST'
     @fetch(options)
+    
+  checkForNewAchievement: (options={}) ->
+    options.url = _.result(@, 'url') + '/check-for-new-achievement'
+    options.type = 'POST'
+    @fetch(options)
 
 tiersByLevel = [-1, 0, 0.05, 0.14, 0.18, 0.32, 0.41, 0.5, 0.64, 0.82, 0.91, 1.04, 1.22, 1.35, 1.48, 1.65, 1.78, 1.96, 2.1, 2.24, 2.38, 2.55, 2.69, 2.86, 3.03, 3.16, 3.29, 3.42, 3.58, 3.74, 3.89, 4.04, 4.19, 4.32, 4.47, 4.64, 4.79, 4.96,
   5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 10, 10.5, 11, 11.5, 12, 12.5, 13, 13.5, 14, 14.5, 15

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -344,6 +344,7 @@ _.extend UserSchema.properties,
   schoolName: {type: 'string'}
   role: {type: 'string', enum: ["God", "advisor", "parent", "principal", "student", "superintendent", "teacher", "technology coordinator"]}
   birthday: c.stringDate({title: "Birthday"})
+  lastAchievementChecked: c.objectId({ name: 'Last Achievement Checked' })
 
 c.extendBasicProperties UserSchema, 'user'
 

--- a/server/handlers/earned_achievement_handler.coffee
+++ b/server/handlers/earned_achievement_handler.coffee
@@ -15,10 +15,9 @@ class EarnedAchievementHandler extends Handler
 
   editableProperties: ['notified']
 
-  # Don't allow POSTs or anything yet
   hasAccess: (req) ->
     return false unless req.user
-    req.method in ['GET', 'POST', 'PUT'] # or req.user.isAdmin()
+    req.method in ['GET', 'PUT'] # or req.user.isAdmin()
 
   get: (req, res) ->
     return @getByAchievementIDs(req, res) if req.query.view is 'get-by-achievement-ids'
@@ -44,71 +43,6 @@ class EarnedAchievementHandler extends Handler
       return @sendDatabaseError(res, err) if err
       documents = (@formatEntity(req, doc) for doc in documents)
       @sendSuccess(res, documents)
-
-  post: (req, res) ->
-    achievementID = req.body.achievement
-    triggeredBy = req.body.triggeredBy
-    collection = req.body.collection
-    if collection isnt 'level.sessions' and not testing # TODO: remove this restriction
-      return @sendBadInputError(res, 'Only doing level session achievements for now.')
-
-    model = mongoose.modelNameByCollection(collection)
-
-    async.parallel({
-      achievement: (callback) ->
-        Achievement.findById achievementID, (err, achievement) -> callback(err, achievement)
-
-      trigger: (callback) ->
-        model.findById triggeredBy, (err, trigger) -> callback(err, trigger)
-
-      earned: (callback) ->
-        q = { achievement: achievementID, user: req.user._id+'' }
-        EarnedAchievement.findOne q, (err, earned) -> callback(err, earned)
-    }, (err, { achievement, trigger, earned } ) =>
-      return @sendDatabaseError(res, err) if err
-      if not achievement
-        return @sendNotFoundError(res, 'Could not find achievement.')
-      else if not trigger
-        return @sendNotFoundError(res, 'Could not find trigger.')
-      else if achievement.get('proportionalTo') and earned
-        EarnedAchievement.createForAchievement(achievement, trigger, {previouslyEarnedAchievement: earned}).then (earnedAchievementDoc) =>
-          @sendCreated(res, (earnedAchievementDoc or earned)?.toObject())
-      else if earned
-        achievementEarned = achievement.get('rewards')
-        actuallyEarned = earned.get('earnedRewards')
-        if not _.isEqual(achievementEarned, actuallyEarned)
-          earned.set('earnedRewards', achievementEarned)
-          earned.save((err) =>
-            return @sendDatabaseError(res, err) if err
-            @upsertNonNumericRewards(req.user, achievement, (err) =>
-              return @sendDatabaseError(res, err) if err
-              return @sendSuccess(res, earned.toObject())
-            )
-          )
-        else
-          @upsertNonNumericRewards(req.user, achievement, (err) =>
-            return @sendDatabaseError(res, err) if err
-            return @sendSuccess(res, earned.toObject())
-          )
-      else
-        EarnedAchievement.createForAchievement(achievement, trigger).then (earnedAchievementDoc) =>
-          if earnedAchievementDoc
-            @sendCreated(res, earnedAchievementDoc.toObject())
-          else
-            console.error "Couldn't create achievement", achievement, trigger
-            @sendNotFoundError res, "Couldn't create achievement"
-    )
-
-  upsertNonNumericRewards: (user, achievement, done) ->
-    update = {}
-    for rewardType, rewards of achievement.get('rewards') ? {}
-      continue if rewardType is 'gems'
-      if rewards.length
-        update.$addToSet ?= {}
-        update.$addToSet["earned.#{rewardType}"] = $each: rewards
-    User.update {_id: user._id}, update, {}, (err, result) ->
-      log.error err if err?
-      done?(err)
 
   getByAchievementIDs: (req, res) ->
     query = { user: req.user._id+''}

--- a/server/middleware/earned-achievements.coffee
+++ b/server/middleware/earned-achievements.coffee
@@ -1,0 +1,57 @@
+log = require 'winston'
+mongoose = require 'mongoose'
+Achievement = require './../models/Achievement'
+EarnedAchievement = require './../models/EarnedAchievement'
+errors = require '../commons/errors'
+wrap = require 'co-express'
+
+
+exports.post = wrap (req, res) ->
+  achievementID = req.body.achievement
+  triggeredBy = req.body.triggeredBy
+  collection = req.body.collection
+  if collection isnt 'level.sessions' and not testing # TODO: remove this restriction
+    throw new errors.UnprocessableEntity('Only doing level session achievements for now.')
+
+  model = mongoose.modelNameByCollection(collection)
+
+  [achievement, trigger, earned] = yield [
+    Achievement.findById(achievementID),
+    model.findById(triggeredBy)
+    EarnedAchievement.findOne({ achievement: achievementID, user: req.user.id })
+  ]
+
+  if not achievement
+    throw new errors.NotFound('Could not find achievement.')
+  if not trigger
+    throw new errors.NotFound('Could not find trigger.')
+    
+  if achievement.get('proportionalTo') and earned
+    earnedAchievementDoc = yield EarnedAchievement.createForAchievement(achievement, trigger, {previouslyEarnedAchievement: earned})
+    res.status(201).send((earnedAchievementDoc or earned)?.toObject({req}))
+
+  else if earned
+    achievementEarned = achievement.get('rewards')
+    actuallyEarned = earned.get('earnedRewards')
+    if not _.isEqual(achievementEarned, actuallyEarned)
+      earned.set('earnedRewards', achievementEarned)
+      yield earned.save()
+
+    # make sure user has all the levels and items they should have
+    update = {}
+    for rewardType, rewards of achievement.get('rewards') ? {}
+      continue if rewardType is 'gems'
+      if rewards.length
+        update.$addToSet ?= {}
+        update.$addToSet["earned.#{rewardType}"] = { $each: rewards }
+    yield req.user.update(update)
+  
+    return res.status(200).send(earned.toObject({req}))
+
+  else
+    earnedAchievementDoc = yield EarnedAchievement.createForAchievement(achievement, trigger)
+    if not earnedAchievementDoc
+      console.error "Couldn't create achievement", achievement, trigger
+      throw new errors.NotFound("Couldn't create achievement")
+    res.status(201).send(earnedAchievementDoc.toObject({res}))
+  

--- a/server/middleware/index.coffee
+++ b/server/middleware/index.coffee
@@ -7,6 +7,7 @@ module.exports =
   contact: require './contact'
   courseInstances: require './course-instances'
   courses: require './courses'
+  earnedAchievements: require './earned-achievements'
   files: require './files'
   healthcheck: require './healthcheck'
   levels: require './levels'

--- a/server/middleware/users.coffee
+++ b/server/middleware/users.coffee
@@ -267,7 +267,7 @@ module.exports =
 
     if not achievement
       userUpdate = { 'lastAchievementChecked': new mongoose.Types.ObjectId() }
-      user.update(userUpdate)
+      user.update({$set: userUpdate}).exec()
       return res.send(userUpdate)
 
     userUpdate = { 'lastAchievementChecked': achievement._id }
@@ -283,19 +283,19 @@ module.exports =
       })
     else
       userUpdate = { 'lastAchievementChecked': new mongoose.Types.ObjectId() }
-      user.update(userUpdate)
+      user.update({$set: userUpdate}).exec()
       return res.send(userUpdate)
       
     trigger = _.find(triggers, (trigger) -> LocalMongo.matchesQuery(trigger.toObject(), query))
     
     if not trigger
-      user.update(userUpdate)
+      user.update({$set: userUpdate}).exec()
       return res.send(userUpdate)
 
     earned = yield EarnedAchievement.findOne({ achievement: achievement.id, user: req.user })
     yield [
       EarnedAchievement.upsertFor(achievement, trigger, earned, req.user)
-      user.update(userUpdate)
+      user.update({$set: userUpdate})
     ]
     user = yield User.findById(user.id).select({points: 1, earned: 1})
     return res.send(_.assign({}, userUpdate, user.toObject()))

--- a/server/models/Achievement.coffee
+++ b/server/models/Achievement.coffee
@@ -6,6 +6,7 @@ plugins = require('../plugins/plugins')
 AchievablePlugin = require '../plugins/achievements'
 TreemaUtils = require '../../bower_components/treema/treema-utils.js'
 config = require '../../server_config'
+co = require 'co'
 
 # `pre` and `post` are not called for update operations executed directly on the database,
 # including `Model.update`,`.findByIdAndUpdate`,`.findOneAndUpdate`, `.findOneAndRemove`,and `.findByIdAndRemove`.order
@@ -53,27 +54,29 @@ AchievementSchema.statics.achievementCollections = {}
 
 # Reloads all achievements into memory.
 # TODO might want to tweak this to only load new achievements
-AchievementSchema.statics.loadAchievements = (done) ->
+AchievementSchema.statics.loadAchievements = co.wrap ->
   AchievementSchema.statics.resetAchievements()
+  t0 = new Date()
   Achievement = require('./Achievement')
-  query = Achievement.find({collection: {$ne: 'level.sessions'}})
-  query.exec (err, docs) ->
-    _.each docs, (achievement) ->
-      collection = achievement.get 'collection'
-      AchievementSchema.statics.achievementCollections[collection] ?= []
-      if _.find AchievementSchema.statics.achievementCollections[collection], ((a) -> a.get('_id').toHexString() is achievement.get('_id').toHexString())
-        log.warn "Uh oh, we tried to add another copy of the same achievement #{achievement.get('_id')} #{achievement.get('name')} to the #{collection} achievement list..."
-      else
-        AchievementSchema.statics.achievementCollections[collection].push achievement
-      unless achievement.get('query')
-        log.error "Uh oh, there is an achievement with an empty query: #{achievement}"
-    done?(AchievementSchema.statics.achievementCollections) # TODO: Return with err as first parameter  
+  achievements = yield Achievement.find({collection: {$ne: 'level.sessions'}})
+  return if t0 < @lastReset # if a test has run resetAchievements during the fetch, abort
+  for achievement in achievements
+    collection = achievement.get 'collection'
+    AchievementSchema.statics.achievementCollections[collection] ?= []
+    if _.find AchievementSchema.statics.achievementCollections[collection], ((a) -> a.get('_id').toHexString() is achievement.get('_id').toHexString())
+      log.warn "Uh oh, we tried to add another copy of the same achievement #{achievement.get('_id')} #{achievement.get('name')} to the #{collection} achievement list..."
+    else
+      AchievementSchema.statics.achievementCollections[collection].push achievement
+    unless achievement.get('query')
+      log.error "Uh oh, there is an achievement with an empty query: #{achievement}"
+  return AchievementSchema.statics.achievementCollections
 
 AchievementSchema.statics.getLoadedAchievements = ->
   AchievementSchema.statics.achievementCollections
 
 AchievementSchema.statics.resetAchievements = ->
   delete AchievementSchema.statics.achievementCollections[collection] for collection of AchievementSchema.statics.achievementCollections
+  @lastReset = new Date()
   
 AchievementSchema.statics.editableProperties = [
   'name'

--- a/server/models/EarnedAchievement.coffee
+++ b/server/models/EarnedAchievement.coffee
@@ -2,6 +2,7 @@ mongoose = require 'mongoose'
 jsonschema = require '../../app/schemas/models/earned_achievement'
 util = require '../../app/core/utils'
 log = require 'winston'
+co = require 'co'
 
 EarnedAchievementSchema = new mongoose.Schema({
   notified:
@@ -16,81 +17,74 @@ EarnedAchievementSchema.pre 'save', (next) ->
 EarnedAchievementSchema.index({user: 1, achievement: 1}, {unique: true, name: 'earned achievement index'})
 EarnedAchievementSchema.index({user: 1, changed: -1}, {name: 'latest '})
 
-EarnedAchievementSchema.statics.createForAchievement = (achievement, doc, originalDocObj=null, previouslyEarnedAchievement=null, done) ->
-  User = require './User'
+EarnedAchievementSchema.statics.createForAchievement = co.wrap (achievement, doc, options={}) ->
+  { previouslyEarnedAchievement, originalDocObj } = options
+  
+  User = require('./User')
   userObjectID = doc.get(achievement.get('userField'))
-  userID = if _.isObject userObjectID then userObjectID.toHexString() else userObjectID # Standardize! Use strings, not ObjectId's
+  userID = if _.isObject userObjectID then userObjectID.toHexString() else userObjectID # Standardize! Use ObjectIds
 
-  earned =
+  earnedAttrs = {
     user: userID
     achievement: achievement._id.toHexString()
     achievementName: achievement.get 'name'
     earnedRewards: achievement.get 'rewards'
+  }
 
   pointWorth = achievement.get('worth') ? 10
   gemWorth = achievement.get('rewards')?.gems ? 0
   earnedPoints = 0
   earnedGems = 0
+  earnedDoc = null
 
-  wrapUp = (earnedAchievementDoc) ->
-    # Update user's experience points
+  isRepeatable = achievement.get('proportionalTo')?
+
+  if isRepeatable
+    proportionalTo = achievement.get('proportionalTo')
+    docObj = doc.toObject()
+    newAmount = util.getByPath(docObj, proportionalTo) or 0
+
+    if proportionalTo is 'simulatedBy' and newAmount > 0 and not previouslyEarnedAchievement and Math.random() < 0.1
+      # Because things like simulatedBy get updated with $inc and not the post-save plugin hook,
+      # we (infrequently) fetch the previously earned achievement so we can really update.
+      previouslyEarnedAchievement = yield EarnedAchievement.findOne({user: earnedAttrs.user, achievement: earnedAttrs.achievement})
+
+    if previouslyEarnedAchievement
+      originalAmount = previouslyEarnedAchievement.get('achievedAmount') or 0
+    else if originalDocObj  # This branch could get buggy if unchangedCopy tracking isn't working.
+      originalAmount = util.getByPath(originalDocObj, proportionalTo) or 0
+    else
+      originalAmount = 0
+
+    if originalAmount isnt newAmount
+      expFunction = achievement.getExpFunction()
+      earnedAttrs.notified = false
+      earnedAttrs.achievedAmount = newAmount
+      earnedPoints = earnedAttrs.earnedPoints = (expFunction(newAmount) - expFunction(originalAmount)) * pointWorth
+      earnedGems = earnedAttrs.earnedGems = (expFunction(newAmount) - expFunction(originalAmount)) * gemWorth ? 0
+      earnedAttrs.previouslyAchievedAmount = originalAmount
+      yield EarnedAchievement.update({achievement: earnedAttrs.achievement, user: earnedAttrs.user}, earnedAttrs, {upsert: true})
+      earnedDoc = new EarnedAchievement(earnedAttrs)
+
+  else # not alreadyAchieved
+    earnedAttrs.earnedPoints = pointWorth
+    earnedAttrs.earnedGems = gemWorth
+    earnedDoc = new EarnedAchievement(earnedAttrs)
+    yield earnedDoc.save()
+    earnedPoints = pointWorth
+    earnedGems = gemWorth
+
+  User.saveActiveUser(userID, "achievement")
+
+  if earnedDoc
     update = {$inc: {points: earnedPoints, 'earned.gems': earnedGems}}
     for rewardType, rewards of achievement.get('rewards') ? {}
       continue if rewardType is 'gems'
       if rewards.length
         update.$addToSet ?= {}
         update.$addToSet["earned.#{rewardType}"] = $each: rewards
-    User.update {_id: mongoose.Types.ObjectId(userID)}, update, {}, (err, result) ->
-      log.error err if err?
-      done?(earnedAchievementDoc)
+    yield User.update({_id: mongoose.Types.ObjectId(userID)}, update, {})
 
-  isRepeatable = achievement.get('proportionalTo')?
-  if isRepeatable
-    #log.debug 'Upserting repeatable achievement called \'' + (achievement.get 'name') + '\' for ' + userID
-    proportionalTo = achievement.get 'proportionalTo'
-    docObj = doc.toObject()
-    newAmount = util.getByPath(docObj, proportionalTo) or 0
-    updateEarnedAchievement = (originalAmount) ->
-      #console.log 'original amount is', originalAmount, 'and new amount is', newAmount, 'for', proportionalTo, 'with doc', docObj, 'and previously earned achievement amount', previouslyEarnedAchievement?.get('achievedAmount'), 'because we had originalDocObj', originalDocObj
-
-      if originalAmount isnt newAmount
-        expFunction = achievement.getExpFunction()
-        earned.notified = false
-        earned.achievedAmount = newAmount
-        #console.log 'earnedPoints is', (expFunction(newAmount) - expFunction(originalAmount)) * pointWorth, 'was', earned.earnedPoints, earned.previouslyAchievedAmount, 'got exp function for new amount', newAmount, expFunction(newAmount), 'for original amount', originalAmount, expFunction(originalAmount), 'with point worth', pointWorth
-        earnedPoints = earned.earnedPoints = (expFunction(newAmount) - expFunction(originalAmount)) * pointWorth
-        earnedGems = earned.earnedGems = (expFunction(newAmount) - expFunction(originalAmount)) * gemWorth ? 0
-        earned.previouslyAchievedAmount = originalAmount
-        EarnedAchievement.update {achievement: earned.achievement, user: earned.user}, earned, {upsert: true}, (err) ->
-          return log.error err if err?
-
-        wrapUp(new EarnedAchievement(earned))
-      else
-        done?()
-
-    if proportionalTo is 'simulatedBy' and newAmount > 0 and not previouslyEarnedAchievement and Math.random() < 0.1
-      # Because things like simulatedBy get updated with $inc and not the post-save plugin hook,
-      # we (infrequently) fetch the previously earned achievement so we can really update.
-      EarnedAchievement.findOne {user: earned.user, achievement: earned.achievement}, (err, previouslyEarnedAchievement) ->
-        log.error err if err?
-        updateEarnedAchievement previouslyEarnedAchievement?.get('achievedAmount') or 0
-    else if previouslyEarnedAchievement
-      updateEarnedAchievement previouslyEarnedAchievement.get('achievedAmount') or 0
-    else if originalDocObj  # This branch could get buggy if unchangedCopy tracking isn't working.
-      updateEarnedAchievement util.getByPath(originalDocObj, proportionalTo) or 0
-    else
-      updateEarnedAchievement 0
-
-  else # not alreadyAchieved
-    #log.debug 'Creating a new earned achievement called \'' + (achievement.get 'name') + '\' for ' + userID
-    earned.earnedPoints = pointWorth
-    earned.earnedGems = gemWorth
-    (new EarnedAchievement(earned)).save (err, doc) ->
-      return log.error err if err?
-      earnedPoints = pointWorth
-      earnedGems = gemWorth
-      wrapUp(doc)
-
-  User.saveActiveUser userID, "achievement"
+  return earnedDoc
 
 module.exports = EarnedAchievement = mongoose.model('EarnedAchievement', EarnedAchievementSchema)

--- a/server/models/EarnedAchievement.coffee
+++ b/server/models/EarnedAchievement.coffee
@@ -34,8 +34,9 @@ EarnedAchievementSchema.statics.upsertFor = (achievement, trigger, earned, user)
     # make sure user has all the levels and items they should have
     update = {}
     for rewardType, rewards of achievement.get('rewards') ? {}
-      continue if rewardType is 'gems'
-      if rewards.length
+      if rewardType is 'gems'
+        update.$inc = { 'earned.gems': rewards - (actuallyEarned.gems ? 0) }
+      else if rewards.length
         update.$addToSet ?= {}
         update.$addToSet["earned.#{rewardType}"] = { $each: rewards }
     yield user.update(update)
@@ -54,7 +55,7 @@ EarnedAchievementSchema.statics.createForAchievement = co.wrap (achievement, doc
   
   User = require('./User')
   userObjectID = doc.get(achievement.get('userField'))
-  userID = if _.isObject userObjectID then userObjectID.toHexString() else userObjectID # Standardize! Use ObjectIds
+  userID = if _.isObject userObjectID then userObjectID.toHexString() else userObjectID # TODO: Migrate to ObjectIds
 
   earnedAttrs = {
     user: userID

--- a/server/plugins/achievements.coffee
+++ b/server/plugins/achievements.coffee
@@ -42,7 +42,6 @@ AchievablePlugin = (schema, options) ->
           alreadyAchieved = if isNew then false else LocalMongo.matchesQuery unchangedCopy, query
           newlyAchieved = LocalMongo.matchesQuery(docObj, query)
           return unless newlyAchieved and (not alreadyAchieved or isRepeatable)
-          #log.info "Making an achievement: #{achievement.get('name')} #{achievement.get('_id')} for doc: #{doc.get('name')} #{doc.get('_id')}"
-          EarnedAchievement.createForAchievement(achievement, doc, unchangedCopy)
+          EarnedAchievement.createForAchievement(achievement, doc, {originalDocObj: unchangedCopy})
 
 module.exports = AchievablePlugin

--- a/server/routes/index.coffee
+++ b/server/routes/index.coffee
@@ -96,7 +96,10 @@ module.exports.setup = (app) ->
   app.post('/db/course_instance/:handle/members', mw.auth.checkLoggedIn(), mw.courseInstances.addMembers)
   app.get('/db/course_instance/:handle/classroom', mw.auth.checkLoggedIn(), mw.courseInstances.fetchClassroom)
   app.get('/db/course_instance/:handle/course', mw.auth.checkLoggedIn(), mw.courseInstances.fetchCourse)
-
+  
+  EarnedAchievement = require '../models/EarnedAchievement'
+  app.post('/db/earned_achievement', mw.earnedAchievements.post)
+  
   Level = require '../models/Level'
   app.post('/db/level/:handle', mw.auth.checkLoggedIn(), mw.versions.postNewVersion(Level, { hasPermissionsOrTranslations: 'artisan' })) # TODO: add /new-version to route like Article has
   app.get('/db/level/:handle/session', mw.auth.checkHasUser(), mw.levels.upsertSession)

--- a/server/routes/index.coffee
+++ b/server/routes/index.coffee
@@ -98,7 +98,7 @@ module.exports.setup = (app) ->
   app.get('/db/course_instance/:handle/course', mw.auth.checkLoggedIn(), mw.courseInstances.fetchCourse)
   
   EarnedAchievement = require '../models/EarnedAchievement'
-  app.post('/db/earned_achievement', mw.earnedAchievements.post)
+  app.post('/db/earned_achievement', mw.auth.checkLoggedIn(), mw.earnedAchievements.post)
   
   Level = require '../models/Level'
   app.post('/db/level/:handle', mw.auth.checkLoggedIn(), mw.versions.postNewVersion(Level, { hasPermissionsOrTranslations: 'artisan' })) # TODO: add /new-version to route like Article has
@@ -118,7 +118,8 @@ module.exports.setup = (app) ->
   app.post('/db/user/:handle/signup-with-password', mw.users.signupWithPassword)
   app.post('/db/user/:handle/destudent', mw.auth.checkHasPermission(['admin']), mw.users.destudent)
   app.post('/db/user/:handle/deteacher', mw.auth.checkHasPermission(['admin']), mw.users.deteacher)
-  
+  app.post('/db/user/:handle/check-for-new-achievement', mw.auth.checkLoggedIn(), mw.users.checkForNewAchievement)
+
   app.get('/db/prepaid', mw.auth.checkLoggedIn(), mw.prepaids.fetchByCreator)
   app.get('/db/prepaid/-/active-schools', mw.auth.checkHasPermission(['admin']), mw.prepaids.fetchActiveSchools)
   app.post('/db/prepaid', mw.auth.checkHasPermission(['admin']), mw.prepaids.post)

--- a/spec/server/functional/achievement.spec.coffee
+++ b/spec/server/functional/achievement.spec.coffee
@@ -240,7 +240,7 @@ describe 'automatically achieving achievements', ->
   it 'happens when an object\'s properties meet achievement goals', utils.wrap (done) ->
     # load achievements on server
     @achievements = yield Achievement.loadAchievements()
-    expect(@achievements.length).toBe(2)
+    expect(@achievements.users.length).toBe(2)
     loadedAchievements = Achievement.getLoadedAchievements()
     expect(Object.keys(loadedAchievements).length).toBe(1)
     


### PR DESCRIPTION
Have the users periodically check for new achievements and check if they've been earned, so that they automatically get awarded new achievements retroactively.

Also refactored the POST /db/earned_achievement endpoint and some related logic.

For now, the client DOES NOT actually check for achievements to award retroactively. I'd like to deploy the endpoint and test it through a dev proxy to ensure it works correctly.