### PR TITLE
Experiment: cmd+alt+click a translated element to open the translation file to that element

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -852,7 +852,6 @@
     more_info_3: "is a good place to connect with fellow educators who are using CodeCombat."
     licenses_needed: "Licenses needed"
 
-
   teachers_quote:
     name: "Demo Form"
     subtitle: "Get your students started in less than an hour. You'll be able to <strong>create a class, add students, and monitor their progress</strong> as they learn computer science."

--- a/app/views/core/CocoView.coffee
+++ b/app/views/core/CocoView.coffee
@@ -197,12 +197,12 @@ module.exports = class CocoView extends Backbone.View
     e.stopPropagation() # Backbone subviews and superviews will handle this call repeatedly otherwise
     AuthModal = require 'views/core/AuthModal'
     @openModalView(new AuthModal())
-  
+
   onClickLoadingErrorCreateAccountButton: (e) ->
     e.stopPropagation()
     CreateAccountModal = require 'views/core/CreateAccountModal'
     @openModalView(new CreateAccountModal({mode: 'signup'}))
-  
+
   onClickLoadingErrorLogoutButton: (e) ->
     e.stopPropagation()
     auth.logoutUser()
@@ -268,7 +268,7 @@ module.exports = class CocoView extends Backbone.View
     @_lastLoading.find('.loading-screen').remove()
     @_lastLoading.find('>').removeClass('hidden')
     @_lastLoading = null
-    
+
   showError: (jqxhr) ->
     return unless @_lastLoading?
     context = {
@@ -476,11 +476,11 @@ module.exports = class CocoView extends Backbone.View
     slider.on('slide', changeCallback)
     slider.on('slidechange', changeCallback)
     slider
-    
+
   scrollToLink: (link, speed=300) ->
     scrollTo = $(link).offset().top
     $('html, body').animate({ scrollTop: scrollTo }, speed)
-    
+
   scrollToTop: (speed=300) ->
     $('html, body').animate({ scrollTop: 0 }, speed)
 
@@ -522,6 +522,32 @@ module.exports = class CocoView extends Backbone.View
       noty text: message, layout: 'topCenter', type: 'error', killer: false
 
   wait: (event) -> new Promise((resolve) => @once(event, resolve))
+
+  onClickTranslatedElement: (e) ->
+    return unless (key.ctrl or key.command) and key.alt
+    e.preventDefault()
+    e.stopImmediatePropagation()
+    i18nKey = _.last($(e.currentTarget).data('i18n').split(';')).replace(/\[.*?\]/, '')
+    base = $.i18n.t(i18nKey, {lng: 'en'})
+    translated = $.i18n.t(i18nKey)
+    en = require('locale/en')
+    [clickedSection, clickedKey] = i18nKey.split('.')
+    lineNumber = 2
+    found = false
+    for enSection, enEntries of en.translation
+      for enKey, enValue of enEntries
+        ++lineNumber
+        if clickedSection is enSection and clickedKey is enKey
+          found = true
+          break
+      break if found
+      lineNumber += 2
+    unless found
+      return console.log "Couldn't find #{i18nKey} in app/locale/en.coffee."
+    targetLanguage = me.get('preferredLanguage') or 'en'
+    targetLanguage = 'en' if targetLanguage.split('-')[0] is 'en'
+    githubUrl = "https://github.com/codecombat/codecombat/blob/master/app/locale/#{targetLanguage}.coffee#L#{lineNumber}"
+    window.open githubUrl, target: '_blank'
 
 mobileRELong = /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i
 

--- a/app/views/core/ModalView.coffee
+++ b/app/views/core/ModalView.coffee
@@ -13,6 +13,7 @@ module.exports = class ModalView extends CocoView
     'click a': 'toggleModal'
     'click button': 'toggleModal'
     'click li': 'toggleModal'
+    'click [data-i18n]': 'onClickTranslatedElement'
 
   shortcuts:
     'esc': 'hide'

--- a/app/views/core/RootView.coffee
+++ b/app/views/core/RootView.coffee
@@ -31,7 +31,7 @@ module.exports = class RootView extends CocoView
     'click button': 'toggleModal'
     'click li': 'toggleModal'
     'treema-error': 'onTreemaError'
-    'click *[data-i18n]': 'onClickTranslatedElement'
+    'click [data-i18n]': 'onClickTranslatedElement'
 
   subscriptions:
     'achievements:new': 'handleNewAchievements'
@@ -190,24 +190,3 @@ module.exports = class RootView extends CocoView
 
   onTreemaError: (e) ->
     noty text: e.message, layout: 'topCenter', type: 'error', killer: false, timeout: 5000, dismissQueue: true
-
-  onClickTranslatedElement: (e) ->
-    return unless (key.ctrl or key.command) and key.alt
-    e.preventDefault()
-    e.stopImmediatePropagation()
-    i18nKey = $(e.target).data('i18n')
-    base = $.i18n.t(i18nKey, {lng: 'en'})
-    translated = $.i18n.t(i18nKey)
-    en = require('locale/en')
-    [clickedSection, clickedKey] = i18nKey.split('.')
-    lineNumber = 2
-    found = false
-    for enSection, enEntries of en.translation
-      for enKey, enValue of enEntries
-        ++lineNumber
-        if clickedSection is enSection and clickedKey is enKey
-          found = true
-          break
-      break if found
-      lineNumber += 2
-    window.open "https://github.com/codecombat/codecombat/blob/master/app/locale/#{me.get('preferredLanguage') or 'en'}.coffee#L#{lineNumber}", target: '_blank'

--- a/app/views/core/RootView.coffee
+++ b/app/views/core/RootView.coffee
@@ -31,6 +31,7 @@ module.exports = class RootView extends CocoView
     'click button': 'toggleModal'
     'click li': 'toggleModal'
     'treema-error': 'onTreemaError'
+    'click *[data-i18n]': 'onClickTranslatedElement'
 
   subscriptions:
     'achievements:new': 'handleNewAchievements'
@@ -113,7 +114,7 @@ module.exports = class RootView extends CocoView
     $('body').removeClass('is-playing')
 
     if title = @getTitle() then title += ' | CodeCombat'
-    else title = 'CodeCombat - Learn how to code by playing a game' 
+    else title = 'CodeCombat - Learn how to code by playing a game'
 
     $('title').text(title)
 
@@ -189,3 +190,24 @@ module.exports = class RootView extends CocoView
 
   onTreemaError: (e) ->
     noty text: e.message, layout: 'topCenter', type: 'error', killer: false, timeout: 5000, dismissQueue: true
+
+  onClickTranslatedElement: (e) ->
+    return unless (key.ctrl or key.command) and key.alt
+    e.preventDefault()
+    e.stopImmediatePropagation()
+    i18nKey = $(e.target).data('i18n')
+    base = $.i18n.t(i18nKey, {lng: 'en'})
+    translated = $.i18n.t(i18nKey)
+    en = require('locale/en')
+    [clickedSection, clickedKey] = i18nKey.split('.')
+    lineNumber = 2
+    found = false
+    for enSection, enEntries of en.translation
+      for enKey, enValue of enEntries
+        ++lineNumber
+        if clickedSection is enSection and clickedKey is enKey
+          found = true
+          break
+      break if found
+      lineNumber += 2
+    window.open "https://github.com/codecombat/codecombat/blob/master/app/locale/#{me.get('preferredLanguage') or 'en'}.coffee#L#{lineNumber}", target: '_blank'


### PR DESCRIPTION
What could go wrong with this?

Test here: http://e0z6mg-codecombat-staging-codecombat.runnableapp.com/

You should be able to cmd+alt+click (on Mac) an element and open up GitHub right to where the element's translation is, if it has one.

@Imperadeiro98 @Bryukh is this helpful?