### PR TITLE
Update web_dev section in uk.cofee

### DIFF
--- a/app/locale/uk.coffee
+++ b/app/locale/uk.coffee
@@ -1545,20 +1545,20 @@ module.exports = nativeDescription: "Українська", englishDescription: 
 #  game_dev:
 #    creator: "Creator"
 
-#  web_dev:
-#    image_gallery_title: "Image Gallery"
-#    select_an_image: "Select an image you want to use"
-#    scroll_down_for_more_images: "(Scroll down for more images)"
-#    copy_the_url: "Copy the URL below"
-#    copy_the_url_description: "Useful if you want to replace an existing image."
-#    copy_the_img_tag: "Copy the <img> tag"
-#    copy_the_img_tag_description: "Useful if you want to insert a new image."
-#    copy_url: "Copy URL"
-#    copy_img: "Copy <img>"
-#    how_to_copy_paste: "How to Copy/Paste"
-#    copy: "Copy"
-#    paste: "Paste"
-#    back_to_editing: "Back to Editing"
+  web_dev:
+    image_gallery_title: "Галерея картинок"
+    select_an_image: "Вибери картинку, яку хочеш використати"
+    scroll_down_for_more_images: "(Прокрути вниз, щоб побачити більше картинок)"
+    copy_the_url: "Скопіюй URL нижче"
+    copy_the_url_description: "Корисно, якщо ти хочешь замінити існуючу картинку."
+    copy_the_img_tag: "Скопіюй <img> тег"
+    copy_the_img_tag_description: "Корисно, якщо ти хочешь вставити нову картинку."
+    copy_url: "Скопіювати URL"
+    copy_img: "Скопіювати <img>"
+    how_to_copy_paste: "Як скопіювати/вставити"
+    copy: "Скопіювати"
+    paste: "Вставити"
+    back_to_editing: "Назад до редагування"
 
   classes:
     archmage_title: "Архімаг"


### PR DESCRIPTION
Proposed translation of the web_dev section. "картинки" has been chosen intentionally as less formal than "зображення" and thus more children-friendly.
