### PR TITLE
Support RTL text

### DIFF
--- a/app/locale/he.coffee
+++ b/app/locale/he.coffee
@@ -110,8 +110,8 @@ module.exports = nativeDescription: "עברית", englishDescription: "Hebrew", 
   diplomat_suggestion:
     title: "עזרו לתרגם את CodeCombat!" # This shows up when a player switches to a non-English language using the language selector.
     sub_heading: "אנו זקוקים לכישורי השפה שלכם"
-    pitch_body: "אנו מפתחים את CodeCombat בשפה האנגלית, אך כבר יש לנו שחקנים בכל העולם. רבים מהם רוצים לשחק בשפה {English} אך אינם דוברים אנגלית. לכן, אם אתם דוברים את שתי השפות, אנא שקלו להירשם בתור דיפלומט ולעזור לתרגם את אתר האינטרנט ואת כל השלבים של CodeCombat לשפה {English}."
-    missing_translations: "עד שנצליח לתרגם הכול לשפה {English}, יופיע בפניכם תוכן באנגלית כאשר השפה {English} אינה זמינה."
+    pitch_body: "אנו מפתחים את CodeCombat בשפה האנגלית, אך כבר יש לנו שחקנים בכל העולם. רבים מהם רוצים לשחק בשפה English אך אינם דוברים אנגלית. לכן, אם אתם דוברים את שתי השפות, אנא שקלו להירשם בתור דיפלומט ולעזור לתרגם את אתר האינטרנט ואת כל השלבים של CodeCombat לשפה English."
+    missing_translations: "עד שנצליח לתרגם הכול לשפה English, יופיע בפניכם תוכן באנגלית כאשר השפה English אינה זמינה."
     learn_more: "למידע נוסף על הצטרפות כדיפלומט"
     subscribe_as_diplomat: "הירשם כמנוי דיפלומט"
 

--- a/app/styles/courses/enrollments-view.sass
+++ b/app/styles/courses/enrollments-view.sass
@@ -29,8 +29,17 @@
     color: black
     text-decoration: underline
 
+  [dir="rtl"] .prepaid-card-container
+    float: right
+
   .prepaid-card-container
     height: 309px
+
+    &[dir="rtl"] .pull-left
+      float: right !important
+
+    &[dir="rtl"] .pull-right
+      float: left !important
 
   .share-details
     text-align: right

--- a/app/styles/courses/teacher-class-view.sass
+++ b/app/styles/courses/teacher-class-view.sass
@@ -70,6 +70,9 @@
     li.active
       border-bottom: none
 
+  [dir="rtl"] .bulk-assign-controls
+    float: left
+
   .bulk-assign-controls
     position: relative
     float: right

--- a/app/styles/courses/teacher-classes-view.sass
+++ b/app/styles/courses/teacher-classes-view.sass
@@ -84,6 +84,9 @@
       &:hover
         text-decoration: none
 
+  [dir="rtl"] .view-class-arrow .view-class-arrow-inner
+    transform: rotate(180deg)
+
   .progress-dot
     display: inline-block
     margin: 10px

--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -568,6 +568,9 @@ $gameControlMargin: 30px
         height: 32px
         color: white
 
+      .rtl-allowed
+        display: inline-block
+
       .gem, .player-hero-icon
         position: absolute
         top: 1px

--- a/app/styles/play/level/goals.sass
+++ b/app/styles/play/level/goals.sass
@@ -27,6 +27,9 @@
     color: white
     text-transform: uppercase
 
+    &[dir="rtl"]
+      right: 0
+
     .success
       color: lightgreen
       text-shadow: 1px 1px 0px black
@@ -44,6 +47,9 @@
     padding-left: 0
     margin-bottom: 0
     color: black
+
+    body[lang="he"] &, body[lang="ar"] &
+      padding-right: 0
     
   li
     list-style: none

--- a/app/styles/play/level/level-loading-view.sass
+++ b/app/styles/play/level/level-loading-view.sass
@@ -79,6 +79,12 @@ $UNVEIL_TIME: 1.2s
     .level-loading-goals
       text-align: left
 
+      body[lang="he"] &, body[lang="ar"] &
+        text-align: right
+
+        ul
+          padding-right: 0
+
       .goals-title
         font-size: 32px
         color: black

--- a/app/styles/play/level/modal/hero-victory-modal.sass
+++ b/app/styles/play/level/modal/hero-victory-modal.sass
@@ -613,7 +613,7 @@ body[lang='ru'], body[lang^='es-ES'], body[lang^='it'], body[lang^='hu'], body[l
   #hero-victory-modal #totals .total-wrapper .total-label
     font-size: 12px
 
-body[lang^='nl'], body[lang^='de']
+body[lang^='nl'], body[lang^='de'], body[lang^='he']
   #hero-victory-modal #totals .total-wrapper .total-label
     font-size: 15px
 

--- a/app/styles/play/menu/game-menu-modal.sass
+++ b/app/styles/play/menu/game-menu-modal.sass
@@ -61,6 +61,9 @@
         background: url(/images/pages/play/modal/menu-tab-selected.png)
         width: 197px
 
+      &[dir="rtl"]
+        text-align: right
+
       a
         font-size: 18px
         line-height: 50px

--- a/app/styles/play/modal/item-details-view.sass
+++ b/app/styles/play/modal/item-details-view.sass
@@ -94,12 +94,14 @@
 
     .item-description
       margin: 15px 15px 0 25px
+      padding-right: 5px
       
     #skills
       margin: 15px 15px 0 25px
       
       h3
         color: rgb(41,35,25)
+        padding-right: 5px
         
       strong
         color: rgb(50,50,30)

--- a/app/styles/play/modal/play-heroes-modal.sass
+++ b/app/styles/play/modal/play-heroes-modal.sass
@@ -99,6 +99,9 @@ $heroCanvasHeight: 275px
           &:nth-child(15), &:nth-child(16)
             float: right
 
+            body[lang="he"] &, body[lang="ar"] &
+              float: left
+
           &.active
             background: url(/images/pages/play/modal/hero-portrait-selected.png)
             z-index: 5
@@ -244,10 +247,16 @@ $heroCanvasHeight: 275px
             width: 100px
             color: rgb(203,170,148)
 
+            &[dir="rtl"]
+              float: right
+
           .stat-value
             display: inline-block
             width: 280px
             color: rgb(244,189,68)
+
+            &[dir="rtl"]
+              float: right
 
           .stat-progress
             background: rgb(32,27,22)
@@ -415,6 +424,18 @@ $heroCanvasHeight: 275px
 
     select
       font-size: 18px
+
+    &[dir="rtl"] .fancy-select
+      .trigger
+        padding-right: 30px
+
+      .options
+        padding-right: 0
+
+        li
+          background-position-x: right
+          padding-left: 0
+          padding-right: 40px
 
     .fancy-select
       display: inline-block

--- a/app/styles/style-flat.sass
+++ b/app/styles/style-flat.sass
@@ -511,6 +511,8 @@ body[lang='ru'], body[lang='uk'], body[lang='bg'], body[lang^='mk'], body[lang='
       width: 150px
       margin: 0 10px
 
+    .contact-info
+      display: inline-block
       
   // modal-base-flat.jade
   

--- a/app/templates/base-flat.jade
+++ b/app/templates/base-flat.jade
@@ -156,13 +156,14 @@ mixin accountLinks
                 li
                   a(href="https://twitter.com/codecombat", data-i18n="nav.twitter")
 
-      #final-footer.small.text-center
+      #final-footer.small.text-center(dir="ltr")
         | Copyright ©2017 CodeCombat. All Rights Reserved.
         br.hidden-lg.hidden-md
         img(src="/images/pages/base/logo.png" alt="CodeCombat")
         br.hidden-lg.hidden-md
         if !me.isStudent()
-          span.spr(data-i18n="nav.help_pref")
-          - var supportEmail = (me.get('preferredLanguage', true) || 'en-US').split('-')[0] == 'nl' ? 'klantenservice@codecombat.nl' : 'team@codecombat.com';
-          a(href="mailto:" + supportEmail)= supportEmail
-          span.spl(data-i18n="nav.help_suff")
+          .contact-info.rtl-allowed
+            span.spr(data-i18n="nav.help_pref")
+            - var supportEmail = (me.get('preferredLanguage', true) || 'en-US').split('-')[0] == 'nl' ? 'klantenservice@codecombat.nl' : 'team@codecombat.com';
+            a(href="mailto:" + supportEmail)= supportEmail
+            span.spl(data-i18n="nav.help_suff")

--- a/app/templates/courses/courses-update-account-view.jade
+++ b/app/templates/courses/courses-update-account-view.jade
@@ -26,7 +26,7 @@ block content
             .col-md-6
               if view.accountType
                 div #{view.accountType}
-              div
+              div.rtl-allowed
                 span.spr #{me.get('email') || me.get('name')}
                 span.not_you
                   span.spr(data-i18n="courses.not_you")
@@ -85,6 +85,6 @@ block content
                     button.update-student-btn.btn.btn-forest(data-i18n="courses.update_account_update_student")
                 br
           br
-          .small.text-center
+          .small.text-center.rtl-allowed
             span.spr(data-i18n="courses.update_account_not_sure")
             a(href='mailto:team@codecombat.com') team@codecombat.com

--- a/app/templates/courses/courses-view.jade
+++ b/app/templates/courses/courses-view.jade
@@ -11,7 +11,7 @@ block content
             p We are transitioning to a new classroom management system; this page will soon be student-only.
             a(href="/teachers/classes") Go to teachers area.
 
-        #main-content
+        #main-content(dir="auto")
           if me.isAnonymous()
 
             h1.text-center(data-i18n="courses.welcome_to_courses")
@@ -43,7 +43,7 @@ block content
             .current-hero-container.text-center.row
               .hero-avatar
                 img(src=view.hero.getPortraitURL())
-              .current-hero-right-col
+              .current-hero-right-col.rtl-allowed
                 .semibold.current-hero-text
                   span.spr(data-i18n="courses.current_hero")
                   span.current-hero-name= view.hero.getHeroShortName()
@@ -62,8 +62,8 @@ block content
                   #just-added-text.text-center(data-i18n="courses.class_added")
 
                 //- sigh
-                div(class=classroomClass)
-                  h5
+                div(class=classroomClass).rtl-allowed
+                  h5(dir="auto")
                     span.spr= classroom.get('name')
                     span.spr (#{(classroom.get('aceConfig') || {}).language === 'javascript' ? 'JavaScript' : 'Python'})
                   p
@@ -75,7 +75,7 @@ block content
                   - var courseInstances = view.courseInstances.where({classroomID: classroom.id});
                   for courseInstance in courseInstances
 
-                    .course-instance-entry
+                    .course-instance-entry.rtl-allowed
                       - var course = view.courses.get(courseInstance.get('courseID'));
                       h6
                         span.spr= i18n(course.attributes, 'name')

--- a/app/templates/courses/enrollments-view.jade
+++ b/app/templates/courses/enrollments-view.jade
@@ -5,7 +5,7 @@ block page_nav
 
 block content
   if me.isAnonymous() || (!me.isTeacher() && !view.classrooms.size())
-    .container
+    .container(dir="auto")
       .access-restricted.container.text-center.m-y-3
         h5(data-i18n='teacher.access_restricted')
         p(data-i18n='teacher.teacher_account_required')
@@ -34,7 +34,7 @@ block content
 
     if view.state.get('shouldUpsell')
       .bg-forest
-        .container
+        .container(dir="auto")
           .row
             .col-xs-9.m-t-1
               b
@@ -47,7 +47,7 @@ block content
               a.btn.btn-lg.btn-forest-alt.m-t-2.m-b-2(href="/teachers/starter-licenses")
                 b(data-i18n="general.learn_more")
 
-    .container.m-t-5
+    .container.m-t-5(dir="auto")
       h3(data-i18n='teacher.enrollments')
       h4#enrollments-blurb(data-i18n="teacher.enrollments_blurb")  
       - var available = view.state.get('prepaidGroups').available
@@ -62,26 +62,26 @@ block content
 
       .row.m-t-3
         if anyPrepaids
-          #prepaids-col.col-md-9
+          #prepaids-col.col-md-9.rtl-allowed
             if _.size(available) > 0
               h5.m-b-1(data-i18n="teacher.available_credits")
               .row
                 for prepaid in available
-                  .prepaid-card-container.col-sm-4.col-xs-6
+                  .prepaid-card-container.col-sm-4.col-xs-6.rtl-allowed
                     +prepaidCard(prepaid)
 
             if _.size(pending) > 0
               h5.m-b-1.m-t-3(data-i18n="teacher.pending_credits")
               .row
                 for prepaid in pending
-                  .prepaid-card-container.col-sm-4.col-xs-6
+                  .prepaid-card-container.col-sm-4.col-xs-6.rtl-allowed
                     +prepaidCard(prepaid, 'pending-prepaid-card')
 
             if _.size(empty) > 0
               h5.m-b-1(data-i18n="teacher.empty_credits")
               .row
                 for prepaid in empty
-                  .prepaid-card-container.col-sm-4.col-xs-6
+                  .prepaid-card-container.col-sm-4.col-xs-6.rtl-allowed
                     +prepaidCard(prepaid, 'empty-prepaid-card')
 
           #actions-col.col-md-3
@@ -93,13 +93,13 @@ block content
             +addCredits
 
 mixin prepaidCard(prepaid, className)
-  .prepaid-card.bg-navy.text-center.p-a-2(class=className)
+  .prepaid-card.bg-navy.text-center.p-a-2.rtl-allowed(class=className)
     h1.m-t-2.m-b-0= prepaid.openSpots()
     if prepaid.get('type') === 'starter_license'
-      div(data-i18n="teacher.starter_licenses")
+      div.rtl-allowed(data-i18n="teacher.starter_licenses")
     else
-      div(data-i18n="teacher.licenses_remaining")
-    div.m-t-1
+      div.rtl-allowed(data-i18n="teacher.licenses_remaining")
+    div.m-t-1.rtl-allowed(dir="auto")
       i.small-details
         if prepaid.usedSpots() === 1
           = translate('teacher.one_license_used')

--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -16,7 +16,7 @@ block content
         a.btn.btn-primary.btn-lg(href="/teachers/update-account") Upgrade to teacher account
 
   if classroom.loaded
-    .container
+    .container(dir="auto")
       +breadcrumbs
       div#classes-nag-subview
       if classroom.get('archived')
@@ -32,15 +32,15 @@ block content
         .update-class
           .alert.alert-info.text-center
             strong(data-i18n='courses.update_old_classroom') 
-            .small-details
+            .small-details.rtl-allowed
               span.spr(data-i18n='courses.update_old_classroom_detail')
               a(data-i18n="courses.teacher_dashboard" href="/teachers/")
               span.spl(data-i18n="courses.update_old_classroom_detail_2") 
 
-      h3.m-t-2= classroom.get('name')
+      h3.m-t-2(dir="auto")= classroom.get('name')
       a.label.edit-classroom(data-classroom-id=classroom.id)
         span(data-i18n='teacher.edit_class_settings')
-      h4= classroom.get('description')
+      h4(dir="auto")= classroom.get('description')
 
       .classroom-info-row.row.m-t-5
         .classroom-details.col-md-3
@@ -113,7 +113,7 @@ block content
         .completeness-info.col-md-4
           h4.m-b-2
             | &nbsp;
-          div.small-details
+          div.small-details.rtl-allowed
             if state.get('earliestIncompleteLevel')
               span(data-i18n='teacher.earliest_incomplete')
               span :
@@ -124,7 +124,7 @@ block content
               span :
               div(data-i18n='common.loading')
 
-          div.small-details.m-t-3
+          div.small-details.m-t-3.rtl-allowed
             if state.get('latestCompleteLevel')
               span(data-i18n='teacher.latest_complete')
               span :
@@ -465,7 +465,7 @@ mixin copyCodes
 
   div.copy-button-group.form-inline.m-b-3
     .form-group
-      input.form-control.text-h4.semibold#join-url-input(value=state.get('joinURL'))
+      input.form-control.text-h4.semibold#join-url-input(value=state.get('joinURL'), dir="ltr")
     button#copy-url-btn.form-control.btn.btn-lg.btn-forest
       span(data-i18n='teacher.copy_class_url')
     div.text-center.small.class-code-blurb(data-i18n='teacher.class_join_url_blurb')

--- a/app/templates/courses/teacher-classes-view.jade
+++ b/app/templates/courses/teacher-classes-view.jade
@@ -61,21 +61,22 @@ block content
         +archivedClassRow(classroom)
 
 mixin classRow(classroom)
-  .class.row
-    .class-details-col
-      .text-h4.semibold
+  .class.row.rtl-allowed(dir="auto")
+    .class-details-col.rtl-allowed(dir="auto")
+      .text-h4.semibold.rtl-allowed(dir="auto")
         = classroom.get('name')
-      .language.small
+      .language.small.rtl-allowed(dir="auto")
         span(data-i18n='teacher.language')
         | :&nbsp;
         span.language-name
           = classroom.capitalLanguage
-      .student-count.small
+      | &nbsp;
+      .student-count.small.rtl-allowed(dir="auto")
         span(data-i18n='courses.students')
         | :&nbsp;
         span
           = classroom.get('members').length
-      .class-links
+      .class-links.rtl-allowed(dir="auto")
         a.view-class-btn.text-h6(data-i18n='teacher.view_class' data-classroom-id=classroom.id data-event-action="Teachers Classes View Class Link")
         a.edit-classroom.text-h6(data-i18n='teacher.edit_class_settings' data-classroom-id=classroom.id data-event-action="Teachers Classes Edit Class Started")
         a.archive-classroom.text-h6(data-i18n='teacher.archive_class' data-classroom-id=classroom.id data-event-action="Teachers Classes Archive Class")
@@ -125,11 +126,11 @@ mixin progressDotLabel(label)
 
 mixin archivedClassRow(classroom)
   .class.row
-    .col-xs-10
+    .col-xs-10(dir="auto")
       span
         = classroom.get('name')
     .col-xs-2
-      .class-links.pull-right
+      .class-links.pull-right(dir="auto")
         a.unarchive-classroom.text-h6(data-i18n='teacher.unarchive_class' data-classroom-id=classroom.id)
 
 mixin teacher-quests

--- a/app/templates/courses/teacher-courses-view.jade
+++ b/app/templates/courses/teacher-courses-view.jade
@@ -14,13 +14,13 @@ block content
           | Please convert your account to ensure you retain access to your classrooms.
         a.btn.btn-primary.btn-lg(href="/teachers/update-account") Upgrade to teacher account
 
-  .container
+  .container(dir="auto")
     h1(data-i18n="nav.courses")
     h2(data-i18n="courses.subtitle")
     //- p
     //-   a(href="https://discourse.codecombat.com/t/course-level-changelog/7352" data-i18n="courses.changelog")
 
-  .courses.container
+  .courses.container(dir="auto")
     - var courses = view.courses.models;
     - var courseIndex = 0;
     while courseIndex < courses.length

--- a/app/templates/home-view.jade
+++ b/app/templates/home-view.jade
@@ -69,7 +69,6 @@ block content
             h2
               span.glyphicon.glyphicon-chevron-down
 
-
   .container#classroom-in-box-container
     #classroom-in-box-row.row
       .col-sm-6

--- a/app/templates/play/campaign-view.jade
+++ b/app/templates/play/campaign-view.jade
@@ -113,17 +113,17 @@ if view.showAds()
             else if level.unlocksHero
               img.treasure-chest(src="/images/pages/play/gold-chest.png")
         div(style="left: #{level.position.x}%; bottom: #{level.position.y}%",class="level-shadow" + (level.next ? " next" : "") + (level.locked ? " locked" : "") + " " + (levelStatusMap[level.slug] || ""))
-        .level-info-container(data-level-slug=level.slug, data-level-path=level.levelPath || 'level', data-level-name=level.name)
+        .level-info-container.rtl-allowed(data-level-slug=level.slug, data-level-path=level.levelPath || 'level', data-level-name=level.name)
           - var playCount = levelPlayCountMap[level.slug]
           .progress.progress-striped.active.hide
             .progress-bar(style="width: 100%")
           - var showsLeaderboard = view.shouldShow('leaderboard') && (levelStatusMap[level.slug] === 'complete' && ((level.scoreTypes && level.scoreTypes.length) || ['hero-ladder', 'course-ladder'].indexOf(level.type) !== -1));
 
-          div(class="level-info " + (levelStatusMap[level.slug] || "") + (level.requiresSubscription ? " premium" : "") + (showsLeaderboard ? " shows-leaderboard" : ""))
-            .level-status
+          div(class="level-info rtl-allowed " + (levelStatusMap[level.slug] || "") + (level.requiresSubscription ? " premium" : "") + (showsLeaderboard ? " shows-leaderboard" : ""))
+            .level-status.rtl-allowed(dir="auto")
             h3= levelNumber + i18n(level, 'name') + (level.disabled ? " (" + translate('common.coming_soon') + ")" : (level.locked ? " (" + translate('play.locked') + ")" : (level.practice ? " (" + translate('courses.practice') + ")" : "")))
             - var description = i18n(level, 'description') || level.description || ""
-            .level-description!= marked(description, {sanitize: !picoCTF})
+            .level-description.rtl-allowed(dir="auto")!= marked(description, {sanitize: !picoCTF})
             if level.disabled
               p
                 span.spr(data-i18n="play.awaiting_levels_adventurer_prefix") We release five levels per week.
@@ -201,7 +201,7 @@ if view.showAds()
                       else
                         btn.btn.btn-illustrated.btn-lg.btn-primary.play-button(data-i18n="common.play")
                     if campaign && campaign.get('description')
-                      p.campaign-description
+                      p.campaign-description(dir="auto")
                         span= i18n(campaign.attributes, 'description')
           else
             - var campaign = campaigns[campaignSlug];
@@ -226,7 +226,7 @@ if view.showAds()
                   else
                     btn(data-i18n="common.play").btn.btn-illustrated.btn-lg.btn-success.play-button
                 if campaign && campaign.get('description')
-                  p.campaign-description
+                  p.campaign-description(dir="auto")
                     span= i18n(campaign.attributes, 'description')
 
   .game-controls.header-font.picoctf-hide
@@ -257,8 +257,9 @@ if view.showAds()
           span.gem.gem-30
           span#gems-count.spr= me.gems()
         if view.shouldShow('level')
-          span.level-indicator(data-i18n="general.player_level")
-          span.player-level.spr= me.level()
+          .rtl-allowed
+            span.level-indicator(data-i18n="general.player_level")
+            span.player-level.spr= me.level()
         span.player-hero-icon
         if me.get('anonymous')
           span.player-name.spr(data-i18n="play.anonymous") Anonymous Player
@@ -289,10 +290,10 @@ if view.showAds()
 
   if campaign && campaign.loaded
     h1#campaign-status.picoctf-hide
-      .campaign-status-background
-        .campaign-name
+      .campaign-status-background.rtl-allowed
+        .campaign-name.rtl-allowed
           span= i18n(campaign.attributes, 'fullName')
-        .levels-completed
+        .levels-completed.rtl-allowed
           span= levelsCompleted
           | /
           span= levelsTotal

--- a/app/templates/play/level/control-bar-view.jade
+++ b/app/templates/play/level/control-bar-view.jade
@@ -8,7 +8,7 @@ if includeHomeLink
 
 if includeHomeLink
   .levels-link-area
-    a.levels-link(href=homeLink || "/")
+    a.levels-link(href=homeLink || "/", dir="ltr")
       .glyphicon.glyphicon-play
       span(data-i18n=me.isSessionless() ? "nav.courses" : (ladderGame ? "general.ladder" : "nav.map")).home-text
 

--- a/app/templates/play/level/goals.jade
+++ b/app/templates/play/level/goals.jade
@@ -1,5 +1,5 @@
-ul#primary-goals-list
-div.goals-status
+ul#primary-goals-list(dir="auto")
+div.goals-status.rtl-allowed
   span(data-i18n="play_level.goals") Goals
   span.spr :
   span(data-i18n="play_level.running").secret.goal-status.running Running...

--- a/app/templates/play/level/hints-view.jade
+++ b/app/templates/play/level/hints-view.jade
@@ -2,10 +2,10 @@
 button.close-hint-btn.btn.btn-illustrated.btn-danger
   span.glyphicon.glyphicon-remove
 
-h1.text-center.hint-title
-  span= view.state.get('hintsTitle')
+h1.text-center.hint-title(dir="auto")
+  span(dir="auto")= view.state.get('hintsTitle')
 
-.hint-body
+.hint-body(dir="auto")
   != view.getProcessedHint()
 
 .row.btn-area

--- a/app/templates/play/level/level-loading-view.jade
+++ b/app/templates/play/level/level-loading-view.jade
@@ -4,9 +4,9 @@
 
 #loading-details.loading-container
 
-  .level-loading-goals.secret
+  .level-loading-goals.secret.rtl-allowed
     .goals-title(data-i18n="play_level.goals") Goals
-    ul.list-unstyled
+    ul.list-unstyled(dir="auto")
 
   .errors
 

--- a/app/templates/play/level/modal/hero-victory-modal.jade
+++ b/app/templates/play/level/modal/hero-victory-modal.jade
@@ -9,24 +9,24 @@ block modal-header-content
 
 block modal-body-content
   if victoryText
-    #victory-text= victoryText
+    #victory-text(dir="auto")= victoryText
 
   if isCourseLevel
     .course-name-container
       if currentCourseName
         p
           span.spr.level-title(data-i18n="play_level.course")
-          span.level-name= currentCourseName
+          span.level-name(dir="auto")= currentCourseName
     .container-fluid
       .row
         .col-md-6
           if currentLevelName
             .level-title(data-i18n="play_level.completed_level")
-            .level-name= currentLevelName.replace('Course: ', '')
+            .level-name(dir="auto")= currentLevelName.replace('Course: ', '')
         .col-md-6
           if nextLevelName
             .level-title(data-i18n="play_level.next_level")
-            .level-name= nextLevelName.replace('Course: ', '')
+            .level-name(dir="auto")= nextLevelName.replace('Course: ', '')
           else
             .level-title(data-i18n="play_level.course")
             .level-name(data-i18n="play_level.victory_title_suffix")
@@ -34,7 +34,7 @@ block modal-body-content
     br
 
   #level-feedback
-    div.rating.secret
+    div.rating.secret.rtl-allowed
       div.rating-label(data-i18n="play_level.victory_rate_the_level") Rate the level:
       i.glyphicon.glyphicon-star-empty
       i.glyphicon.glyphicon-star-empty
@@ -56,7 +56,7 @@ block modal-body-content
       .achievement-panel(class=achievement.completedAWhileAgo ? 'earned' : '' data-achievement-id=achievement.id data-animate=animate)
         - var rewards = achievement.get('rewards') || {};
 
-        div.achievement-description= achievement.description
+        div.achievement-description(dir="auto")= achievement.description
 
         div.achievement-rewards
           - var worth = achievement.worth;
@@ -84,7 +84,7 @@ block modal-body-content
                 if animate
                   .reward-text(data-i18n="play_level.victory_new_hero") New Hero
                 else
-                  .reward-text= i18n(hero.attributes, 'name')
+                  .reward-text(dir="auto")= i18n(hero.attributes, 'name')
 
           if rewards.items
             for item in rewards.items
@@ -98,14 +98,14 @@ block modal-body-content
                   if animate
                     .reward-text(data-i18n="play_level.victory_new_item") New Item
                   else
-                    .reward-text= i18n(item.attributes, 'name')
+                    .reward-text(dir="auto")= i18n(item.attributes, 'name')
 
 
 block modal-footer-content
   #totals
     .total-wrapper#xp-wrapper
       .total-count#xp-total 0
-      .total-label
+      .total-label.rtl-allowed
         span.spr(data-i18n="play_level.victory_experience_gained") XP Gained
         | -
         span.spl.spr(data-i18n="general.player_level") Level

--- a/app/templates/play/level/tome/spell_palette_entry_popover.jade
+++ b/app/templates/play/level/tome/spell_palette_entry_popover.jade
@@ -1,4 +1,4 @@
-h4
+h4(dir="ltr")
   span.prop-name= doc.shortName
   |  - 
   - var skillType = (doc.type == 'function' && doc.owner == 'this' ? 'method' : doc.type)
@@ -18,8 +18,8 @@ if doc.translatedShortName
   h5
     span.translated-name= doc.translatedShortName
 
-.description
-  p!= marked(doc.description || 'Still undocumented, sorry.')
+.description.rtl-allowed(dir="auto")
+  p(dir="auto")!= marked(doc.description || 'Still undocumented, sorry.')
   div.clear(style="clear: both")
   if cooldowns && (cooldowns.cooldown || cooldowns.specificCooldown)
     p
@@ -106,7 +106,7 @@ if (doc.type != 'function' && doc.type != 'snippet' && doc.type != 'spawnable' &
       code.current-value(data-prop=doc.name)= value
 
 mixin argumentEntry(arg)
-  div
+  div(dir="auto")
     code= arg.name
     span.spr :
     code= arg.type
@@ -117,9 +117,9 @@ mixin argumentEntry(arg)
       code= arg.example
       | )
     if arg.description
-      div!= marked(arg.description)
+      div(dir="auto")!= marked(arg.description)
     if arg.default
-      div
+      div(dir="auto")
         em
           span(data-i18n="skill_docs.default_value") Default value
           span.spr :
@@ -127,7 +127,7 @@ mixin argumentEntry(arg)
 
 if doc.args && doc.args.length
   - var hasOptionalArguments = _.any(doc.args, function(arg){ return arg.optional })
-  p.args
+  p.args(dir="auto")
     strong
       if hasOptionalArguments
         span(data-i18n="skill_docs.required_parameters") Required Parameters
@@ -138,7 +138,7 @@ if doc.args && doc.args.length
       unless arg.optional
         +argumentEntry(arg)
   if hasOptionalArguments
-    p.args
+    p.args(dir="auto")
       strong
         span(data-i18n="skill_docs.optional_parameters") Optional Parameters
         span.spr :
@@ -148,7 +148,7 @@ if doc.args && doc.args.length
 
 
 if doc.returns
-  p.returns
+  p.returns(dir="auto")
     strong
       span(data-i18n="skill_docs.returns") Returns
       span.spr :

--- a/app/templates/play/menu/game-menu-modal.jade
+++ b/app/templates/play/menu/game-menu-modal.jade
@@ -5,7 +5,7 @@
     div#close-modal
       span.glyphicon.glyphicon-remove
 
-    ul#game-menu-nav.nav.nav-pills.nav-stacked
+    ul#game-menu-nav.nav.nav-pills.nav-stacked(dir="ltr")
       if view.showsChooseHero()
         li
           a#change-hero-tab

--- a/app/templates/play/modal/item-details-view.jade
+++ b/app/templates/play/modal/item-details-view.jade
@@ -1,6 +1,6 @@
 
 #item-title
-  h2.one-line.big-font= item ? item.name : ''
+  h2.one-line.big-font(dir="auto")= item ? item.name : ''
 
 #item-details-body
   if item
@@ -20,7 +20,7 @@
             img.hr(src="/images/pages/play/modal/hr.png", class=stat.isLast ? "" : "faded", draggable="false")
 
         if item.description
-          .item-description= item.description
+          .item-description(dir="auto")= item.description
 
         if !me.isStudent()
           if props.length

--- a/app/templates/play/modal/play-heroes-modal.jade
+++ b/app/templates/play/modal/play-heroes-modal.jade
@@ -25,7 +25,7 @@
             canvas.hero-canvas
             .hero-pose-image
               img(draggable="false")
-            .hero-stats
+            .hero-stats.rtl-allowed(dir="auto")
               h2= hero.name
               .hero-description= hero.description
               

--- a/app/templates/play/modal/poll-modal.jade
+++ b/app/templates/play/modal/poll-modal.jade
@@ -1,18 +1,18 @@
 extends /templates/core/modal-base
 block modal-header-content
-  h1
+  h1(dir="auto")
     span= i18n(poll.attributes, "name")
 
 block modal-body-content
-  .description
+  .description.rtl-allowed
     if poll.get("description")
-      div!= marked(i18n(poll.attributes, "description"))
+      div(dir="auto")!= marked(i18n(poll.attributes, "description"))
     else
       div &nbsp;
 
   .answers-container-wrapper
     .answers-container
-      table.table.table-hover
+      table.table.table-hover.rtl-allowed(dir="auto")
         for answer in poll.get("answers") || []
           tr(class="answer", data-answer=answer.key)
             td!= marked(i18n(answer, "text"))

--- a/app/templates/teachers/resource-hub-view.jade
+++ b/app/templates/teachers/resource-hub-view.jade
@@ -6,7 +6,7 @@ block page_nav
 block content
   .container
 
-    .content
+    .content.rtl-allowed
       if me.attributes.hourOfCode && me.isAnonymous()
         #hour-of-code
           h3
@@ -57,7 +57,7 @@ block content
       h1(data-i18n="teacher.resource_hub")
 
       h4(data-i18n="teacher.getting_started")
-      ul
+      ul(dir="auto")
         li
           strong(data-i18n="teacher.pacing_guides")
           p 

--- a/app/views/common/SearchView.coffee
+++ b/app/views/common/SearchView.coffee
@@ -82,6 +82,7 @@ module.exports = class SearchView extends RootView
     table = $(@tableTemplate(documents: documents, me: me, page: @page, moment: moment))
     @$el.find('table').replaceWith(table)
     @$el.find('table').i18n()
+    @applyRTLIfNeeded()
 
   removeOldSearch: ->
     return unless @collection?

--- a/app/views/core/CocoView.coffee
+++ b/app/views/core/CocoView.coffee
@@ -87,7 +87,7 @@ module.exports = class CocoView extends Backbone.View
     return if @viewVisibleTimer
     @viewVisibleTimer = new ViewVisibleTimer()
     @trackViewLifecycle = trackViewLifecycle
-    
+
   # Report the currently visible feature — this is the default handler for whole-view tracking
   # Views with more involved features should implement this method instead.
   currentVisiblePremiumFeature: ->
@@ -95,7 +95,7 @@ module.exports = class CocoView extends Backbone.View
       return { viewName: @.id }
     else
       return null
-  
+
   updateViewVisibleTimer: ->
     return if not @viewVisibleTimer
     visibleFeature = not @hidden and not @destroyed and @currentVisiblePremiumFeature()
@@ -133,7 +133,20 @@ module.exports = class CocoView extends Backbone.View
     @listenToShortcuts() if wasHidden
     view.didReappear() for id, view of @subviews
 
+
   # View Rendering
+
+  isRTL: (s) ->
+    # Hebrew is 0x0590 - 0x05FF, which is adjacent to Arabic at 0x0600 - 0x06FF
+    /[\u0590-\u06FF]/.test s
+
+  applyRTLIfNeeded: ->
+    return unless me.get('preferredLanguage') in ['he', 'ar']
+    @$('[data-i18n]').each (i, el) =>
+      return unless @isRTL(el.innerHTML)
+      el.dir = 'rtl'
+      $(el).parentsUntil('table, form, noscript, div:not([class~="rtl-allowed"]):not([class~="form"]):not([class~="form-group"]):not([class~="form-group"]), [dir="ltr"]').attr('dir', 'rtl')
+      $(el).parents('div.form').attr('dir', 'rtl')
 
   renderSelectors: (selectors...) ->
     newTemplate = $(@template(@getRenderData()))
@@ -142,6 +155,7 @@ module.exports = class CocoView extends Backbone.View
         $(elPair[0]).replaceWith($(elPair[1]))
     @delegateEvents()
     @$el.i18n()
+    @applyRTLIfNeeded()
 
   render: ->
     return @ unless me
@@ -165,6 +179,7 @@ module.exports = class CocoView extends Backbone.View
 
     @afterRender()
     @$el.i18n()
+    @applyRTLIfNeeded()
     @
 
   getRenderData: (context) ->
@@ -299,6 +314,7 @@ module.exports = class CocoView extends Backbone.View
   showLoading: ($el=@$el) ->
     $el.find('>').addClass('hidden')
     $el.append(loadingScreenTemplate()).i18n()
+    @applyRTLIfNeeded()
     @_lastLoading = $el
 
   hideLoading: ->
@@ -316,6 +332,7 @@ module.exports = class CocoView extends Backbone.View
     }
     @_lastLoading.find('.loading-screen').replaceWith((loadingErrorTemplate(context)))
     @_lastLoading.i18n()
+    @applyRTLIfNeeded()
 
   forumLink: ->
     link = 'http://discourse.codecombat.com/'

--- a/app/views/editor/article/ArticleSearchView.coffee
+++ b/app/views/editor/article/ArticleSearchView.coffee
@@ -16,4 +16,5 @@ module.exports = class ArticleSearchView extends SearchView
     context.currentSearch = 'editor.article_search_title'
     context.newModelsAdminOnly = true
     @$el.i18n()
+    @applyRTLIfNeeded()
     context

--- a/app/views/editor/course/CourseSearchView.coffee
+++ b/app/views/editor/course/CourseSearchView.coffee
@@ -17,4 +17,5 @@ module.exports = class LevelSearchView extends SearchView
     context.currentNewSignup = 'editor.new_course_title_login'
     context.currentSearch = 'editor.course_search_title'
     @$el.i18n()
+    @applyRTLIfNeeded()
     context

--- a/app/views/editor/level/LevelSearchView.coffee
+++ b/app/views/editor/level/LevelSearchView.coffee
@@ -16,4 +16,5 @@ module.exports = class LevelSearchView extends SearchView
     context.currentNewSignup = 'editor.new_level_title_login'
     context.currentSearch = 'editor.level_search_title'
     @$el.i18n()
+    @applyRTLIfNeeded()
     context

--- a/app/views/editor/thang/ThangTypeSearchView.coffee
+++ b/app/views/editor/thang/ThangTypeSearchView.coffee
@@ -18,6 +18,7 @@ module.exports = class ThangTypeSearchView extends SearchView
     context.currentSearch = 'editor.thang_search_title'
     context.newModelsAdminOnly = true
     @$el.i18n()
+    @applyRTLIfNeeded()
     context
 
   onSearchChange: =>

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -263,19 +263,19 @@ module.exports = class CampaignView extends RootView
   openPlayItemsModal: (e) ->
     e.stopPropagation()
     @openModalView new PlayItemsModal()
-    
+
   openPlayHeroesModal: (e) ->
     e.stopPropagation()
     @openModalView new PlayHeroesModal()
-    
+
   openPlayAchievementsModal: (e) ->
     e.stopPropagation()
     @openModalView new PlayAchievementsModal()
-    
+
   openBuyGemsModal: (e) ->
     e.stopPropagation()
     @openModalView new BuyGemsModal()
-    
+
   openContactModal: (e) ->
     e.stopPropagation()
     @openModalView new ContactModal()
@@ -308,6 +308,8 @@ module.exports = class CampaignView extends RootView
     @checkForUnearnedAchievements()
     @preloadTopHeroes() unless me.get('heroConfig')?.thangType
     @$el.find('#campaign-status').delay(4000).animate({top: "-=58"}, 1000) unless @terrain is 'dungeon' or @courseStats?
+    if @campaign and @isRTL utils.i18n(@campaign.attributes, 'fullName')
+      @$('.campaign-name').attr('dir', 'rtl')
     if not me.get('hourOfCode') and @terrain
       if features.codePlay
         if me.get('anonymous') and me.get('lastLevel') is 'true-names' and me.level() < 5

--- a/app/views/play/level/tome/SpellPaletteView.coffee
+++ b/app/views/play/level/tome/SpellPaletteView.coffee
@@ -372,6 +372,7 @@ module.exports = class SpellPaletteView extends CocoView
     content = @$el.find(".rightContentTarget")
     content.html(e.entry.doc.initialHTML)
     content.i18n()
+    @applyRTLIfNeeded()
     codeLanguage = e.entry.options.language
     oldEditor.destroy() for oldEditor in @aceEditors
     @aceEditors = []

--- a/app/views/play/menu/InventoryModal.coffee
+++ b/app/views/play/menu/InventoryModal.coffee
@@ -67,7 +67,7 @@ module.exports = class InventoryModal extends ModalView
       for item in baseItems
         unless item in me.get('earned').items
           me.get('earned').items.push(item) # Allow HoC players to access the cat
-    
+
     @onScrollUnequipped = _.throttle(_.bind(@onScrollUnequipped, @), 200)
     super(arguments...)
     @items = new CocoCollection([], {model: ThangType})
@@ -682,6 +682,7 @@ module.exports = class InventoryModal extends ModalView
     ).popover 'show'
     popover = unlockButton.data('bs.popover')
     popover?.$tip?.i18n()
+    @applyRTLIfNeeded()
 
   onBuyGemsPromptButtonClicked: (e) ->
     @playSound 'menu-button-click'

--- a/app/views/play/modal/PlayHeroesModal.coffee
+++ b/app/views/play/modal/PlayHeroesModal.coffee
@@ -290,6 +290,7 @@ module.exports = class PlayHeroesModal extends ModalView
       #- ...then rerender visible hero
       heroEntry = @$el.find(".hero-item[data-hero-id='#{@visibleHero.get('original')}']")
       heroEntry.find('.hero-status-value').attr('data-i18n', 'play.available').i18n()
+      @applyRTLIfNeeded()
       heroEntry.removeClass 'locked purchasable'
       @selectedHero = @visibleHero
       @rerenderFooter()
@@ -318,6 +319,7 @@ module.exports = class PlayHeroesModal extends ModalView
     ).popover 'show'
     popover = unlockButton.data('bs.popover')
     popover?.$tip?.i18n()
+    @applyRTLIfNeeded()
 
   onBuyGemsPromptButtonClicked: (e) ->
     return @askToSignUp() if me.get('anonymous')

--- a/app/views/play/modal/PlayItemsModal.coffee
+++ b/app/views/play/modal/PlayItemsModal.coffee
@@ -181,7 +181,7 @@ module.exports = class PlayItemsModal extends ModalView
       return { viewName: @.id, featureName: 'filter-ranger' }
     else
       return null
-  
+
   onTabClicked: (e) ->
     @playSound 'game-menu-tab-switch'
     nano = $($(e.target).attr('href')).find('.nano')
@@ -264,6 +264,7 @@ module.exports = class PlayItemsModal extends ModalView
     ).popover 'show'
     popover = unlockButton.data('bs.popover')
     popover?.$tip?.i18n()
+    @applyRTLIfNeeded()
 
   onBuyGemsPromptButtonClicked: (e) ->
     @playSound 'menu-button-click'


### PR DESCRIPTION
In order for Hebrew and Arabic to display correctly, we need to figure out on an element-by-element basis whether we should have `dir="auto"` or `dir="rtl"` set. My approach: automatically set the easy, harmless ones:

```coffeescript
  isRTL: (s) ->
    # Hebrew is 0x0590 - 0x05FF, which is adjacent to Arabic at 0x0600 - 0x06FF
    /[\u0590-\u06FF]/.test s

  applyRTLIfNeeded: ->
    return unless me.get('preferredLanguage') in ['he', 'ar']
    @$('[data-i18n]').each (i, el) =>
      return unless @isRTL(el.innerHTML)
      el.dir = 'rtl'
      $(el).parentsUntil('table, form, noscript, div:not([class~="rtl-allowed"]):not([class~="form"]):not([class~="form-group"]):not([class~="form-group"]), [dir="ltr"]').attr('dir', 'rtl')
      $(el).parents('div.form').attr('dir', 'rtl')
```

This goes through all the elements that we translate with the `data-i18n` approach and sets `dir="rtl"` if they now actually contain Hebrew or Arabic text, plus sets the same thing on any "safe" parent elements. (Usually we stop at a `div` that we haven't explicitly marked as `.rtl-allowed` or that is a form.)

Then I also manually tagged a lot of things throughout the code with `dir="auto"` and `.rtl-allowed` and fixed up the styles in various places as needed.

I did a pass through main screens of student, teacher, and home player views, using our current level of Hebrew translation support to spot check things. I know I must have missed many places, but this should be a good start.