### PR TITLE
Fixing vagrant issues on mac os x

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,13 +4,14 @@
 # Original content copyright (c) 2014 dpen2000 licensed under the MIT license
 
 VAGRANTFILE_API_VERSION = "2"
-Vagrant.require_version ">= 1.5.0"
+Vagrant.require_version ">= 1.5.0" , "<= 1.8.6"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Ubuntu 14.04 compatible with both VirtualBox and VMWare Fusion
   # see https://github.com/phusion/open-vagrant-boxes#readme
-  config.vm.box = "phusion/ubuntu-14.04-amd64"
+  config.vm.box = "ubuntu-14.04-amd64"
+  config.vm.box_url = "https://oss-binaries.phusionpassenger.com/vagrant/boxes/latest/ubuntu-14.04-amd64-vbox.box"
 
   config.vm.hostname = "coco-dev"
 

--- a/scripts/vagrant/core/provision.sh
+++ b/scripts/vagrant/core/provision.sh
@@ -62,4 +62,5 @@ sudo apt-get -y install --no-install-recommends mongodb-org
 
 # populate mongo
 echo "populating mongodb..."
+chmod a+x /vagrant/scripts/vagrant/core/fillMongo.sh
 exec /vagrant/scripts/vagrant/core/fillMongo.sh


### PR DESCRIPTION
1) fixes error for box not found by using hard url
2) fixes issue with most current vagrant
3) fixes issue with script permission error for applying dump ([issue 4061](https://github.com/codecombat/codecombat/issues/4061))

