### PR TITLE
Fix Level Editor interactions with Box2D

### DIFF
--- a/app/lib/world/box2d.coffee
+++ b/app/lib/world/box2d.coffee
@@ -1,5 +1,4 @@
-# Box2D is defined in global namespace
-Box2D = require('exports-loader?Box2D!vendor/scripts/Box2dWeb-2.1.a.3')
+# Box2D is defined in global namespace by box2d_content
 
 # Used to have Box2DJS, but got rid of it.
 if Box2D?  # box2dweb, compiled from Flash port: https://code.google.com/p/box2dweb/

--- a/app/lib/world/box2d_content.coffee
+++ b/app/lib/world/box2d_content.coffee
@@ -1,0 +1,8 @@
+# This file is a hack to work around some places that depend on window.box2d and
+#   window.BOX2D_ENABLED to be set in a certain order.
+# Especially: Adding a Thang in the Editor needs BOX2D_ENABLED to be false to
+#   prevent trying (and failing) to set up the Collision system for that thang.
+
+
+# This file is included in the world.js bundle, and executed by world_worker.
+window.Box2D = require('exports-loader?Box2D!vendor/scripts/Box2dWeb-2.1.a.3')

--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -23,7 +23,6 @@ EXISTS_ORIGINAL = '524b4150ff92f1f4f8000024'
 COUNTDOWN_LEVELS = ['sky-span']
 window.string_score = require 'vendor/scripts/string_score.js' # Used as a global in DB code
 require 'vendor/scripts/coffeescript' # Install the global CoffeeScript compiler #TODO Performance: Load this only when necessary
-window.box2d = require('lib/world/box2d') # TODO webpack: only load this when necessary
 require('lib/worldLoader') # Install custom hack to dynamically require library files
 
 module.exports = class World

--- a/app/lib/worldLoader.coffee
+++ b/app/lib/worldLoader.coffee
@@ -6,7 +6,6 @@ module.exports = window.libWorldRequire = (path) ->
     when 'lib/world/box2d' then require('lib/world/box2d')
     when 'lib/world/GoalManager' then require('lib/world/GoalManager')
     when 'lib/world/Grid' then require('lib/world/Grid')
-    when 'lib/world/box2d' then require('lib/world/box2d')
     when 'lib/world/component' then require('lib/world/component')
     when 'lib/world/ellipse' then require('lib/world/ellipse')
     when 'lib/world/errors' then require('lib/world/errors')

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -24,7 +24,6 @@ module.exports = (env) => {
         './app/lib/worldLoader',
         './app/core/CocoClass.coffee',
         './app/core/utils.coffee',
-        './vendor/scripts/Box2dWeb-2.1.a.3',
         './vendor/scripts/string_score.js',
         './bower_components/underscore.string',
         './vendor/scripts/coffeescript.js',


### PR DESCRIPTION
This changes the bundling of Box2D to be more similar to the old Brunch setup, by including it and executing it in the World bundle, separately from `lib/box2d` which sets up the global BOX2D_ENABLED when DB code requires `lib/box2d`.

The problem that was occurring before this change was that BOX2D_ENABLED was being set to `true` in the level editor, when it wouldn't have been set before. This caused the Collision system to do work it wouldn't have before when adding a Thang to a level, but it would error out because it wasn't set up enough to do so (missing a `collisionCategory`).

To have the box2d vendor script run, we need it at a root level of an entry point (which we achieve by having it be in an array entry point), but we still need to use `exports-loader` to get it set to `window` correctly. Thus the file `box2d_content` which just wraps it in the necessary `exports-loader`.