### PR TITLE
End hints A/B test in favor of manual style and enable hints to show general articles

### DIFF
--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -185,18 +185,6 @@ module.exports = class User extends CocoModel
     application.tracker.identify fourthLevelGroup: @fourthLevelGroup unless me.isAdmin()
     @fourthLevelGroup
 
-  getHintsGroup: ->
-    # A/B testing two styles of hints
-    return @hintsGroup if @hintsGroup
-    group = me.get('testGroupNumber') % 3
-    @hintsGroup = switch group
-      when 0 then 'no-hints'  # Only show intro and overview in hints dialog
-      when 1 then 'hints'     # Automatically created code, doled out line-by-line, without full solutions
-      when 2 then 'hintsB'    # Manually created FAQ-style hints, reusable across levels
-    @hintsGroup = 'hints' if me.isAdmin()
-    application.tracker.identify hintsGroup: @hintsGroup unless me.isAdmin()
-    @hintsGroup
-
   getDefaultLanguageGroup: ->
     # A/B test default programming language in home version
     return @defaultLanguageGroup if @defaultLanguageGroup
@@ -335,7 +323,7 @@ module.exports = class User extends CocoModel
     return 'not-enrolled' unless coursePrepaid
     return 'enrolled' unless coursePrepaid.endDate
     return if coursePrepaid.endDate > new Date().toISOString() then 'enrolled' else 'expired'
-  
+
   prepaidType: ->
     # TODO: remove once legacy prepaidIDs are migrated to objects
     return undefined unless @get('coursePrepaid') or @get('coursePrepaidID')
@@ -454,7 +442,7 @@ module.exports = class User extends CocoModel
     return null unless coursePrepaid
     Prepaid = require 'models/Prepaid'
     return new Prepaid(coursePrepaid)
-  
+
   # TODO: Probably better to denormalize this into the user
   getLeadPriority: ->
     request = $.get('/db/user/-/lead-priority')

--- a/app/views/play/level/HintsState.coffee
+++ b/app/views/play/level/HintsState.coffee
@@ -1,7 +1,9 @@
+Article = require 'models/Article'
+
 module.exports = class HintsState extends Backbone.Model
 
   initialize: (attributes, options) ->
-    { @level, @session } = options
+    { @level, @session, @supermodel } = options
     @listenTo(@level, 'change:documentation', @update)
     @update()
 
@@ -9,20 +11,15 @@ module.exports = class HintsState extends Backbone.Model
     @get('hints')?[index]
 
   update: ->
-    hints = switch me.getHintsGroup()
-      when 'hints' then _.cloneDeep(@level.get('documentation')?.hints or [])
-      when 'hintsB' then _.cloneDeep(@level.get('documentation')?.hintsB or [])
-      else []
-    haveIntro = false
-    haveOverview = false
-    for article in @level.get('documentation')?.specificArticles ? []
-      if not haveIntro and article.name is 'Intro'
-        hints.unshift(article)
-        haveIntro = true
-      if not haveOverview and article.name is 'Overview'
-        hints.push(article)
-        haveOverview = true
-      break if haveIntro and haveOverview
+    articles = @supermodel.getModels(Article)
+    docs = @level.get('documentation') ? {}
+    general = _.filter (_.find(articles, (article) -> article.get('original') is doc.original)?.attributes for doc in docs.generalArticles or [])
+    specific = docs.specificArticles or []
+    hints = (docs.hintsB or docs.hints or []).concat(specific).concat(general)
+    hints = _.sortBy hints, (doc) ->
+      return -1 if doc.name is 'Intro'
+      return 0
+
     total = _.size(hints)
     @set({
       hints

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -280,7 +280,7 @@ module.exports = class PlayLevelView extends RootView
     @initGoalManager()
 
   insertSubviews: ->
-    @hintsState = new HintsState({ hidden: true }, { @session, @level })
+    @hintsState = new HintsState({ hidden: true }, { @session, @level, @supermodel })
     @insertSubView @tome = new TomeView { @levelID, @session, @otherSession, thangs: @world?.thangs ? [], @supermodel, @level, @observing, @courseID, @courseInstanceID, @god, @hintsState }
     @insertSubView new LevelPlaybackView session: @session, level: @level unless @level.isType('web-dev')
     @insertSubView new GoalsView {level: @level}


### PR DESCRIPTION
@differentmatt see anything wrong with this? Before, we weren't showing non-Intro/Overview specific articles nor general articles in hints, and this makes us do that.

Any other A/B testing stuff you wanted to remove? I left the events in.