### PR TITLE
Add Israel signup view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - "node index.js --unittest &"
-  - "sleep 15" # to give node a chance to start
+  - n=0
+  - until [ $n -ge 60 ]; do curl http://localhost:3000 && break; n=$[$n+1]; sleep 1; done
 
 script:
   - "./node_modules/karma/bin/karma start --browsers Firefox --single-run --reporters dots"

--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -125,6 +125,7 @@ module.exports = class CocoRouter extends Backbone.Router
     'i18n/course/:handle': go('i18n/I18NEditCourseView')
 
     'identify': go('user/IdentifyView')
+    'il-signup': go('account/IsraelSignupView')
 
     'legal': go('LegalView')
 

--- a/app/core/utils.coffee
+++ b/app/core/utils.coffee
@@ -1,11 +1,11 @@
-module.exports.clone = (obj) ->
+clone = (obj) ->
   return obj if obj is null or typeof (obj) isnt 'object'
   temp = obj.constructor()
   for key of obj
-    temp[key] = module.exports.clone(obj[key])
+    temp[key] = clone(obj[key])
   temp
 
-module.exports.combineAncestralObject = (obj, propertyName) ->
+combineAncestralObject = (obj, propertyName) ->
   combined = {}
   while obj?[propertyName]
     for key, value of obj[propertyName]
@@ -18,7 +18,7 @@ module.exports.combineAncestralObject = (obj, propertyName) ->
       obj = Object.getPrototypeOf(obj)
   combined
 
-module.exports.courseIDs = courseIDs =
+courseIDs =
   INTRODUCTION_TO_COMPUTER_SCIENCE: '560f1a9f22961295f9427742'
   COMPUTER_SCIENCE_2: '5632661322961295f9428638'
   GAME_DEVELOPMENT_1: '5789587aad86a6efb573701e'
@@ -29,7 +29,7 @@ module.exports.courseIDs = courseIDs =
   COMPUTER_SCIENCE_4: '56462f935afde0c6fd30fc8d'
   COMPUTER_SCIENCE_5: '569ed916efa72b0ced971447'
 
-module.exports.orderedCourseIDs = orderedCourseIDs = [
+orderedCourseIDs = [
   courseIDs.INTRODUCTION_TO_COMPUTER_SCIENCE
   courseIDs.COMPUTER_SCIENCE_2
   courseIDs.GAME_DEVELOPMENT_1
@@ -41,7 +41,7 @@ module.exports.orderedCourseIDs = orderedCourseIDs = [
   courseIDs.COMPUTER_SCIENCE_5
 ]
 
-module.exports.normalizeFunc = (func_thing, object) ->
+normalizeFunc = (func_thing, object) ->
   # func could be a string to a function in this class
   # or a function in its own right
   object ?= {}
@@ -53,10 +53,10 @@ module.exports.normalizeFunc = (func_thing, object) ->
     func_thing = func
   return func_thing
 
-module.exports.objectIdToDate = (objectID) ->
+objectIdToDate = (objectID) ->
   new Date(parseInt(objectID.toString().slice(0,8), 16)*1000)
 
-module.exports.hexToHSL = (hex) ->
+hexToHSL = (hex) ->
   rgbToHsl(hexToR(hex), hexToG(hex), hexToB(hex))
 
 hexToR = (h) -> parseInt (cutHex(h)).substring(0, 2), 16
@@ -64,7 +64,7 @@ hexToG = (h) -> parseInt (cutHex(h)).substring(2, 4), 16
 hexToB = (h) -> parseInt (cutHex(h)).substring(4, 6), 16
 cutHex = (h) -> (if (h.charAt(0) is '#') then h.substring(1, 7) else h)
 
-module.exports.hslToHex = (hsl) ->
+hslToHex = (hsl) ->
   '#' + (toHex(n) for n in hslToRgb(hsl...)).join('')
 
 toHex = (n) ->
@@ -72,11 +72,11 @@ toHex = (n) ->
   h = '0'+h if h.length is 1
   h
 
-module.exports.pathToUrl = (path) ->
+pathToUrl = (path) ->
   base = location.protocol + '//' + location.hostname + (location.port && ":" + location.port)
   base + path
 
-module.exports.i18n = (say, target, language=me.get('preferredLanguage', true), fallback='en') ->
+i18n = (say, target, language=me.get('preferredLanguage', true), fallback='en') ->
   generalResult = null
   fallBackResult = null
   fallForwardResult = null  # If a general language isn't available, the first specific one will do.
@@ -102,7 +102,7 @@ module.exports.i18n = (say, target, language=me.get('preferredLanguage', true), 
   return say[target] if target of say
   null
 
-module.exports.getByPath = (target, path) ->
+getByPath = (target, path) ->
   throw new Error 'Expected an object to match a query against, instead got null' unless target
   pieces = path.split('.')
   obj = target
@@ -111,9 +111,9 @@ module.exports.getByPath = (target, path) ->
     obj = obj[piece]
   obj
 
-module.exports.isID = (id) -> _.isString(id) and id.length is 24 and id.match(/[a-f0-9]/gi)?.length is 24
+isID = (id) -> _.isString(id) and id.length is 24 and id.match(/[a-f0-9]/gi)?.length is 24
 
-module.exports.round = _.curry (digits, n) ->
+round = _.curry (digits, n) ->
   n = +n.toFixed(digits)
 
 positify = (func) -> (params) -> (x) -> if x > 0 then func(params)(x) else 0
@@ -134,20 +134,20 @@ createLogFunc = (params) ->
 createPowFunc = (params) ->
   (x) -> (params.a or 1) * Math.pow(x, params.b or 1) + (params.c or 0)
 
-module.exports.functionCreators =
+functionCreators =
   linear: positify(createLinearFunc)
   quadratic: positify(createQuadraticFunc)
   logarithmic: positify(createLogFunc)
   pow: positify(createPowFunc)
 
 # Call done with true to satisfy the 'until' goal and stop repeating func
-module.exports.keepDoingUntil = (func, wait=100, totalWait=5000) ->
+keepDoingUntil = (func, wait=100, totalWait=5000) ->
   waitSoFar = 0
   (done = (success) ->
     if (waitSoFar += wait) <= totalWait and not success
       _.delay (-> func done), wait) false
 
-module.exports.grayscale = (imageData) ->
+grayscale = (imageData) ->
   d = imageData.data
   for i in [0..d.length] by 4
     r = d[i]
@@ -159,7 +159,7 @@ module.exports.grayscale = (imageData) ->
 
 # Deep compares l with r, with the exception that undefined values are considered equal to missing values
 # Very practical for comparing Mongoose documents where undefined is not allowed, instead fields get deleted
-module.exports.kindaEqual = compare = (l, r) ->
+kindaEqual = compare = (l, r) ->
   if _.isObject(l) and _.isObject(r)
     for key in _.union Object.keys(l), Object.keys(r)
       return false unless compare l[key], r[key]
@@ -170,7 +170,7 @@ module.exports.kindaEqual = compare = (l, r) ->
     return false
 
 # Return UTC string "YYYYMMDD" for today + offset
-module.exports.getUTCDay = (offset=0) ->
+getUTCDay = (offset=0) ->
   day = new Date()
   day.setDate(day.getUTCDate() + offset)
   partYear = day.getUTCFullYear()
@@ -186,7 +186,7 @@ if document?.createElement
   dummy = document.createElement 'div'
   dummy.innerHTML = 'text'
   TEXT = if dummy.textContent is 'text' then 'textContent' else 'innerText'
-  module.exports.replaceText = (elems, text) ->
+  replaceText = (elems, text) ->
     elem[TEXT] = text for elem in elems
     null
 
@@ -194,7 +194,7 @@ if document?.createElement
 # http://stackoverflow.com/questions/524696/how-to-create-a-style-tag-with-javascript/26230472#26230472
 # Don't use wantonly, or we'll have to implement a simple mechanism for clearing out old rules.
 if document?.createElement
-  module.exports.injectCSS = ((doc) ->
+  injectCSS = ((doc) ->
     # wrapper for all injected styles and temp el to create them
     wrap = doc.createElement("div")
     temp = doc.createElement("div")
@@ -212,17 +212,26 @@ if document?.createElement
   )(document)
 
 # So that we can stub out userAgent in tests
-module.exports.userAgent = ->
+userAgent = ->
   window.navigator.userAgent
 
-module.exports.getQueryVariable = getQueryVariable = (param, defaultValue) ->
-  query = document.location.search.substring 1
-  pairs = (pair.split('=') for pair in query.split '&')
-  for pair in pairs when pair[0] is param
-    return {'true': true, 'false': false}[pair[1]] ? decodeURIComponent(pair[1])
-  defaultValue
+getDocumentSearchString = ->
+  # moved to a separate function so it can be mocked for testing
+  return document.location.search
 
-module.exports.getSponsoredSubsAmount = getSponsoredSubsAmount = (price=999, subCount=0, personalSub=false) ->
+getQueryVariables = ->
+  query = module.exports.getDocumentSearchString().substring(1) # use module.exports so spy is used in testing
+  pairs = (pair.split('=') for pair in query.split '&')
+  variables = {}
+  for [key, value] in pairs
+    variables[key] = {'true': true, 'false': false}[value] ? decodeURIComponent(value)
+  return variables
+
+getQueryVariable = (param, defaultValue) ->
+  variables = getQueryVariables()
+  return variables[param] ? defaultValue
+
+getSponsoredSubsAmount = (price=999, subCount=0, personalSub=false) ->
   # 1 100%
   # 2-11 80%
   # 12+ 60%
@@ -236,7 +245,7 @@ module.exports.getSponsoredSubsAmount = getSponsoredSubsAmount = (price=999, sub
   else
     Math.round((1 - offset) * price + 10 * price * 0.8 + (subCount - 11 + offset) * price * 0.6)
 
-module.exports.getCourseBundlePrice = getCourseBundlePrice = (coursePrices, seats=20) ->
+getCourseBundlePrice = (coursePrices, seats=20) ->
   totalPricePerSeat = coursePrices.reduce ((a, b) -> a + b), 0
   if coursePrices.length > 2
     pricePerSeat = Math.round(totalPricePerSeat / 2.0)
@@ -244,7 +253,7 @@ module.exports.getCourseBundlePrice = getCourseBundlePrice = (coursePrices, seat
     pricePerSeat = parseInt(totalPricePerSeat)
   seats * pricePerSeat
 
-module.exports.getCoursePraise = getCoursePraise = ->
+getCoursePraise = ->
   praise = [
     {
       quote:  "The kids love it."
@@ -281,13 +290,14 @@ module.exports.getCoursePraise = getCoursePraise = ->
   ]
   praise[_.random(0, praise.length - 1)]
 
-module.exports.getPrepaidCodeAmount = getPrepaidCodeAmount = (price=0, users=0, months=0) ->
+getPrepaidCodeAmount = (price=0, users=0, months=0) ->
   return 0 unless users > 0 and months > 0
   total = price * users * months
   total
 
 startsWithVowel = (s) -> s[0] in 'aeiouAEIOU'
-module.exports.filterMarkdownCodeLanguages = (text, language) ->
+  
+filterMarkdownCodeLanguages = (text, language) ->
   return '' unless text
   currentLanguage = language or me.get('aceConfig')?.language or 'python'
   excludedLanguages = _.without ['javascript', 'python', 'coffeescript', 'clojure', 'lua', 'java', 'io', 'html'], currentLanguage
@@ -320,7 +330,7 @@ module.exports.filterMarkdownCodeLanguages = (text, language) ->
 
   return text
 
-module.exports.aceEditModes = aceEditModes =
+aceEditModes =
   javascript: 'ace/mode/javascript'
   coffeescript: 'ace/mode/coffee'
   python: 'ace/mode/python'
@@ -330,7 +340,7 @@ module.exports.aceEditModes = aceEditModes =
 
 # These ACEs are used for displaying code snippets statically, like in SpellPaletteEntryView popovers
 # and have short lifespans
-module.exports.initializeACE = (el, codeLanguage) ->
+initializeACE = (el, codeLanguage) ->
   contents = $(el).text().trim()
   editor = ace.edit el
   editor.setOptions maxLines: Infinity
@@ -352,7 +362,7 @@ module.exports.initializeACE = (el, codeLanguage) ->
   session.setNewLineMode 'unix'
   return editor
 
-module.exports.capitalLanguages = capitalLanguages =
+capitalLanguages =
   'javascript': 'JavaScript'
   'coffeescript': 'CoffeeScript'
   'python': 'Python'
@@ -360,7 +370,7 @@ module.exports.capitalLanguages = capitalLanguages =
   'lua': 'Lua'
   'html': 'HTML'
 
-module.exports.createLevelNumberMap = (levels) ->
+createLevelNumberMap = (levels) ->
   levelNumberMap = {}
   practiceLevelTotalCount = 0
   practiceLevelCurrentCount = 0
@@ -375,7 +385,7 @@ module.exports.createLevelNumberMap = (levels) ->
     levelNumberMap[level.key] = levelNumber
   levelNumberMap
 
-module.exports.findNextLevel = (levels, currentIndex, needsPractice) ->
+findNextLevel = (levels, currentIndex, needsPractice) ->
   # levels = [{practice: true/false, complete: true/false}]
   index = currentIndex
   index++
@@ -402,17 +412,17 @@ module.exports.findNextLevel = (levels, currentIndex, needsPractice) ->
     index++ while index < levels.length and (levels[index].practice or levels[index].complete)
   index
 
-module.exports.needsPractice = (playtime=0, threshold=2) ->
+needsPractice = (playtime=0, threshold=2) ->
   playtime / 60 > threshold
 
-module.exports.sortCourses = (courses) ->
+sortCourses = (courses) ->
   _.sortBy courses, (course) ->
     # ._id can be from classroom.courses, otherwise it's probably .id
     index = orderedCourseIDs.indexOf(course.id ? course._id)
     index = 9001 if index is -1
     index
 
-module.exports.usStateCodes =
+usStateCodes =
   # https://github.com/mdzhang/us-state-codes
   # generated by js2coffee 2.2.0
   (->
@@ -512,3 +522,43 @@ module.exports.usStateCodes =
     }
   )()
 
+
+module.exports = {
+  aceEditModes
+  capitalLanguages
+  clone
+  combineAncestralObject
+  courseIDs
+  createLevelNumberMap
+  filterMarkdownCodeLanguages
+  findNextLevel
+  functionCreators
+  getByPath
+  getCourseBundlePrice
+  getCoursePraise
+  getDocumentSearchString
+  getPrepaidCodeAmount
+  getQueryVariable
+  getQueryVariables
+  getSponsoredSubsAmount
+  getUTCDay
+  grayscale
+  hexToHSL
+  hslToHex
+  i18n
+  initializeACE
+  injectCSS
+  isID
+  keepDoingUntil
+  kindaEqual
+  needsPractice
+  normalizeFunc
+  objectIdToDate
+  orderedCourseIDs
+  pathToUrl
+  replaceText
+  round
+  sortCourses
+  usStateCodes
+  userAgent
+}

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -342,10 +342,25 @@ _.extend UserSchema.properties,
   }
   enrollmentRequestSent: { type: 'boolean' }
 
-  schoolName: {type: 'string'}
+  schoolName: {type: 'string', description: 'Deprecated string. Use "school" object instead.'}
   role: {type: 'string', enum: ["God", "advisor", "parent", "principal", "student", "superintendent", "teacher", "technology coordinator"]}
   birthday: c.stringDate({title: "Birthday"})
   lastAchievementChecked: c.stringDate({ name: 'Last Achievement Checked' })
+  
+  israelId: {type: 'string', description: 'ID string used just for il.codecombat.com'}
+  school: { 
+    type: 'object', 
+    description: 'Generic property for storing school information. Currently
+                  only used by Israel; if/when we use it for other purposes,
+                  think about how to keep the data consistent.',
+    properties: {
+      name: { type: 'string' }
+      city: { type: 'string' }
+      district: { type: 'string' }
+      state: { type: 'string' }
+      country: { type: 'string' }
+    }
+  }
 
 c.extendBasicProperties UserSchema, 'user'
 

--- a/app/templates/account/israel-signup-view.jade
+++ b/app/templates/account/israel-signup-view.jade
@@ -1,0 +1,72 @@
+extends /templates/base-flat
+
+block content
+  
+  .container
+    h1.m-t-3.m-b-2.text-center Create Account
+    
+    if loading
+      h5.text-center Loading
+    
+    else if fatalError
+      .alert.alert-danger.text-center
+  
+        if fatalError === 'signed-in'
+          h3 You already have an account
+          a(href="/play") Play CodeCombat!
+          
+        else if fatalError === 'missing-input'
+          h3 Not enough information was provided
+          p Need at least "israelId" and "email" included in GET parameters.
+          
+        else if fatalError === 'email-exists'
+          h3 Your email is already in use
+          a.login-button(data-i18n="login.log_in")
+  
+        else
+          h3 Error
+          p= fatalError
+          
+    else
+      .row
+        .col-md-6.col-md-offset-3.col-sm-8.col-sm-offset-2
+          table.table.table-condensed
+            tr
+              th Israel Id
+              td= queryParams.israelId
+            tr
+              th Email
+              td= queryParams.email
+            if queryParams.firstName
+              tr
+                th First Name
+                td= queryParams.firstName
+            if queryParams.lastName
+              tr
+                th Last Name
+                td= queryParams.lastName
+            if queryParams.school
+              tr
+                th School
+                td= queryParams.school
+            if queryParams.city
+              tr
+                th City
+                td= queryParams.city
+            if queryParams.district
+              tr
+                th District
+                td= queryParams.district
+          form
+            .form-group
+              label.control-label(for="username-input" data-i18n="general.username")
+              input.form-control.input-lg(name="name" value=name)
+            
+            .form-group
+              label.control-label(for="password-input" data-i18n="general.password")
+              input.form-control.input-lg(name="password" type="password" value=password)
+              
+            if formError
+              .alert.alert-danger.text-center= formError
+
+            button#create-account-btn.btn.btn-lg.btn-block.btn-navy(type="submit" data-i18n="login.sign_up")

--- a/app/views/account/IsraelSignupView.coffee
+++ b/app/views/account/IsraelSignupView.coffee
@@ -1,0 +1,142 @@
+RootView = require 'views/core/RootView'
+template = require 'templates/account/israel-signup-view'
+forms = require 'core/forms'
+errors = require 'core/errors'
+utils = require 'core/utils'
+User = require 'models/User'
+State = require 'models/State'
+
+class AbortError extends Error
+
+formSchema =
+  type: 'object'
+  properties: _.pick(User.schema.properties, 'name', 'password')
+  required: ['name', 'password']
+
+
+module.exports = class IsraelSignupView extends RootView
+  id: 'israel-signup-view'
+  template: template
+  
+  events:
+    'submit form': 'onSubmitForm'
+    'input input[name="name"]': 'onChangeName'
+    'input input[name="password"]': 'onChangePassword'
+    
+  initialize: ->
+    @state = new State({
+      fatalError: null
+      # Possible errors:
+      #   'signed-in': They are logged in
+      #   'missing-input': Required query parameters are not provided
+      #   'email-exists': Given email exists in our system
+      #   Any other string will be shown directly to user
+      
+      formError: null
+      loading: true
+      submitting: false
+      queryParams: _.pick(utils.getQueryVariables(),
+        'israelId'
+        'firstName'
+        'lastName'
+        'email'
+        'school'
+        'city'
+        'state'
+        'district'
+      )
+      name: ''
+      password: ''
+    })
+    
+    { israelId, email } = @state.get('queryParams')
+    
+    # sanity checks
+    if not me.isAnonymous()
+      @state.set({fatalError: 'signed-in', loading: false})
+    
+    else if not (israelId and email) or not forms.validateEmail(email)
+      @state.set({fatalError: 'missing-input', loading: false})
+      
+    else
+      User.checkEmailExists(email)
+      .then ({exists}) =>
+        @state.set({loading: false})
+        if exists
+          @state.set({fatalError: 'email-exists'})
+          
+      .catch =>
+        @state.set({fatalError: $.i18n.t('loading_error.unknown'), loading: false})
+        
+    @listenTo(@state, 'change', _.debounce(@render))
+
+  getRenderData: ->
+    c = super()
+    return _.extend({}, @state.attributes, c)
+    
+  onChangeName: (e) ->
+    # sync form info with state, but do not re-render
+    @state.set({name: $(e.currentTarget).val()}, {silent: true})
+    
+  onChangePassword: (e) ->
+    @state.set({password: $(e.currentTarget).val()}, {silent: true})
+
+  displayFormSubmitting: ->
+    @$('#create-account-btn').text($.i18n.t('signup.creating')).attr('disabled', true)
+    @$('input').attr('disabled', true)
+
+  displayFormStandingBy: ->
+    @$('#create-account-btn').text($.i18n.t('login.sign_up')).attr('disabled', false)
+    @$('input').attr('disabled', false)
+    
+  onSubmitForm: (e) ->
+    
+    # validate form with schema
+    e.preventDefault()
+    forms.clearFormAlerts(@$el)
+    @state.set('formError', null)
+    data = forms.formToObject(e.currentTarget)
+    res = tv4.validateMultiple data, formSchema
+    if not res.valid
+      forms.applyErrorsToForm(@$('form'), res.errors)
+      return
+
+    # check for name conflicts
+    queryParams = @state.get('queryParams')
+    @displayFormSubmitting()
+    User.checkNameConflicts(data.name)
+    .then ({ suggestedName, conflicts }) =>
+      nameField = @$('input[name="name"]')
+      if conflicts
+        suggestedNameText = $.i18n.t('signup.name_taken').replace('{{suggestedName}}', suggestedName)
+        forms.setErrorToField(nameField, suggestedNameText)
+        throw AbortError
+      
+      # Save new user settings, particularly properties handed in
+      school = _.pick(queryParams, 'state', 'city', 'district')
+      school.name = queryParams.school if queryParams.school
+      me.set(_.pick(queryParams, 'firstName', 'lastName', 'israelId'))
+      me.set({school})
+      return me.save()
+        
+    .then =>
+      # sign up
+      return me.signupWithPassword(
+        @state.get('name'),
+        queryParams.email,
+        @state.get('password')
+      )
+      
+    .then =>
+      # successful signup
+      application.router.navigate('/play', { trigger: true })
+      
+    .catch (e) =>
+      # if we threw the AbortError, the error was handled
+      @displayFormStandingBy()
+      if e is AbortError
+        return
+      else
+        # Otherwise, show a generic error
+        console.error 'IsraelSignupView form submission Promise error:', e
+        @state.set('formError', e.responseJSON?.message or e.message or 'Unknown Error')

--- a/config.coffee
+++ b/config.coffee
@@ -5,6 +5,7 @@ sysPath = require 'path'
 fs = require('fs')
 commonjsHeader = require('commonjs-require-definition')
 TRAVIS = process.env.COCO_TRAVIS_TEST
+console.log 'Travis Build' if TRAVIS
 
 
 #- regJoin replace a single '/' with '[\/\\]' so it can handle either forward or backslash

--- a/server/models/User.coffee
+++ b/server/models/User.coffee
@@ -463,7 +463,7 @@ UserSchema.statics.editableProperties = [
   'testGroupNumber', 'music', 'hourOfCode', 'hourOfCodeComplete', 'preferredLanguage',
   'wizard', 'aceConfig', 'autocastDelay', 'lastLevel', 'jobProfile', 'savedEmployerFilterAlerts',
   'heroConfig', 'iosIdentifierForVendor', 'siteref', 'referrer', 'schoolName', 'role', 'birthday',
-  'enrollmentRequestSent'
+  'enrollmentRequestSent', 'israelId', 'school'
 ]
 
 UserSchema.statics.serverProperties = ['passwordHash', 'emailLower', 'nameLower', 'passwordReset', 'lastIP']

--- a/test/app/core/utils.spec.coffee
+++ b/test/app/core/utils.spec.coffee
@@ -1,5 +1,25 @@
 describe 'Utility library', ->
   utils = require 'core/utils'
+  
+  describe 'getQueryVariable(param, defaultValue)', ->
+    beforeEach ->
+      spyOn(utils, 'getDocumentSearchString').and.returnValue(
+        '?key=value&bool1=false&bool2=true&email=test%40email.com'
+      )
+    
+    it 'returns the query parameter', ->
+      expect(utils.getQueryVariable('key')).toBe('value')
+      
+    it 'returns Boolean types if the value is "true" or "false"', ->
+      expect(utils.getQueryVariable('bool1')).toBe(false)
+      expect(utils.getQueryVariable('bool2')).toBe(true)
+      
+    it 'decodes encoded strings', ->
+      expect(utils.getQueryVariable('email')).toBe('test@email.com')
+      
+    it 'returns the given default value if the key is not present', ->
+      expect(utils.getQueryVariable('key', 'other-value')).toBe('value')
+      expect(utils.getQueryVariable('NaN', 'other-value')).toBe('other-value')
 
   describe 'i18n', ->
     beforeEach ->

--- a/test/app/views/account/IsraelSignupView.spec.coffee
+++ b/test/app/views/account/IsraelSignupView.spec.coffee
@@ -1,0 +1,36 @@
+IsraelSignupView = require('views/account/IsraelSignupView')
+utils = require 'core/utils'
+
+describe 'IsraelSignupView', ->
+  describe 'initialize()', ->
+    it 'sets state.fatalError to "signed-in" if the user is not anonymous', ->
+      spyOn(me, 'isAnonymous').and.returnValue(false)
+      view = new IsraelSignupView()
+      expect(view.state.get('fatalError')).toBe('signed-in')
+      
+    it 'sets state.fatalError to "missing-input" if the proper query parameters are not provided', ->
+      queryVariables = null
+      spyOn(me, 'isAnonymous').and.returnValue(true)
+      spyOn(utils, 'getQueryVariables').and.callFake(-> queryVariables)
+
+      # no inputs
+      queryVariables = {}
+      expect(new IsraelSignupView().state.get('fatalError')).toBe('missing-input')
+      
+      # id but no email
+      queryVariables = { israelId: '...' }
+      expect(new IsraelSignupView().state.get('fatalError')).toBe('missing-input')
+
+      # email but no id
+      queryVariables = { email: 'test@email.com' }
+      expect(new IsraelSignupView().state.get('fatalError')).toBe('missing-input')
+      
+      # id and email but email is not valid
+      queryVariables = { email: 'notanemail', israelId: '...' }
+      expect(new IsraelSignupView().state.get('fatalError')).toBe('missing-input')
+
+      # valid inputs
+      queryVariables = { email: 'test@email.com', israelId: '...' }
+      expect(new IsraelSignupView().state.get('fatalError')).toBe(null)
+      
+# TODO: Add more test cases when this view is more finalized


### PR DESCRIPTION
Add a dedicated signup page for Israel. In the future, student and individuals creating accounts will be redirected to a separate site to sign up. This site will then redirect to `/il-signup`, providing information about the user through GET parameters, including email and an ID which will be saved, and all the student needs to do on our end is provide a username and password.