### PR TITLE
Track shareable level views

### DIFF
--- a/app/schemas/models/level_session.coffee
+++ b/app/schemas/models/level_session.coffee
@@ -57,6 +57,8 @@ _.extend LevelSessionSchema.properties,
 #    title: 'Completed'
 #    readOnly: true
 
+  fourDayViewCount: { type: 'number' }
+
   team: c.shortString()
   level: LevelSessionLevelSchema
 

--- a/server/handlers/level_session_handler.coffee
+++ b/server/handlers/level_session_handler.coffee
@@ -15,6 +15,7 @@ class LevelSessionHandler extends Handler
     super(arguments...)
 
   formatEntity: (req, document) ->
+    # TODO: Delete this as it's duplicated in LevelSession
     document = super(req, document)
     submittedCode = document.submittedCode ? {}
     unless req.user?.isAdmin() or

--- a/server/middleware/index.coffee
+++ b/server/middleware/index.coffee
@@ -16,6 +16,7 @@ module.exports =
   headers: require './headers'
   healthcheck: require './healthcheck'
   levels: require './levels'
+  levelSessions: require './level-sessions'
   logging: require './logging'
   named: require './named'
   patchable: require './patchable'

--- a/server/middleware/level-sessions.coffee
+++ b/server/middleware/level-sessions.coffee
@@ -1,0 +1,29 @@
+_ = require 'lodash'
+errors = require '../commons/errors'
+wrap = require 'co-express'
+database = require '../commons/database'
+LevelSession = require '../models/LevelSession'
+moment = require 'moment'
+
+getByHandle = wrap (req, res) ->
+  session = yield database.getDocFromHandle(req, LevelSession)
+  if not session
+    throw new errors.NotFound('Level session not found.')
+    
+  unless _.any([
+    session.get('submitted'),
+    not session.get('submittedCode'), # Allow leaderboard access to non-multiplayer sessions
+    session.hasPermissionsForMethod?(req.user, 'GET')
+  ])
+    throw new errors.Forbidden('Cannot access this session.')
+
+  if session.get('dateFirstCompleted') and (not req.user?.isTeacher()) and (req.user?.id isnt session.get('creator'))
+    cutoff = moment(session.get('dateFirstCompleted')).add(4, 'days')
+    if cutoff.isAfter(new Date())
+      yield session.update({$inc: {fourDayViewCount: 1}})
+      
+  res.status(200).send(session.toObject({req}))
+
+module.exports = {
+  getByHandle
+}

--- a/server/models/LevelSession.coffee
+++ b/server/models/LevelSession.coffee
@@ -4,6 +4,7 @@ AchievablePlugin = require '../plugins/achievements'
 jsonschema = require '../../app/schemas/models/level_session'
 log = require 'winston'
 config = require '../../server_config'
+LZString = require 'lz-string'
 
 LevelSessionSchema = new mongoose.Schema({
   created:

--- a/server/routes/index.coffee
+++ b/server/routes/index.coffee
@@ -150,6 +150,9 @@ module.exports.setup = (app) ->
   LevelComponent = require '../models/LevelComponent'
   app.post('/db/level.component/:handle/patch', mw.auth.checkLoggedIn(), mw.patchable.postPatch(LevelComponent, 'level_component'))
   app.get('/db/level.component/:handle/patches', mw.patchable.patches(LevelComponent))
+  
+  LevelSession = require '../models/LevelSession'
+  app.get('/db/level.session/:handle', mw.levelSessions.getByHandle)
 
   LevelSystem = require '../models/LevelSystem'
   app.post('/db/level.system/:handle/patch', mw.auth.checkLoggedIn(), mw.patchable.postPatch(LevelSystem, 'level_system'))

--- a/spec/server/functional/user.spec.coffee
+++ b/spec/server/functional/user.spec.coffee
@@ -546,6 +546,22 @@ describe 'GET /db/user/:handle', ->
     expect(res.body.coursePrepaid.startDate).toBe(Prepaid.DEFAULT_START_DATE)
     done()
     
+    
+describe 'GET /db/user/:handle/level.sessions', ->
+  
+  it 'gets a user\'s level sessions', utils.wrap ->
+    yield utils.logout()
+    user = yield utils.initUser()
+    session = yield utils.makeLevelSession({}, {creator: user})
+    [res, body] = yield request.getAsync {uri: getURL("/db/user/#{user.id}/level.sessions"), json: true}
+    expect(res.statusCode).toBe 200
+    expect(res.body.length).toBe 1
+    expect(res.body[0]._id).toBe(session.id)
+    
+  it 'returns 404 if user not found', utils.wrap ->
+    [res, body] = yield request.getAsync {uri: getURL("/db/user/dne/level.sessions"), json: true}
+    expect(res.statusCode).toBe 404
+
 
 describe 'DELETE /db/user', ->
   it 'can delete a user', utils.wrap (done) ->


### PR DESCRIPTION
For measuring how often shareable projects are shared.
Do not count views by the session creator or teachers.