### PR TITLE
Update d3 to version 4.12.0 to remove contextify

### DIFF
--- a/app/core/d3_utils.coffee
+++ b/app/core/d3_utils.coffee
@@ -1,4 +1,4 @@
-# Caller needs require 'd3/d3.js'
+# Caller needs require 'd3'
 
 module.exports.createContiguousDays = (timeframeDays, skipToday=true, dayOffset=0) ->
   # Return list of last 'timeframeDays' contiguous days in yyyy-mm-dd format

--- a/app/views/admin/AnalyticsSubscriptionsView.coffee
+++ b/app/views/admin/AnalyticsSubscriptionsView.coffee
@@ -6,7 +6,7 @@ User = require 'models/User'
 
 # TODO: Graphing code copied/mangled from campaign editor level view.  OMG, DRY.
 
-require 'd3/d3.js'
+require 'd3'
 
 module.exports = class AnalyticsSubscriptionsView extends RootView
   id: 'admin-analytics-subscriptions-view'

--- a/app/views/admin/AnalyticsView.coffee
+++ b/app/views/admin/AnalyticsView.coffee
@@ -2,7 +2,7 @@ require('app/styles/admin/analytics.sass')
 CocoCollection = require 'collections/CocoCollection'
 Course = require 'models/Course'
 CourseInstance = require 'models/CourseInstance'
-require 'd3/d3.js'
+require 'd3'
 d3Utils = require 'core/d3_utils'
 Payment = require 'models/Payment'
 RootView = require 'views/core/RootView'

--- a/app/views/editor/campaign/CampaignAnalyticsModal.coffee
+++ b/app/views/editor/campaign/CampaignAnalyticsModal.coffee
@@ -1,7 +1,7 @@
 require('app/styles/editor/campaign/campaign-analytics-modal.sass')
 template = require 'templates/editor/campaign/campaign-analytics-modal'
 utils = require 'core/utils'
-require 'd3/d3.js' # TODO Webpack: Extract this modal from main chunk
+require 'd3' # TODO Webpack: Extract this modal from main chunk
 ModalView = require 'views/core/ModalView'
 
 # TODO: jquery-ui datepicker doesn't work well in this view

--- a/app/views/ladder/LadderTabView.coffee
+++ b/app/views/ladder/LadderTabView.coffee
@@ -8,7 +8,7 @@ User = require 'models/User'
 LeaderboardCollection  = require 'collections/LeaderboardCollection'
 {teamDataFromLevel} = require './utils'
 ModelModal = require 'views/modal/ModelModal'
-require 'd3/d3.js'
+require 'd3'
 CreateAccountModal = require 'views/core/CreateAccountModal'
 utils = require 'core/utils'
 

--- a/app/views/ladder/MyMatchesTabView.coffee
+++ b/app/views/ladder/MyMatchesTabView.coffee
@@ -5,7 +5,7 @@ LevelSession = require 'models/LevelSession'
 LeaderboardCollection  = require 'collections/LeaderboardCollection'
 LadderSubmissionView = require 'views/play/common/LadderSubmissionView'
 {teamDataFromLevel} = require './utils'
-require 'd3/d3.js'
+require 'd3'
 
 module.exports = class MyMatchesTabView extends CocoView
   id: 'my-matches-tab-view'

--- a/app/views/teachers/TeacherStudentView.coffee
+++ b/app/views/teachers/TeacherStudentView.coffee
@@ -9,7 +9,7 @@ LevelSessions = require 'collections/LevelSessions'
 User = require 'models/User'
 Users = require 'collections/Users'
 CourseInstances = require 'collections/CourseInstances'
-require 'd3/d3.js'
+require 'd3'
 utils = require 'core/utils'
 
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "cookie-session": "^1.2.0",
     "country-list": "0.0.3",
     "css-loader": "^0.25.0",
-    "d3": "~3.4.4",
+    "d3": "4.12.0",
     "esper.js": "codecombat/esper.js",
     "event-hooks-webpack-plugin": "^1.0.0",
     "express": "^4.14.0",


### PR DESCRIPTION
Hi nick，I am berlin. I get a error when run `npm install` , you advised me to upgrading d3 to version 4.12.0 to remove contextify and it work. so I submit a pull request