### PR TITLE
Send license request via sendwithus when necessary

### DIFF
--- a/app/views/teachers/TeachersContactModal.coffee
+++ b/app/views/teachers/TeachersContactModal.coffee
@@ -77,4 +77,3 @@ module.exports = class TeachersContactModal extends ModalView
         , 3000)
       error: -> @state.set({ sendingState: 'error' })
     })
-

--- a/server/lib/closeIO.coffee
+++ b/server/lib/closeIO.coffee
@@ -9,47 +9,6 @@ module.exports =
   logError: (msg) ->
     log.error("Close.io Error: #{msg}")
 
-  createSalesLead: (user, email, newLeadData) ->
-    return @logError('No API key available') unless apiKey
-    @getLead email, (error, lead) =>
-      return @logError(JSON.stringify(error)) if error
-      return if lead
-      @createLead(user, email, newLeadData)
-
-  createLead: (user, email, newLeadData) ->
-    name = newLeadData.name ? email
-    postData =
-      display_name: newLeadData.organization ? name
-      name: newLeadData.organization ? name
-      contacts: [{
-        emails: [{email: email}]
-        name: name
-      }]
-      custom: {}
-    postData.contacts[0].phones = [phone: newLeadData.phone] if newLeadData.phone
-    for key, val of newLeadData
-      continue if key in ['name', 'organization', 'phone']
-      continue if _.isEmpty(val)
-      postData.custom[key] = val
-    postData.custom['userID'] = user.get('_id').valueOf() if user
-    options =
-      uri: 'https://' + apiKey + ':X@app.close.io/api/v1/lead/',
-      body: JSON.stringify(postData)
-    request.post options, (error, response, body) =>
-      return @logError(JSON.stringify(error)) if error
-
-  getLead: (email, done) ->
-    uri = 'https://' + apiKey + ':X@app.close.io/api/v1/lead/?query=email_address:' + email
-    request.get uri, (error, response, body) =>
-      return done(error) if error
-      leads = JSON.parse(body)
-      return done("Unexpected leads format: " + body) unless leads.data?
-      if leads.data?.length is 1
-        return done(null, leads.data[0])
-      else if leads.data?.length > 1
-        return done('ERROR: multiple leads returned for ' + email + ' ' + leads.data.length)
-      return done()
-
   getSalesContactEmail: (userEmail, done) ->
     # Sales contact email precedence: previous email to contact, previous email to lead, lead custom field, lead status default
     try
@@ -59,7 +18,8 @@ module.exports =
         return done(error) if error
         leads = JSON.parse(body)
         return done("Unexpected Close leads format: " + body) unless leads.data?
-        return done("No existing Close.IO lead found for #{userEmail}") unless leads.data?.length > 0
+        if leads.data?.length is 0
+          return done(null, config.mail.supportSchools, defaultSalesContactUserID, null)
         lead = leads.data[0]
         uri = "https://#{apiKey}:X@app.close.io/api/v1/activity/?lead_id=#{lead.id}"
         request.get uri, (error, response, body) =>
@@ -98,7 +58,7 @@ module.exports =
                 @logError("No user found for leadID=#{lead.id} user=#{userEmail} auto_sales_email=#{lead.custom?['auto_sales_email']}")
                 return done(null, config.mail.supportSchools, defaultSalesContactUserID, lead.id)
           else
-             return done(null, config.mail.supportSchools, defaultSalesContactUserID, lead.id)
+            return done(null, config.mail.supportSchools, defaultSalesContactUserID, lead.id)
     catch error
       log.error("closeIO.getSalesContactEmail Error for #{userEmail}: #{JSON.stringify(error)}")
       return done(error)

--- a/server/routes/contact.coffee
+++ b/server/routes/contact.coffee
@@ -16,6 +16,13 @@ module.exports.setup = (app) ->
     createMailContent req, fromAddress, (subject, content) ->
       if (req.body.licensesNeeded or req.user.isTeacher()) and subject.indexOf('Level Load Error:') < 0
         closeIO.getSalesContactEmail fromAddress, (err, salesContactEmail, userID, leadID) ->
+          if not leadID
+            log.debug "No close.io lead found for #{fromAddress}; sending license request via sendwithus"
+            createSendWithUsLicenseRequestContext req, fromAddress, salesContactEmail, subject, content, (err, context) ->
+              sendwithus.api.send context, (err, result) ->
+                log.error "Error sending license request form email via sendwithus: #{err.message or err}" if err
+                req.user.update({$set: { enrollmentRequestSent: true }}).exec(_.noop)
+            return res.end()
           return log.error("Error getting sales contact for #{fromAddress}: #{err.message or err}") if err
           closeIO.sendMail fromAddress, subject, content, salesContactEmail, leadID, (err) ->
             return log.error("Error sending contact form email via Close.io: #{err.message or err}") if err
@@ -55,6 +62,22 @@ createMailContent = (req, fromAddress, done) ->
   if req.body.browser
     content += "\n#{req.body.browser} - #{req.body.screenSize}"
   done(subject, content)
+
+createSendWithUsLicenseRequestContext = (req, fromAddress, salesContactEmail, subject, content, done) ->
+  user = req.user
+  context =
+    email_id: sendwithus.templates.plain_text_email
+    recipient:
+      address: salesContactEmail
+    sender:
+      address: config.mail.username
+      reply_to: fromAddress
+      name: user.get('name')
+    email_data:
+      subject: subject
+      content: content
+      contentHTML: content.replace /\n/g, '\n<br>'
+  return done(null, context)
 
 createSendWithUsContext = (req, fromAddress, subject, content, done) ->
   user = req.user


### PR DESCRIPTION
If a close.io lead can't be found to use to send the license request, send it via sendwithus instead.