### PR TITLE
Try out Dexecure

### DIFF
--- a/app/assets/dexecure-c167a5675c.js
+++ b/app/assets/dexecure-c167a5675c.js
@@ -1,0 +1,18 @@
+var dexecure = {
+	"server": {
+		"codecombat.com": "codecombat.dexecure.net",
+		"www.codecombat.com": "codecombat.dexecure.net",
+		"staging.codecombat.com": "codecombat-staging.dexecure.net"
+	},
+	"firstPartyDomain": [
+		"codecombat.com",
+		"www.codecombat.com",
+		"staging.codecombat.com"
+	],
+	"optimisationsEnabled": true,
+	"debugMode": false,
+	"imageMatchRegex": "\\.jpe?g|\\.png|\\.js(\\?.*)?(#.*)?$|\\.css",
+	"pagesEnabled": [
+		""
+	]
+};"use strict";function isFirstPartyDomain(e){for(var r=new URL(e),o=dexecure.firstPartyDomain,t=o.length-1;t>=0;t--)if(o[t].toLowerCase()==r.host.toLowerCase())return!0;return!1}function changeToDexecureURL(e){var r=new URL(e);return dexecure.debugMode&&console.log("inputURL is ",e),dexecure.debugMode&&console.log("inputURL.hostname is ",e.hostname),r.hostname=dexecure.server[r.hostname],dexecure.debugMode&&console.log("changedURL.hostname is ",r.hostname),dexecure.debugMode&&console.log("changedURL is ",r.href),r.href}function isPageEnabled(e){return!0}dexecure.optimisationsEnabled&&(self.addEventListener("install",function(e){dexecure.debugMode&&console.log("install triggered"),e.waitUntil(self.skipWaiting())}),self.addEventListener("activate",function(e){e.waitUntil(self.clients.claim())}),self.addEventListener("fetch",function(e){dexecure.debugMode&&console.log("fetch triggered");var r={};e.request.headers.has("Accept")&&(r.Accept=e.request.headers.get("Accept"));var o=new Headers(r),t=new RegExp(dexecure.imageMatchRegex,"i");if(dexecure.debugMode&&console.log("input url is ",e.request.url),isPageEnabled(e.request.referrer)&&t.test(e.request.url.toLowerCase())&&isFirstPartyDomain(e.request.url)){var n=changeToDexecureURL(e.request.url);n=decodeURIComponent(n),dexecure.debugMode&&console.log("output url is ",n),e.respondWith(fetch(n,{mode:"cors",headers:o}).then(function(r){if(r.ok)return r;throw dexecure.debugMode&&console.log("Responding with original image as optimiser was not reachable ",e.request.url),new Error("Unable to fetch optimised image")}).catch(function(r){return dexecure.debugMode&&(console.log("Sending original image as an error occured when trying to optimise ",e.request.url),console.log("The error was ",r)),fetch(e.request)}))}}));

--- a/app/assets/main.html
+++ b/app/assets/main.html
@@ -7,6 +7,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=1024">
+  <meta http-equiv="Accept-CH" content="Viewport-Width">  <!-- Dexecure -->
 
   <title>CodeCombat - Learn how to code by playing a game</title>
   <meta name="description" content="Learn programming with a multiplayer live coding strategy game for beginners. Learn Python or JavaScript as you defeat ogres, solve mazes, and level up. Open source HTML5 game!">
@@ -28,6 +29,11 @@
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link rel="stylesheet" href="/stylesheets/app.css">
   <link href='//fonts.googleapis.com/css?family=Merriweather' rel='stylesheet' type='text/css'>
+
+  <script>
+    var DEXECURE_URL = "/dexecure-c167a5675c.js";
+    "serviceWorker"in navigator&&navigator.serviceWorker.register(DEXECURE_URL,{scope:'/'}).then(function(e){"/"!=new URL(e.scope).pathname&&console.log("Service worker scope is not /")})["catch"](function(e){console.log("Unable to register service worker.");console.log(e)});
+  </script>
 
   <!-- Google Analytics -->
   <script>


### PR DESCRIPTION
It should replace images that are needlessly large with smaller images automatically. It does it with ServiceWorkers and has a Cloudflare integration. It seems to work (tried on staging), but the only thing to watch out for will be possibly more aggressive caching–not sure.

In their words why it's better than alternatives:
* Support for various browser specific formats (WebP for Blink browsers, JPEG XR for IE11 and Edge)
* Automatic removal of metadata in images which can make the image up to 14% smaller if present
* Different images served for desktop and mobile devices adjusting the quality of the image accordingly. 
* Automatically inter-convert between various formats - PNGs are good for certain images, JPEGs for other kinds!
* Support for progressive JPEGs which leads to a much better user experience