### PR TITLE
Pin travis npm version to 4.6.x to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
     - bower_components
 before_install:
   - export COCO_TRAVIS_TEST=1
-  - npm install -g npm@latest
+  - npm install -g npm@4.6.x
 before_script:
   - npm update
   - export DISPLAY=:99.0


### PR DESCRIPTION
Our build doesn't work with npm 5, so need to pin to 4.6 to make build working again.