### PR TITLE
Add timeout request and a self-health checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "co-express": "^1.2.1",
     "coffee-script": "1.9.x",
     "compression": "^1.6.2",
+    "connect-timeout": "^1.9.0",
     "cookie-parser": "^1.4.3",
     "cookie-session": "^1.2.0",
     "country-list": "0.0.3",

--- a/server.coffee
+++ b/server.coffee
@@ -9,12 +9,38 @@ express = require 'express'
 http = require 'http'
 log = require 'winston'
 serverSetup = require './server_setup'
+co = require 'co'
+config = require './server_config'
+{ runHealthcheck }  = require './server/middleware/healthcheck'
+Promise = require 'bluebird'
 
 module.exports.startServer = (done) ->
   app = createAndConfigureApp()
   httpServer = http.createServer(app).listen app.get('port'), -> done?()
   log.info('Express SSL server listening on port ' + app.get('port'))
+  runHealthcheckForever() if config.isProduction
   {app, httpServer}
+  
+runHealthcheckForever = ->
+  log.info('Running healthchecks forever')
+  co ->
+    sleep = (time, result=null) -> new Promise((resolve) -> setTimeout((-> resolve(result)), time))
+    failures = 0
+    yield sleep(15000) # give server time to start up
+    while true
+      passed = yield Promise.race([
+        runHealthcheck()
+        new sleep(5000, false)
+      ])
+      if passed
+        failures = 0
+        yield sleep(15000)
+      else
+        failures += 1
+        log.warn("Healthcheck failure ##{failures}.")
+      if failures >= 3
+        log.error('Three healthcheck failures in a row. Killing self.')
+        process.exit(1)
 
 createAndConfigureApp = module.exports.createAndConfigureApp = ->
   serverSetup.setupLogging()

--- a/server/commons/errors.coffee
+++ b/server/commons/errors.coffee
@@ -95,6 +95,10 @@ module.exports.InternalServerError = class InternalServerError extends NetworkEr
   code: 500
   errorName: 'Internal Server Error'
 
+module.exports.ServiceUnavailable = class ServiceUnavailable extends NetworkError
+  code: 503
+  errorName: 'Service Unavailable'
+
 module.exports.GatewayTimeout = class GatewayTimeout extends NetworkError
   code: 504
   errorName: 'Gateway Timeout'

--- a/server/middleware/healthcheck.coffee
+++ b/server/middleware/healthcheck.coffee
@@ -1,7 +1,12 @@
 wrap = require 'co-express'
 errors = require '../commons/errors'
+co = require 'co'
 
-module.exports = wrap (req, res) ->
+healthcheckRoute = wrap (req, res) ->
+  yield runHealthcheck()
+  res.status(200).send('OK')
+  
+runHealthcheck = co.wrap ->
   User = require '../models/User'
   user = yield User.findOne({})
   throw new errors.InternalServerError('No users found') unless user
@@ -19,4 +24,9 @@ module.exports = wrap (req, res) ->
     yield hcUser.save()
   activity = hcUser.trackActivity('healthcheck', 1)
   yield hcUser.update({activity: activity})
-  res.status(200).send('OK')
+  return true
+
+module.exports = {
+  healthcheckRoute
+  runHealthcheck
+}

--- a/server/routes/index.coffee
+++ b/server/routes/index.coffee
@@ -244,4 +244,4 @@ module.exports.setup = (app) ->
 
   app.all('/headers', mw.headers)
 
-  app.get('/healthcheck', mw.healthcheck)
+  app.get('/healthcheck', mw.healthcheck.healthcheckRoute)

--- a/server_config.coffee
+++ b/server_config.coffee
@@ -12,6 +12,8 @@ if cluster.worker?
 config.unittest = global.testing
 config.proxy = process.env.COCO_PROXY
 
+config.timeout = parseInt(process.env.COCO_TIMEOUT) or 60*1000
+
 config.chinaDomain = "cn.codecombat.com;ccombat.cn;contributors.codecombat.com"
 config.brazilDomain = "br.codecombat.com;contributors.codecombat.com"
 config.port = process.env.COCO_PORT or process.env.COCO_NODE_PORT or process.env.PORT  or 3000

--- a/server_setup.coffee
+++ b/server_setup.coffee
@@ -31,6 +31,7 @@ wrap = require 'co-express'
 codePlayTags = require './server/lib/code-play-tags'
 morgan = require 'morgan'
 domainFilter = require './server/middleware/domain-filter'
+timeout = require('connect-timeout')
 
 {countries} = require './app/core/utils'
 
@@ -74,6 +75,8 @@ setupErrorMiddleware = (app) ->
         err = new errors.Conflict(err.response)
       if err.name is 'MongoError' and err.message.indexOf('timed out')
         err = new errors.GatewayTimeout('MongoDB timeout error.')
+      if req.timedout # set by connect-timeout
+        err = new errors.ServiceUnavailable('Request timed out.')
 
       # TODO: Make all errors use this
       if err instanceof errors.NetworkError
@@ -279,6 +282,7 @@ setupAPIDocs = (app) ->
   app.use('/api-docs', swaggerUi.setup(swaggerDoc))
 
 exports.setupMiddleware = (app) ->
+  app.use(timeout(config.timeout))
   setupHandlerTraceMiddleware app if config.TRACE_ROUTES
   setupSecureMiddleware app
   setupPerfMonMiddleware app


### PR DESCRIPTION
Node doesn't handle timeouts well; by default it returns nothing and reports
200 after two minutes.

Add a connect timeout middleware to limit responses to one minute and
return 503. Also have production node instances continuously run
healthchecks and kill themselves if they fail repeatedly. `multicore.coffee`
will then spin up a replacement worker.