### PR TITLE
Fix translations not being used on first load

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -1,4 +1,5 @@
 dynamicRequire = require('lib/dynamicRequire')
+locale = require 'locale/locale'
 
 go = (path, options) -> -> @routeDirectly path, arguments, options
 
@@ -246,7 +247,11 @@ module.exports = class CocoRouter extends Backbone.Router
       path = 'play/CampaignView'
 
     path = "views/#{path}" if not _.string.startsWith(path, 'views/')
-    dynamicRequire(path).then (ViewClass) =>
+    Promise.all([
+      dynamicRequire(path), # Load the view file
+      # The locale load is already initialized by `application`, just need the promise
+      locale.load(me.get('preferredLanguage', true))
+    ]).then ([ViewClass]) =>
       return go('NotFoundView') if not ViewClass
       view = new ViewClass(options, args...)  # options, then any path fragment args
       view.render()


### PR DESCRIPTION
This defers merging the non-static page until after the locale finishes loading. The locale load was already initialized in `application.coffee`, but this gets the promise from that and waits for it to finish before merging the view (and most importantly, before rendering the dynamic view)