### PR TITLE
Remove payment processor choice

### DIFF
--- a/app/styles/modal/subscribe-modal.sass
+++ b/app/styles/modal/subscribe-modal.sass
@@ -264,7 +264,7 @@
 
   //- Lifetime button
 
-  .lifetime-button
+  .stripe-lifetime-button
     font-size: 24px
     line-height: 30px
     border-style: solid
@@ -279,17 +279,11 @@
     span
       pointer-events: none
   
-  // Payment method selection screen
-  .payment-selection-screen
-    .big-text:first-child
-      color: black
-    
-    #paypal-button-container
-      // Prevent jitter
-      height: 45px
-      width: 276px
-      display: block
-      margin: 0 auto 10px auto
+  #paypal-button-container
+    height: 45px
+    width: 250px
+    display: inline-block
+    margin: 5px auto 0px auto
 
   .email-parent-form
     .email_invalid

--- a/app/templates/core/subscribe-modal.jade
+++ b/app/templates/core/subscribe-modal.jade
@@ -15,77 +15,56 @@
         span.glyphicon.glyphicon-remove
 
       div.paper-area
-        if view.state === 'choosing-payment-method'
-          .payment-selection-screen
-            a.back-to-products
-              ="< "
-              span(data-i18n="common.go_back")
-            .container-fluid
-              .text-center
-                mixin productPurchaseInfo(productDescriptionTranslationKey)
-                  .big-text(data-i18n=productDescriptionTranslationKey)
-                  .med-text
-                    = translate("subscribe.you_will_be_charged", { priceString: view.selectedProduct.adjustedPriceStringNoSymbol() })
-                  hr
-                  .big-text(data-i18n="subscribe.choose_payment_method")
+        div.benefits-header.text-center(data-i18n="[html]subscribe.comparison_blurb")
+
+
+        .container-fluid
+          .row
+            .col-xs-5.feature-col.col-xs-offset-1
+              ul
+                li(data-i18n="subscribe.feature_levels" data-i18n-options={premiumLevelsCount:view.i18nData.premiumLevelsCount})
+                if view.basicProduct
+                  li(data-i18n="subscribe.feature_gems", data-i18n-options={gems:view.basicProduct.get('gems')})
+                li(data-i18n="subscribe.feature_heroes")
+
+
+            .col-xs-5.feature-col
+              ul
+                li(data-i18n="subscribe.feature_games")
+                li(data-i18n="subscribe.feature_websites")
+                li(data-i18n="subscribe.feature_items")
+
+          hr
+
+          mixin price(name, p)
+            - var origPrice = p.priceStringNoSymbol()
+            - var salePrice = p.adjustedPriceStringNoSymbol()
+            if origPrice == salePrice
+              .price(data-i18n=name, data-i18n-options={price:origPrice})
+            else
+              div
+                span.old-price(data-i18n=name, data-i18n-options={price:origPrice})
+                span.price(data-i18n=name, data-i18n-options={price:salePrice})
+
+          .row
+            - var secondRowClass = '.col-xs-5'
+            if view.basicProduct
+              .col-xs-5.option-col.col-xs-offset-1
+                .option-header.text-center(data-i18n="subscribe.stripe_description")
+                +price("subscribe.month_price", view.basicProduct)
+                button.btn.btn-lg.btn-illustrated.purchase-button(data-i18n="premium_features.subscribe_now")
+
+            else
+              - var secondRowClass = '.col-xs-12'
+
+            if view.lifetimeProduct
+              .option-col(class=secondRowClass)
+                .option-header.text-center(data-i18n="subscribe.lifetime")
+                +price("subscribe.lifetime_price", view.lifetimeProduct)
+                if view.paymentProcessor === 'PayPal'
                   #paypal-button-container
-                  button#stripe-button.btn.btn-lg.btn-success(data-i18n="subscribe.pay_with_credit_card_or_bitcoin")
-
-                if view.selectedProduct === view.lifetimeProduct
-                  +productPurchaseInfo("subscribe.you_are_purchasing_lifetime_sub")
                 else
-                  h2
-                    | Something went wrong :(
-
-
-        else
-          div.benefits-header.text-center(data-i18n="[html]subscribe.comparison_blurb")
-
-
-          .container-fluid
-            .row
-              .col-xs-5.feature-col.col-xs-offset-1
-                ul
-                  li(data-i18n="subscribe.feature_levels" data-i18n-options={premiumLevelsCount:view.i18nData.premiumLevelsCount})
-                  if view.basicProduct
-                    li(data-i18n="subscribe.feature_gems", data-i18n-options={gems:view.basicProduct.get('gems')})
-                  li(data-i18n="subscribe.feature_heroes")
-
-
-              .col-xs-5.feature-col
-                ul
-                  li(data-i18n="subscribe.feature_games")
-                  li(data-i18n="subscribe.feature_websites")
-                  li(data-i18n="subscribe.feature_items")
-
-            hr
-
-            mixin price(name, p)
-              - var origPrice = p.priceStringNoSymbol()
-              - var salePrice = p.adjustedPriceStringNoSymbol()
-              if origPrice == salePrice
-                .price(data-i18n=name, data-i18n-options={price:origPrice})
-              else
-                div
-                  span.old-price(data-i18n=name, data-i18n-options={price:origPrice})
-                  span.price(data-i18n=name, data-i18n-options={price:salePrice})
-
-            .row
-              - var secondRowClass = '.col-xs-5'
-              if view.basicProduct
-                .col-xs-5.option-col.col-xs-offset-1
-                  .option-header.text-center(data-i18n="subscribe.stripe_description")
-                  +price("subscribe.month_price", view.basicProduct)
-                  button.btn.btn-lg.btn-illustrated.purchase-button(data-i18n="premium_features.subscribe_now")
-
-              else
-                - var secondRowClass = '.col-xs-12'
-
-              if view.lifetimeProduct
-                .option-col(class=secondRowClass)
-                  .option-header.text-center(data-i18n="subscribe.lifetime")
-                  +price("subscribe.lifetime_price", view.lifetimeProduct)
-                  button.btn.btn-lg.btn-illustrated.lifetime-button(data-i18n="subscribe.buy_now")
+                  button.stripe-lifetime-button.btn.btn-lg.btn-illustrated(data-i18n="subscribe.buy_now")
 
         div
           p

--- a/app/views/core/SubscribeModal.coffee
+++ b/app/views/core/SubscribeModal.coffee
@@ -19,14 +19,12 @@ module.exports = class SubscribeModal extends ModalView
     'click .popover-content .parent-send': 'onClickParentSendButton'
     'click .email-parent-complete button': 'onClickParentEmailCompleteButton'
     'click .purchase-button': 'onClickPurchaseButton'
-    'click .lifetime-button': 'onClickLifetimeButton'
+    'click .stripe-lifetime-button': 'onClickStripeLifetimeButton'
     'click .back-to-products': 'onClickBackToProducts'
-    'click #stripe-button': 'onClickStripeButton'
 
   constructor: (options={}) ->
     super(options)
     @state = 'standby'
-    @selectedProduct = null # Used for payment processing screen
     if options.products
       # this is just to get the test demo to work
       @products = options.products
@@ -43,7 +41,13 @@ module.exports = class SubscribeModal extends ModalView
   onLoaded: ->
     @basicProduct = @products.getBasicSubscriptionForUser(me)
     @lifetimeProduct = @products.getLifetimeSubscriptionForUser(me)
+    if @lifetimeProduct?.get('name') isnt 'lifetime_subscription'
+      # Use PayPal for international users with regional pricing
+      @paymentProcessor = 'PayPal'
+    else
+      @paymentProcessor = 'stripe'
     super()
+    @render()
 
   getRenderData: ->
     context = super(arguments...)
@@ -56,19 +60,18 @@ module.exports = class SubscribeModal extends ModalView
     return if @state is 'purchasing'
     super(arguments...)
     # NOTE: The PayPal button MUST NOT be removed from the page between clicking it and completing the payment, or the payment is cancelled.
-    if @state is 'choosing-payment-method' and @selectedProduct
-      @renderPayPalButton()
+    @renderPayPalButton()
     null
 
   renderPayPalButton: ->
-    if @$('#paypal-button-container').length
+    if @$('#paypal-button-container').length and not @$('#paypal-button-container').children().length
       descriptionTranslationKey = 'subscribe.lifetime'
-      discount = @basicProduct.get('amount') * 12 - @selectedProduct.get('amount')
+      discount = @basicProduct.get('amount') * 12 - @lifetimeProduct.get('amount')
       discountString = (discount/100).toFixed(2)
       description = $.i18n.t(descriptionTranslationKey).replace('{{discount}}', discountString)
       payPal?.makeButton({
         buttonContainerID: '#paypal-button-container'
-        product: @selectedProduct
+        product: @lifetimeProduct
         onPaymentStarted: @onPayPalPaymentStarted
         onPaymentComplete: @onPayPalPaymentComplete
         description
@@ -101,11 +104,6 @@ module.exports = class SubscribeModal extends ModalView
     ).on 'shown.bs.popover', =>
       application.tracker?.trackEvent 'Subscription ask parent button click'
 
-  onClickBackToProducts: (e) ->
-    @state = 'standby'
-    @selectedProduct = null
-    @render()
-
   onClickParentSendButton: (e) ->
     # TODO: Popover sometimes dismisses immediately after send
 
@@ -123,6 +121,7 @@ module.exports = class SubscribeModal extends ModalView
   onClickParentEmailCompleteButton: (e) ->
     @$el.find('.parent-link').popover('hide')
 
+  # For monthly subs
   onClickPurchaseButton: (e) ->
     return unless @basicProduct
     @playSound 'menu-button-click'
@@ -156,16 +155,8 @@ module.exports = class SubscribeModal extends ModalView
       out.data.coupon = utils.getQueryVariable('coupon')
     out
 
-  onClickLifetimeButton: ->
-    unless @reportedLifetimeClick
-      application.tracker?.trackEvent 'SubscribeModal Lifetime Button Click'
-      @reportedLifetimeClick = true
-    @state = 'choosing-payment-method'
-    @selectedProduct = @lifetimeProduct
-    @render()
-
+  # For lifetime subs
   onPayPalPaymentStarted: =>
-    throw new Error("Can't use PayPal on that product! Something went wrong.") unless @selectedProduct is @lifetimeProduct
     @playSound 'menu-button-click'
     return @openModalView new CreateAccountModal() if me.get('anonymous')
     startEvent = 'Start Lifetime Purchase'
@@ -173,14 +164,14 @@ module.exports = class SubscribeModal extends ModalView
     @state = 'purchasing'
     @render() # TODO: Make sure this doesn't break paypal from button regenerating
 
+  # For lifetime subs
   onPayPalPaymentComplete: (payment) =>
     # NOTE: payment is a PayPal payment object, not a CoCo Payment model
     # TODO: Send payment info to server, confirm it
-    throw new Error("Can't use stripe on that product! Something went wrong.") unless @selectedProduct is @lifetimeProduct
     finishEvent = 'Finish Lifetime Purchase'
     failureMessage = 'Fail Lifetime Purchase'
     @purchasedAmount = Number(payment.transactions[0].amount.total) * 100
-    return Promise.resolve(@selectedProduct.purchaseWithPayPal(payment, @makePurchaseOps()))
+    return Promise.resolve(@lifetimeProduct.purchaseWithPayPal(payment, @makePurchaseOps()))
     .then (response) =>
       application.tracker?.trackEvent finishEvent, { value: @purchasedAmount, service: 'paypal' }
       me.set 'payPal', response?.payPal if response?.payPal?
@@ -189,8 +180,7 @@ module.exports = class SubscribeModal extends ModalView
       return unless jqxhr # in case of cancellations
       @onSubscriptionError(jqxhr, failureMessage)
 
-  onClickStripeButton: ->
-    throw new Error("Can't use stripe on that product! Something went wrong.") unless @selectedProduct is @lifetimeProduct
+  onClickStripeLifetimeButton: ->
     @playSound 'menu-button-click'
     return @openModalView new CreateAccountModal() if me.get('anonymous')
     startEvent = 'Start Lifetime Purchase'
@@ -198,19 +188,19 @@ module.exports = class SubscribeModal extends ModalView
     descriptionTranslationKey = 'subscribe.lifetime'
     failureMessage = 'Fail Lifetime Purchase'
     application.tracker?.trackEvent startEvent, { service: 'stripe' }
-    discount = @basicProduct.get('amount') * 12 - @selectedProduct.get('amount')
+    discount = @basicProduct.get('amount') * 12 - @lifetimeProduct.get('amount')
     discountString = (discount/100).toFixed(2)
     options = @stripeOptions {
       description: $.i18n.t(descriptionTranslationKey).replace('{{discount}}', discountString)
-      amount: @selectedProduct.adjustedPrice()
+      amount: @lifetimeProduct.adjustedPrice()
     }
     @purchasedAmount = options.amount
     stripeHandler.makeNewInstance().openAsync(options)
     .then ({token}) =>
       @state = 'purchasing'
       @render()
-      # Purchasing a year
-      return Promise.resolve(@selectedProduct.purchase(token, @makePurchaseOps()))
+      # Purchasing a lifetime sub
+      return Promise.resolve(@lifetimeProduct.purchase(token, @makePurchaseOps()))
     .then (response) =>
       application.tracker?.trackEvent finishEvent, { value: @purchasedAmount, service: 'stripe' }
       me.set 'stripe', response?.stripe if response?.stripe?


### PR DESCRIPTION
Forces either Stripe or Paypal, depending on whether the user is in a country with regional pricing. Removes the extra UI for the choice between the two.