### PR TITLE
Fix, update and enable achievement updates

### DIFF
--- a/app/core/application.coffee
+++ b/app/core/application.coffee
@@ -65,7 +65,7 @@ Application = {
     unless me.get('anonymous')
       # TODO: Remove logging later, once this system has proved stable
       me.on 'change:earned', (user, newEarned) ->
-        oldEarned = user.previous('earned')
+        oldEarned = user.previous('earned') ? {}
         if oldEarned.gems isnt newEarned.gems
           console.log 'Gems changed', oldEarned.gems, '->', newEarned.gems
         newLevels = _.difference(newEarned.levels, oldEarned.levels)

--- a/app/lib/LocalMongo.coffee
+++ b/app/lib/LocalMongo.coffee
@@ -6,10 +6,10 @@ mapred = (left, right, func) ->
     result or (_.reduce (_.map right, (singleRight) -> func(singleLeft, singleRight)),
       ((intermediate, value) -> intermediate or value), false)), false)
 
-doQuerySelector = (value, operatorObj) ->
-  value = [value] unless _.isArray value # left hand can be an array too
-  for operator, body of operatorObj
-    body = [body] unless _.isArray body # right hand can be an array too
+doQuerySelector = (originalValue, operatorObj) ->
+  value = if _.isArray originalValue then originalValue else [originalValue] # left hand can be an array too
+  for operator, originalBody of operatorObj
+    body = if _.isArray originalBody then originalBody else [originalBody] # right hand can be an array too
     switch operator
       when '$gt' then return false unless mapred value, body, (l, r) -> l > r
       when '$gte' then return false unless mapred value, body, (l, r) -> l >= r
@@ -19,7 +19,9 @@ doQuerySelector = (value, operatorObj) ->
       when '$in' then return false unless _.reduce value, ((result, val) -> result or val in body), false
       when '$nin' then return false if _.reduce value, ((result, val) -> result or val in body), false
       when '$exists' then return false if value[0]? isnt body[0]
-      else return false
+      else 
+        trimmedOperator = _.pick(operatorObj, operator)
+        return false unless _.isObject(originalValue) and matchesQuery(originalValue, trimmedOperator)
   true
 
 matchesQuery = (target, queryObj) ->

--- a/app/schemas/models/achievement.coffee
+++ b/app/schemas/models/achievement.coffee
@@ -82,6 +82,7 @@ _.extend AchievementSchema.properties,
   i18n: {type: 'object', format: 'i18n', props: ['name', 'description'], description: 'Help translate this achievement'}
   rewards: c.RewardSchema 'awarded by this achievement'
   hidden: {type: 'boolean', description: 'Hide achievement from user if true'}
+  updated: c.stringDate({ description: 'When the achievement was changed in such a way that earned achievements should get updated.' })
 
 
 _.extend AchievementSchema, # Let's have these on the bottom

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -344,7 +344,7 @@ _.extend UserSchema.properties,
   schoolName: {type: 'string'}
   role: {type: 'string', enum: ["God", "advisor", "parent", "principal", "student", "superintendent", "teacher", "technology coordinator"]}
   birthday: c.stringDate({title: "Birthday"})
-  lastAchievementChecked: c.objectId({ name: 'Last Achievement Checked' })
+  lastAchievementChecked: c.stringDate({ name: 'Last Achievement Checked' })
 
 c.extendBasicProperties UserSchema, 'user'
 

--- a/scripts/mongodb/migrations/2016-08-31-add-achievements-updated.js
+++ b/scripts/mongodb/migrations/2016-08-31-add-achievements-updated.js
@@ -1,0 +1,7 @@
+var d = new Date();
+
+db.achievements.find({}, {_id:1}).sort({_id:1}).forEach(function(achievement) {
+  db.achievements.update({_id: achievement._id}, {$set: {updated: d.toISOString()}})
+  print('set', achievement._id, 'to', d);
+  d.setSeconds(d.getSeconds() + 1)
+});

--- a/server/middleware/achievements.coffee
+++ b/server/middleware/achievements.coffee
@@ -19,7 +19,7 @@ module.exports =
     unless hasPermission or database.isJustFillingTranslations(req, achievement)
       throw new errors.Forbidden('Must be an admin, artisan or submitting translations to edit an achievement')
 
-    propsWatching = ['query', 'proportionalTo', 'rewards', 'worth']
+    propsWatching = ['query', 'proportionalTo', 'rewards', 'worth', 'function']
     oldCopy = _.pick(achievement.toObject(), propsWatching)
     database.assignBody(req, achievement)
     newCopy = _.pick(achievement.toObject(), propsWatching)

--- a/server/middleware/achievements.coffee
+++ b/server/middleware/achievements.coffee
@@ -19,7 +19,12 @@ module.exports =
     unless hasPermission or database.isJustFillingTranslations(req, achievement)
       throw new errors.Forbidden('Must be an admin, artisan or submitting translations to edit an achievement')
 
+    propsWatching = ['query', 'proportionalTo', 'rewards', 'worth']
+    oldCopy = _.pick(achievement.toObject(), propsWatching)
     database.assignBody(req, achievement)
+    newCopy = _.pick(achievement.toObject(), propsWatching)
+    unless _.isEqual(oldCopy, newCopy)
+      achievement.set('updated', new Date().toISOString())
     database.validateDoc(achievement)
     achievement = yield achievement.save()
     res.status(200).send(achievement.toObject({req: req}))

--- a/server/models/Achievement.coffee
+++ b/server/models/Achievement.coffee
@@ -33,6 +33,7 @@ AchievementSchema.index(
 AchievementSchema.index({i18nCoverage: 1}, {name: 'translation coverage index', sparse: true})
 AchievementSchema.index({slug: 1}, {name: 'slug index', sparse: true, unique: true})
 AchievementSchema.index({related: 1}, {name: 'related index', sparse: true})
+AchievementSchema.index({updated: 1}, {name: 'updated index'})
 
 AchievementSchema.methods.objectifyQuery = ->
   try
@@ -105,6 +106,8 @@ AchievementSchema.post 'init', (doc) -> doc.objectifyQuery()
 
 AchievementSchema.pre 'save', (next) ->
   @stringifyQuery()
+  if not @get('updated')
+    @set('updated', new Date().toISOString())
   next()
 
 # Reload achievements upon save

--- a/spec/server/functional/achievement.spec.coffee
+++ b/spec/server/functional/achievement.spec.coffee
@@ -109,7 +109,7 @@ describe 'PUT /db/achievement', ->
     expect(res.body.name).toBe('whatev')
     done()
     
-  it 'touches "updated" if query, proportionalTo, worth, or rewards change', utils.wrap (done) ->
+  it 'touches "updated" if query, proportionalTo, worth, rewards or function change', utils.wrap (done) ->
     lastUpdated = @unlockable.get('updated')
     expect(lastUpdated).toBeDefined()
     [res, body] = yield request.putAsync {uri: url + '/'+@unlockable.id, json: {
@@ -139,6 +139,11 @@ describe 'PUT /db/achievement', ->
 
     newWorth = 1000
     [res, body] = yield request.putAsync {uri: url + '/'+@unlockable.id, json: {worth: newWorth}}
+    expect(res.body.updated).not.toBe(lastUpdated)
+    lastUpdated = res.body.updated
+    
+    newFunction = { kind: 'logarithmic', parameters: { a: 1, b: 2, c: 3 } }
+    [res, body] = yield request.putAsync {uri: url + '/'+@unlockable.id, json: {function: newFunction}}
     expect(res.body.updated).not.toBe(lastUpdated)
     done()
     

--- a/spec/server/functional/user.spec.coffee
+++ b/spec/server/functional/user.spec.coffee
@@ -1039,6 +1039,22 @@ describe 'POST /db/user/:handle/deteacher', ->
 
     
 describe 'POST /db/user/:handle/check-for-new-achievements', ->
+  achievementURL = getURL('/db/achievement')
+  achievementJSON = {
+    collection: 'users'
+    query: {'points': {$gt: 50}}
+    userField: '_id'
+    recalculable: true
+    worth: 75
+    rewards: {
+      gems: 50
+      levels: [new mongoose.Types.ObjectId().toString()]
+    }
+    name: 'Dungeon Arena Started'
+    description: 'Started playing Dungeon Arena.'
+    related: 'a'
+  }
+  
   
   beforeEach utils.wrap (done) ->
     yield utils.clearModels [Achievement, EarnedAchievement, LevelSession, User]
@@ -1055,36 +1071,132 @@ describe 'POST /db/user/:handle/check-for-new-achievements', ->
     earned = yield EarnedAchievement.count()
     expect(earned).toBe(0)
 
-    achievementURL = getURL('/db/achievement')
-    achievementJSON = {
-      collection: 'users'
-      query: {'points': {$gt: 50}}
-      userField: '_id'
-      recalculable: true
-      worth: 75
-      rewards: {
-        gems: 50
-        levels: [new mongoose.Types.ObjectId().toString()]
-      }
-      name: 'Dungeon Arena Started'
-      description: 'Started playing Dungeon Arena.'
-      related: 'a'
-    }
-
     admin = yield utils.initAdmin()
     yield utils.loginUser(admin)
     [res, body] = yield request.postAsync { uri: achievementURL, json: achievementJSON }
-    achievementID = body._id
+    achievementUpdated = res.body.updated
     expect(res.statusCode).toBe(201)
     
     user = yield User.findById(user.id)
-    expect(user.get('rewards')).toBeUndefined()
+    expect(user.get('earned')).toBeUndefined()
     
     yield utils.loginUser(user)
     [res, body] = yield request.postAsync({ url, json })
     expect(body.points).toBe(175)
     earned = yield EarnedAchievement.count()
     expect(earned).toBe(1)
-    expect(body.lastAchievementChecked).toBe(achievementID)
+    expect(body.lastAchievementChecked).toBe(achievementUpdated)
     
+    done()
+    
+  it 'updates the user if they already earned the achievement but the rewards changed', utils.wrap (done) ->
+    user = yield utils.initUser({points: 100})
+    yield utils.loginUser(user)
+    url = utils.getURL("/db/user/#{user.id}/check-for-new-achievement")
+    json = true
+    [res, body] = yield request.postAsync({ url, json })
+
+    admin = yield utils.initAdmin()
+    yield utils.loginUser(admin)
+    [res, body] = yield request.postAsync { uri: achievementURL, json: achievementJSON }
+    achievement = yield Achievement.findById(body._id)
+    expect(res.statusCode).toBe(201)
+
+    user = yield User.findById(user.id)
+    expect(user.get('rewards')).toBeUndefined()
+
+    yield utils.loginUser(user)
+    [res, body] = yield request.postAsync({ url, json })
+    expect(res.body.points).toBe(175)
+    expect(res.body.earned.gems).toBe(50)
+
+    achievement.set({
+      updated: new Date().toISOString()
+      rewards: { gems: 100 }
+      worth: 200
+    })
+    yield achievement.save()
+
+    [res, body] = yield request.postAsync({ url, json })
+    expect(res.body.earned.gems).toBe(100)
+    expect(res.body.points).toBe(300)
+    expect(res.statusCode).toBe(200)
+
+    # special case: no worth, should default to 10
+    
+    yield achievement.update({
+      $set: {updated: new Date().toISOString()},
+      $unset: {worth:''}
+    })
+    [res, body] = yield request.postAsync({ url, json })
+    expect(res.body.earned.gems).toBe(100)
+    expect(res.body.points).toBe(110)
+    expect(res.statusCode).toBe(200)
+    done()
+    
+  it 'works for level sessions', utils.wrap (done) ->
+    admin = yield utils.initAdmin()
+    yield utils.loginUser(admin)
+    level = yield utils.makeLevel()
+    achievement = yield utils.makeAchievement({
+      collection: 'level.sessions'
+      userField: 'creator'
+      query: {
+        'level.original': level.get('original').toString()
+        'state': {complete: true}
+      }
+      worth: 100
+      proportionalTo: 'state.difficulty'
+    })
+    levelSession = yield utils.makeLevelSession({state: {complete: true, difficulty:2}}, { creator:admin, level })
+    url = utils.getURL("/db/user/#{admin.id}/check-for-new-achievement")
+    json = true
+    [res, body] = yield request.postAsync({ url, json })
+    expect(body.points).toBe(200)
+    
+    # check idempotency
+    achievement.set('updated', new Date().toISOString())
+    yield achievement.save()
+    [res, body] = yield request.postAsync({ url, json })
+    expect(body.points).toBe(200)
+    admin = yield User.findById(admin.id)
+    done()
+
+  it 'skips achievements which have not been satisfied', utils.wrap (done) ->
+    admin = yield utils.initAdmin()
+    yield utils.loginUser(admin)
+    level = yield utils.makeLevel()
+    achievement = yield utils.makeAchievement({
+      collection: 'level.sessions'
+      userField: 'creator'
+      query: {
+        'level.original': 'does not matter'
+      }
+      worth: 100
+    })
+    expect(admin.get('lastAchievementChecked')).toBeUndefined()
+    url = utils.getURL("/db/user/#{admin.id}/check-for-new-achievement")
+    json = true
+    [res, body] = yield request.postAsync({ url, json })
+    expect(body.points).toBeUndefined()
+    admin = yield User.findById(admin.id)
+    expect(admin.get('lastAchievementChecked')).toBe(achievement.get('updated'))
+    done()
+
+  it 'skips achievements which are not either for the users collection or the level sessions collection with level.original included', utils.wrap (done) ->
+    admin = yield utils.initAdmin()
+    yield utils.loginUser(admin)
+    achievement = yield utils.makeAchievement({
+      collection: 'not.supported'
+      userField: 'creator'
+      query: {}
+      worth: 100
+    })
+    expect(admin.get('lastAchievementChecked')).toBeUndefined()
+    url = utils.getURL("/db/user/#{admin.id}/check-for-new-achievement")
+    json = true
+    [res, body] = yield request.postAsync({ url, json })
+    expect(body.points).toBeUndefined()
+    admin = yield User.findById(admin.id)
+    expect(admin.get('lastAchievementChecked')).toBe(achievement.get('updated'))
     done()

--- a/test/app/lib/local_mongo.spec.coffee
+++ b/test/app/lib/local_mongo.spec.coffee
@@ -9,6 +9,9 @@ describe 'Local Mongo queries', ->
       'worth': 6
       'type': 'unicorn'
       'likes': ['poptarts', 'popsicles', 'popcorn']
+      nested: {
+        str:'ing'
+      }
 
     @fixture2 = this: is: so: 'deep'
 
@@ -24,6 +27,11 @@ describe 'Local Mongo queries', ->
 
   it 'nested match', ->
     expect(LocalMongo.matchesQuery(@fixture2, 'this.is.so': 'deep')).toBeTruthy()
+    expect(LocalMongo.matchesQuery(@fixture2, {this:{is:{so: 'deep'}}})).toBeTruthy()
+    expect(LocalMongo.matchesQuery(@fixture2, {'this.is':{so: 'deep'}})).toBeTruthy()
+    mixedQuery = { nested: {str:'ing'}, worth: {$gt:3} }
+    expect(LocalMongo.matchesQuery(@fixture1, mixedQuery)).toBeTruthy()
+    expect(LocalMongo.matchesQuery(@fixture2, mixedQuery)).toBeFalsy()
 
   it '$gt selector', ->
     expect(LocalMongo.matchesQuery(@fixture1, 'value': '$gt': 8000)).toBeTruthy()


### PR DESCRIPTION
* Clients check updated achievements as well as new ones
* Clients do not wait to keep checking
* Update achievement points along with everything else in EarnedAchievement.upsertFor
* Fix various bugs