### PR TITLE
Shareable License Pools

### DIFF
--- a/app/assets/markdown/faq.md
+++ b/app/assets/markdown/faq.md
@@ -26,6 +26,7 @@
 * [Is there a limit to how many students I can add in Introduction to Computer Science?](#is-there-a-limit-to-how-many-students-i-can-add-in-introduction-to-computer-science-)
 * [How do I reset my student's password?](#how-do-i-reset-my-student-s-password-)
 * [How do I transfer a license from one student to another?](#how-do-i-transfer-a-license-from-one-student-to-another-)
+* [How do I share licenses to other teachers in my organization?](#how-do-i-share-licenses-to-other-teachers-in-my-organization-)
 
 
 ### What is CodeCombat?
@@ -137,5 +138,12 @@ If your student has verified their email, they will need to use the 'Forgot your
 ### How do I transfer a license from one student to another?
 
 A Full License can be removed from a student at any time before the license expires, and assigned to another student. To do so, go to that student's class, click the "License Status" tab, and click "Revoke License" from the student you wish to revoke the license from. This student will not be able to play any new levels that require a license (they will still be able to access any levels they've already started). The license will be available to assign to another student (the license expiration date will remain the same) -- see the [Student Licenses](https://codecombat.com/teachers/licenses) page for all of your available licenses.
+
+### How do I share licenses to other teachers in my organization?
+If you have Full Licenses, you can share access to them with other teachers in your organization. Navigate to the [Student Licenses tab](/teachers/licenses), then click the "Share Licenses" link below any group of licenses. This will popup a dialog that allows you to add teachers to the shared licenses.
+
+You can only add teachers in your organization that have already created a Teacher Account ([here's how](/teachers/resources/getting-started)). Once a teacher has been added to a shared license pool, they have the ability to use any of the licenses you've shared.
+
+When a license has been used, it is not available to be used by another teacher until that teacher revokes the license from the student (see [How to Transfer a License](#how-do-i-transfer-a-license-from-one-student-to-another-)).
 
 [Back to Top](#frequently-asked-questions)

--- a/app/collections/Prepaids.coffee
+++ b/app/collections/Prepaids.coffee
@@ -30,3 +30,6 @@ module.exports = class Prepaids extends CocoCollection
     opts.data ?= {}
     opts.data.creator = creatorID
     @fetch opts
+  
+  fetchMineAndShared: ->
+    @fetchByCreator(me.id, { data: {includeShared: true} })

--- a/app/core/api/index.coffee
+++ b/app/core/api/index.coffee
@@ -1,6 +1,7 @@
 module.exports = {
   admin: require('./admin')
   levelSessions: require('./level-sessions')
+  prepaids: require('./prepaids')
   skippedContacts: require('./skipped-contacts')
   trialRequests: require('./trial-requests')
   users: require('./users')

--- a/app/core/api/prepaids.coffee
+++ b/app/core/api/prepaids.coffee
@@ -1,0 +1,14 @@
+fetchJson = require './fetch-json'
+
+module.exports = {
+  url: (prepaidID, path) -> if path then "/db/prepaid/#{prepaidID}/#{path}" else "/db/prepaid/#{prepaidID}"
+  
+  addJoiner: ({ prepaidID, userID }, options={}) ->
+    fetchJson(@url(prepaidID, 'joiners'), _.assign {}, options, {
+      method: 'POST'
+      json: { userID }
+    })
+
+  fetchJoiners: ({ prepaidID }, options={}) ->
+    fetchJson(@url(prepaidID, 'joiners'))
+}

--- a/app/core/api/users.coffee
+++ b/app/core/api/users.coffee
@@ -6,6 +6,9 @@ module.exports = {
   getByHandle: (handle, options) ->
     fetchJson("/db/user/#{handle}", options)
 
+  getByEmail: (email, options={}) ->
+    fetchJson("/db/user", _.merge {}, options, { data: { email } })
+
   signupWithPassword: ({userId, name, email, password}, options={}) ->
     fetchJson(@url(userId, 'signup-with-password'), _.assign({}, options, {
       method: 'POST'

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1445,7 +1445,11 @@
     changed: "Changed"
     available_credits: "Available Licenses"
     pending_credits: "Pending Licenses"
-    credits: "licenses"
+    empty_credits: "Exhausted Licenses"
+    license_remaining: "license remaining"
+    licenses_remaining: "licenses remaining"
+    one_license_used: "1 license has been used"
+    num_licenses_used: "__numLicensesUsed__ licenses have been used"
     starter_licenses: "starter licenses"
     start_date: "start date:"
     end_date: "end date:"
@@ -1601,6 +1605,22 @@
     teacher_quest_more: "See all quests"
     teacher_quest_less: "See fewer quests"
     refresh_to_update: "(refresh the page to see updates)"
+  
+  share_licenses:
+    share_licenses: "Share Licenses"
+    shared_by: "Shared By:"
+    add_teacher_label: "Enter exact teacher email:"
+    add_teacher_button: "Add Teacher"
+    subheader: "You can make your licenses available to other teachers in your organization. Each license can only be used for one student at a time."
+    teacher_not_found: "Teacher not found. Please make sure this teacher has already created a Teacher Account."
+    teacher_not_valid: "This is not a valid Teacher Account. Only teacher accounts can share licenses."
+    already_shared: "You've already shared these licenses with that teacher."
+    teachers_using_these: "Teachers who can access these licenses:"
+    footer: "When teachers revoke licenses from students, the licenses will be returned to the shared pool for other teachers in this group to use."
+    you: "(you)"
+    one_license_used: "(1 license used)"
+    licenses_used: "(__licensesUsed__ licenses used)"
+    more_info: "More info"
 
   sharing:
     game: "Game"
@@ -2245,5 +2265,3 @@
     fx_missing_paren: "If you want to call `$1` as function, you need `()`'s"
     unmatched_token: "Unmatched `$1`.  Every opening `$2` needs a closing `$3` to match it."
     unterminated_string: "Unterminated string. Add a matching `\"` at the end of your string."
-
-  

--- a/app/models/Prepaid.coffee
+++ b/app/models/Prepaid.coffee
@@ -10,6 +10,9 @@ module.exports = class Prepaid extends CocoModel
   openSpots: ->
     return @get('maxRedeemers') - @get('redeemers')?.length if @get('redeemers')?
     @get('maxRedeemers')
+  
+  usedSpots: ->
+    _.size(@get('redeemers'))
 
   userHasRedeemed: (userID) ->
     for redeemer in @get('redeemers')
@@ -57,3 +60,8 @@ module.exports = class Prepaid extends CocoModel
     options.data ?= {}
     options.data.userID = user.id or user
     @fetch(options)
+
+  hasBeenUsedByTeacher: (userID) ->
+    if @get('creator') is userID and _.detect(@get('redeemers'), { teacherID: undefined })
+      return true
+    _.detect(@get('redeemers'), { teacherID: userID })

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -260,6 +260,9 @@ module.exports = class User extends CocoModel
     courseID = course.id or course
     # NOTE: Full licenses implicitly include all courses
     return !includedCourseIDs or courseID in includedCourseIDs
+  
+  fetchCreatorOfPrepaid: (prepaid) ->
+    @fetch({url: "/db/prepaid/#{prepaid.id}/creator"})
 
   # Function meant for "me"
 

--- a/app/schemas/models/prepaid.schema.coffee
+++ b/app/schemas/models/prepaid.schema.coffee
@@ -7,14 +7,19 @@ PrepaidSchema = c.object({title: 'Prepaid', required: ['type']}, {
     c.object {required: ['date', 'userID']},
       date: c.date {title: 'Redeemed date'}
       userID: c.objectId(links: [ {rel: 'extra', href: '/db/user/{($)}'} ])
+      teacherID: c.objectId(links: [ {rel: 'extra', href: '/db/user/{($)}'} ],
+        description: 'userID of teacher that applied the license, if not the creator')
   maxRedeemers: { type: 'integer' }
   code: c.shortString(title: "Unique code to redeem")
   type: { type: 'string' }
-  properties: {type: 'object' }
+  properties: { type: 'object' }
   exhausted: { type: 'boolean' }
   startDate: c.stringDate()
   endDate: c.stringDate()
   includedCourseIDs: c.array({ description: 'courseIDs that this prepaid includes access to' }, c.objectId())
+  joiners: c.array {title: 'Teachers this Prepaid is shared with'},
+    c.object {required: ['userID']},
+      userID: c.objectId(links: [ {rel: 'extra', href: '/db/user/{($)}'} ])
 })
 
 c.extendBasicProperties(PrepaidSchema, 'prepaid')

--- a/app/styles/courses/enrollments-view.sass
+++ b/app/styles/courses/enrollments-view.sass
@@ -21,7 +21,19 @@
       
     &.pending-prepaid-card
       background: #6e939f
-      
+
+    &.empty-prepaid-card
+      background: #bbbbbb
+
+  .share-details .share-licenses-link
+    color: black
+    text-decoration: underline
+
+  .prepaid-card-container
+    height: 309px
+
+  .share-details
+    text-align: right
   
   .how-to-enroll
     padding: 10px

--- a/app/styles/teachers/share-licenses-modal.sass
+++ b/app/styles/teachers/share-licenses-modal.sass
@@ -1,0 +1,37 @@
+@import "app/styles/style-flat-variables"
+
+#share-licenses-modal
+  .modal-header
+    text-transform: capitalize
+
+#share-licenses-component
+  padding-top: 5px
+
+  .list-item
+    transition: background-color 0.5s ease-out
+  .list-enter
+    background-color: $navy
+  
+  .error-message
+    color: red
+    text-align: right
+    a
+      color: inherit
+      text-decoration: underline
+  
+  h4
+    font-size: 16px
+    font-weight: 600
+  input
+    width: 100%
+    border: 1px solid black
+  .add-teacher-btn
+    width: 100%
+  
+  .subheader-text
+    margin-left: 8%
+    margin-right: 8%
+    
+  .footer-text
+    margin-left: 9%
+    margin-right: 9%

--- a/app/templates/courses/enrollments-view.jade
+++ b/app/templates/courses/enrollments-view.jade
@@ -52,7 +52,8 @@ block content
       h4#enrollments-blurb(data-i18n="teacher.enrollments_blurb")  
       - var available = view.state.get('prepaidGroups').available
       - var pending = view.state.get('prepaidGroups').pending
-      - var anyPrepaids = available || pending
+      - var empty = view.state.get('prepaidGroups').empty
+      - var anyPrepaids = available || pending ||  empty
       
       .text-center.m-t-3
         span.glyphicon.glyphicon-question-sign
@@ -66,15 +67,22 @@ block content
               h5.m-b-1(data-i18n="teacher.available_credits")
               .row
                 for prepaid in available
-                  .col-sm-4.col-xs-6
+                  .prepaid-card-container.col-sm-4.col-xs-6
                     +prepaidCard(prepaid)
 
             if _.size(pending) > 0
               h5.m-b-1.m-t-3(data-i18n="teacher.pending_credits")
               .row
                 for prepaid in pending
-                  .col-sm-4.col-xs-6
+                  .prepaid-card-container.col-sm-4.col-xs-6
                     +prepaidCard(prepaid, 'pending-prepaid-card')
+
+            if _.size(empty) > 0
+              h5.m-b-1(data-i18n="teacher.empty_credits")
+              .row
+                for prepaid in empty
+                  .prepaid-card-container.col-sm-4.col-xs-6
+                    +prepaidCard(prepaid, 'empty-prepaid-card')
 
           #actions-col.col-md-3
             +addCredits
@@ -85,14 +93,20 @@ block content
             +addCredits
 
 mixin prepaidCard(prepaid, className)
-  .prepaid-card.bg-navy.text-center.m-b-2.p-a-2(class=className)
+  .prepaid-card.bg-navy.text-center.p-a-2(class=className)
     h1.m-t-2.m-b-0= prepaid.openSpots()
     if prepaid.get('type') === 'starter_license'
       div(data-i18n="teacher.starter_licenses")
     else
-      div(data-i18n="teacher.credits")
+      div(data-i18n="teacher.licenses_remaining")
+    div.m-t-1
+      i.small-details
+        if prepaid.usedSpots() === 1
+          = translate('teacher.one_license_used')
+        else
+          = translate('teacher.num_licenses_used', {numLicensesUsed: prepaid.usedSpots()})
     hr
-    em.small-details
+    i.small-details
       .pull-left(data-i18n="teacher.start_date")
       .pull-right= moment(prepaid.get('startDate')).utc().format('l')
       .clearfix
@@ -100,7 +114,16 @@ mixin prepaidCard(prepaid, className)
       .pull-left(data-i18n="teacher.end_date")
       .pull-right= moment(prepaid.get('endDate')).utc().format('l')
       .clearfix
-
+  if prepaid.get('type') === 'course'
+    .share-details.small-details.m-b-2
+      if prepaid.get('creator') === me.id
+        a.share-licenses-link(data-prepaid-id=prepaid.id)
+          span(data-i18n="share_licenses.share_licenses")
+      else if !prepaid.creator.loading
+        span(data-i18n="share_licenses.shared_by")
+        = " "
+        a(href="mailto:" + prepaid.creator.get('email'))
+          span= prepaid.creator.broadName()
 
 mixin addCredits
   .text-center.m-b-3.m-t-3

--- a/app/templates/teachers/share-licenses-component.jade
+++ b/app/templates/teachers/share-licenses-component.jade
@@ -1,0 +1,43 @@
+#share-licenses-component.modal-body 
+  .text-center.subheader-text
+    p.small
+      {{ $t("share_licenses.subheader") }}
+  
+  h4.m-t-3.input-label
+    {{ $t("share_licenses.add_teacher_label") }}
+  
+  form.row.form-group
+    .col-xs-8
+      input.form-control(v-model:value.trim="teacherSearchInput")
+    .col-xs-4
+      button.add-teacher-btn.btn.btn-navy(v-on:click.prevent="addTeacher")
+        span.m-l-1.m-r-1
+          {{ $t("share_licenses.add_teacher_button") }}
+  
+  .row(v-if="error")
+    .col-xs-8
+      p.error-message.small
+        {{ error }}
+        =" "
+        a(href='/teachers/resources/faq#how-do-i-share-licenses-to-other-teachers-in-my-organization-')
+          span
+            {{ $t("share_licenses.more_info") }}
+  
+  h4.m-t-5
+    {{ $t("share_licenses.teachers_using_these") }}
+  
+  transition-group.m-b-5(name="list" v-if="prepaid" tag="div")
+    li.list-item( is="share-licenses-joiner-row",
+        v-if="joiner",
+        v-for="joiner in prepaid.joiners",
+        :key="joiner.userID",
+        :joiner="joiner",
+        :prepaid="prepaid")
+  
+  .text-center.footer-text
+    p.small
+      {{ $t("share_licenses.footer") }}
+  
+    button.btn.btn-lg.btn-navy-alt(data-dismiss="modal")
+      span.m-l-3.m-r-3
+        {{ $t("general.close_window") }}

--- a/app/templates/teachers/share-licenses-joiner-row.jade
+++ b/app/templates/teachers/share-licenses-joiner-row.jade
@@ -1,0 +1,16 @@
+div.row.p-t-1.p-b-1(v-if="joiner")
+  div.col-xs-8
+    div
+      b
+        {{ broadName }}
+        span(v-if="joiner.email === me.get('email')")
+          = " "
+          {{ $t("share_licenses.you") }}
+    div.small
+      {{ joiner.email }}
+      
+  div.col-xs-4
+    b(v-if="joiner.licensesUsed === 1")
+      {{ $t("share_licenses.one_license_used") }}
+    b(v-else)
+      {{ $t("share_licenses.licenses_used", { licensesUsed: joiner.licensesUsed }) }}

--- a/app/templates/teachers/share-licenses-modal.jade
+++ b/app/templates/teachers/share-licenses-modal.jade
@@ -1,0 +1,11 @@
+extends /templates/core/modal-base-flat
+
+block modal-header
+  span.glyphicon.glyphicon-remove.button.close(data-dismiss="modal" aria-hidden="true")
+  h3.text-center.modal-header
+    span(data-i18n="share_licenses.share_licenses")
+
+block modal-body
+  #share-licenses-component
+
+block modal-footer

--- a/app/views/core/ModalView.coffee
+++ b/app/views/core/ModalView.coffee
@@ -46,6 +46,12 @@ module.exports = class ModalView extends CocoView
     # This makes sure if you press enter right after opening the players guide,
     # it doesn't just reopen the modal.
     $(document.activeElement).blur()
+    
+    if localStorage?.showViewNames
+      title = @constructor.name
+      setTimeout ->
+        $('title').text(title)
+      , 500
 
   showLoading: ($el) ->
     $el = @$el.find('.modal-body') unless $el

--- a/app/views/core/RootView.coffee
+++ b/app/views/core/RootView.coffee
@@ -124,6 +124,9 @@ module.exports = class RootView extends CocoView
 
     if title = @getTitle() then title += ' | CodeCombat'
     else title = 'CodeCombat - Learn how to code by playing a game'
+    
+    if localStorage?.showViewNames
+      title = @constructor.name
 
     $('title').text(title)
 

--- a/app/views/courses/ActivateLicensesModal.coffee
+++ b/app/views/courses/ActivateLicensesModal.coffee
@@ -34,7 +34,7 @@ module.exports = class ActivateLicensesModal extends ModalView
     @users.comparator = (user) -> user.broadName().toLowerCase()
     @prepaids = new Prepaids()
     @prepaids.comparator = 'endDate' # use prepaids in order of expiration
-    @supermodel.trackRequest @prepaids.fetchByCreator(me.id)
+    @supermodel.trackRequest @prepaids.fetchMineAndShared()
     @classrooms = new Classrooms()
     @supermodel.trackRequest @classrooms.fetchMine({
       data: {archived: false}

--- a/app/views/courses/TeacherClassView.coffee
+++ b/app/views/courses/TeacherClassView.coffee
@@ -94,7 +94,7 @@ module.exports = class TeacherClassView extends RootView
     @sortedCourses = []
 
     @prepaids = new Prepaids()
-    @supermodel.trackRequest @prepaids.fetchByCreator(me.id)
+    @supermodel.trackRequest @prepaids.fetchMineAndShared()
 
     @students = new Users()
     @classroom.sessions = new LevelSessions()

--- a/app/views/teachers/MarkdownResourceView.coffee
+++ b/app/views/teachers/MarkdownResourceView.coffee
@@ -1,3 +1,5 @@
+# This is the generic view for rendering content from /app/assets/markdown
+
 RootView = require 'views/core/RootView'
 utils = require 'core/utils'
 ace = require 'ace'
@@ -5,6 +7,7 @@ ace = require 'ace'
 module.exports = class MarkdownResourceView extends RootView
   id: 'markdown-resource-view'
   template: require 'templates/teachers/markdown-resource-view'
+  
   initialize: (options, @name) ->
     super(options)
     @content = ''
@@ -22,7 +25,7 @@ module.exports = class MarkdownResourceView extends RootView
         $('body').append($("<img src='https://code.org/api/hour/begin_code_combat_teacher.png' style='visibility: hidden;'>"))
       @loadingData = false
       @render()
-
+  
 
   afterRender: ->
     super()
@@ -40,3 +43,7 @@ module.exports = class MarkdownResourceView extends RootView
       aceEditor.setBehavioursEnabled false
       aceEditor.setAnimatedScroll false
       aceEditor.$blockScrolling = Infinity
+    if _.contains(location.href, '#')
+      _.defer =>
+        # Remind the browser of the fragment in the URL, so it jumps to the right section.
+        location.href = location.href

--- a/app/views/teachers/ShareLicensesJoinerRow.coffee
+++ b/app/views/teachers/ShareLicensesJoinerRow.coffee
@@ -1,0 +1,25 @@
+store = require('core/store')
+ShareLicensesStoreModule = require './ShareLicensesStoreModule'
+User = require 'models/User'
+
+module.exports = ShareLicensesJoinerRow =
+  name: 'share-licenses-joiner-row'
+  template: require('templates/teachers/share-licenses-joiner-row')()
+  storeModule: ShareLicensesStoreModule
+  props:
+    joiner:
+      type: Object
+      default: -> {}
+    prepaid:
+      type: Object
+      default: ->
+        joiners: []
+  created: ->
+  data: ->
+    me: me
+  computed:
+    broadName: ->
+      (new User(@joiner)).broadName()
+  components: {}
+  methods:
+    {}

--- a/app/views/teachers/ShareLicensesModal.coffee
+++ b/app/views/teachers/ShareLicensesModal.coffee
@@ -1,0 +1,52 @@
+ModalView = require 'views/core/ModalView'
+State = require 'models/State'
+TrialRequests = require 'collections/TrialRequests'
+forms = require 'core/forms'
+store = require('core/store')
+ShareLicensesStoreModule = require('./ShareLicensesStoreModule')
+
+module.exports = class ShareLicensesModal extends ModalView
+  id: 'share-licenses-modal'
+  template: require 'templates/teachers/share-licenses-modal'
+  events: {}
+  initialize: (options={}) ->
+    @shareLicensesComponent = null
+    store.registerModule('modal', ShareLicensesStoreModule)
+    store.dispatch('modal/setPrepaid', options.prepaid.attributes)
+  afterRender: ->
+    target = @$el.find('#share-licenses-component')
+    if @shareLicensesComponent
+      target.replaceWith(@shareLicensesComponent.$el)
+    else
+      @shareLicensesComponent = new ShareLicensesComponent({
+        el: target[0]
+        store
+      })
+      @shareLicensesComponent.$on 'setJoiners', (prepaidID, joiners) =>
+        @trigger 'setJoiners', prepaidID, joiners
+  destroy: ->
+    @shareLicensesComponent.$destroy()
+    super(arguments...)
+
+ShareLicensesComponent = Vue.extend
+  name: 'share-licenses-component'
+  template: require('templates/teachers/share-licenses-component')()
+  storeModule: ShareLicensesStoreModule
+  data: ->
+    me: me
+    teacherSearchInput: ''
+  computed: _.assign({}, Vuex.mapGetters(prepaid: 'modal/prepaid', error: 'modal/error', rawJoiners: 'modal/rawJoiners'))
+  watch:
+    teacherSearchInput: ->
+      @$store.commit('modal/setError', '')
+  components:
+    'share-licenses-joiner-row': require('./ShareLicensesJoinerRow')
+  methods:
+    addTeacher: ->
+      @$store.dispatch('modal/addTeacher', @teacherSearchInput).then =>
+        # Send an event back to backbone-land so it can update its model
+        @$emit 'setJoiners', @prepaid._id, @rawJoiners
+  created: ->
+  destroyed: ->
+    @$store.commit('modal/clearData')
+    @$store.unregisterModule('modal')

--- a/app/views/teachers/ShareLicensesStoreModule.coffee
+++ b/app/views/teachers/ShareLicensesStoreModule.coffee
@@ -1,0 +1,67 @@
+api = require 'core/api'
+
+initialState = {
+  _prepaid: { joiners: [] }
+  error: ''
+}
+
+translateError = (error) ->
+  if error.i18n
+    return i18n.t(error.i18n)
+  else if error.errorID is 'no-user-with-that-email'
+    return i18n.t('share_licenses.teacher_not_found')
+  else if error.errorID is 'cant-fetch-nonteacher-by-email'
+    return i18n.t('share_licenses.teacher_not_valid')
+  else
+    return error.message or error
+
+module.exports = ShareLicensesStoreModule =
+  namespaced: true
+  state: _.cloneDeep(initialState)
+  mutations:
+    # NOTE: Ideally, this store should fetch the prepaid, but we're already handed it by the Backbone parent
+    setPrepaid: (state, prepaid) ->
+      state._prepaid = prepaid
+    addTeacher: (state, user) ->
+      state._prepaid.joiners.push({
+        userID: user._id
+        name: user.name
+        email: user.email
+        firstName: user.firstName
+        lastName: user.lastName
+      })
+    setError: (state, error) ->
+      state.error = error
+    clearData: (state) ->
+      _.assign state, initialState
+  actions:
+    setPrepaid: ({ commit }, prepaid) ->
+      prepaid = _.cloneDeep(prepaid)
+      prepaid.joiners ?= []
+      api.prepaids.fetchJoiners({ prepaidID: prepaid._id }).then (joiners) ->
+        prepaid.joiners.forEach (slimJoiner) ->
+          fullJoiner = _.find(joiners, {_id: slimJoiner.userID})
+          _.assign(slimJoiner, fullJoiner)
+      .then ->
+        commit('setPrepaid', prepaid)
+    addTeacher: ({ commit, state }, email) ->
+      return if _.isEmpty(email)
+      api.users.getByEmail(email).then (user) =>
+        api.prepaids.addJoiner({prepaidID: state._prepaid._id, userID: user._id}).then =>
+          commit('addTeacher', user)
+      .catch (error) =>
+        commit('setError', translateError(error.responseJSON or error))
+  getters:
+    prepaid: (state) ->
+      joinersAndMe = state._prepaid.joiners.concat _.assign({ userID: me.id }, me.pick('name', 'firstName', 'lastName', 'email'))
+      _.assign({}, state._prepaid, {
+        joiners: joinersAndMe.map((joiner) ->
+          _.assign {}, joiner,
+            licensesUsed: _.countBy(state._prepaid.redeemers, (redeemer) ->
+              (not redeemer.teacherID and joiner.userID is me.id) or (redeemer.teacherID is joiner.userID)
+            )[true] or 0
+        ).reverse()
+      })
+    rawJoiners: (state) ->
+      state._prepaid.joiners.map (joiner) -> _.pick(joiner, 'userID')
+    error: (state) -> state.error

--- a/server/middleware/prepaids.coffee
+++ b/server/middleware/prepaids.coffee
@@ -16,6 +16,7 @@ Promise.promisifyAll(StripeUtils)
 moment = require 'moment'
 slack = require '../slack'
 delighted = require '../delighted'
+sendwithus = require '../sendwithus'
 
 { STARTER_LICENSE_COURSE_IDS } = require '../../app/core/constants'
 {formatDollarValue} = require '../../app/core/utils'
@@ -60,18 +61,18 @@ module.exports =
     if not user
       throw new errors.NotFound('User not found.')
 
-    unless prepaid.get('creator').equals(req.user._id)
+    unless prepaid.canBeUsedBy(req.user._id)
       throw new errors.Forbidden('You may not redeem licenses from this prepaid')
     unless prepaid.get('type') in ['course', 'starter_license']
       throw new errors.Forbidden('This prepaid is not of type "course" or "starter_license"')
     unless prepaid.canReplaceUserPrepaid(user.get('coursePrepaid'))
       return res.status(200).send(prepaid.toObject({req: req}))
 
-    yield prepaid.redeem(user)
+    yield prepaid.redeem(user, req.user._id)
 
     # return prepaid with new redeemer added locally
     redeemers = _.clone(prepaid.get('redeemers') or [])
-    redeemers.push({ date: new Date(), userID: user._id })
+    redeemers.push({ date: new Date(), userID: user._id, teacherID: req.user._id })
     prepaid.set('redeemers', redeemers)
     res.status(201).send(prepaid.toObject({req: req}))
 
@@ -84,7 +85,7 @@ module.exports =
     if not prepaid
       throw new errors.NotFound('Prepaid not found.')
 
-    unless prepaid.get('creator').equals(req.user._id)
+    unless prepaid.canBeUsedBy(req.user._id)
       throw new errors.Forbidden('You may not revoke enrollments you do not own.')
     unless prepaid.get('type') is 'course'
       throw new errors.Forbidden('This prepaid is not of type "course".')
@@ -116,6 +117,83 @@ module.exports =
     prepaid.set('redeemers', _.filter(prepaid.get('redeemers') or [], (obj) -> not obj.userID.equals(user._id)))
     res.status(200).send(prepaid.toObject({req: req}))
 
+  # Add teachers to a Shared License
+  addJoiner: wrap (req, res) ->
+    if not req.user?.isTeacher()
+      throw new errors.Forbidden('Must be a teacher to share licenses')
+
+    prepaid = yield database.getDocFromHandle(req, Prepaid)
+    if not prepaid
+      throw new errors.NotFound('Prepaid not found.')
+
+    unless prepaid.get('creator').equals(req.user._id)
+      throw new errors.Forbidden('You may not share licenses you do not own.')
+    unless prepaid.get('type') is 'course'
+      throw new errors.Forbidden('This prepaid is not of type "course".')
+
+    if _.find(prepaid.get('joiners'), (joiner) -> joiner.userID.equals(req.body?.userID)) or req.body?.userID is req.user.id
+      throw new errors.UnprocessableEntity("You've already shared these licenses with that teacher.", { i18n: 'share_licenses.already_shared' })
+
+    joiner = yield User.findById(req.body?.userID)
+    if not joiner
+      throw new errors.NotFound('User not found.')
+
+    if not joiner.isTeacher()
+      throw new errors.UnprocessableEntity('User to share with must be a Teacher.', { i181: 'share_licenses.teacher_not_valid' })
+    
+    query =
+      _id: prepaid._id
+    update = { $addToSet: { joiners : { userID: joiner._id } }}
+    result = yield Prepaid.update(query, update)
+    
+    context =
+      email_id: sendwithus.templates.share_licenses_joiner
+      recipient:
+        address: joiner.get('email')
+        name: joiner.broadName()
+      email_data:
+        joiner_email: joiner.get('email')
+        creator_email: req.user.get('email')
+        creator_name: req.user.broadName()
+    sendwithus.api.send context, (err, result) ->
+    
+    res.status(201).send(prepaid.toObject({req}))
+  
+  fetchJoiners: wrap (req, res) ->
+    if not req.user?.isTeacher()
+      throw new errors.Forbidden('Must be a teacher to fetch joiners for a license.')
+  
+    prepaid = yield database.getDocFromHandle(req, Prepaid)
+    if not prepaid
+      throw new errors.NotFound('Prepaid not found.')
+  
+    unless prepaid.get('creator').equals(req.user._id)
+      throw new errors.Forbidden('You may not fetch the joiners of a license you do not own.')
+    unless prepaid.get('type') is 'course'
+      throw new errors.Forbidden('This prepaid is not of type "course".')
+  
+    joinerIDs = (prepaid.get('joiners') or []).map((j)->j.userID)
+  
+    joiners = (yield joinerIDs.map (id) ->
+      User.findById(id)
+    ).map (user) ->
+      _.pick(user.toObject(), ['_id', 'email', 'name', 'firstName', 'lastName'])
+    
+    res.status(200).send(joiners)
+  
+  fetchCreator: wrap (req, res) ->
+    unless req.user
+      throw new errors.Unauthorized()
+    unless req.user.isAdmin() or req.user.isTeacher()
+      throw new errors.Forbidden()
+    prepaid = yield database.getDocFromHandle(req, Prepaid)
+    unless prepaid
+      throw new errors.NotFound('No prepaid with that ID found')
+    unless prepaid.canBeUsedBy(req.user._id)
+      throw new errors.Forbidden('You can only look up the owner of prepaids that have been shared with you.')
+    creator = yield User.findOne({ _id: prepaid.get('creator') })
+    res.status(200).send(_.pick(creator.toObject(), ['_id', 'email', 'name', 'firstName', 'lastName']))
+  
   fetchByCreator: wrap (req, res, next) ->
     creator = req.query.creator
     return next() if not creator
@@ -129,6 +207,14 @@ module.exports =
       _id: { $gt: cutoffID }
       creator: mongoose.Types.ObjectId(creator)
     }
+    if req.query.includeShared
+      q = {
+        _id: { $gt: cutoffID }
+        $or: [
+          { creator: mongoose.Types.ObjectId(creator) }
+          { "joiners.userID": mongoose.Types.ObjectId(creator) }
+        ]
+      }
     q.type = { $in: ['course', 'starter_license'] } unless req.query.allTypes
 
     prepaids = yield Prepaid.find(q)
@@ -214,7 +300,10 @@ module.exports =
       continue unless prepaid.creator
       userPrepaidsMap[prepaid.creator.valueOf()] ?= []
       userPrepaidsMap[prepaid.creator.valueOf()].push(prepaid)
+      # NOTE: May not correctly account for shared licenses
       userIDs.push prepaid.creator
+      for joiner in prepaid.joiners ? []
+        userIDs.push joiner.userID + ''
       for redeemer in prepaid.redeemers ? []
         redeemerIDs.push redeemer.userID + ""
         redeemerPrepaidMap[redeemer.userID + ""] = prepaid._id.valueOf()

--- a/server/middleware/users.coffee
+++ b/server/middleware/users.coffee
@@ -25,6 +25,7 @@ LevelSession = require '../models/LevelSession'
 config = require '../../server_config'
 utils = require '../lib/utils'
 CLASubmission = require '../models/CLASubmission'
+Prepaid = require '../models/Prepaid'
 
 module.exports =
   fetchByGPlusID: wrap (req, res, next) ->
@@ -60,11 +61,18 @@ module.exports =
   fetchByEmail: wrap (req, res, next) ->
     email = req.query.email
     return next() unless email
-    throw new errors.Forbidden('Only admins can search by email') unless req.user?.isAdmin()
-    
-    user = yield User.findOne({ emailLower: email.toLowerCase() })
-    throw new errors.NotFound('No user with that email') unless user
-    res.status(200).send(user.toObject({req}))
+    if req.user?.isAdmin()
+      user = yield User.findOne({ emailLower: email.toLowerCase() })
+      throw new errors.NotFound('No user with that email', { errorID: 'no-user-with-that-email' }) unless user
+      res.status(200).send(user.toObject({req}))
+    else if req.user?.isTeacher()
+      user = yield User.findOne({ emailLower: email.toLowerCase() })
+      throw new errors.NotFound('No user with that email', { errorID: 'no-user-with-that-email' }) unless user
+      throw new errors.Forbidden('Teacher Accounts can only look up other Teacher Accounts.', { errorID: 'cant-fetch-nonteacher-by-email' }) unless user.isTeacher()
+      trimUser = _.pick(user.toObject(), ['_id', 'email', 'firstName', 'lastName', 'name'])
+      res.status(200).send(trimUser)
+    else
+      throw new errors.Forbidden('Only admins and teachers can search by email')
 
   removeFromClassrooms: wrap (req, res, next) ->
     yield req.user.removeFromClassrooms()
@@ -405,7 +413,7 @@ module.exports =
     [rows, fields] = yield connection.queryAsync(mysqlq, params)
     ids = rows.map (r) -> mongoose.Types.ObjectId(r.mongoid)
     connection.end()
-    return ids    
+    return ids
 
   resetProgress: wrap (req, res) ->
     unless req.user

--- a/server/routes/index.coffee
+++ b/server/routes/index.coffee
@@ -198,11 +198,14 @@ module.exports.setup = (app) ->
   app.get('/db/poll/:handle/patches', mw.patchable.patches(Poll))
 
   app.get('/db/prepaid', mw.auth.checkLoggedIn(), mw.prepaids.fetchByCreator)
+  app.get('/db/prepaid/:handle/creator', mw.prepaids.fetchCreator)
+  app.get('/db/prepaid/:handle/joiners', mw.prepaids.fetchJoiners)
   app.get('/db/prepaid/-/active-school-licenses', mw.auth.checkHasPermission(['admin']), mw.prepaids.fetchActiveSchoolLicenses)
   app.get('/db/prepaid/-/active-schools', mw.auth.checkHasPermission(['admin']), mw.prepaids.fetchActiveSchools)
   app.post('/db/prepaid', mw.auth.checkHasPermission(['admin']), mw.prepaids.post)
   app.post('/db/starter-license-prepaid', mw.auth.checkLoggedIn(), mw.prepaids.purchaseStarterLicenses)
   app.post('/db/prepaid/:handle/redeemers', mw.prepaids.redeem)
+  app.post('/db/prepaid/:handle/joiners', mw.prepaids.addJoiner)
   app.delete('/db/prepaid/:handle/redeemers', mw.prepaids.revoke)
 
   app.get('/db/products', mw.auth.checkHasUser(), mw.products.get)

--- a/server/sendwithus.coffee
+++ b/server/sendwithus.coffee
@@ -44,3 +44,4 @@ module.exports.templates =
   teacher_drip_day_5: 'tem_7Xh9HwxyQDrVRYTK37JgMXYF'
   teacher_drip_day_7: 'tem_SRcvbYCd9QXRDvr68qWhD66d'
   sunburst_referral: 'tem_MWgdKKv7JwD8c6WdbRyRSG89'
+  share_licenses_joiner: 'tem_7brGYfbJpYkx3qHXx33Yb8xQ'

--- a/spec/server/functional/user.spec.coffee
+++ b/spec/server/functional/user.spec.coffee
@@ -510,6 +510,94 @@ describe 'GET /db/user', ->
 
 #  xit 'can fetch another user with restricted fields'
   
+describe 'GET /db/user?email=:email', ->
+  beforeEach utils.wrap ->
+    yield Promise.promisify(clearModels)([User])
+    @admin = yield utils.initAdmin()
+    @teacher1 = yield utils.initUser({ role: 'teacher' })
+    @teacher2 = yield utils.initUser({
+      role: 'teacher'
+      email: 'teacher2@example.com'
+      firstName: 'first'
+      lastName: 'last'
+    })
+    @user = yield utils.initUser({
+      email: 'user@example.com'
+      firstName: 'user_first'
+    })
+
+  describe 'when user is a teacher', ->
+    beforeEach utils.wrap ->
+      yield utils.loginUser(@teacher1)
+
+    describe 'and email matches a teacher', ->
+      beforeEach utils.wrap ->
+        @email = 'teacher2@example.com'
+        @url = getURL("/db/user?email=#{@email}")
+
+      it 'returns the user with username, full name, and email', utils.wrap ->
+        [res, body] = yield request.getAsync({ url: @url, json: true })
+        expect(res.statusCode).toBe(200)
+        expect(body.email).toBe(@teacher2.get('email'))
+        expect(body.name).toBe(@teacher2.get('name'))
+        expect(body.firstName).toBe(@teacher2.get('firstName'))
+        expect(body.lastName).toBe(@teacher2.get('lastName'))
+        expect(body.passwordHash).toBeUndefined()
+
+    describe 'and email matches a non-teacher', ->
+      beforeEach utils.wrap ->
+        @email = 'user@example.com'
+        @url = getURL("/db/user?email=#{@email}")
+
+      it 'returns 403', utils.wrap ->
+        [res, body] = yield request.getAsync({ url: @url, json: true })
+        expect(res.statusCode).toBe(403)
+
+    describe "and email doesn't match any users", ->
+      beforeEach utils.wrap ->
+        @email = 'nobody@example.com'
+        @url = getURL("/db/user?email=#{@email}")
+
+      it 'returns 404', utils.wrap ->
+        [res, body] = yield request.getAsync({ url: @url, json: true })
+        expect(res.statusCode).toBe(404)
+
+  describe 'when user is an admin', ->
+    beforeEach utils.wrap ->
+      yield utils.loginUser(@admin)
+
+    describe 'and email matches a user', ->
+      beforeEach utils.wrap ->
+        @email = 'user@example.com'
+        @url = getURL("/db/user?email=#{@email}")
+
+      it 'returns the user with private attributes', utils.wrap ->
+        [res, body] = yield request.getAsync({ url: @url, json: true })
+        expect(res.statusCode).toBe(200)
+        expect(body.role).toBe(@user.get('role'))
+        expect(body.email).toBe(@user.get('email'))
+        expect(body.name).toBe(@user.get('name'))
+        expect(body.firstName).toBe(@user.get('firstName'))
+        expect(body.permissions).toEqual(@user.get('permissions'))
+
+    describe "and email doesn't match any users", ->
+      beforeEach utils.wrap ->
+        @email = 'nobody@example.com'
+        @url = getURL("/db/user?email=#{@email}")
+
+      it 'returns 404', utils.wrap ->
+        [res, body] = yield request.getAsync({ url: @url, json: true })
+        expect(res.statusCode).toBe(404)
+
+  describe 'when user is not a teacher nor an admin', ->
+    beforeEach utils.wrap ->
+      yield utils.loginUser(@user)
+      @email = 'whatever'
+      @url = getURL("/db/user?email=#{@email}")
+
+    it 'returns 403', utils.wrap ->
+      [res, body] = yield request.getAsync({ url: @url, json: true })
+      expect(res.statusCode).toBe(403)
   
 describe 'GET /db/user/:handle', ->
   it 'populates coursePrepaid from coursePrepaidID', utils.wrap ->

--- a/spec/server/utils.coffee
+++ b/spec/server/utils.coffee
@@ -299,6 +299,15 @@ module.exports = mw =
       return done(err) if err
       expect(res.statusCode).toBe(201)
       Prepaid.findById(res.body._id).exec done
+  
+  addJoinerToPrepaid: Promise.promisify (prepaid, joiner, done) ->
+    data = {
+      userID: joiner?.id or joiner
+    }
+    request.post { uri: getURL("/db/prepaid/#{prepaid.id}/joiners"), method: 'POST', json: data }, (err, res) ->
+      return done(err) if err
+      expect(res.statusCode).toBe(201)
+      Prepaid.findById(res.body._id).exec done
 
   makePayment: (data={}) ->
     data = _.extend({}, {

--- a/test/app/views/teachers/ShareLicensesModal.spec.coffee
+++ b/test/app/views/teachers/ShareLicensesModal.spec.coffee
@@ -1,0 +1,53 @@
+ShareLicensesModal = require 'views/teachers/ShareLicensesModal'
+factories = require '../../factories'
+api = require 'core/api'
+
+xdescribe 'ShareLicensesModal', ->
+  afterEach ->
+    @modal?.destroy?() unless @modal?.destroyed
+  
+  describe 'joiner list', ->
+    beforeEach (done) ->
+      window.me = @teacher = factories.makeUser({firstName: 'teacher', lastName: 'one'})
+      @joiner1 = factories.makeUser({firstName: 'joiner', lastName: 'one'})
+      @joiner2 = factories.makeUser({firstName: 'joiner', lastName: 'two'})
+      @prepaid = factories.makePrepaid({ joiners: [{ userID: @joiner1.id }, { userID: @joiner2.id }] })
+      spyOn(api.prepaids, 'fetchJoiners').and.returnValue Promise.resolve([
+          _.pick(@joiner1.attributes, '_id', 'name', 'email', 'firstName', 'lastName')
+          _.pick(@joiner2.attributes, '_id', 'name', 'email', 'firstName', 'lastName')
+        ])
+      @modal = new ShareLicensesModal({ prepaid: @prepaid })
+      @modal.render()
+      @store = @modal.shareLicensesComponent.$store
+      # TODO How do I wait for VueX to finish updating?
+      _.defer ->
+        done()
+    
+    it 'shows a list of joiners in reverse order', ->
+      joiners = @modal.shareLicensesComponent.prepaid.joiners
+      expect(joiners[0]?.firstName).toBe('teacher')
+      expect(joiners[0]?.lastName).toBe('one')
+      expect(joiners[0]?.email).toBe(@teacher.get('email'))
+      expect(joiners[1]?.firstName).toBe('joiner')
+      expect(joiners[1]?.lastName).toBe('two')
+      expect(joiners[1]?.email).toBe(@joiner2.get('email'))
+      expect(joiners[2]?.firstName).toBe('joiner')
+      expect(joiners[2]?.lastName).toBe('one')
+      expect(joiners[2]?.email).toBe(@joiner1.get('email'))
+      
+    describe 'Add Teacher button', ->
+      beforeEach (done) ->
+        @joiner3 = factories.makeUser({firstName: 'joiner', lastName: 'three'})
+        spyOn(api.prepaids, 'addJoiner').and.returnValue Promise.resolve(@prepaid.toJSON())
+        spyOn(api.users, 'getByEmail').and.returnValue Promise.resolve(_.pick(@joiner3.toJSON(), ['_id', 'name', 'email', 'firstName', 'lastName']))
+        _.defer ->
+          done()
+        
+      it 'can add a joiner', (done) ->
+        @modal.shareLicensesComponent.teacherSearchInput = @joiner3.get('email')
+        @modal.shareLicensesComponent.addTeacher().then =>
+          joiners = @modal.shareLicensesComponent.prepaid.joiners
+          expect(joiners[1].firstName).toBe('joiner')
+          expect(joiners[1].lastName).toBe('three')
+          expect(joiners[1].email).toBe(@joiner3.get('email'))
+          done()


### PR DESCRIPTION
Adds the ability to share licenses with other teachers.
- Teacher can add other teachers to a license as "joiners"
- Joiners get the set of licenses in a prepaid added to the ones they can use
- There are no limits on how many licenses from a prepaid that a given joiner can use
- Joiners cannot be removed
- It also emails the joiner to let them know they have licenses to use