### PR TITLE
Look up users by slug instead of name

### DIFF
--- a/server/middleware/users.coffee
+++ b/server/middleware/users.coffee
@@ -143,12 +143,12 @@ module.exports =
     { name, email, password } = req.body
     unless password
       throw new errors.UnprocessableEntity('Requires password')
-    unless name or email
+    if _.isEmpty(name) and _.isEmpty(email)
       throw new errors.UnprocessableEntity('Requires username or email')
 
-    if not _.isEmpty(email) and yield User.findByEmail(email)
+    if yield User.findByEmail(email)
       throw new errors.Conflict('Email already taken')
-    if not _.isEmpty(name) and yield User.findByName(name)
+    if yield User.findByName(name)
       throw new errors.Conflict('Username already taken')
 
     req.user.set({ name, email, password, anonymous: false })
@@ -159,10 +159,10 @@ module.exports =
       throw new errors.Forbidden('You are already signed in.')
 
     { facebookID, facebookAccessToken, email, name } = req.body
-    unless _.all([facebookID, facebookAccessToken, email, name])
+    unless _.all([facebookID, facebookAccessToken, not _.isEmpty(email), not _.isEmpty(name)])
       throw new errors.UnprocessableEntity('Requires facebookID, facebookAccessToken, email, and name')
 
-    if not _.isEmpty(name) and yield User.findByName(name)
+    if yield User.findByName(name)
       throw new errors.Conflict('Username already taken')
 
     facebookResponse = yield facebook.fetchMe(facebookAccessToken)
@@ -183,10 +183,10 @@ module.exports =
       throw new errors.Forbidden('You are already signed in.')
 
     { gplusID, gplusAccessToken, email, name } = req.body
-    unless _.all([gplusID, gplusAccessToken, email, name])
+    unless _.all([gplusID, gplusAccessToken, not _.isEmpty(email), not _.isEmpty(name)])
       throw new errors.UnprocessableEntity('Requires gplusID, gplusAccessToken, email, and name')
 
-    if not _.isEmpty(name) and yield User.findByName(name)
+    if yield User.findByName(name)
       throw new errors.Conflict('Username already taken')
 
     gplusResponse = yield gplus.fetchMe(gplusAccessToken)

--- a/server/models/User.coffee
+++ b/server/models/User.coffee
@@ -125,12 +125,15 @@ UserSchema.statics.search = (term, done) ->
   return User.findOne(query).exec(done)
 
 UserSchema.statics.findByEmail = (email, done=_.noop) ->
-  emailLower = email.toLowerCase()
+  emailLower = email?.toLowerCase()
+  return Promise.resolve(null) if _.isEmpty(emailLower)
   User.findOne({emailLower: emailLower}).exec(done)
 
 UserSchema.statics.findByName = (name, done=_.noop) ->
-  nameLower = name.toLowerCase()
-  User.findOne({nameLower: nameLower}).exec(done)
+  nameLower = name?.toLowerCase()
+  slug = _.str.slugify(name)
+  return Promise.resolve(null) if _.isEmpty(nameLower) and _.isEmpty(slug)
+  User.findOne({$or: [{nameLower}, {slug}]}).exec(done)
 
 emailNameMap =
   generalNews: 'announcement'
@@ -172,7 +175,7 @@ UserSchema.methods.isEmailSubscriptionEnabled = (newName) ->
   _.defaults emails, _.cloneDeep(jsonschema.properties.emails.default)
   return emails[newName]?.enabled
 
-UserSchema.methods.emailChanged = -> @originalEmail isnt @get('emailLower') 
+UserSchema.methods.emailChanged = -> @originalEmail isnt @get('emailLower')
   
 UserSchema.methods.updateServiceSettings = co.wrap ->
   return unless isProduction or GLOBAL.testing
@@ -217,7 +220,7 @@ UserSchema.methods.updateMailChimp = co.wrap ->
   email = @get('emailLower')
   return unless email
 
-  # check if email is verified here or there 
+  # check if email is verified here or there
   emailVerified = @get('emailVerified')
   if mailChimpEmail and not emailVerified
     try

--- a/spec/server/functional/user.spec.coffee
+++ b/spec/server/functional/user.spec.coffee
@@ -798,6 +798,21 @@ describe 'POST /db/user/:handle/signup-with-password', ->
     json = { name, password: '12345' }
     [res, body] = yield request.postAsync({url, json})
     expect(res.statusCode).toBe(409)
+    expect(res.body.message).toBe('Username already taken')
+    done()
+  
+  it 'returns 409 if there is already a user with the same slug', utils.wrap (done) ->
+    name = 'some username'
+    name2 = 'Some.    User.Namé'
+    initialUser = yield utils.initUser({name})
+    expect(initialUser.get('nameLower')).toBeDefined()
+    expect(initialUser.get('slug')).toBeDefined()
+    user = yield utils.becomeAnonymous()
+    url = getURL("/db/user/#{user.id}/signup-with-password")
+    json = { name: name2, password: '12345' }
+    [res, body] = yield request.postAsync({url, json})
+    expect(res.statusCode).toBe(409)
+    expect(res.body.message).toBe('Username already taken')
     done()
     
   it 'disassociates the user from their trial request if the trial request email and signup email do not match', utils.wrap (done) ->


### PR DESCRIPTION
Because name uniqueness is enforced via slug, and all users with names have slugs, we should always just look up based on slug instead. Fixes signup bug which bypassed lookup by nameLower when user had a `.` in their name.