### PR TITLE
Add custom page-load time tracking system

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -1,6 +1,7 @@
 go = (path, options) -> -> @routeDirectly path, arguments, options
 redirect = (path) -> -> @navigate(path + document.location.search, { trigger: true, replace: true })
 utils = require './utils'
+ViewLoadTimer = require 'core/ViewLoadTimer'
 
 module.exports = class CocoRouter extends Backbone.Router
 
@@ -192,6 +193,7 @@ module.exports = class CocoRouter extends Backbone.Router
     @navigate e, {trigger: true}
 
   routeDirectly: (path, args=[], options={}) ->
+    @viewLoad = new ViewLoadTimer() unless options.recursive
     if options.redirectStudents and me.isStudent() and not me.isAdmin()
       return @redirectHome()
     if options.redirectTeachers and me.isTeacher() and not me.isAdmin()
@@ -216,12 +218,15 @@ module.exports = class CocoRouter extends Backbone.Router
     ViewClass = @tryToLoadModule path
     if not ViewClass and application.moduleLoader.load(path)
       @listenToOnce application.moduleLoader, 'load-complete', ->
+        options.recursive = true
         @routeDirectly(path, args, options)
       return
     return go('NotFoundView') if not ViewClass
     view = new ViewClass(options, args...)  # options, then any path fragment args
     view.render()
     @openView(view)
+    @viewLoad.setView(view)
+    @viewLoad.record()
     
   redirectHome: ->
     homeUrl = switch 
@@ -280,12 +285,13 @@ module.exports = class CocoRouter extends Backbone.Router
   _trackPageView: ->
     window.tracker?.trackPageView()
 
-  onNavigate: (e) ->
+  onNavigate: (e, recursive=false) ->
+    @viewLoad = new ViewLoadTimer() unless recursive
     if _.isString e.viewClass
       ViewClass = @tryToLoadModule e.viewClass
       if not ViewClass and application.moduleLoader.load(e.viewClass)
         @listenToOnce application.moduleLoader, 'load-complete', ->
-          @onNavigate(e)
+          @onNavigate(e, true)
         return
       e.viewClass = ViewClass
 
@@ -300,8 +306,11 @@ module.exports = class CocoRouter extends Backbone.Router
       view = new e.viewClass(args...)
       view.render()
       @openView view
+      @viewLoad.setView(view)
     else
       @openView e.view
+      @viewLoad.setView(e.view)
+    @viewLoad.record()
 
   navigate: (fragment, options) ->
     super fragment, options

--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -180,7 +180,7 @@ module.exports = class Tracker extends CocoClass
   trackEventInternal: (event, properties) =>
     return unless @supermodel?
     # Skipping heavily logged actions we don't use internally
-    return if event in ['Simulator Result', 'Started Level Load', 'Finished Level Load']
+    return if event in ['Simulator Result', 'Started Level Load', 'Finished Level Load', 'View Load']
     # Trimming properties we don't use internally
     # TODO: delete properites.level for 'Saw Victory' after 2/8/15.  Should be using levelID instead.
     if event in ['Clicked Start Level', 'Inventory Play', 'Heard Sprite', 'Started Level', 'Saw Victory', 'Click Play', 'Choose Inventory', 'Homepage Loaded', 'Change Hero']

--- a/app/core/ViewLoadTimer.coffee
+++ b/app/core/ViewLoadTimer.coffee
@@ -1,0 +1,75 @@
+VIEW_LOAD_LOG = false
+SHOW_NOTY = false
+
+class ViewLoadTimer
+  @firstLoad: true
+  constructor: (@view) ->
+    @firstLoad = ViewLoadTimer.firstLoad
+    ViewLoadTimer.firstLoad = false
+    return unless window.performance and window.performance.now and window.performance.getEntriesByType
+    @t0 = if @firstLoad then 0 else performance.now()
+
+  setView: (@view) ->
+
+  record: ->
+    console.group('Recording view:', @view.id) if VIEW_LOAD_LOG
+    views = [@view]
+    networkPromises = []
+    while views.length
+      subView = views.pop()
+      views = views.concat(_.values(subView.subviews))
+      if not subView.supermodel.finished()
+        networkPromises.push(subView.supermodel.finishLoading())
+    console.log 'Network promises:', networkPromises.length if VIEW_LOAD_LOG
+
+    Promise.all(networkPromises)
+    .then =>
+      @networkLoad = performance.now()
+      return if @view.destroyed
+      
+      imagePromises = []
+      if VIEW_LOAD_LOG
+        console.groupCollapsed('Images')
+        console.groupCollapsed('Skipping')
+        for img in @view.$('img:not(:visible)')
+          console.log img.src
+        console.groupEnd()
+      for img in @view.$('img:visible')
+        if not img.complete
+          promise = new Promise((resolve) ->
+            if img.complete
+              resolve()
+            else
+              img.onload = resolve
+              img.onerror = resolve
+          )
+          promise.imgSrc = img.src
+          console.log img.src if VIEW_LOAD_LOG
+          imagePromises.push(promise)
+
+      console.groupEnd() if VIEW_LOAD_LOG
+      return Promise.all(imagePromises)
+    .then =>
+      return if @view.destroyed
+      networkTime = @networkLoad - @t0
+      totalTime = performance.now() - @t0 
+      return console.warn("Unknown view at: #{document.location.href}, could not record perf.") if not @view.id
+      return console.warn("Got invalid time result for view #{@view.id}: #{totalTime}, could not record perf.") if not _.isNumber(totalTime)
+      m = "Loaded #{@view.id} in: #{totalTime}ms"
+
+      if @firstLoad
+        entries = performance.getEntriesByType('resource').filter((r) => _.string.startsWith(r.name, location.origin))
+        totalEncodedBodySize = _.reduce(entries, ((total, entry) -> total + entry.encodedBodySize), 0)
+        totalTransferSize = _.reduce(entries, ((total, entry) -> total + entry.transferSize), 0)
+        cachedResources = _.size(_.filter(entries, (entry) -> entry.transferSize / entry.encodedBodySize < 0.1))
+        totalResources = _.size(entries)
+        resourceInfo = { networkTime, totalEncodedBodySize, totalTransferSize, cachedResources, totalResources }
+      else
+        resourceInfo = {}
+      console.log m if VIEW_LOAD_LOG
+      noty({text:m, type:'information', timeout: 1000, layout:'topCenter'}) if SHOW_NOTY
+      window.tracker?.trackEvent 'View Load', _.assign({ totalTime, viewId: @view.id, @firstLoad }, resourceInfo)
+    .then =>
+      console.groupEnd() if VIEW_LOAD_LOG
+
+module.exports = ViewLoadTimer

--- a/app/views/core/CocoView.coffee
+++ b/app/views/core/CocoView.coffee
@@ -11,6 +11,7 @@ waitingModal = null
 classCount = 0
 makeScopeName = -> "view-scope-#{classCount++}"
 doNothing = ->
+ViewLoadTimer = require 'core/ViewLoadTimer'
 
 module.exports = class CocoView extends Backbone.View
   cache: false # signals to the router to keep this view around
@@ -235,6 +236,7 @@ module.exports = class CocoView extends Backbone.View
       return if softly
       return visibleModal.hide() if visibleModal.$el.is(':visible') # close, then this will get called again
       return @modalClosed(visibleModal) # was closed, but modalClosed was not called somehow
+    viewLoad = new ViewLoadTimer(modalView)
     modalView.render()
     
     # Redirect to the woo when trying to log in or signup
@@ -252,7 +254,8 @@ module.exports = class CocoView extends Backbone.View
     window.currentModal = modalView
     @getRootView().stopListeningToShortcuts(true)
     Backbone.Mediator.publish 'modal:opened', {}
-    modalView
+    viewLoad.record()
+    return modalView
 
   modalClosed: =>
     visibleModal.willDisappear() if visibleModal


### PR DESCRIPTION
Measures performance from initial network request through until all images on the page are loaded. Sends events to Snowplow so we can aggregate the data and improve perf on key areas. You can use the two debug constants at the top of ViewLoad to console log or noty the info to check it against reality.