### PR TITLE
Fix ladder codeLanguage for multi-language students

### DIFF
--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -157,6 +157,8 @@ module.exports = class LevelLoader extends CocoClass
       url = "/db/level/#{@levelID}/session"
       if @team
         url += "?team=#{@team}"
+        if @courseInstanceID
+          url += "&courseInstance=#{@courseInstanceID}"
       else if @courseID
         url += "?course=#{@courseID}"
         if @courseInstanceID

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -100,7 +100,7 @@ module.exports = class PlayLevelView extends RootView
     super options
 
     @courseID = options.courseID or @getQueryVariable 'course'
-    @courseInstanceID = options.courseInstanceID or @getQueryVariable 'course-instance'
+    @courseInstanceID = options.courseInstanceID or @getQueryVariable('course-instance') or @getQueryVariable('league')
 
     @isEditorPreview = @getQueryVariable 'dev'
     @sessionID = @getQueryVariable 'session'


### PR DESCRIPTION
Previously, ladder levels would ignore the courseInstance when fetching a user's session. So if a student had already played a ladder with one language, it would not let them play the ladder in a new language (fetching their old code).

Because of the complexity of PlayLevelView/LevelLoader, I'm unsure what things might break if @courseInstanceID is set but @courseID is not set, in PlayLevelView.

There is also concern over what strange things might occur with simulating levels and using different session languages. The current system would likely 'cross streams' between the languages in the ladder page, for example. Nick worries we might get a "you won!" modal and have it recorded as a loss, things like that.
