### PR TITLE
Add Remove Course button

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1436,6 +1436,7 @@
 
   teacher:
     assigning_course: "Assigning course"
+    removing_course: "Removing course"
     course_solution: "Course Solution"
     level_overview_solutions: "Level Overview and Solutions"
     no_student_assigned: "No students have been assigned this course."
@@ -1507,13 +1508,14 @@
     assigned_msg_2: "{{numberEnrolled}} licenses were applied."
     assigned_msg_3: "You now have {{remainingSpots}} available licenses remaining."
     assign_course: "Assign Course"
+    removed_course_msg: "{{numberRemoved}} students were removed from {{courseName}}."
+    remove_course: "Remove Course"
     not_assigned_modal_title: "Courses were not assigned"
     not_assigned_modal_starter_body_1: "This course requires a Starter License. You do not have enough Starter Licenses available to assign this course to all __selected__ selected students."
     not_assigned_modal_starter_body_2: "Purchase Starter Licenses to grant access to this course."
     not_assigned_modal_full_body_1: "This course requires a Full License. You do not have enough Full Licenses available to assign this course to all __selected__ selected students."
     not_assigned_modal_full_body_2: "You only have __numFullLicensesAvailable__ Full Licenses available (__numStudentsWithoutFullLicenses__ students do not currently have a Full License active)."
     not_assigned_modal_full_body_3: "Please select fewer students, or reach out to __supportEmail__ for assistance."
-    assign_to_selected_students: "Assign to Selected Students"
     assigned: "Assigned"
     enroll_selected_students: "Enroll Selected Students"
     no_students_selected: "No students were selected."

--- a/app/models/CourseInstance.coffee
+++ b/app/models/CourseInstance.coffee
@@ -47,6 +47,17 @@ module.exports = class CourseInstance extends CocoModel
     me.set('courseInstances', _.without(me.get('courseInstances'), @id)) if userID is me.id
     return jqxhr
 
+  removeMembers: (userIDs, opts) ->
+    options = {
+      url: _.result(@, 'url') + '/members'
+      type: 'DELETE'
+      data: { userIDs }
+    }
+    _.extend options, opts
+    jqxhr = @fetch(options)
+    me.set('courseInstances', _.without(me.get('courseInstances'), @id)) if me.id in userIDs
+    return jqxhr
+
   firstLevelURL: ->
     "/play/level/dungeons-of-kithgard?course=#{@get('courseID')}&course-instance=#{@id}"
   

--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -472,7 +472,7 @@ mixin copyCodes
 
 mixin bulkAssignControls
   .bulk-assign-controls.form-inline
-    .no-students-selected.small-details(class=state.get('errors').assigningToNobody ? 'visible' : '')
+    .no-students-selected.small-details(class=state.get('errors').nobodySelected ? 'visible' : '')
       span(data-i18n='teacher.no_students_selected')
     span.small
       span(data-i18n='teacher.bulk_assign')
@@ -483,8 +483,10 @@ mixin bulkAssignControls
           = i18n(course.attributes, 'name')
           if !view.availableCourseMap[course.id]
             = " " + translate('teacher.paren_new')
-    button.btn.btn-primary-alt.assign-to-selected-students(disabled=!view.allStatsLoaded())
-      span(data-i18n='teacher.assign_to_selected_students')
+    button.btn.btn-primary.assign-to-selected-students(disabled=!view.allStatsLoaded())
+      span(data-i18n='teacher.assign_course')
+    button.btn.btn-burgundy-alt.remove-from-selected-students(disabled=!view.allStatsLoaded())
+      span(data-i18n='teacher.remove_course')
 
 mixin enrollmentStatusTab
   // TODO: Have search input in all tabs

--- a/app/views/courses/TeacherClassView.coffee
+++ b/app/views/courses/TeacherClassView.coffee
@@ -48,6 +48,7 @@ module.exports = class TeacherClassView extends RootView
     'click .enroll-student-button': 'onClickEnrollStudentButton'
     'click .revoke-student-button': 'onClickRevokeStudentButton'
     'click .assign-to-selected-students': 'onClickBulkAssign'
+    'click .remove-from-selected-students': 'onClickBulkRemoveCourse'
     'click .export-student-progress-btn': 'onClickExportStudentProgress'
     'click .select-all': 'onClickSelectAll'
     'click .student-checkbox': 'onClickStudentCheckbox'
@@ -63,7 +64,7 @@ module.exports = class TeacherClassView extends RootView
       classCode: ""
       joinURL: ""
       errors:
-        assigningToNobody: false
+        nobodySelected: false
       selectedCourse: undefined
       checkboxStates: {}
       classStats:
@@ -448,11 +449,21 @@ module.exports = class TeacherClassView extends RootView
     return unless me.id is @classroom.get('ownerID') # May be viewing page as admin
     courseID = @$('.bulk-course-select').val()
     selectedIDs = @getSelectedStudentIDs()
-    assigningToNobody = selectedIDs.length is 0
-    @state.set errors: { assigningToNobody }
-    return if assigningToNobody
+    nobodySelected = selectedIDs.length is 0
+    @state.set errors: { nobodySelected }
+    return if nobodySelected
     @assignCourse courseID, selectedIDs
     window.tracker?.trackEvent 'Teachers Class Students Assign Selected', category: 'Teachers', classroomID: @classroom.id, courseID: courseID, ['Mixpanel']
+
+  onClickBulkRemoveCourse: ->
+    return unless me.id is @classroom.get('ownerID') # May be viewing page as admin
+    courseID = @$('.bulk-course-select').val()
+    selectedIDs = @getSelectedStudentIDs()
+    nobodySelected = selectedIDs.length is 0
+    @state.set errors: { nobodySelected }
+    return if nobodySelected
+    @removeCourse courseID, selectedIDs
+    window.tracker?.trackEvent 'Teachers Class Students Remove-Course Selected', category: 'Teachers', classroomID: @classroom.id, courseID: courseID, ['Mixpanel']
 
   assignCourse: (courseID, members) ->
     return unless me.id is @classroom.get('ownerID') # May be viewing page as admin
@@ -531,7 +542,7 @@ module.exports = class TeacherClassView extends RootView
         noty text: $.i18n.t('teacher.assigning_course'), layout: 'center', type: 'information', killer: true
         return courseInstance.addMembers(members)
 
-    # Show a success/errror notification
+    # Show a success/error notification
     .then =>
       course = @courses.get(courseID)
       lines = [
@@ -560,6 +571,41 @@ module.exports = class TeacherClassView extends RootView
       throw e if e instanceof Error and not application.isProduction()
       text = if e instanceof Error then 'Runtime error' else e.responseJSON?.message or e.message or $.i18n.t('loading_error.unknown')
       noty { text, layout: 'center', type: 'error', killer: true, timeout: 5000 }
+  
+  removeCourse: (courseID, members) ->
+    return unless me.id is @classroom.get('ownerID') # May be viewing page as admin
+    courseInstance = null
+    numberRemoved = 0
+
+    return Promise.resolve()
+    # Find the necessary course instance
+    .then =>
+      courseInstance = @courseInstances.findWhere({ courseID, classroomID: @classroom.id })
+      # if not courseInstance
+      # TODO: show some message if no courseInstance?
+      return courseInstance
+
+    # Remove the students from the course instance
+    .then =>
+      @fetchStudents()
+
+      @trigger 'begin-remove-course' # Only used for test automation
+      if members.length
+        noty text: $.i18n.t('teacher.removing_course'), layout: 'center', type: 'information', killer: true
+        return courseInstance?.removeMembers(members)
+
+    # Show a success/error notification
+    .then =>
+      course = @courses.get(courseID)
+      lines = [
+        $.i18n.t('teacher.removed_course_msg')
+          .replace('{{numberRemoved}}', members.length)
+          .replace('{{courseName}}', course.get('name'))
+      ]
+      noty text: lines.join('<br />'), layout: 'center', type: 'information', killer: true, timeout: 5000
+
+      @calculateProgressAndLevels()
+      @classroom.fetch()
 
   onClickRevokeStudentButton: (e) ->
     button = $(e.currentTarget)

--- a/server/middleware/course-instances.coffee
+++ b/server/middleware/course-instances.coffee
@@ -58,6 +58,7 @@ module.exports =
     if not (course.get('free') or userPrepaidsIncludeCourse)
       throw new errors.PaymentRequired('Cannot add users to a course instance until they are added to a prepaid that includes this course')
 
+    # Update the course to latest if nobody is in it yet
     unless courseInstance.get('members')?.length
       {oldCourseCount, newCourseCount, oldLevelCount, newLevelCount} = yield classroom.setUpdatedCourse({courseId})
       database.validateDoc(classroom)
@@ -84,6 +85,53 @@ module.exports =
 
     res.status(200).send(courseInstance.toObject({ req }))
 
+  removeMembers: wrap (req, res) ->
+    if req.body.userID
+      userIDs = [req.body.userID]
+    else if req.body.userIDs
+      userIDs = req.body.userIDs
+    else
+      throw new errors.UnprocessableEntity('Must provide userID or userIDs')
+
+    for userID in userIDs
+      unless _.all userIDs, database.isID
+        throw new errors.UnprocessableEntity('Invalid list of user IDs')
+
+    courseInstance = yield database.getDocFromHandle(req, CourseInstance)
+    if not courseInstance
+      throw new errors.NotFound('Course Instance not found.')
+    courseId = courseInstance.get('courseID')
+
+    classroom = yield Classroom.findById courseInstance.get('classroomID')
+    if not classroom
+      throw new errors.NotFound('Classroom not found.')
+
+    classroomMembers = (userID.toString() for userID in classroom.get('members'))
+    unless _.all(userIDs, (userID) -> _.contains classroomMembers, userID)
+      throw new errors.Forbidden('Users must be members of classroom')
+
+    ownsClassroom = classroom.get('ownerID').equals(req.user._id)
+    removingSelf = userIDs.length is 1 and userIDs[0] is req.user.id
+    unless ownsClassroom or removingSelf
+      throw new errors.Forbidden('You must own the classroom to remove members')
+
+    course = yield Course.findById courseId
+    throw new errors.NotFound('Course referenced by course instance not found') unless course
+    
+    userObjectIDs = (mongoose.Types.ObjectId(userID) for userID in userIDs)
+
+    courseInstance = yield CourseInstance.findByIdAndUpdate(
+      courseInstance._id,
+      { $pull: { members: { $in: userObjectIDs } } }
+      { new: true }
+    )
+
+    userUpdateResult = yield User.update(
+      { _id: { $in: userObjectIDs } },
+      { $pull: { courseInstances: courseInstance._id } }
+    )
+    
+    res.status(200).send(courseInstance.toObject({ req }))
 
   fetchNextLevel: wrap (req, res) ->
     unless req.user? then return res.status(200).send({})

--- a/server/routes/index.coffee
+++ b/server/routes/index.coffee
@@ -166,6 +166,7 @@ module.exports.setup = (app) ->
   app.post('/db/course_instance/-/recent', mw.auth.checkHasPermission(['admin']), mw.courseInstances.fetchRecent)
   app.get('/db/course_instance/:handle/levels/:levelOriginal/sessions/:sessionID/next', mw.courseInstances.fetchNextLevel)
   app.post('/db/course_instance/:handle/members', mw.auth.checkLoggedIn(), mw.courseInstances.addMembers)
+  app.delete('/db/course_instance/:handle/members', mw.auth.checkLoggedIn(), mw.courseInstances.removeMembers)
   app.get('/db/course_instance/:handle/classroom', mw.auth.checkLoggedIn(), mw.courseInstances.fetchClassroom)
   app.get('/db/course_instance/:handle/course', mw.auth.checkLoggedIn(), mw.courseInstances.fetchCourse)
   app.get('/db/course_instance/:handle/my-course-level-sessions', mw.auth.checkLoggedIn(), mw.courseInstances.fetchMyCourseLevelSessions)

--- a/spec/server/functional/course_instance.spec.coffee
+++ b/spec/server/functional/course_instance.spec.coffee
@@ -313,8 +313,9 @@ describe 'DELETE /db/course_instance/:id/members', ->
     @campaign = yield utils.makeCampaign({}, {levels: [@level]})
     @course = yield utils.makeCourse({free: true, releasePhase: 'released'}, {campaign: @campaign})
     @student = yield utils.initUser({role: 'student'})
+    @student2 = yield utils.initUser({role: 'student'})
     @prepaid = yield utils.makePrepaid({creator: @teacher.id})
-    members = [@student]
+    members = [@student, @student2]
     yield utils.loginUser(@teacher)
     @classroom = yield utils.makeClassroom({aceConfig: { language: 'javascript' }}, { members })
     @courseInstance = yield utils.makeCourseInstance({}, { @course, @classroom })
@@ -337,23 +338,50 @@ describe 'DELETE /db/course_instance/:id/members', ->
     }).save()
     done()
 
-  it 'removes a member to the given CourseInstance', utils.wrap (done) ->
-    url = getURL("/db/course_instance/#{@courseInstance.id}/members")
-    [res, body] = yield request.delAsync {uri: url, json: {userID: @student.id}}
-    expect(res.statusCode).toBe(200)
-    expect(res.body.members.length).toBe(0)
-    done()
+  describe 'when removing one member', ->
+    it 'removes a member from the given CourseInstance', utils.wrap (done) ->
+      url = getURL("/db/course_instance/#{@courseInstance.id}/members")
+      [res, body] = yield request.delAsync {uri: url, json: {userID: @student.id}}
+      expect(res.statusCode).toBe(200)
+      expect(res.body.members.length).toBe(0)
+      done()
 
-  it 'removes the CourseInstance from the User.courseInstances', utils.wrap (done) ->
-    url = getURL("/db/course_instance/#{@courseInstance.id}/members")
-    user = yield User.findById(@student.id)
-    expect(_.size(user.get('courseInstances'))).toBe(1)
-    [res, body] = yield request.delAsync {uri: url, json: {userID: @student.id}}
-    expect(res.statusCode).toBe(200)
-    expect(res.body.members.length).toBe(0)
-    user = yield User.findById(@student.id)
-    expect(_.size(user.get('courseInstances'))).toBe(0)
-    done()
+    it 'removes the CourseInstance from the User.courseInstances', utils.wrap (done) ->
+      url = getURL("/db/course_instance/#{@courseInstance.id}/members")
+      user = yield User.findById(@student.id)
+      expect(_.size(user.get('courseInstances'))).toBe(1)
+      [res, body] = yield request.delAsync {uri: url, json: {userID: @student.id}}
+      expect(res.statusCode).toBe(200)
+      expect(res.body.members.length).toBe(0)
+      user = yield User.findById(@student.id)
+      expect(_.size(user.get('courseInstances'))).toBe(0)
+      done()
+
+  describe 'when removing multiple members', ->
+    beforeEach utils.wrap ->
+      url = getURL("/db/course_instance/#{@courseInstance.id}/members")
+      [res, body] = yield request.postAsync {uri: url, json: {userID: @student2.id}}
+
+    it 'removes the members from the given CourseInstance', utils.wrap (done) ->
+      url = getURL("/db/course_instance/#{@courseInstance.id}/members")
+      [res, body] = yield request.getAsync {uri: url, json: true}
+      expect(res.body.length).toBe(2)
+      [res, body] = yield request.delAsync {uri: url, json: {userIDs: [@student.id, @student2.id]}}
+      expect(res.statusCode).toBe(200)
+      expect(res.body.members.length).toBe(0)
+      done()
+
+    it 'removes the CourseInstance from the User.courseInstances', utils.wrap (done) ->
+      url = getURL("/db/course_instance/#{@courseInstance.id}/members")
+      user = yield User.findById(@student.id)
+      expect(_.size(user.get('courseInstances'))).toBe(1)
+      [res, body] = yield request.delAsync {uri: url, json: {userIDs: [@student.id, @student2.id]}}
+      expect(res.statusCode).toBe(200)
+      expect(res.body.members.length).toBe(0)
+      user = yield User.findById(@student.id)
+      expect(_.size(user.get('courseInstances'))).toBe(0)
+      done()
+
 
 describe 'GET /db/course_instance/:handle/levels/:levelOriginal/next', ->
 


### PR DESCRIPTION
Adds a "Remove Course" button alongside bulk-assign "Assign Course" button.

Most of the code here is shared/pared down from the analogous functionality for adding, with only minor changes (mostly removing logic that's only needed for adding, like creating course instances or auto-enrolling them).