### PR TITLE
Add paypal payment search to admin page

### DIFF
--- a/app/templates/admin.jade
+++ b/app/templates/admin.jade
@@ -45,6 +45,16 @@ block content
         .col-sm-1
           button.btn.btn-primary.btn-large#user-search-button  Search
     #user-search-result
+    
+    .form-horizontal
+      form(action='/db/payments/-/all').form-group
+        label.control-label.col-sm-2(for="paypal-input") PayPal Search
+        .col-sm-4
+          input.form-control#paypal-input(name="payPalResource", placeholder="PayPal Transaction ID")
+          input(type="hidden", name="project", value="purchaser,recipient,created,service,amount,gems")
+          input(type="hidden", name="limit", value="10")
+        .col-sm-1
+          button.btn.btn-primary(type="submit") Search
 
   if !me.isAdmin()
     div.text-center You must be logged in as an admin to view this page.

--- a/server/commons/parse.coffee
+++ b/server/commons/parse.coffee
@@ -9,6 +9,7 @@ module.exports =
       max: 1000
       default: 100
       param: 'limit'
+      min: 1
     }, options)
 
     limit = options.default
@@ -18,7 +19,7 @@ module.exports =
       valid = tv4.validate(limit, {
         type: 'integer'
         maximum: options.max
-        minimum: 1
+        minimum: options.min
       })
       if not valid
         throw new errors.UnprocessableEntity("Invalid #{options.param} parameter.")

--- a/server/middleware/payments.coffee
+++ b/server/middleware/payments.coffee
@@ -5,11 +5,19 @@ parse = require '../commons/parse'
 
 all = wrap (req, res) ->
   throw new errors.Unauthorized('You must be an administrator.') unless req.user?.isAdmin()
-  query = if req.query.nofree then {amount: {$gt: 0}} else {}
-  if req.query.limit
-    payments = yield Payment.find(query, parse.getProjectFromReq(req)).limit(parse.getLimitFromReq(req)).lean()
-  else
-    payments = yield Payment.find(query, parse.getProjectFromReq(req)).lean()
+  query = {}
+  if req.query.nofree
+    query.amount = {$gt: 0}
+  if req.query.payPalResource
+    query['$or'] = [
+      {'payPal.transactions.related_resources.sale.id': req.query.payPalResource},
+      {'payPalSale.id': req.query.payPalResource},
+    ]
+  dbq = Payment.find(query, parse.getProjectFromReq(req))
+  dbq.limit(parse.getLimitFromReq(req, {min: 0, default: 0}))
+  dbq.skip(parse.getSkipFromReq(req))
+  dbq.select(parse.getProjectFromReq(req))
+  payments = yield dbq.lean().exec()
   res.send(payments)
 
 module.exports = {

--- a/server/models/Payment.coffee
+++ b/server/models/Payment.coffee
@@ -5,5 +5,6 @@ PaymentSchema = new mongoose.Schema({}, {strict: false, read:config.mongo.readpr
 PaymentSchema.index({recipient: 1, 'stripe.timestamp': 1, 'ios.transactionID'}, {unique: true, name: 'unique payment'})
 PaymentSchema.index({'payPal.id': 1}, {unique: true, sparse: true, name: 'unique PayPal payment'})
 PaymentSchema.index({'payPalSale.id': 1}, {unique: true, sparse: true, name: 'unique PayPal sale payment'})
+PaymentSchema.index({'payPal.transactions.related_resources.sale.id': 1}, {sparse: true, name: 'PayPal sale'})
 
 module.exports = mongoose.model('payment', PaymentSchema)


### PR DESCRIPTION
Add a search form to the admin page for searching PayPal transactions, and add an index for those transactions.