### PR TITLE
Campaign stats colorer

### DIFF
--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -328,12 +328,11 @@ $gameControlMargin: 30px
         text-decoration: none
 
   .next-level-line
-    transform-origin: 0 100%
     height: 8px
     position: absolute
 
     .line
-      width: calc(100% - 12px - 10px)
+      width: calc(100% - 24px)
       float: left
       margin-top: 2px
       margin-bottom: 2px
@@ -342,12 +341,13 @@ $gameControlMargin: 30px
       box-shadow: 0px 0px 4px black
 
     .point
-      width: 12px
-      float: left
-      margin-top: -4px
-      border-top: 8px solid transparent
-      border-bottom: 8px solid transparent
-      border-left: 12px solid lighten(#F1EAC0, 10%)
+      width: 24px
+      height: 24px
+      float: right
+      margin-top: -8px
+      border-top: 12px solid transparent
+      border-bottom: 12px solid transparent
+      border-left: 24px solid lighten(#F1EAC0, 10%)
 
   .game-controls
     position: absolute

--- a/app/templates/play/campaign-view.jade
+++ b/app/templates/play/campaign-view.jade
@@ -52,8 +52,8 @@ if view.showAds()
             img.star(src="/images/pages/play/star.png")
           if editorMode
             - var kindKey = ((level.kind && level.kind[0]) || "").toUpperCase();
-            if kindKey
-              div(class="level-kind " + level.kind)= kindKey
+            //if kindKey
+            div(class="level-kind " + level.kind)= kindKey
             - var acronym = level.name.replace(/(A |The )/g, '').replace(/[^A-Z]/g, '');
             .level-acronym= acronym
           if !level.hidden

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -451,11 +451,11 @@ module.exports = class CampaignView extends RootView
     mapWidth = parseFloat($(".map").css("width"))
     return unless mapHeight > 0
     ratio =  mapWidth / mapHeight
-    p1 = x: o1.x, y: o1.y / ratio - 0.5
+    p1 = x: o1.x, y: o1.y / ratio
     p2 = x: o2.x, y: o2.y / ratio
-    length = Math.sqrt((p1.x - p2.x) * (p1.x - p2.x) + (p1.y - p2.y) * (p1.y - p2.y))
+    length = Math.sqrt(Math.pow(p1.x - p2.x , 2) + Math.pow(p1.y - p2.y, 2))
     angle = Math.atan2(p1.y - p2.y, p2.x - p1.x) * 180 / Math.PI
-    transform = "rotate(#{angle}deg)"
+    transform = "translateY(-50%) translateX(-50%) rotate(#{angle}deg) translateX(50%)"
     line = $('<div>').appendTo('.map').addClass('next-level-line').css(transform: transform, width: length + '%', left: o1.x + '%', bottom: (o1.y - 0.5) + '%')
     line.append($('<div class="line">')).append($('<div class="point">'))
 

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -287,16 +287,13 @@ module.exports = class CampaignView extends RootView
     $("#campaign-view").css("background-color", "black")
     for level in @campaign?.renderedLevels ? []
       $("div[data-level-slug=#{level.slug}] .level-kind").text("Loading...")
-      @drawLevelCompletion(level, startDay, endDay)
-
-  drawLevelCompletion: (level, startDay, endDay) =>
-    request = @supermodel.addRequestResource 'level_completions', {
-      url: '/db/analytics_perday/-/level_completions'
-      data: {startDay: startDay, endDay: endDay, slug: level.slug}
-      method: 'POST'
-      success: @onLevelCompletionsLoaded.bind(@, level)
-    }, 0
-    request.load()
+      request = @supermodel.addRequestResource 'level_completions', {
+        url: '/db/analytics_perday/-/level_completions'
+        data: {startDay: startDay, endDay: endDay, slug: level.slug}
+        method: 'POST'
+        success: @onLevelCompletionsLoaded.bind(@, level)
+      }, 0
+      request.load()
     
   onLevelCompletionsLoaded: (level, data) ->
     return if @destroyed

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -304,8 +304,8 @@ module.exports = class CampaignView extends RootView
               ratio = 0
             else
               ratio = finished / started
-            rateDisplay = (ratio * 100).toFixed(2) + '%'
-            $("div[data-level-slug=#{level.slug}] .level-kind").html(started + "<br>" + rateDisplay)
+            rateDisplay = (ratio * 100).toFixed(1) + '%'
+            $("div[data-level-slug=#{level.slug}] .level-kind").html((if started < 1000 then started else (started / 1000).toFixed(1) + "k") + "<br>" + rateDisplay)
             if ratio <= 0.5
               color = "rgb(255, 0, 0)"
             else if ratio > 0.5 and ratio <= 0.85
@@ -317,6 +317,8 @@ module.exports = class CampaignView extends RootView
             else
               color = "rgb(0, 256, 0)"
             $("div[data-level-slug=#{level.slug}] .level-kind").css({"color":color, "width":256+"px", "transform":"translateX(-50%) translateX(15px)"})
+            $(".gradient").remove()
+            $("#campaign-view").css("background-color", "black")
             $("div[data-level-slug=#{level.slug}]").css("background-color", color)
         }, 0
         request.load()

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -284,8 +284,9 @@ module.exports = class CampaignView extends RootView
     startDayDashed = "#{startDay[0..3]}-#{startDay[4..5]}-#{startDay[6..7]}"
     endDay = utils.getUTCDay -1
     endDayDashed = "#{endDay[0..3]}-#{endDay[4..5]}-#{endDay[6..7]}"
+    $(".map-background").css('background-image','url("")')
     for level in @campaign?.renderedLevels ? []
-      #$("div[data-level-slug=#{level.slug}] .level-kind").text("Loading...")
+      $("div[data-level-slug=#{level.slug}] .level-kind").text("Loading...")
       do (level) =>
         console.log(level.slug)
         request = @supermodel.addRequestResource 'level_completions', {
@@ -304,7 +305,7 @@ module.exports = class CampaignView extends RootView
             else
               ratio = finished / started
             rateDisplay = (ratio * 100).toFixed(2) + '%'
-            #$("div[data-level-slug=#{level.slug}] .level-kind").html(finished + " / " + started + "<br>" + rateDisplay)
+            $("div[data-level-slug=#{level.slug}] .level-kind").html(started + "<br>" + rateDisplay)
             if ratio <= 0.5
               color = "rgb(255, 0, 0)"
             else if ratio > 0.5 and ratio <= 0.85
@@ -315,7 +316,7 @@ module.exports = class CampaignView extends RootView
               color = "rgb(#{Math.round(256 * (1-offset))}, 256, 0)"
             else
               color = "rgb(0, 256, 0)"
-            #$("div[data-level-slug=#{level.slug}] .level-kind").css("color", color)
+            $("div[data-level-slug=#{level.slug}] .level-kind").css({"color":color, "width":256+"px", "transform":"translateX(-50%) translateX(15px)"})
             $("div[data-level-slug=#{level.slug}]").css("background-color", color)
         }, 0
         request.load()

--- a/app/views/play/modal/PlayHeroesModal.coffee
+++ b/app/views/play/modal/PlayHeroesModal.coffee
@@ -48,6 +48,7 @@ module.exports = class PlayHeroesModal extends ModalView
     @heroAnimationInterval = setInterval @animateHeroes, 1000
 
   onHeroesLoaded: ->
+    console.log @heroes.models
     @formatHero hero for hero in @heroes.models
 
   formatHero: (hero) ->

--- a/app/views/play/modal/PlayHeroesModal.coffee
+++ b/app/views/play/modal/PlayHeroesModal.coffee
@@ -48,7 +48,6 @@ module.exports = class PlayHeroesModal extends ModalView
     @heroAnimationInterval = setInterval @animateHeroes, 1000
 
   onHeroesLoaded: ->
-    console.log @heroes.models
     @formatHero hero for hero in @heroes.models
 
   formatHero: (hero) ->


### PR DESCRIPTION
Make the campaign editor arrow tips bigger, and actually align the arrows from end to tip at the center of the level circles.

Also added shift-s shortcut in the level editor to display level completion on the campaign edit screen.