### PR TITLE
Tighten Campaign level denormalization and saving

### DIFF
--- a/app/collections/Achievements.coffee
+++ b/app/collections/Achievements.coffee
@@ -9,3 +9,9 @@ module.exports = class AchievementCollection extends CocoCollection
     options = _.extend({data: {}}, options)
     options.data.related = levelOriginal
     @fetch(options)
+
+  fetchForCampaign: (campaignHandle, options) ->
+    options = _.extend({data: {}}, options)
+    options.url = "/db/campaign/#{campaignHandle}/achievements"
+    @fetch(options)
+    

--- a/app/schemas/models/campaign.schema.coffee
+++ b/app/schemas/models/campaign.schema.coffee
@@ -84,7 +84,7 @@ _.extend CampaignSchema.properties, {
   }}
 }
 
-denormalizedLevelProperties = [
+CampaignSchema.denormalizedLevelProperties = [
   'name'
   'description'
   'i18n'
@@ -125,7 +125,7 @@ denormalizedLevelProperties = [
   'scoreTypes'
 ]
 hiddenLevelProperties = ['name', 'description', 'i18n', 'replayable', 'slug', 'original', 'primerLanguage', 'shareable', 'concepts', 'scoreTypes']
-for prop in denormalizedLevelProperties
+for prop in CampaignSchema.denormalizedLevelProperties
   CampaignSchema.properties.levels.additionalProperties.properties[prop] = _.cloneDeep(LevelSchema.properties[prop])
 for hiddenProp in hiddenLevelProperties
   CampaignSchema.properties.levels.additionalProperties.properties[hiddenProp].format = 'hidden'

--- a/app/views/editor/campaign/CampaignEditorView.coffee
+++ b/app/views/editor/campaign/CampaignEditorView.coffee
@@ -61,7 +61,6 @@ module.exports = class CampaignEditorView extends RootView
     @listenToOnce @achievements, 'sync', @onFundamentalLoaded
 
   onLeaveMessage: ->
-    @propagateCampaignIndexes()
     for model in @toSave.models
       diff = model.getDelta()
       if _.size(diff)
@@ -84,20 +83,35 @@ module.exports = class CampaignEditorView extends RootView
   onFundamentalLoaded: ->
     # Load any levels which haven't been denormalized into our campaign.
     return unless @campaign.loaded and @levels.loaded and @achievements.loaded
+    @loadMissingLevelsAndRelatedModels()
+    
+  loadMissingLevelsAndRelatedModels: ->
+    promises = []
     for level in _.values(@campaign.get('levels'))
       continue if model = @levels.findWhere(original: level.original)
       model = new Level({})
       model.setProjection Campaign.denormalizedLevelProperties
       model.setURL("/db/level/#{level.original}/version")
-      @levels.add @supermodel.loadModel(model).model
+      levelResource = @supermodel.loadModel(model)
+      @levels.add levelResource.model
+      # Handle SuperModel's caching, and make sure loaded levels save and notice changes properly
+      if levelResource.jqxhr
+        levelResource.model.once('sync', ->
+          @setURL("/db/level/#{@id}")
+          @markToRevert()
+        )
+        promises.push(levelResource.jqxhr)
       achievements = new RelatedAchievementsCollection level.original
       achievements.setProjection achievementProject
-      @supermodel.loadCollection achievements, 'achievements'
-      @listenToOnce achievements, 'sync', ->
-        @achievements.add(achievements.models)
+      achievementsResource = @supermodel.loadCollection(achievements)
+      promises.push(achievementsResource.jqxhr)
+      @listenToOnce achievements, 'sync', (achievementsLoaded) ->
+        @achievements.add(achievementsLoaded.models)
+    return Promise.resolve($.when(promises...))
 
   onLoaded: ->
     @updateCampaignLevels()
+    @campaignView.render()
     super()
 
   updateCampaignLevels: ->
@@ -107,7 +121,7 @@ module.exports = class CampaignEditorView extends RootView
       levelOriginal = level.get('original')
       campaignLevel = campaignLevels[levelOriginal]
       continue if not campaignLevel
-      $.extend campaignLevel, _.omit(level.attributes, '_id')
+      $.extend campaignLevel, _.pick(level.attributes, Campaign.denormalizedLevelProperties)
       # TODO: better way for it to remember when we intend to not specifically require/restrict gear any more
       delete campaignLevel.requiredGear if not level.attributes.requiredGear
       delete campaignLevel.restrictedGear if not level.attributes.restrictedGear
@@ -124,7 +138,12 @@ module.exports = class CampaignEditorView extends RootView
     for level in _.values campaignLevels
       continue if /test/.test @campaign.get('slug')  # Don't overwrite level stuff for testing Campaigns
       model = @levels.findWhere {original: level.original}
-      model.set key, level[key] for key in Campaign.denormalizedLevelProperties
+      # do not propagate campaignIndex for non-course campaigns
+      propsToPropagate = Campaign.denormalizedLevelProperties
+      if @campaign.get('type') isnt 'course'
+        propsToPropagate = _.without(propsToPropagate, 'campaignIndex')
+      for key in propsToPropagate
+        model.set key, level[key] if model.get(key) isnt level[key]
       @toSave.add model if model.hasLocalChanges()
 
   formatRewards: (level) ->
@@ -184,10 +203,16 @@ module.exports = class CampaignEditorView extends RootView
           @openCampaignLevelView @supermodel.getModelByOriginal Level, original
           break
 
-  onClickSaveButton: ->
-    @propagateCampaignIndexes()
-    @toSave.set @toSave.filter (m) -> m.hasLocalChanges()
-    @openModalView new SaveCampaignModal({}, @toSave)
+  onClickSaveButton: (e) ->
+    return if @openingModal
+    @openingModal = true
+    @loadMissingLevelsAndRelatedModels().then(=>
+      @openingModal = false
+      @propagateCampaignIndexes()
+      @updateCampaignLevels()
+      @toSave.set @toSave.filter (m) -> m.hasLocalChanges()
+      @openModalView new SaveCampaignModal({}, @toSave)
+    )
 
   afterRender: ->
     super()

--- a/server/middleware/campaigns.coffee
+++ b/server/middleware/campaigns.coffee
@@ -50,7 +50,9 @@ module.exports =
     project = parse.getProjectFromReq(req)
     fetches = []
     for level in _.values(levels)
-      fetches.push Achievement.find({ related: level.original }).select(project)
+      # Sometimes, level.original is some sort of object, but not an object id. Add '' to get this to work.
+      # This strange behavior shows itself when making changes in the CampaignEditorView.
+      fetches.push Achievement.find({ related: level.original + '' }).select(project)
     achievementses = yield fetches
     achievements = _.flatten(achievementses)
     res.status(200).send((achievement.toObject({req: req}) for achievement in achievements))


### PR DESCRIPTION
* Before saving the campaign, load all missing levels and achievements so rewards are properly set
* Have individually loaded levels save and report changes properly
* Do not propagate campaignIndex from non-course campaigns to levels
* Do not set level properties to 'undefined', making it seem like they have local changes
* Update campaign indexes before saving the campaign
* Have fetching achievements by campaign handle odd level original values
* When a level is edited, propagate those changes to campaigns immediately