### PR TITLE
Fix leaderboard top scores performance

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -597,6 +597,7 @@
     day: "Today"
     week: "This Week"
     all: "All-Time"
+    latest: "Latest"
     time: "Time"
     damage_taken: "Damage Taken"
     damage_dealt: "Damage Dealt"
@@ -2245,5 +2246,3 @@
     fx_missing_paren: "If you want to call `$1` as function, you need `()`'s"
     unmatched_token: "Unmatched `$1`.  Every opening `$2` needs a closing `$3` to match it."
     unterminated_string: "Unterminated string. Add a matching `\"` at the end of your string."
-
-  

--- a/app/views/play/modal/LeaderboardModal.coffee
+++ b/app/views/play/modal/LeaderboardModal.coffee
@@ -8,7 +8,7 @@ module.exports = class LeaderboardModal extends ModalView
   id: 'leaderboard-modal'
   template: template
   instant: true
-  timespans: ['day', 'week', 'all']
+  timespans: ['latest', 'all']
 
   subscriptions: {}
 

--- a/server/handlers/level_handler.coffee
+++ b/server/handlers/level_handler.coffee
@@ -363,15 +363,15 @@ LevelHandler = class LevelHandler extends Handler
       'level.original': levelOriginal
       'state.topScores.type': scoreType
     now = new Date()
-    if timespan in ['latest', 'all']
-      since = null
+    if timespan is 'latest'
+      query['state.topScores.date'] = $lte: now.toISOString()
     else if timespan is 'day'
       # TODO: remove this old timeframe support after new latest/all version is deployed
       since = new Date now - 1 * 86400 * 1000
+      query['state.topScores.date'] = $gt: since.toISOString()
     else if timespan is 'week'
       # TODO: remove this old timeframe support after new latest/all version is deployed
       since = new Date now - 7 * 86400 * 1000
-    if since
       query['state.topScores.date'] = $gt: since.toISOString()
 
     if timespan is 'all'

--- a/server/handlers/level_handler.coffee
+++ b/server/handlers/level_handler.coffee
@@ -363,15 +363,21 @@ LevelHandler = class LevelHandler extends Handler
       'level.original': levelOriginal
       'state.topScores.type': scoreType
     now = new Date()
-    if timespan is 'day'
+    if timespan in ['latest', 'all']
+      since = null
+    else if timespan is 'day'
+      # TODO: remove this old timeframe support after new latest/all version is deployed
       since = new Date now - 1 * 86400 * 1000
     else if timespan is 'week'
+      # TODO: remove this old timeframe support after new latest/all version is deployed
       since = new Date now - 7 * 86400 * 1000
     if since
       query['state.topScores.date'] = $gt: since.toISOString()
 
-    sort =
-      'state.topScores.score': -1
+    if timespan is 'all'
+      sort = 'state.topScores.score': -1
+    else
+      sort = 'state.topScores.date': -1
 
     select = ['state.topScores', 'creatorName', 'creator', 'codeLanguage', 'heroConfig']
     if req.user.isAdmin()

--- a/server/models/LevelSession.coffee
+++ b/server/models/LevelSession.coffee
@@ -24,7 +24,8 @@ LevelSessionSchema.index({team: 1}, {sparse: true})
 LevelSessionSchema.index({totalScore: 1}, {sparse: true})
 LevelSessionSchema.index({user: 1, changed: -1}, {name: 'last played index', sparse: true})
 LevelSessionSchema.index({levelID: 1, changed: -1}, {name: 'last played by level index', sparse: true})  # Needed for getRecentSessions for CampaignLevelView
-LevelSessionSchema.index({'level.original': 1, 'state.topScores.type': 1, 'state.topScores.date': -1, 'state.topScores.score': -1}, {name: 'top scores index', sparse: true})
+LevelSessionSchema.index({'level.original': 1, 'state.topScores.type': 1, 'state.topScores.score': -1}, {name: 'all-time top scores index', sparse: true})
+LevelSessionSchema.index({'level.original': 1, 'state.topScores.type': 1, 'state.topScores.date': -1}, {name: 'latest top scores index', sparse: true})
 LevelSessionSchema.index({submitted: 1, team: 1, level: 1, totalScore: -1}, {name: 'rank counting index', sparse: true})
 #LevelSessionSchema.index({level: 1, 'leagues.leagueID': 1, submitted: 1, team: 1, totalScore: -1}, {name: 'league rank counting index', sparse: true})  # needed for league leaderboards?
 LevelSessionSchema.index({levelID: 1, submitted: 1, team: 1}, {name: 'get all scores index', sparse: true})


### PR DESCRIPTION
Switch queries and indexes to do latest/all leaderboard scores instead of day/week/all. (We couldn't performantly do top-scores-from-last-day/week and were actually firing off all sorts of queries that ran for hours in our Mongo, long after a two-minute webserver request timeout.)

I'll delete the old index and remove the old day/week once this is up.