### PR TITLE
Premium time tracking

### DIFF
--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -127,7 +127,7 @@ module.exports = class Tracker extends CocoClass
     console.log 'Tracking external analytics event:', action, properties, includeIntegrations if debugAnalytics
     return unless me and @isProduction and not me.isAdmin()
 
-    @trackEventInternal action, _.cloneDeep properties    
+    @trackEventInternal action, _.cloneDeep properties
     @trackSnowplow action, _.cloneDeep properties
 
 

--- a/app/core/ViewVisibleTimer.coffee
+++ b/app/core/ViewVisibleTimer.coffee
@@ -1,0 +1,99 @@
+CocoClass = require 'core/CocoClass'
+
+idleTracker = new Idle
+  onAway: ->
+    Backbone.Mediator.publish 'view-visibility:away', {}
+  onAwayBack: ->
+    Backbone.Mediator.publish 'view-visibility:away-back', {}
+  onHidden: ->
+    Backbone.Mediator.publish 'view-visibility:hidden', {}
+  onVisible: ->
+    Backbone.Mediator.publish 'view-visibility:visible', {}
+  awayTimeout: 1000
+
+idleTracker.start()
+
+###
+This adds analytics events for when premium features are viewed.
+
+Notes about the structure:
+
+CocoView will trigger an update to the timer, if it exists, any time the view
+is hidden/reappears/is inserted.
+
+Any view inheriting from CocoView can call @trackTimeVisible(), which creates
+the viewVisibleTimer which CocoView will manage automatically.
+
+Calling @trackTimeVisible({ trackViewLifecycle: true }) will treat the view
+being open as the only feature being tracked for that view.
+
+If trackViewLifecycle is not set, the view must implement currentVisiblePremiumFeature
+which should return an object describing the premium feature currently in view, or null if none are visible.
+CocoView's updateViewVisibleTimer will call this function and update the timer if necessary.
+
+The view should also call updateViewVisibleTimer after any time the visible premium feature may have changed. This function is idempotent.
+###
+class ViewVisibleTimer extends CocoClass
+  subscriptions:
+    'view-visibility:away': 'onAway'
+    'view-visibility:away-back': 'onAwayBack'
+    'view-visibility:hidden': 'onHidden'
+    'view-visibility:visible': 'onVisible'
+  
+  constructor: () ->
+    @running = false
+    # If the user is inactive for this many seconds, stop the timer and
+    #   record the time they were active (NOT including this timeout)
+    # If they come back before this timeout, include the time they were "away"
+    #   in the timer
+    @awayTimeoutLimit = 5 * 1000
+    @awayTimeoutId = null
+    @throttleRate = 50
+    super()
+
+  startTimer: (@featureData) ->
+    { viewName, featureName, premiumThang } = @featureData
+    if not viewName
+      throw new Error('No view name!')
+    if @running and window.performance.now() - @startTime > @throttleRate
+      throw(new Error('Starting a timer over another one!'))
+    if not @running and (not @startTime or window.performance.now() - @startTime > @throttleRate)
+      @running = true
+      @startTime = window.performance.now()
+
+  stopTimer: ({ subtractTimeout = false, clearName = false } = { })->
+    clearTimeout(@awayTimeoutId)
+    if @running
+      @running = false
+      @endTime = if subtractTimeout then @lastActive else window.performance.now()
+      timeViewed = @endTime - @startTime
+      if timeViewed > @throttleRate # Prevent event spam when triggered in rapid succession
+        window.tracker.trackEvent 'Premium Feature Viewed', { @featureData, timeViewed }
+    @featureData = null if clearName
+    
+  markLastActive: ->
+    @lastActive = window.performance.now()
+
+  onAway: ->
+    @markLastActive()
+    e = new Error()
+    if @running
+      @awayTimeoutId = setTimeout(( =>
+        @stopTimer({ subtractTimeout: true })
+      ), @awayTimeoutLimit)
+    
+  onAwayBack: ->
+    clearTimeout(@awayTimeoutId)
+    @startTimer(@featureData) if not @running and @featureData
+    
+  onHidden: ->
+    @stopTimer({ subtractTimeout: false })
+    
+  onVisible: ->
+    @startTimer(@featureData) if @featureData
+    
+  destroy: ->
+    @stopTimer()
+    super()
+
+module.exports = ViewVisibleTimer

--- a/app/schemas/subscriptions/misc.coffee
+++ b/app/schemas/subscriptions/misc.coffee
@@ -3,6 +3,12 @@ c = require 'schemas/schemas'
 module.exports =
   'application:idle-changed': c.object {},
     idle: {type: 'boolean'}
+    type: {enum: ['activity', 'visibility']}
+
+  'view-visibility:away': c.object {}
+  'view-visibility:away-back': c.object {}
+  'view-visibility:hidden': c.object {}
+  'view-visibility:visible': c.object {}
 
   'application:error': c.object {},
     message: {type: 'string'}

--- a/app/views/core/SubscribeModal.coffee
+++ b/app/views/core/SubscribeModal.coffee
@@ -32,6 +32,7 @@ module.exports = class SubscribeModal extends ModalView
     @state = 'standby'
     @products = new Products()
     @supermodel.loadCollection(@products, 'products')
+    @trackTimeVisible({ trackViewLifecycle: true })
 
   onLoaded: ->
     @basicProduct = @products.findWhere { name: 'basic_subscription' }

--- a/app/views/play/modal/BuyGemsModal.coffee
+++ b/app/views/play/modal/BuyGemsModal.coffee
@@ -39,6 +39,7 @@ module.exports = class BuyGemsModal extends ModalView
         if jqxhr.status is 201
           @state = 'recovered_charge'
           @render()
+    @trackTimeVisible({ trackViewLifecycle: true })
 
   onLoaded: ->
     @basicProduct = @products.findWhere { name: 'basic_subscription' }

--- a/app/views/play/modal/PlayHeroesModal.coffee
+++ b/app/views/play/modal/PlayHeroesModal.coffee
@@ -37,7 +37,7 @@ module.exports = class PlayHeroesModal extends ModalView
     @confirmButtonI18N = options.confirmButtonI18N ? "common.save"
     @heroes = new CocoCollection([], {model: ThangType})
     @heroes.url = '/db/thang.type?view=heroes'
-    @heroes.setProjection ['original','name','slug','soundTriggers','featureImages','gems','heroClass','description','components','extendedName','unlockLevelName','i18n','poseImage']
+    @heroes.setProjection ['original','name','slug','soundTriggers','featureImages','gems','heroClass','description','components','extendedName','unlockLevelName','i18n','poseImage','tier']
     @heroes.comparator = 'gems'
     @listenToOnce @heroes, 'sync', @onHeroesLoaded
     @supermodel.loadCollection(@heroes, 'heroes')
@@ -46,6 +46,7 @@ module.exports = class PlayHeroesModal extends ModalView
     @session = options.session
     @initCodeLanguageList options.hadEverChosenHero
     @heroAnimationInterval = setInterval @animateHeroes, 1000
+    @trackTimeVisible()
 
   onHeroesLoaded: ->
     @formatHero hero for hero in @heroes.models
@@ -62,6 +63,19 @@ module.exports = class PlayHeroesModal extends ModalView
       hero.restricted = not (hero.get('original') in allowedHeroes)
     hero.class = (hero.get('heroClass') or 'warrior').toLowerCase()
     hero.stats = hero.getHeroStats()
+    
+  currentVisiblePremiumFeature: ->
+    isPremium = not (@visibleHero.class is 'warrior' and @visibleHero.get('tier') is 0)
+    if isPremium
+      return {
+        viewName: @.id
+        featureName: 'view-hero'
+        premiumThang:
+          _id: @visibleHero.id
+          slug: @visibleHero.get('slug')
+      }
+    else
+      return null
 
   getRenderData: (context={}) ->
     context = super(context)
@@ -74,6 +88,10 @@ module.exports = class PlayHeroesModal extends ModalView
     context.gems = me.gems()
     context.isIE = @isIE()
     context
+  
+  afterInsert: ->
+    @updateViewVisibleTimer()
+    super()
 
   afterRender: ->
     super()
@@ -139,6 +157,7 @@ module.exports = class PlayHeroesModal extends ModalView
     @visibleHero = hero
     @rerenderFooter()
     @trigger 'hero-loaded', {hero: hero}
+    @updateViewVisibleTimer()
 
   getFullHero: (original) ->
     url = "/db/thang.type/#{original}/version"

--- a/server/models/User.coffee
+++ b/server/models/User.coffee
@@ -240,7 +240,7 @@ UserSchema.methods.updateMailChimp = co.wrap ->
   }
   yield mailChimp.api.put(mailChimp.makeSubscriberUrl(email), body)
   yield @update({$set: {mailChimp: {email}}})
-  
+
 
 UserSchema.statics.statsMapping =
   edits:
@@ -476,7 +476,7 @@ UserSchema.post 'save', co.wrap ->
   catch e
     console.error 'User Post Save Error:', e.stack
 
-  
+
 UserSchema.post 'init', ->
   @set('anonymous', false) if @get('email') # TODO: Remove once User handler waterfall-signup system is removed, and we make sure all signup methods set anonymous to false
   @originalEmail = @get('emailLower')


### PR DESCRIPTION
This adds analytics events for when premium features are viewed.
Notes about the structure:

CocoView will trigger an update to the timer, if it exists, any time the view is hidden/reappears/is inserted

Any view inheriting from CocoView can call `@trackTimeVisible()`, which creates the `viewVisibleTimer` which CocoView will manage automatically

Calling `@trackTimeVisible({ trackViewLifecycle: true })` will treat the view being open as the only feature being tracked for that view

If `trackViewLifecycle` is not set, the view must implement `currentVisiblePremiumFeature` which should return an object describing the premium feature currently in view, or `null` if none are visible. CocoView's `updateViewVisibleTimer` will call this function and update the timer if necessary.
- The view should also call `updateViewVisibleTimer` after any time the visible premium feature may have changed. This function is idempotent.