### PR TITLE
Update classroom world map

### DIFF
--- a/app/core/urls.coffee
+++ b/app/core/urls.coffee
@@ -15,7 +15,7 @@ module.exports =
     url += "&codeLanguage=#{level.get('primerLanguage')}" if level.get('primerLanguage')
     url
 
-  courseWorldMap: ({course, courseInstance, classroom}) ->
+  courseWorldMap: ({course, courseInstance}) ->
     "/play/#{course.get('campaignID')}?course-instance=#{courseInstance.id}"
 
   courseProjectGallery: ({courseInstance}) ->

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -65,6 +65,7 @@
     want_coco: "Want CodeCombat at your school?"
 
   nav:
+    map: "Map"
     play: "Levels"  # The top nav bar entry where players choose which levels to play
     community: "Community"
     courses: "Courses"

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -424,11 +424,13 @@
     years: "years"
 
   play_level:
+    back_to_map: "Back to Map"
     directions: "Directions"
     edit_level: "Edit Level"
     explore_codecombat: "Explore CodeCombat"
     finished_hoc: "I'm finished with my Hour of Code"
     get_certificate: "Get your certificate!"
+    ladder: "Ladder"
     level_complete: "Level Complete"
     completed_level: "Completed Level:"
     course: "Course:"

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -430,7 +430,6 @@
     explore_codecombat: "Explore CodeCombat"
     finished_hoc: "I'm finished with my Hour of Code"
     get_certificate: "Get your certificate!"
-    ladder: "Ladder"
     level_complete: "Level Complete"
     completed_level: "Completed Level:"
     course: "Course:"

--- a/app/models/Classroom.coffee
+++ b/app/models/Classroom.coffee
@@ -117,7 +117,6 @@ module.exports = class Classroom extends CocoModel
     arena = @getLadderLevel(courseID)
     project = @getProjectLevel(courseID)
     courseLevels = @getLevels({courseID: courseID, withoutLadderLevels: true})
-    #courseLevelsWithLadder = @getLevels({courseID: courseID, withoutLadderLevels: false})
     levelSessionMap = {}
     levelSessionMap[session.get('level').original] = session for session in sessions
     currentIndex = -1

--- a/app/styles/courses/courses-view.sass
+++ b/app/styles/courses/courses-view.sass
@@ -19,6 +19,10 @@
     padding-bottom: 20px
     opacity: 0.5
 
+  .view-levels-btn
+    font-size: 13px
+    padding-left: 10px
+
   .view-project-gallery-link
     font-size: 13px
     padding-left: 10px

--- a/app/styles/courses/courses-view.sass
+++ b/app/styles/courses/courses-view.sass
@@ -19,11 +19,9 @@
     padding-bottom: 20px
     opacity: 0.5
 
-  .view-levels-btn, .view-project-gallery-link
+  .view-project-gallery-link
     font-size: 13px
     padding-left: 10px
-
-  .view-project-gallery-link
     float: right
 
   .text-uppercase

--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -857,9 +857,10 @@ $gameControlMargin: 30px
 
   .under-logo
     position: absolute
-    top: calc(1% + 55px)
-    left: calc(1% + 20px)
+    top: calc(1% + 64px)
+    left: 1%
     z-index: 1
+    width: 193px
 
   .picoctf-powered-by
     color: rgb(227, 173, 53)

--- a/app/templates/courses/classroom-settings-modal.jade
+++ b/app/templates/courses/classroom-settings-modal.jade
@@ -11,13 +11,13 @@ block modal-body-content
     .form-group
       label(data-i18n="courses.class_name")
       input#name-input.form-control(name="name" type='text' value=view.classroom.get('name'))
-      
+
     .form-group
       label
         span(data-i18n="general.description")
         i.spl.text-muted(data-i18n="signup.optional")
       textarea.form-control(name="description" rows=2)= view.classroom.get('description')
-      
+
     .form-group
       label(data-i18n="choose_hero.programming_language")
       - var aceConfig = view.classroom.get('aceConfig') || {};
@@ -28,7 +28,7 @@ block modal-body-content
         option(value="" data-i18n="courses.language_select")
         option(value="python") Python
         option(value="javascript") JavaScript
-        
+
     .form-group
       label
         span(data-i18n="courses.avg_student_exp_label")
@@ -41,7 +41,7 @@ block modal-body-content
         option(value="intermediate" data-i18n="courses.avg_student_exp_intermediate")
         option(value="advanced" data-i18n="courses.avg_student_exp_advanced")
         option(value="varied" data-i18n="courses.avg_student_exp_varied")
-        
+
     .form-group
       label
         span(data-i18n="courses.student_age_range_label")
@@ -50,7 +50,7 @@ block modal-body-content
         +ageRange("ageRangeMin")
         span.spl.spr(data-i18n="courses.student_age_range_to")
         +ageRange("ageRangeMax")
-        
+
       mixin ageRange(name)
         select.age-range-select.form-control(name=name value=view.classroom.get(name))
           option(value="") -
@@ -59,25 +59,13 @@ block modal-body-content
             option(value=i)= i
           option(value="18" data-i18n="courses.student_age_range_older")
 
-    if view.classroom.getSetting('optionsEditable') || me.isAdmin()
-      .form-group
-        label Student Experience Options
-        - var settings = view.schema.properties.settings.properties
-        for opt,name in settings
-          if name != "optionsEditable" || me.isAdmin()
-          .form-group
-            div.checkbox
-              input(type="checkbox", id="settings_"+name, name="settings/"+name, checked=view.classroom.getSetting(name))
-              label(for="settings_" + name)
-                span= opt.description
-    
 block modal-footer-content
   .text-center
     if view.classroom.isNew()
       button#save-settings-btn.btn.btn-primary.btn-lg(data-i18n="courses.create_class")
     else
       button#save-settings-btn.btn.btn-primary.btn-lg(data-i18n="common.save_changes")
-      
+
     if me.isAdmin()
       hr
       // DNT

--- a/app/templates/courses/courses-view.jade
+++ b/app/templates/courses/courses-view.jade
@@ -10,12 +10,12 @@ block content
             h3 ATTENTION TEACHERS:
             p We are transitioning to a new classroom management system; this page will soon be student-only.
             a(href="/teachers/classes") Go to teachers area.
-        
+
         #main-content
           if me.isAnonymous()
-      
+
             h1.text-center(data-i18n="courses.welcome_to_courses")
-      
+
             .text-center
               p
                 h2(data-i18n="courses.ready_to_play")
@@ -27,16 +27,16 @@ block content
                 span.spl -
               p
                 button#log-in-btn.btn.btn-forest(data-i18n="login.log_in")
-      
+
             h2#play-now-to-learn-header.text-center.text-uppercase(data-i18n="courses.play_now_learn_header")
             ul#benefits-ul
               li(data-i18n="courses.play_now_learn_1")
               li(data-i18n="courses.play_now_learn_2")
               li(data-i18n="courses.play_now_learn_3")
               li(data-i18n="courses.play_now_learn_4")
-    
+
           else
-      
+
             .text-center
               h1(data-i18n="courses.welcome_to_page")
 
@@ -49,7 +49,7 @@ block content
                   span.current-hero-name= view.hero.getHeroShortName()
                 button.change-hero-btn.btn.btn-lg.btn-forest
                   span(data-i18n="courses.change_hero")
-      
+
             if view.classrooms.size()
               br
               h3(data-i18n="courses.my_classes")
@@ -60,7 +60,7 @@ block content
                 - var classroomClass = justAdded ? 'just-added' : '';
                 if justAdded
                   #just-added-text.text-center(data-i18n="courses.class_added")
-      
+
                 //- sigh
                 div(class=classroomClass)
                   h5
@@ -74,32 +74,28 @@ block content
 
                   - var courseInstances = view.courseInstances.where({classroomID: classroom.id});
                   for courseInstance in courseInstances
-      
+
                     .course-instance-entry
                       - var course = view.courses.get(courseInstance.get('courseID'));
                       h6
                         span.spr= i18n(course.attributes, 'name')
-                        small
-                          a.view-levels-btn(data-course-id=courseInstance.get('courseID'), data-courseinstance-id=courseInstance.id, data-i18n="courses.view_levels")
-                          if view.courseInstanceHasProject(courseInstance)
-                            a.view-project-gallery-link(data-course-id=courseInstance.get('courseID'), data-courseinstance-id=courseInstance.id, data-i18n="courses.view_project_gallery")
                       +course-instance-body(courseInstance, classroom)
                       .clearfix
 
             h3.text-uppercase(data-i18n="courses.join_class")
             hr
-      
+
             form#join-class-form.form-inline
               .help-block
                 em(data-i18n="courses.ask_teacher_for_code")
               .form-group
                 input#class-code-input.form-control(data-i18n="[placeholder]courses.enter_c_code", placeholder="<Enter Class Code>", value=view.classCode)
               input#join-class-button.btn.btn-navy(type="submit", data-i18n="[value]courses.join", value="Join")
-      
+
               if view.state === 'enrolling'
                 .progress.progress-striped.active
                   .progress-bar(style="width: 100%", data-i18n="courses.joining") Joining class
-      
+
               if view.errorMessage
                 .alert.alert-danger= view.errorMessage
 
@@ -107,11 +103,6 @@ block content
 mixin course-instance-body(courseInstance, classroom)
   - var course = view.courses.get(courseInstance.get('courseID'));
   - var stats = classroom.statsForSessions(courseInstance.sessions, course.id);
-  - var bgimg = view.getCourseWorldImage(course)
-  if classroom.getSetting('map')
-    div(style="position: relative")
-      div(style="position: absolute; left: -80px; top: -20px")
-        img(src="/images/pages/play/worlds/" + bgimg + "_small.png")
   if stats.levels.done
     .text-success
       span.glyphicon.glyphicon-ok
@@ -131,28 +122,15 @@ mixin course-instance-body(courseInstance, classroom)
           span(data-i18n="courses.view_project")
       else
         a.btn.btn-default.btn-lg.m-b-1(disabled=true, data-i18n="courses.course_complete")
-    else if stats.levels.next != stats.levels.first
+    else
       - var next = stats.levels.next;
-      - var mapurl = view.urls.courseWorldMap({course: course, courseInstance: courseInstance});
-      if classroom.getSetting('map')
-        a.play-btn.btn.btn-forest.btn-lg.m-b-1(data-href=mapurl, data-level-slug=next.get('slug'), data-event-action="Students Continue Course")
+      - var url = view.urls.courseWorldMap({course: course, courseInstance: courseInstance});
+      if stats.levels.next != stats.levels.first
+        a.play-btn.btn.btn-forest.btn-lg.m-b-1(data-href=url, data-level-slug=next.get('slug'), data-event-action="Students Continue Course")
           span(data-i18n="common.continue")
       else
-        - var url = view.urls.courseLevel({level: view.originalLevelMap[next.get('original')] || next, courseInstance: courseInstance});
-        a.play-btn.btn.btn-forest.btn-lg.m-b-1(data-href=url, data-level-slug=next.get('slug'), data-event-action="Students Continue Course")
-         span(data-i18n="common.continue")
-
-    else
-      - var firstLevel = stats.levels.first;
-      if classroom.getSetting('map')
-        - var url = view.urls.courseWorldMap({course: course, courseInstance: courseInstance});
-        a.play-btn.btn.btn-navy.btn-lg.m-b-1(data-href=url, data-event-action="Students Start Course")
+        a.play-btn.btn.btn-navy.btn-lg.m-b-1(data-href=url, data-level-slug=next.get('slug'), data-event-action="Students Start Course")
           span(data-i18n="courses.start")
-      else
-        - var url = view.urls.courseLevel({level: view.originalLevelMap[firstLevel.get('original')] || firstLevel, courseInstance: courseInstance, classroom: classroom});
-        a.play-btn.btn.btn-navy.btn-lg.m-b-1(data-href=url, data-level-slug=firstLevel.get('slug'), data-event-action="Students Start Course")
-          span(data-i18n="courses.start")
-        
 
   if stats.levels.lastPlayed
     div

--- a/app/templates/courses/courses-view.jade
+++ b/app/templates/courses/courses-view.jade
@@ -79,6 +79,10 @@ block content
                       - var course = view.courses.get(courseInstance.get('courseID'));
                       h6
                         span.spr= i18n(course.attributes, 'name')
+                        small
+                          a.view-levels-btn(data-course-id=courseInstance.get('courseID'), data-courseinstance-id=courseInstance.id, data-i18n="courses.view_levels")
+                          if view.courseInstanceHasProject(courseInstance)
+                            a.view-project-gallery-link(data-course-id=courseInstance.get('courseID'), data-courseinstance-id=courseInstance.id, data-i18n="courses.view_project_gallery")
                       +course-instance-body(courseInstance, classroom)
                       .clearfix
 

--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -212,10 +212,6 @@ mixin studentRow(student)
       a.edit-student-button(data-student-id=student.id)
         span.glyphicon.glyphicon-edit
         span(data-i18n='teacher.edit')
-    if view.classroom.getSetting('gems')
-      td
-        span.gem.gem-20
-        span(style="font-size: 20px; line-height: 10px")= student.gems()
     td.latest-level-col.small
       div
         i

--- a/app/templates/play/campaign-view.jade
+++ b/app/templates/play/campaign-view.jade
@@ -30,7 +30,7 @@ if view.showAds()
         img(src="/images/pages/base/logo.png", title="Powered by CodeCombat - Learn how to code by playing a game ", alt="Powered by CodeCombat")
 
     if view.shouldShow('back-to-classroom')
-      a.btn.btn-primary.under-logo(href='/play', data-i18n="play.back_to_classroom")
+      a.btn.btn-illustrated.btn-success.btn-block.btn-lg.text-uppercase.under-logo(href='/play', data-i18n="play.back_to_classroom")
 
   if serverConfig.codeNinjas
     a(href="https://code.ninja")
@@ -55,14 +55,19 @@ if view.showAds()
       .map-background(alt="", draggable="false")
 
       each level in levels
-        - if ((campaign.levelIsPractice(level) || !level.unlockedInSameCampaign) && level.hidden)
+        if ((campaign.levelIsPractice(level) || !level.unlockedInSameCampaign) && level.hidden)
           - continue;
+        - var levelNumber = '';
+        if view.shouldShow('back-to-classroom')
+          - levelNumber = campaign.getLevelNumber(level.original, '');
+          if (levelNumber)
+            - levelNumber += '. ';
         div(
           style="left: #{level.position.x}%; bottom: #{level.position.y}%; background-color: #{level.color}",
           class="level" + (level.next ? " next" : "") + (level.disabled ? " disabled" : "") + (level.locked ? " locked" : "") + " " + (levelStatusMap[level.slug] || ""),
           data-level-slug=level.slug,
           data-level-original=level.original,
-          title=i18n(level, 'name') + (level.disabled ? " (" + translate('common.coming_soon') + ")" : '')
+          title=levelNumber + i18n(level, 'name') + (level.disabled ? " (" + translate('common.coming_soon') + ")" : (level.practice ? " (" + translate('courses.practice') + ")" : ""))
         )
           if level.unlocksHero && (!level.purchasedHero || editorMode) && (level.hidden || levelStatusMap[level.slug] === 'complete')
             img.hero-portrait(src="/file/db/thang.type/#{level.unlocksHero}/portrait.png")
@@ -113,7 +118,7 @@ if view.showAds()
 
           div(class="level-info " + (levelStatusMap[level.slug] || "") + (level.requiresSubscription ? " premium" : "") + (showsLeaderboard ? " shows-leaderboard" : ""))
             .level-status
-            h3= i18n(level, 'name') + (level.disabled ? " (" + translate('common.coming_soon') + ")" : (level.locked ? " (" + translate('play.locked') + ")" : ""))
+            h3= levelNumber + i18n(level, 'name') + (level.disabled ? " (" + translate('common.coming_soon') + ")" : (level.locked ? " (" + translate('play.locked') + ")" : (level.practice ? " (" + translate('courses.practice') + ")" : "")))
             - var description = i18n(level, 'description') || level.description || ""
             .level-description!= marked(description, {sanitize: !picoCTF})
             if level.disabled

--- a/app/templates/play/level/control-bar-view.jade
+++ b/app/templates/play/level/control-bar-view.jade
@@ -7,7 +7,7 @@
 .levels-link-area
   a.levels-link(href=homeLink || "/")
     .glyphicon.glyphicon-play
-    span(data-i18n=me.isSessionless() ? "nav.courses" : (ladderGame ? "general.ladder" : "nav.play")).home-text
+    span(data-i18n=me.isSessionless() ? "nav.courses" : (ladderGame ? "general.ladder" : "nav.map")).home-text
 
 .level-name-area-container
   .level-name-area

--- a/app/templates/play/level/modal/course-victory-modal.jade
+++ b/app/templates/play/level/modal/course-victory-modal.jade
@@ -2,3 +2,4 @@
   .background-wrapper
     .modal-content
       .modal-body
+//- See progress-view for content

--- a/app/templates/play/level/modal/progress-view.jade
+++ b/app/templates/play/level/modal/progress-view.jade
@@ -103,7 +103,6 @@
         
     .row
       .col-sm-5.col-sm-offset-2
-        // TODO: Add rest of campaign functionality
         if view.level.isProject()
           button#keep-editing-btn.btn.btn-illustrated.btn-default.btn-block.btn-lg.text-uppercase(data-i18n="play_level.keep_editing" data-dismiss="modal")
         else if view.level.get('type') === 'course-ladder'
@@ -118,6 +117,6 @@
             button#publish-btn.btn.btn-illustrated.btn-success.btn-block.btn-lg.text-uppercase(data-i18n="common.publish")
         else
           if !view.nextLevel.isNew()
-            button#next-level-btn.btn.btn-illustrated.btn-primary.btn-block.btn-lg.text-uppercase(data-i18n='play_level.next_level')
+            button#next-level-btn.btn.btn-illustrated.btn-success.btn-block.btn-lg.text-uppercase(data-i18n='play_level.next_level')
           else
             button#done-btn.btn.btn-illustrated.btn-primary.btn-block.btn-lg.text-uppercase(data-i18n='play_level.done')

--- a/app/templates/play/level/modal/progress-view.jade
+++ b/app/templates/play/level/modal/progress-view.jade
@@ -108,16 +108,16 @@
           button#keep-editing-btn.btn.btn-illustrated.btn-default.btn-block.btn-lg.text-uppercase(data-i18n="play_level.keep_editing" data-dismiss="modal")
         else if view.level.get('type') === 'course-ladder'
           button#ladder-btn.btn.btn-illustrated.btn-default.btn-block.btn-lg.text-uppercase(data-i18n="general.ladder")
+        else if !view.nextLevel.isNew() && view.classroom
+          button#map-btn.btn.btn-illustrated.btn-primary.btn-block.btn-lg.text-uppercase(data-i18n='play_level.back_to_map')
       .col-sm-5
         if view.level.isProject()
           if view.session.get('published')
             button#publish-btn.btn.btn-illustrated.btn-success.btn-block.btn-lg.text-uppercase(data-i18n="play_level.view_gallery")
           else
             button#publish-btn.btn.btn-illustrated.btn-success.btn-block.btn-lg.text-uppercase(data-i18n="common.publish")
-        else if view.classroom && view.classroom.getSetting('backToMap') && view.classroom.getSetting('map')
-          button#map-btn.btn.btn-illustrated.btn-primary.btn-block.btn-lg(data-i18n='play_level.done')
         else
           if !view.nextLevel.isNew()
             button#next-level-btn.btn.btn-illustrated.btn-primary.btn-block.btn-lg.text-uppercase(data-i18n='play_level.next_level')
           else
-            button#done-btn.btn.btn-illustrated.btn-primary.btn-block.btn-lg.text-uppercase(data-i18n='play_level.done')          
+            button#done-btn.btn.btn-illustrated.btn-primary.btn-block.btn-lg.text-uppercase(data-i18n='play_level.done')

--- a/app/views/courses/ClassroomSettingsModal.coffee
+++ b/app/views/courses/ClassroomSettingsModal.coffee
@@ -33,20 +33,7 @@ module.exports = class ClassroomSettingsModal extends ModalView
     else
       forms.setErrorToProperty(form, 'language', $.i18n.t('common.required_field'))
       return
-    
-    settings = @classroom.get('settings') or {}
-    mayTweak = settings?.optionsEditable or me.isAdmin()
-    for k in Object.keys(attrs)
-      if /^settings\//.test(k)
-        val = (attrs[k].length > 0)
-        key = k.substring(9)
-        if val isnt @classroom.getSetting key
-          settings[key] = val
-        delete attrs[k]
 
-    if mayTweak
-      attrs.settings = settings
-    
     @classroom.set(attrs)
     schemaErrors = @classroom.getValidationErrors()
     if schemaErrors

--- a/app/views/courses/CoursesView.coffee
+++ b/app/views/courses/CoursesView.coffee
@@ -35,7 +35,6 @@ module.exports = class CoursesView extends RootView
     'submit #join-class-form': 'onSubmitJoinClassForm'
     'click .play-btn': 'onClickPlay'
     'click .view-class-btn': 'onClickViewClass'
-    'click .view-levels-btn': 'onClickViewLevels'
     'click .view-project-gallery-link': 'onClickViewProjectGalleryLink'
 
   getTitle: -> return $.i18n.t('courses.students')
@@ -191,21 +190,6 @@ module.exports = class CoursesView extends RootView
       @errorMessage = "#{jqxhr.responseText}"
     @renderSelectors '#join-class-form'
 
-  getCourseWorldImage: (course) ->
-    slug = course.get('slug')
-    return 'dungeon' if slug is 'introduction-to-computer-science'
-    return 'forest' if slug is 'computer-science-2'
-    return 'forest' if slug is 'computer-science-3'
-    return 'desert' if slug is 'computer-science-4'
-    return 'mountain' if slug is 'computer-science-5'
-    return 'mountain' if slug is 'computer-science-6'
-    return 'game_dev_1' if slug is 'game-development-1'
-    return 'game_dev_2' if slug is 'game-development-2'
-    return 'web_dev_1' if slug is 'web-development-1'
-    return 'web_dev_2' if slug is 'web-development-2'
-
-    return slug
-
   onJoinClassroomSuccess: (newClassroom, data, options) ->
     @state = null
     application.tracker?.trackEvent 'Joined classroom', {
@@ -235,12 +219,6 @@ module.exports = class CoursesView extends RootView
     classroomID = $(e.target).data('classroom-id')
     window.tracker?.trackEvent 'Students View Class', category: 'Students', classroomID: classroomID, ['Mixpanel']
     application.router.navigate("/students/#{classroomID}", { trigger: true })
-
-  onClickViewLevels: (e) ->
-    courseID = $(e.target).data('course-id')
-    courseInstanceID = $(e.target).data('courseinstance-id')
-    window.tracker?.trackEvent 'Students View Levels', category: 'Students', courseID: courseID, courseInstanceID: courseInstanceID, ['Mixpanel']
-    application.router.navigate("/students/#{courseID}/#{courseInstanceID}", { trigger: true })
 
   onClickViewProjectGalleryLink: (e) ->
     courseID = $(e.target).data('course-id')

--- a/app/views/courses/CoursesView.coffee
+++ b/app/views/courses/CoursesView.coffee
@@ -35,6 +35,7 @@ module.exports = class CoursesView extends RootView
     'submit #join-class-form': 'onSubmitJoinClassForm'
     'click .play-btn': 'onClickPlay'
     'click .view-class-btn': 'onClickViewClass'
+    'click .view-levels-btn': 'onClickViewLevels'
     'click .view-project-gallery-link': 'onClickViewProjectGalleryLink'
 
   getTitle: -> return $.i18n.t('courses.students')
@@ -219,6 +220,15 @@ module.exports = class CoursesView extends RootView
     classroomID = $(e.target).data('classroom-id')
     window.tracker?.trackEvent 'Students View Class', category: 'Students', classroomID: classroomID, ['Mixpanel']
     application.router.navigate("/students/#{classroomID}", { trigger: true })
+
+  onClickViewLevels: (e) ->
+    courseID = $(e.target).data('course-id')
+    courseInstanceID = $(e.target).data('courseinstance-id')
+    window.tracker?.trackEvent 'Students View Levels', category: 'Students', courseID: courseID, courseInstanceID: courseInstanceID, ['Mixpanel']
+    course = @courses.get(courseID)
+    courseInstance = @courseInstances.get(courseInstanceID)
+    levelsUrl = @urls.courseWorldMap({course, courseInstance})
+    application.router.navigate(levelsUrl, { trigger: true })
 
   onClickViewProjectGalleryLink: (e) ->
     courseID = $(e.target).data('course-id')

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -1103,12 +1103,12 @@ module.exports = class CampaignView extends RootView
         level.hidden = false
         level.next = true
         found = true
+      else if playerState in ['started', 'complete']
+        level.hidden = false
+        level.locked = false
       else
         if level.practice
-          if playerState in ['started', 'complete']
-            level.hidden = false
-            level.locked = false
-          else if prev?.next
+          if prev?.next
             level.hidden = !prev?.practice
             level.locked = true
           else if prev

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -74,7 +74,7 @@ module.exports = class CampaignView extends RootView
     'click .poll': 'showPoll'
     'click #brain-pop-replay-btn': 'onClickBrainPopReplayButton'
     'click .premium-menu-icon': 'onClickPremiumButton'
-    
+
   shortcuts:
     'shift+s': 'onShiftS'
 
@@ -136,7 +136,7 @@ module.exports = class CampaignView extends RootView
       @supermodel.trackRequest(jqxhr)
       new Promise(jqxhr.then).then(=>
         courseID = @courseInstance.get('courseID')
-        
+
         @course = new Course(_id: courseID)
         @supermodel.trackRequest @course.fetch()
         if @courseInstance.get('classroomID')
@@ -144,8 +144,6 @@ module.exports = class CampaignView extends RootView
           @classroom = new Classroom(_id: classroomID)
           @supermodel.trackRequest @classroom.fetch()
           @listenToOnce @classroom, 'sync', =>
-            if me.get('role') is 'student' and not @classroom.getSetting('map')
-              application.router.redirectHome()
             @courseInstance.sessions = new CocoCollection([], {
               url: @courseInstance.url() + '/my-course-level-sessions',
               model: LevelSession
@@ -461,7 +459,7 @@ module.exports = class CampaignView extends RootView
 
   annotateLevels: (orderedLevels) ->
     return if @course?
-  
+
     for level, levelIndex in orderedLevels
       level.position ?= { x: 10, y: 10 }
       level.locked = not me.ownsLevel(level.original)
@@ -487,7 +485,7 @@ module.exports = class CampaignView extends RootView
       level.unlocksItem = _.find(level.rewards, 'item')?.item
       level.unlocksPet = utils.petThangIDs.indexOf(level.unlocksItem) isnt -1
 
-      if @classroom? and not @classroom.getSetting('drop-items')
+      if @classroom?
         level.unlocksItem = false
         level.unlocksPet = false
 
@@ -769,15 +767,17 @@ module.exports = class CampaignView extends RootView
       window.tracker?.trackEvent 'Clicked Start Level', category: 'World Map', levelID: levelSlug
 
   onClickCourseVersion: (e) ->
+    levelSlug = $(e.target).parents('.level-info-container').data 'level-slug'
     courseID = $(e.target).parents('.course-version').data 'course-id'
-    levelElement = $(e.target).parents('.level-info-container')
-    @startLevel levelElement, courseID, @getQueryVariable('course-instance')
+    courseInstanceID = $(e.target).parents('.course-version').data 'course-instance-id'
+    url = "/play/level/#{levelSlug}?course=#{courseID}&course-instance=#{courseInstanceID}"
+    Backbone.Mediator.publish 'router:navigate', route: url
 
-  startLevel: (levelElement, courseID, courseInstanceID) ->
+  startLevel: (levelElement) ->
     @setupManager?.destroy()
     levelSlug = levelElement.data 'level-slug'
     session = @preloadedSession if @preloadedSession?.loaded and @preloadedSession.levelSlug is levelSlug
-    @setupManager = new LevelSetupManager supermodel: @supermodel, levelID: levelSlug, levelPath: levelElement.data('level-path'), levelName: levelElement.data('level-name'), hadEverChosenHero: @hadEverChosenHero, parent: @, session: session, courseID: courseID, courseInstanceID: courseInstanceID
+    @setupManager = new LevelSetupManager supermodel: @supermodel, levelID: levelSlug, levelPath: levelElement.data('level-path'), levelName: levelElement.data('level-name'), hadEverChosenHero: @hadEverChosenHero, parent: @, session: session
     unless @setupManager?.navigatingToPlay
       @$levelInfo?.find('.level-info, .progress').toggleClass('hide')
       @listenToOnce @setupManager, 'open', ->
@@ -1092,6 +1092,7 @@ module.exports = class CampaignView extends RootView
 
     courseOrder = _.sortBy orderedLevels, 'courseIdx'
     found = false
+    prev = null
     for level, levelIndex in courseOrder
       playerState = @levelStatusMap[level.slug]
       level.color = 'rgb(255, 80, 60)'
@@ -1099,34 +1100,36 @@ module.exports = class CampaignView extends RootView
 
       if level.slug is nextSlug
         level.locked = false
-        level.hidden = level.locked
-        level.color = 'rgb(255, 80, 60)'
+        level.hidden = false
         level.next = true
         found = true
       else
         if level.practice
-          if playerState not in ['started', 'complete']
-            level.hidden = true
-            level.locked = true
-          else
+          if playerState in ['started', 'complete']
             level.hidden = false
             level.locked = false
-        else if found
-          level.locked = true
-          level.hidden = false
+          else if prev?.next
+            level.hidden = !prev?.practice
+            level.locked = true
+          else if prev
+            level.hidden = prev.hidden
+            level.locked = prev.locked
+          else
+            level.hidden = true
+            level.locked = true
         else
-          level.locked = false
+          level.locked = found
           level.hidden = false
 
-      #level.hidden = level.locked
       level.color = 'rgb(193, 193, 193)' if level.locked
-      level.noFlag = level.locked
+      level.noFlag = !level.next
+      prev = level
     return true
 
   shouldShow: (what) ->
     isStudent = me.get('role') in ['student']
     isIOS = me.get('iosIdentifierForVendor') || application.isIPadApp
-    
+
     if features.codePlay and what in ['clans', 'settings']
       return false
 
@@ -1137,19 +1140,13 @@ module.exports = class CampaignView extends RootView
       return !me.finishedAnyLevels() && serverConfig.showCodePlayAds && !features.noAds && me.get('role') isnt 'student'
 
     if what in ['status-line']
-      return true unless isStudent
-      return false unless @classroom?
-      return @classroom.getSetting('gems') || @classroom.getSetting('xp')
+      return !isStudent
 
     if what in ['gems']
-      return true unless isStudent
-      return false unless @classroom?
-      return @classroom.getSetting('gems')
+      return !isStudent
 
-    if what in ['level', 'xp']   
-      return true unless isStudent    
-      return false unless @classroom?   
-      return @classroom.getSetting('xp')
+    if what in ['level', 'xp']
+      return !isStudent
 
     if what in ['settings', 'leaderboard', 'back-to-campaigns', 'poll', 'items', 'heros', 'achievements', 'clans', 'poll']
       return !isStudent

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -226,7 +226,7 @@ module.exports = class CampaignView extends RootView
     @render()
     @checkForUnearnedAchievements()
     @preloadTopHeroes() unless me.get('heroConfig')?.thangType
-    @$el.find('#campaign-status').delay(4000).animate({top: "-=58"}, 1000) unless @terrain is 'dungeon'
+    @$el.find('#campaign-status').delay(4000).animate({top: "-=58"}, 1000) unless @terrain is 'dungeon' or @courseStats?
     if not me.get('hourOfCode') and @terrain
       if features.codePlay
         if me.get('anonymous') and me.get('lastLevel') is 'true-names' and me.level() < 5
@@ -1123,6 +1123,8 @@ module.exports = class CampaignView extends RootView
 
       level.color = 'rgb(193, 193, 193)' if level.locked
       level.noFlag = !level.next
+      level.unlocksHero = false
+      level.unlocksItem = false
       prev = level
     return true
 

--- a/app/views/play/level/ControlBarView.coffee
+++ b/app/views/play/level/ControlBarView.coffee
@@ -109,25 +109,14 @@ module.exports = class ControlBarView extends CocoView
         @homeViewArgs.push leagueID
         @homeLink += "/#{leagueType}/#{leagueID}"
     else if @level.isType('course') or @courseID
-      if @classroom?.getSetting('map')
-        @homeLink = "/play"
-        if @course?
-          @homeLink += "/#{@course.get('campaignID')}"
-          @homeViewArgs.push @course.get('campaignID')
-        if @courseInstanceID
-          @homeLink += "?course-instance=#{@courseInstanceID}"
-          
-        @homeViewClass = 'views/play/CampaignView'
-      else
-        @homeLink = '/students'
-        @homeViewClass = 'views/courses/CoursesView'
-        if @courseID
-          @homeLink += "/#{@courseID}"
-          @homeViewArgs.push @courseID
-          @homeViewClass = 'views/courses/CourseDetailsView'
-          if @courseInstanceID
-            @homeLink += "/#{@courseInstanceID}"
-            @homeViewArgs.push @courseInstanceID
+      @homeLink = "/play"
+      if @course?
+        @homeLink += "/#{@course.get('campaignID')}"
+        @homeViewArgs.push @course.get('campaignID')
+      if @courseInstanceID
+        @homeLink += "?course-instance=#{@courseInstanceID}"
+        
+      @homeViewClass = 'views/play/CampaignView'
     else if @level.isType('hero', 'hero-coop', 'game-dev', 'web-dev') or window.serverConfig.picoCTF
       @homeLink = '/play'
       @homeViewClass = 'views/play/CampaignView'

--- a/app/views/play/level/modal/CourseVictoryModal.coffee
+++ b/app/views/play/level/modal/CourseVictoryModal.coffee
@@ -114,6 +114,7 @@ module.exports = class CourseVictoryModal extends ModalView
     application.router.navigate(link, {trigger: true})
 
   onToMap: ->
+    window.tracker?.trackEvent 'Play Level Victory Modal Back to Map', category: 'Students', levelSlug: @level.get('slug'), []
     link = "/play/#{@course.get('campaignID')}?course-instance=#{@courseInstanceID}"
     application.router.navigate(link, {trigger: true})
 


### PR DESCRIPTION
Student classes view continue and start buttons goes to world map
Remove student view levels link

Student world map changes:
Show level numbers in level info popup
Hide student, gems, and experience
Remove item inventory
Only show flag on next level
Unlock all linked practice levels when completing a main level

Course victory modal changes:
Change done button to next level
Add back to map button in course victory modal