### PR TITLE
Script for test user creation

### DIFF
--- a/scripts/test-data/createTestUsers.coffee
+++ b/scripts/test-data/createTestUsers.coffee
@@ -1,0 +1,99 @@
+#
+# Test User Creation Script
+#
+# Creates test users, with optional group (clan or classroom) for them
+#
+# Usage:
+#   node_modules/coffee-script/bin/coffee scripts/node/test-data/createTestUsers.coffee -n run [numUsers] [prefix] [group group_id]
+#
+# Args:
+#   numUsers - number of users to create, default 1
+#   prefix - prefix for user/group name, default 'test'
+#   group - 'clan' or 'classroom' (default: no group membership)
+#   group_id - id of an existing clan or classroom to put the new users into, or id of an existing user to own a newly-created one
+#
+_ = require 'lodash'
+log = require 'winston'
+str = require 'underscore.string'
+co = require 'co'
+
+exports.run = (numUsers, prefix, group, group_id) ->
+  co ->
+    mongoose = require 'mongoose'
+    User = require '../../server/models/User'
+    Clan = require '../../server/models/Clan'
+    Classroom = require '../../server/models/Classroom'
+
+    console.log "test users to create:", numUsers
+    console.log "test user name prefix:", prefix
+
+    if group?
+      group_class = if group is 'clan' then Clan else Classroom
+
+      if group_id
+        try
+          console.log 'searching group'
+          group_inst = yield group_class.findOne({_id: group_id})
+        catch e
+          console.error e
+        if group_inst
+          console.log 'Found group:', group.name, group.get('members')
+        else
+          console.log 'Creating new group'
+          group_inst = group_class(
+            ownerID: group_id
+            name: "#{prefix} #{group}"
+          )
+          try
+            yield group_inst.save()
+            console.log "Created new #{group}: #{group_inst.name}"
+          catch e
+            console.error "Could not create group:", e
+
+    if numUsers > 0
+      users = []
+      for i in [1..numUsers]
+        user = User(
+          name: prefix + i
+          password: prefix + i
+          email: prefix + i + '@' + prefix + '.example'
+        )
+        try
+          yield user.save()
+          console.log 'Created user:', user.name
+          users.push user
+          if group_inst
+            yield group_inst.update({ '$push': {members: user._id}})
+        catch e
+          console.error e
+
+    return 'Done'
+
+if process.argv[0] is 'coffee'
+  proc_arg = process.argv[3]
+  user_args = process.argv[4..]
+else
+  proc_arg = process.argv[2]
+  user_args = process.argv[3..]
+
+if proc_arg is 'run'
+  database = require '../../server/commons/database'
+  mongoose = require 'mongoose'
+
+  ### SET UP ###
+  do (setupLodash = this) ->
+    GLOBAL._ = require 'lodash'
+    _.str = require 'underscore.string'
+    _.mixin _.str.exports()
+    GLOBAL.tv4 = require('tv4').tv4
+
+  numUsers = if user_args[0] then user_args[0] | 0 else 1
+  userPrefix = user_args[1] ? 'test'
+  group = user_args[2]
+  group_id = user_args[3]
+
+  database.connect()
+  co ->
+    yield exports.run(numUsers, userPrefix, group, group_id)
+    process.exit()
+  


### PR DESCRIPTION
Script that creates test users and optionally a clan or classroom for them.

This is useful for dev instances whenever a number of users is needed for developing / debugging / testing something.

As an example: #2975

The script takes 3 seconds to create 0-100 users and 6 seconds to create 1000 users in my dev vm.

It is well-structured and has a usage comment at the top and can serve as an inspiration for more test data scripts.

My motivation for this, copied from previous slack discussion:
> from the wiki pages and issues I've read so far it seems a common workflow is "if you need data, let us create a dump from prod for you" - giving people the facilities to create the data by themselves means they don't need to wait for it, and means nobody has to go make a dump and sanitise it. Having a handful of (ideally well-maintained and integrated into automatic tests) scripts to generate some commonly-needed data also gives people something to push off of to adapt them to make their own for their own use cases.