### PR TITLE
Log an error instead of crashing when setting header twice

### DIFF
--- a/server/queues/scoring/scoringUtils.coffee
+++ b/server/queues/scoring/scoringUtils.coffee
@@ -23,9 +23,12 @@ module.exports.simulatorIsTooOld = (req, res) ->
 
 
 module.exports.sendResponseObject = (res, object) ->
-  res.setHeader('Content-Type', 'application/json')
-  res.send(object)
-  res.end()
+  try
+    res.setHeader('Content-Type', 'application/json')
+    res.send(object)
+    res.end()
+  catch error
+    log.error("ERROR in #{res.req.method} #{res.req.url}:\n" + error.stack)
 
 module.exports.formatSessionInformation = (session) ->
   heroID = if session.team is 'ogres' then 'hero-placeholder-1' else 'hero-placeholder'


### PR DESCRIPTION
Logs an error instead of raising an unhandled exception.