### PR TITLE
Quick stab at webpack auto refresh with webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "sass-loader": "^6.0.6",
     "telepath-brunch": "https://github.com/nwinter/telepath-brunch/tarball/master",
     "webpack-bundle-analyzer": "^2.9.0",
-    "webpack-dev-server": "^2.7.1"
+    "webpack-livereload-plugin": "^1.0.0"
   },
   "optionalDependencies": {
     "newrelic": "^1.24.0",

--- a/webpack.development.config.js
+++ b/webpack.development.config.js
@@ -3,6 +3,7 @@
 // process.traceDeprecation = true;
 const webpack = require('webpack');
 const _ = require('lodash');
+const LiveReloadPlugin = require('webpack-livereload-plugin');
 
 const baseConfigFn = require('./webpack.base.config')
 // Development webpack config
@@ -14,12 +15,12 @@ module.exports = (env) => {
       chunkFilename: 'javascripts/chunks/[name].bundle.js',
     }),
     devtool: 'eval-source-map', // https://webpack.js.org/configuration/devtool/
-    devServer: {
-      contentBase: './public'
-    },
     plugins: baseConfig.plugins.concat([
       new webpack.BannerPlugin({ // Label each module in the output bundle
         banner: "hash:[hash], chunkhash:[chunkhash], name:[name], filebase:[filebase], query:[query], file:[file]"
+      }),
+      new LiveReloadPlugin({ // Reload the page upon rebuild
+        appendScriptTag: true,
       }),
     ])
   })


### PR DESCRIPTION
Doesn’t do hot swap for CSS like brunch did, but reloads on build now. Probably buggy and gross but needed it today.