### PR TITLE
Fix shareable links being broken by level rename

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -157,8 +157,12 @@ module.exports = class CocoRouter extends Backbone.Router
     'play/ladder/:levelID': go('ladder/LadderView')
     'play/ladder': go('ladder/MainLadderView')
     'play/level/:levelID': go('play/level/PlayLevelView')
-    'play/game-dev-level/:levelID/:sessionID': go('play/level/PlayGameDevLevelView')
-    'play/web-dev-level/:levelID/:sessionID': go('play/level/PlayWebDevLevelView')
+    'play/game-dev-level/:sessionID': go('play/level/PlayGameDevLevelView')
+    'play/web-dev-level/:sessionID': go('play/level/PlayWebDevLevelView')
+    'play/game-dev-level/:levelID/:sessionID': (levelID, sessionID) ->
+      @navigate("play/game-dev-level/#{sessionID}", { trigger: true, replace: true })
+    'play/web-dev-level/:levelID/:sessionID': (levelID, sessionID) ->
+      @navigate("play/web-dev-level/#{sessionID}", { trigger: true, replace: true })
     'play/spectate/:levelID': go('play/SpectateView')
     'play/:map': go('play/CampaignView', { redirectTeachers: true })
 

--- a/app/core/api/levels.coffee
+++ b/app/core/api/levels.coffee
@@ -1,4 +1,6 @@
 fetchJson = require './fetch-json'
 
 module.exports = {
+  getByOriginal: (original) ->
+    return fetchJson("/db/level/#{original}/version")
 }

--- a/app/views/play/level/PlayGameDevLevelView.coffee
+++ b/app/views/play/level/PlayGameDevLevelView.coffee
@@ -17,6 +17,7 @@ Course = require 'models/Course'
 GameDevVictoryModal = require './modal/GameDevVictoryModal'
 aetherUtils = require 'lib/aether_utils'
 GameDevTrackView = require './GameDevTrackView'
+api = require 'core/api'
 
 require 'lib/game-libraries'
 
@@ -37,7 +38,7 @@ module.exports = class PlayGameDevLevelView extends RootView
     'click #copy-url-btn': 'onClickCopyURLButton'
     'click #play-more-codecombat-btn': 'onClickPlayMoreCodeCombatButton'
 
-  initialize: (@options, @levelID, @sessionID) ->
+  initialize: (@options, @sessionID) ->
     @state = new State({
       loading: true
       progress: 0
@@ -48,17 +49,23 @@ module.exports = class PlayGameDevLevelView extends RootView
     @supermodel.on 'update-progress', (progress) =>
       @state.set({progress: (progress*100).toFixed(1)+'%'})
     @level = new Level()
-    @session = new LevelSession()
+    @session = new LevelSession({ _id: @sessionID })
     @gameUIState = new GameUIState()
     @courseID = utils.getQueryVariable 'course'
     @courseInstanceID = utils.getQueryVariable 'course-instance'
     @god = new God({ @gameUIState, indefiniteLength: true })
-    @levelLoader = new LevelLoader({ @supermodel, @levelID, @sessionID, observing: true, team: TEAM, @courseID })
-    @supermodel.setMaxProgress 1 # Hack, why are we setting this to 0.2 in LevelLoader?
-    @listenTo @state, 'change', _.debounce @renderAllButCanvas
-    @updateDb = _.throttle(@updateDb, 1000)
 
-    @levelLoader.loadWorldNecessities()
+    @supermodel.registerModel(@session)
+    new Promise((accept,reject) => @session.fetch({ cache: false }).then(accept, reject)).then (sessionData) =>
+      api.levels.getByOriginal(sessionData.level.original)
+    .then (levelData) =>
+      @levelID = levelData.slug
+      @levelLoader = new LevelLoader({ @supermodel, @levelID, @sessionID, observing: true, team: TEAM, @courseID })
+      @supermodel.setMaxProgress 1 # Hack, why are we setting this to 0.2 in LevelLoader?
+      @listenTo @state, 'change', _.debounce @renderAllButCanvas
+      @updateDb = _.throttle(@updateDb, 1000)
+
+      @levelLoader.loadWorldNecessities()
 
     .then (levelLoader) =>
       { @level, @session, @world } = levelLoader

--- a/app/views/play/level/PlayWebDevLevelView.coffee
+++ b/app/views/play/level/PlayWebDevLevelView.coffee
@@ -4,6 +4,7 @@ RootView = require 'views/core/RootView'
 Level = require 'models/Level'
 LevelSession = require 'models/LevelSession'
 WebSurfaceView = require './WebSurfaceView'
+api = require 'core/api'
 
 require 'lib/game-libraries'
 utils = require 'core/utils'
@@ -12,10 +13,18 @@ module.exports = class PlayWebDevLevelView extends RootView
   id: 'play-web-dev-level-view'
   template: require 'templates/play/level/play-web-dev-level-view'
 
-  initialize: (@options, @levelID, @sessionID) ->
+  initialize: (@options, @sessionID) ->
     @courseID = utils.getQueryVariable 'course'
-    @level = @supermodel.loadModel(new Level _id: @levelID).model
     @session = @supermodel.loadModel(new LevelSession _id: @sessionID).model
+    @level = new Level()
+    @session.once 'sync', =>
+      levelResource = @supermodel.addSomethingResource('level')
+      api.levels.getByOriginal(@session.get('level').original).then (levelData) =>
+        @levelID = levelData.slug
+        @level.set({ _id: @levelID })
+        @level.fetch()
+        @level.once 'sync', =>
+          levelResource.markLoaded()
 
   onLoaded: ->
     super()

--- a/app/views/play/level/modal/HeroVictoryModal.coffee
+++ b/app/views/play/level/modal/HeroVictoryModal.coffee
@@ -75,7 +75,7 @@ module.exports = class HeroVictoryModal extends ModalView
       @loadExistingFeedback()
 
     if @level.get('shareable') is 'project'
-      @shareURL = "#{window.location.origin}/play/#{@level.get('type')}-level/#{@level.get('slug')}/#{@session.id}"
+      @shareURL = "#{window.location.origin}/play/#{@level.get('type')}-level/#{@session.id}"
 
   destroy: ->
     clearInterval @sequentialAnimationInterval


### PR DESCRIPTION
Fetches levels based on the `original` in the Session instead of by URL query parameter.

Has some jank from bridging the supermodel+backbone/fetch API bridge, but it works. Let me know if there's a better way to bridge it in PlayWebDevLevelView especially.