### PR TITLE
Be a little more picky about requiring a user supplied string.

### DIFF
--- a/server/routes/db.coffee
+++ b/server/routes/db.coffee
@@ -72,7 +72,7 @@ module.exports.setup = (app) ->
 
 getSchema = (req, res, moduleName) ->
   try
-    name = moduleName.replace '.', '_'
+    name = moduleName.replace /[^a-z_-]/gi, '_'
     schema = require('../../app/schemas/models/' + name)
 
     res.send(JSON.stringify(schema, null, '\t'))


### PR DESCRIPTION
Also, schemas in the `x.schema.coffee` don't work, but I guess those never worked for the most part.  Should we make them work? @sderickson 