### PR TITLE
Log PayPal monthly payments and award gems immediately

### DIFF
--- a/app/schemas/models/payment.schema.coffee
+++ b/app/schemas/models/payment.schema.coffee
@@ -34,6 +34,7 @@ PaymentSchema = c.object({title: 'Payment', required: []}, {
     title: 'PayPal Payment Sale Data',
     description: 'The payment sale object as received from PayPal' 
   }
+  payPalBillingAgreementID: { type: 'string', description: 'Used to connect initial subscribe payments with recurring payments.' }
 })
 
 c.extendBasicProperties(PaymentSchema, 'payment')

--- a/server/routes/paypal.coffee
+++ b/server/routes/paypal.coffee
@@ -12,8 +12,10 @@ module.exports.setup = (app) ->
   app.post '/paypal/webhook', expressWrap (req, res) ->
     try
       if req.body.event_type is "PAYMENT.SALE.COMPLETED"
+        log.info "PayPal webhook event #{req.body.event_type} received"
         yield handlePaymentSucceeded(req, res)
       else if req.body.event_type is "BILLING.SUBSCRIPTION.CANCELLED"
+        log.info "PayPal webhook event #{req.body.event_type} received"
         yield handleSubscriptionCancelled(req, res)
       else
         log.info "PayPal webhook unknown event #{req.body.event_type}"

--- a/spec/server/functional/subscription.spec.coffee
+++ b/spec/server/functional/subscription.spec.coffee
@@ -1434,7 +1434,17 @@ describe 'POST /db/user/:handle/paypal', ->
           expect(res.statusCode).toBe(404)
 
       describe 'when token passed', ->
-
+        beforeEach utils.wrap ->
+          @product = yield Product.findOne({name: 'basic_subscription'})
+          unless @product
+            @localProduct = true
+            @product = Product({name: 'basic_subscription', gems: 20, amount: 30})
+            yield @product.save()
+          # else
+          #   console.log '@product exists', @product
+        afterEach utils.wrap ->
+          if @localProduct
+            yield Product.remove({_id: @product.get('_id')})
         it 'subscribes the user', utils.wrap ->
           expect(@user.hasSubscription()).not.toBeTruthy()
           url = utils.getUrl("/db/user/#{@user.id}/paypal/execute-billing-agreement")
@@ -1449,6 +1459,12 @@ describe 'POST /db/user/:handle/paypal', ->
           expect(userPayPalData.subscribeDate).toBeDefined()
           expect(userPayPalData.subscribeDate).toBeLessThan(new Date())
           expect(user.hasSubscription()).toBeTruthy()
+          payment = yield Payment.findOne payPalBillingAgreementID: userPayPalData.billingAgreementID
+          expect(payment).toBeDefined()
+          expect(payment.get('recipient').toString()).toEqual(user.id)
+          expect(payment.get('amount')).toEqual(@product.get('amount'))
+          expect(payment.get('gems')).toEqual(@product.get('gems'))
+          expect(user.get('purchased').gems).toEqual(@product.get('gems'))
 
   describe '/cancel-billing-agreement', ->
     beforeEach utils.wrap ->
@@ -1637,6 +1653,22 @@ describe 'POST /paypal/webhook', ->
               expect(res.body).toEqual("Payment already recorded for #{@paymentEventData.resource.id}")
               payments = yield Payment.find({'payPalSale.id': @paymentEventData.resource.id}).lean()
               expect(payments?.length).toEqual(1)
+
+          describe 'when initial subscribe payment already recorded', ->
+            beforeEach utils.wrap ->
+              yield utils.clearModels([Payment])
+              @payment = yield Payment({'payPalBillingAgreementID': @paymentEventData.resource.billing_agreement_id}).save()
+              payments = yield Payment.find({'payPalBillingAgreementID': @paymentEventData.resource.billing_agreement_id}).lean()
+              expect(payments?.length).toEqual(1)
+
+            it 'does not create a new payment and updates the existing one', utils.wrap ->
+              url = getURL('/paypal/webhook')
+              [res, body] = yield request.postAsync({ uri: url, json: @paymentEventData })
+              expect(res.statusCode).toEqual(200)
+              expect(res.body).toEqual("Payment sale object #{@paymentEventData.resource.id} added to initial payment #{@payment.id}")
+              payments = yield Payment.find({'payPalSale.id': @paymentEventData.resource.id}).lean()
+              expect(payments?.length).toEqual(1)
+              expect(payments[0].payPalBillingAgreementID).toEqual(@paymentEventData.resource.billing_agreement_id)
 
   describe 'when BILLING.SUBSCRIPTION.CANCELLED event', ->
     beforeEach utils.wrap ->


### PR DESCRIPTION
This is for the first subscribe payment, to remove the delay between
subscribing and PayPal the webhook getting called minutes later.
Recurring payments will be handled by the webhook.

The billing agreement id is used to lookup and attach the sale payment
object in the webhook later, after the initial subscribe event.