### PR TITLE
Add AWS HoC tracking events

### DIFF
--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -168,7 +168,11 @@ module.exports = class Tracker extends CocoClass
 
   trackSnowplow: (event, properties) =>
     return if me.isSmokeTestUser()
-    return if event in ['Simulator Result', 'Started Level Load', 'Finished Level Load']
+    return if event in [
+      'Simulator Result',
+      'Started Level Load', 'Finished Level Load',
+      'Start HoC Campaign', 'Show Amazon Modal Button', 'Click Amazon Modal Button', 'Click Amazon link',
+    ]
     # Trimming properties we don't use internally
     # TODO: delete properites.level for 'Saw Victory' after 2/8/15.  Should be using levelID instead.
     if event in ['Clicked Start Level', 'Inventory Play', 'Heard Sprite', 'Started Level', 'Saw Victory', 'Click Play', 'Choose Inventory', 'Homepage Loaded', 'Change Hero']

--- a/app/templates/play/modal/amazon-hoc-modal.jade
+++ b/app/templates/play/modal/amazon-hoc-modal.jade
@@ -15,7 +15,7 @@
       p
         span(data-i18n="amazon_hoc.educate_1") 
         =" "
-        a(href="https://aws.amazon.com/education/awseducate/" data-i18n="amazon_hoc.educate_2")
+        a#aws-educate-link(href="https://aws.amazon.com/education/awseducate/" data-i18n="amazon_hoc.educate_2")
         span .
       
       img(src="/images/pages/play/future-engineer-logo.png")
@@ -23,10 +23,10 @@
       p
         span(data-i18n="amazon_hoc.future_eng_1")
         =" "
-        a(href="https://learn.amazonfutureengineer.com/alexa/fact-skill/#/" data-i18n="amazon_hoc.future_eng_2")
+        a#aws-alexa-link(href="https://learn.amazonfutureengineer.com/alexa/fact-skill/#/" data-i18n="amazon_hoc.future_eng_2")
         =" "
         span(data-i18n="amazon_hoc.future_eng_3")
         =" "
-        a(href="http://amazonfutureengineer.com/" data-i18n="amazon_hoc.future_eng_4")
+        a#aws-future-eng-link(href="http://amazonfutureengineer.com/" data-i18n="amazon_hoc.future_eng_4")
         =" "
         span(data-i18n="amazon_hoc.future_eng_5")

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -119,6 +119,8 @@ module.exports = class CampaignView extends RootView
               application.router.navigate((if me.isStudent() then '/students' else '/teachers'), {trigger: true, replace: true})
               noty({text: 'Please create or join a classroom first', layout: 'topCenter', timeout: 8000, type: 'success'})
           return
+      if @terrain is 'game-dev-hoc'
+        window.tracker?.trackEvent 'Start HoC Campaign', label: 'game-dev-hoc'
       me.set('hourOfCode', true)
       me.patch()
       pixelCode = switch @terrain

--- a/app/views/play/level/modal/HeroVictoryModal.coffee
+++ b/app/views/play/level/modal/HeroVictoryModal.coffee
@@ -77,6 +77,9 @@ module.exports = class HeroVictoryModal extends ModalView
     if @level.get('shareable') is 'project'
       @shareURL = "#{window.location.origin}/play/#{@level.get('type')}-level/#{@session.id}"
 
+    @trackAwsButtonShown = _.once ->
+      window.tracker?.trackEvent 'Show Amazon Modal Button'
+
   destroy: ->
     clearInterval @sequentialAnimationInterval
     @saveReview() if @$el.find('.review textarea').val()
@@ -221,6 +224,8 @@ module.exports = class HeroVictoryModal extends ModalView
       # Show the "I'm done" button between 30 - 120 minutes if they definitely came from Hour of Code
       c.showHourOfCodeDoneButton = showDone
       @showAmazonHocButton = (gameDevHoc is 'game-dev-hoc') and lastLevel
+      if @showAmazonHocButton
+        @trackAwsButtonShown()
       @showHoc2016ExploreButton = gameDevHoc and lastLevel
 
     c.showLeaderboard = @level.get('scoreTypes')?.length > 0 and not @level.isType('course') and not @showAmazonHocButton and not @showHoc2016ExploreButton
@@ -527,6 +532,7 @@ module.exports = class HeroVictoryModal extends ModalView
     @tryCopy()
 
   onClickAmazonHocButton: ->
+    window.tracker?.trackEvent 'Click Amazon Modal Button'
     @openModalView new AmazonHocModal()
 
   onSubscribeButtonClicked: ->

--- a/app/views/play/modal/AmazonHocModal.coffee
+++ b/app/views/play/modal/AmazonHocModal.coffee
@@ -8,3 +8,15 @@ module.exports = class AmazonHocModal extends ModalView
 
   events:
     'click #close-modal': 'hide'
+    'mouseup #aws-educate-link': 'onClickAwsEducateLink' # mouseup detects middle click as well
+    'mouseup #aws-alexa-link': 'onClickAwsAlexaLink'
+    'mouseup #aws-future-eng-link': 'onClickAwsFutureEngLink'
+  
+  onClickAwsEducateLink: ->
+    window.tracker?.trackEvent 'Click Amazon link', label: 'aws-educate-link'
+  
+  onClickAwsAlexaLink: ->
+    window.tracker?.trackEvent 'Click Amazon link', label: 'aws-alexa-link'
+    
+  onClickAwsFutureEngLink: ->
+    window.tracker?.trackEvent 'Click Amazon link', label: 'aws-future-eng-link'


### PR DESCRIPTION
Adds analytics events for AWS HoC buttons/links.

Please sanity check if any snowplow or schema things may break with this in production.

Please check if the values given to trackEvent make sense.

A single user may trigger any of these multiple times, so for the ones where we want unique counts we'll need to do aggregation with that in mind.