### PR TITLE
Refactored out manual fs traversal in coverage.js

### DIFF
--- a/bin/coverage.js
+++ b/bin/coverage.js
@@ -1,38 +1,21 @@
 fs = require('fs')
+_ = require('lodash')
 child_process = require('child_process')
 
 // Have to convert all CS server files to JS for coverage to work.
 // Walk through folders in server/ and compile each .coffee file,
 // keeping a list of generated files so they can be deleted later.
 
-var directories = ['./server']
 var convertedFiles = [];
 console.log('Convert server coffeescript files.')
 
-while(directories.length) {
-  directory = directories.pop()
-  console.log('*', directory)
+try{
+  var find_output = child_process.execSync('coffee --compile ./server && find ./server -name "*.js"');
+  var splits      = find_output.toString().split("\n")
+  convertedFiles  = _.compact(splits);
 
-  fs.readdirSync(directory).forEach((fileOrDir) => {
-    absPath = directory + '/' + fileOrDir
-    stat = fs.statSync(absPath)
-
-    // .coffee => .js
-    if(stat.isFile() && fileOrDir.endsWith('.coffee')) {
-      child_process.execSync(`coffee -c ${absPath}`)
-      convertedFiles.push(absPath.replace('.coffee', '.js'))
-    }
-
-    // Add to list of directories to walk
-    if(stat.isDirectory()) {
-      directories.push(absPath);
-    }
-  })
-}
-
-// Run Istanbul
-console.log(`Converted ${convertedFiles.length} server coffeescript files. Running tests...`)
-try {
+  // Run Istanbul
+  console.log(`Converted ${convertedFiles.length} server coffeescript files. Running tests...`)
   child_process.execSync('istanbul cover ./node_modules/jasmine/bin/jasmine.js')
 }
 catch (e) {


### PR DESCRIPTION
Per issue #4335, this PR shaves off about 30s from the coverage tasks's runtime on my
local machine by using `coffee` to compile the entire directory, rather than the manual fs traversal preent before.

@duk3luk3 do you think it'd work on Travis CI?