### PR TITLE
Fix /?hour_of_code=true redirect

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -23,6 +23,7 @@ module.exports = class CocoRouter extends Backbone.Router
       if window.serverConfig.picoCTF
         return @routeDirectly 'play/CampaignView', ['picoctf'], {}
       if utils.getQueryVariable 'hour_of_code'
+        delete window.alreadyLoadedView
         return @navigate "/play?hour_of_code=true", {trigger: true, replace: true}
       unless me.isAnonymous() or me.isStudent() or me.isTeacher() or me.isAdmin() or me.hasSubscription()
         delete window.alreadyLoadedView


### PR DESCRIPTION
Static page merging was breaking the `/?hour_of_code=true` redirect to `/play?hour_of_code=true`. This fixes it the same way it was already fixed for `/` -> `/premium`