### PR TITLE
Add button to quickly spy a teacher dashboard

### DIFF
--- a/app/templates/courses/teacher-classes-view.jade
+++ b/app/templates/courses/teacher-classes-view.jade
@@ -4,7 +4,7 @@ block page_nav
   include ./teacher-dashboard-nav.jade
 
 block content
-  if (!me.isTeacher() && !view.classrooms.size()) || me.isAnonymous()
+  if (!me.isTeacher() && !me.isAdmin() && !view.classrooms.size()) || me.isAnonymous()
     .access-restricted.container.text-center.m-y-3
       h5(data-i18n='teacher.access_restricted')
       p(data-i18n='teacher.teacher_account_required')

--- a/app/views/admin/MainAdminView.coffee
+++ b/app/views/admin/MainAdminView.coffee
@@ -25,6 +25,7 @@ module.exports = class MainAdminView extends RootView
     'click #stop-spying-btn': 'onClickStopSpyingButton'
     'click #increment-button': 'incrementUserAttribute'
     'click .user-spy-button': 'onClickUserSpyButton'
+    'click .teacher-dashboard-button': 'onClickTeacherDashboardButton'
     'click #user-search-result': 'onClickUserSearchResult'
     'click #create-free-sub-btn': 'onClickFreeSubLink'
     'click #terminal-create': 'onClickTerminalSubLink'
@@ -79,6 +80,14 @@ module.exports = class MainAdminView extends RootView
         errors.showNotyNetworkError(arguments...)
     })
 
+  onClickTeacherDashboardButton: (e) ->
+    e.stopPropagation()
+    userID = $(e.target).closest('tr').data('user-id')
+    button = $(e.currentTarget)
+    forms.disableSubmit(button)
+    url = "/teachers/classes?teacherID=#{userID}"
+    application.router.navigate(url, { trigger: true })
+
   onSubmitUserSearchForm: (e) ->
     e.preventDefault()
     searchValue = @$el.find('#user-search').val()
@@ -104,7 +113,16 @@ module.exports = class MainAdminView extends RootView
     forms.enableSubmit(@$('#user-search-button'))
     result = ''
     if users.length
-      result = ("<tr data-user-id='#{user._id}'><td><code>#{user._id}</code></td><td>#{_.escape(user.name or 'Anonymous')}</td><td>#{_.escape(user.email)}</td><td><button class='user-spy-button'>Spy</button></td></tr>" for user in users)
+      result = ("
+      <tr data-user-id='#{user._id}'>
+        <td><code>#{user._id}</code></td>
+        <td>#{_.escape(user.name or 'Anonymous')}</td>
+        <td>#{_.escape(user.email)}</td>
+        <td>
+          <button class='user-spy-button'>Spy</button>
+          #{if new User(user).isTeacher() then "<button class='teacher-dashboard-button'>View Classes</button>" else ""}
+        </td>
+      </tr>" for user in users)
       result = "<table class=\"table\">#{result.join('\n')}</table>"
     @$el.find('#user-search-result').html(result)
 

--- a/app/views/courses/TeacherClassesView.coffee
+++ b/app/views/courses/TeacherClassesView.coffee
@@ -34,9 +34,10 @@ module.exports = class TeacherClassesView extends RootView
 
   initialize: (options) ->
     super(options)
+    @teacherID = (me.isAdmin() and utils.getQueryVariable('teacherID')) or me.id
     @classrooms = new Classrooms()
     @classrooms.comparator = (a, b) -> b.id.localeCompare(a.id)
-    @classrooms.fetchMine()
+    @classrooms.fetchByOwner(@teacherID)
     @supermodel.trackCollection(@classrooms)
     @listenTo @classrooms, 'sync', ->
       for classroom in @classrooms.models
@@ -51,7 +52,7 @@ module.exports = class TeacherClassesView extends RootView
     @supermodel.trackCollection(@courses)
 
     @courseInstances = new CourseInstances()
-    @courseInstances.fetchByOwner(me.id)
+    @courseInstances.fetchByOwner(@teacherID)
     @supermodel.trackCollection(@courseInstances)
     @progressDotTemplate = require 'templates/teachers/hovers/progress-dot-whole-course'
 
@@ -81,6 +82,7 @@ module.exports = class TeacherClassesView extends RootView
     @listenToOnce modal, 'hide', @render
 
   onClickCreateClassroomButton: (e) ->
+    return unless me.id is @teacherID # Viewing page as admin
     window.tracker?.trackEvent 'Teachers Classes Create New Class Started', category: 'Teachers', ['Mixpanel']
     classroom = new Classroom({ ownerID: me.id })
     modal = new ClassroomSettingsModal({ classroom: classroom })
@@ -108,6 +110,7 @@ module.exports = class TeacherClassesView extends RootView
     @listenToOnce modal, 'hide', @render
 
   onClickArchiveClassroom: (e) ->
+    return unless me.id is @teacherID # Viewing page as admin
     classroomID = $(e.currentTarget).data('classroom-id')
     classroom = @classrooms.get(classroomID)
     classroom.set('archived', true)
@@ -118,6 +121,7 @@ module.exports = class TeacherClassesView extends RootView
     }
 
   onClickUnarchiveClassroom: (e) ->
+    return unless me.id is @teacherID # Viewing page as admin
     classroomID = $(e.currentTarget).data('classroom-id')
     classroom = @classrooms.get(classroomID)
     classroom.set('archived', false)


### PR DESCRIPTION
So admins don't have to do a full spy on a teacher to check their classes. This is immediately accessible via the search results on /admin, but the main use will be attaching this link to the notes in Close.io.

Current caveats with this implementation, that could be worked around with a bit extra code if we want:

When you've clicked into a single TeacherClassView, the "My Classes" link will bring you back to YOUR classes, not the teacher's you were looking at.

The TeacherClassesView also does not have a clear visual indicator (other than the URL) that you're looking at someone else's classes.