### PR TITLE
Unenroll students on removal from last classroom

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1348,6 +1348,7 @@
     are_you_sure: "Are you sure you want to remove this student from this class?"
     remove_description1: "Student will lose access to this classroom and assigned classes. Progress and gameplay is NOT lost, and the student can be added back to the classroom at any time."
     remove_description2: "The activated paid license will not be returned."
+    license_will_revoke: "This student's paid license will be revoked and made available to assign to another student."
     keep_student: "Keep Student"
     removing_user: "Removing user"
     subtitle: "Review course overviews and levels" # Flat style redesign

--- a/app/models/Classroom.coffee
+++ b/app/models/Classroom.coffee
@@ -58,9 +58,8 @@ module.exports = class Classroom extends CocoModel
 
   removeMember: (userID, opts) ->
     options = {
-      url: _.result(@, 'url') + '/members'
+      url: _.result(@, 'url') + "/members/#{userID}"
       type: 'DELETE'
-      data: { userID: userID }
     }
     _.extend options, opts
     @fetch(options)

--- a/app/templates/courses/remove-student-modal.jade
+++ b/app/templates/courses/remove-student-modal.jade
@@ -13,8 +13,12 @@ block modal-header-content
 block modal-body-content
   p.text-center
     span(data-i18n="courses.remove_description1")
-    if view.user.isEnrolled()
-      span(data-i18n="courses.remove_description2")
+  if view.user.isEnrolled()
+    p.text-center
+      if view.willRevokeLicense
+        span(data-i18n="courses.license_will_revoke")
+      else
+        span(data-i18n="courses.remove_description2")
 
 block modal-footer-content
   #remove-student-buttons.text-center

--- a/app/views/courses/RemoveStudentModal.coffee
+++ b/app/views/courses/RemoveStudentModal.coffee
@@ -12,7 +12,14 @@ module.exports = class RemoveStudentModal extends ModalView
   initialize: (options) ->
     @classroom = options.classroom
     @user = options.user
+    @supermodel.trackRequest @user.fetch()
     @courseInstances = options.courseInstances
+    request = $.ajax("/db/classroom/#{@classroom.id}/members/#{@user.id}/is-auto-revokable")
+    @supermodel.trackRequest request
+    request.then (data) =>
+      @willRevokeLicense = data.willRevokeLicense
+    , (err) =>
+      console.error err, arguments
 
   onClickRemoveStudentButton: ->
     @$('#remove-student-buttons').addClass('hide')

--- a/server/middleware/prepaids.coffee
+++ b/server/middleware/prepaids.coffee
@@ -89,31 +89,10 @@ module.exports =
 
     unless prepaid.canBeUsedBy(req.user._id)
       throw new errors.Forbidden('You may not revoke enrollments you do not own.')
-    unless prepaid.get('type') is 'course'
-      throw new errors.Forbidden('This prepaid is not of type "course".')
-    if prepaid.get('endDate') and new Date(prepaid.get('endDate')) < new Date()
-      throw new errors.Forbidden('This prepaid is expired.')
-
+      
     user = yield User.findById(req.body?.userID)
-    if not user
-      throw new errors.NotFound('User not found.')
 
-    if not user.isEnrolled()
-      throw new errors.UnprocessableEntity('User to revoke must be enrolled first.')
-    if not _.any(prepaid.get('redeemers'), (obj) -> obj.userID.equals(user._id))
-      throw new errors.UnprocessableEntity('User was not enrolled with this set of enrollments')
-
-    query =
-      _id: prepaid._id
-      'redeemers.userID': { $eq: user._id }
-    update = { $pull: { redeemers : { userID: user._id } }}
-    result = yield Prepaid.update(query, update)
-    if result.nModified is 0
-      @logError(req.user, "POST prepaid redeemer lost race on maxRedeemers")
-      throw new errors.UnprocessableEntity('User was not enrolled with this set of enrollments (race)')
-
-    user.set('coursePrepaid', undefined)
-    yield user.save()
+    yield prepaid.revoke(user)
 
     # return prepaid with new redeemer added locally
     prepaid.set('redeemers', _.filter(prepaid.get('redeemers') or [], (obj) -> not obj.userID.equals(user._id)))

--- a/server/routes/index.coffee
+++ b/server/routes/index.coffee
@@ -135,6 +135,8 @@ module.exports.setup = (app) ->
   app.post('/db/classroom/:handle/invite-members', mw.classrooms.inviteMembers)
   app.get('/db/classroom/:handle/member-sessions', mw.classrooms.fetchMemberSessions)
   app.get('/db/classroom/:handle/members', mw.classrooms.fetchMembers) # TODO: Use mw.auth?
+  app.get('/db/classroom/:classroomID/members/:memberID/is-auto-revokable', mw.classrooms.checkIsAutoRevokable)
+  app.delete('/db/classroom/:classroomID/members/:memberID', mw.classrooms.deleteMember)
   app.post('/db/classroom/:classroomID/members/:memberID/reset-password', mw.classrooms.setStudentPassword)
   app.post('/db/classroom/:anything/members', mw.auth.checkLoggedIn(), mw.classrooms.join)
   app.post('/db/classroom/:handle/update-courses', mw.classrooms.updateCourses)

--- a/spec/server/functional/classrooms.spec.coffee
+++ b/spec/server/functional/classrooms.spec.coffee
@@ -13,6 +13,7 @@ CourseInstance = require '../../../server/models/CourseInstance'
 Campaign = require '../../../server/models/Campaign'
 LevelSession = require '../../../server/models/LevelSession'
 Level = require '../../../server/models/Level'
+Prepaid = require '../../../server/models/Prepaid'
 mongoose = require 'mongoose'
 subscriptions = require '../../../server/middleware/subscriptions'
 
@@ -432,26 +433,102 @@ describe 'POST /db/classroom/-/members', ->
     expect(res.statusCode).toBe(401)
     done()
 
-describe 'DELETE /db/classroom/:id/members', ->
+describe 'GET /db/classroom/:classroomID/members/:memberID/is-auto-revokable', ->
 
   beforeEach utils.wrap (done) ->
-    yield utils.clearModels([User, Classroom])
+    yield utils.clearModels([User, Classroom, Prepaid])
     @teacher = yield utils.initUser({role: 'teacher'})
     yield utils.loginUser(@teacher)
     @student = yield utils.initUser()
     @classroom = yield utils.makeClassroom({}, {members:[@student]})
-    @url = utils.getURL("/db/classroom/#{@classroom.id}/members")
+    @url = utils.getURL("/db/classroom/#{@classroom.id}/members/#{@student.id}/is-auto-revokable")
+    done()
+  
+  describe 'when the user does NOT have a license', ->
+    it 'says it will NOT revoke the license', utils.wrap (done) ->
+      [res, body] = yield request.getAsync { @url, json: true }
+      expect(res.statusCode).toBe(200)
+      expect(res.body.willRevokeLicense).toBe(false)
+      done()
+  
+  describe 'when the user has a license', ->
+    beforeEach utils.wrap (done) ->
+      @admin = yield utils.initAdmin()
+      yield utils.loginUser(@admin)
+      @prepaid = yield utils.makePrepaid({ creator: @teacher.id })
+      yield utils.loginUser(@teacher)
+      yield utils.addRedeemerToPrepaid(@prepaid, @student)
+      @prepaid = yield Prepaid.findById(@prepaid.id)
+      done()
+
+    describe 'and the user is in other classrooms', ->
+      beforeEach utils.wrap (done) ->
+        @classroom2 = yield utils.makeClassroom({}, {members:[@student]})
+        done()
+
+      it 'says it will NOT revoke the license', utils.wrap (done) ->
+        [res, body] = yield request.getAsync { @url, json: true }
+        expect(res.statusCode).toBe(200)
+        expect(res.body.willRevokeLicense).toBe(false)
+        done()
+
+    describe 'and the user is NOT in any other classrooms', ->
+      it 'says it will revoke the license', utils.wrap (done) ->
+        [res, body] = yield request.getAsync { @url, json: true }
+        expect(res.statusCode).toBe(200)
+        expect(res.body.willRevokeLicense).toBe(true)
+        done()
+
+describe 'DELETE /db/classroom/:classroomID/members/:memberID', ->
+
+  beforeEach utils.wrap (done) ->
+    yield utils.clearModels([User, Classroom, Prepaid])
+    @teacher = yield utils.initUser({role: 'teacher'})
+    yield utils.loginUser(@teacher)
+    @student = yield utils.initUser()
+    @classroom = yield utils.makeClassroom({}, {members:[@student]})
+    @url = utils.getURL("/db/classroom/#{@classroom.id}/members/#{@student.id}")
     done()
 
   it 'removes the given user from the list of members in the classroom', utils.wrap (done) ->
     expect(@classroom.get('members').length).toBe(1)
-    json = { userID: @student.id }
-    [res, body] = yield request.delAsync { @url, json }
+    [res, body] = yield request.delAsync { @url }
     expect(res.statusCode).toBe(200)
     classroom = yield Classroom.findById(@classroom.id)
     expect(classroom.get('members').length).toBe(0)
     done()
+  
+  describe 'when the user has a license', ->
+    beforeEach utils.wrap (done) ->
+      @admin = yield utils.initAdmin()
+      yield utils.loginUser(@admin)
+      @prepaid = yield utils.makePrepaid({ creator: @teacher.id })
+      yield utils.loginUser(@teacher)
+      yield utils.addRedeemerToPrepaid(@prepaid, @student)
+      @prepaid = yield Prepaid.findById(@prepaid.id)
+      done()
 
+    describe 'and the user is in other classrooms', ->
+      beforeEach utils.wrap (done) ->
+        @classroom2 = yield utils.makeClassroom({}, {members:[@student]})
+        done()
+
+      it 'does NOT revoke the license', utils.wrap (done) ->
+        expect(@prepaid.get('redeemers').length).toBe(1)
+        [res, body] = yield request.delAsync { @url }
+        expect(res.statusCode).toBe(200)
+        prepaid = yield Prepaid.findById(@prepaid.id)
+        expect(@prepaid.get('redeemers').length).toBe(1)
+        done()
+
+    describe 'and the user is NOT in any other classrooms', ->
+      it 'revokes the license', utils.wrap (done) ->
+        expect(@prepaid.get('redeemers').length).toBe(1)
+        [res, body] = yield request.delAsync { @url }
+        expect(res.statusCode).toBe(200)
+        prepaid = yield Prepaid.findById(@prepaid.id)
+        expect(prepaid.get('redeemers').length).toBe(0)
+        done()
 
 describe 'POST /db/classroom/:id/invite-members', ->
 
@@ -462,7 +539,7 @@ describe 'POST /db/classroom/:id/invite-members', ->
     url = classroomsURL + "/#{classroom.id}/invite-members"
     data = { emails: ['test@test.com'] }
     sendwithus = require '../../../server/sendwithus'
-    spyOn(sendwithus.api, 'send').and.callFake (context, cb) -> 
+    spyOn(sendwithus.api, 'send').and.callFake (context, cb) ->
       expect(context.email_id).toBe(sendwithus.templates.course_invite_email)
       expect(context.recipient.address).toBe('test@test.com')
       expect(context.email_data.teacher_name).toBe('Mr Professerson')

--- a/spec/server/utils.coffee
+++ b/spec/server/utils.coffee
@@ -317,6 +317,15 @@ module.exports = mw =
       expect(res.statusCode).toBe(201)
       Prepaid.findById(res.body._id).exec done
   
+  addRedeemerToPrepaid: Promise.promisify (prepaid, redeemer, done) ->
+    data = {
+      userID: redeemer?.id or redeemer
+    }
+    request.post { uri: getURL("/db/prepaid/#{prepaid.id}/redeemers"), method: 'POST', json: data }, (err, res) ->
+      return done(err) if err
+      expect(res.statusCode).toBe(201)
+      Prepaid.findById(res.body._id).exec done
+  
   addJoinerToPrepaid: Promise.promisify (prepaid, joiner, done) ->
     data = {
       userID: joiner?.id or joiner


### PR DESCRIPTION
When removing a student from a classroom, if the student is in no other classrooms:
- Inform the teacher that the license will be restored IF they have rights to the license
- Revoke the license

If the student is still in other classrooms, the old behavior still takes place — the student stays enrolled, and the teacher is told they will not get the license back.