### PR TITLE
HoC perf improvements

### DIFF
--- a/app/templates/play/level/modal/hero-victory-modal.jade
+++ b/app/templates/play/level/modal/hero-victory-modal.jade
@@ -166,7 +166,7 @@ block modal-footer-content
       button.btn.btn-illustrated.btn-success.btn-lg.world-map-button.next-level-button.hide#continue-button(data-i18n="common.continue") Continue
 
   if !me.get('anonymous') && !showHourOfCodeDoneButton && !features.codePlay && showLeaderboard
-    button.btn.btn-illustrated.btn-success.leaderboard-button.btn-lg(data-dismiss="modal", data-i18n="leaderboard.view_other_solutions")
+    //button.btn.btn-illustrated.btn-success.leaderboard-button.btn-lg(data-dismiss="modal", data-i18n="leaderboard.view_other_solutions")
   else if showReturnToCourse
     button.btn.btn-illustrated.btn-warning.return-to-course-button.btn-lg(data-dismiss="modal", data-i18n="play_level.victory_go_home") Go Home
 

--- a/app/views/ladder/LadderTabView.coffee
+++ b/app/views/ladder/LadderTabView.coffee
@@ -352,7 +352,10 @@ module.exports.LeaderboardData = LeaderboardData = class LeaderboardData extends
         success = (@myRank) =>
         loadURL = "/db/level/#{level}/leaderboard_rank?scoreOffset=#{score}&team=#{@team}"
         loadURL += '&leagues.leagueID=' + @league.id if @league
-        promises.push $.ajax(loadURL, cache: false, success: success)
+        $.ajax(loadURL, cache: false, success: success).then =>
+          # still try to load ranks, but if they fail, do show the rest of the ladder
+          if @loaded
+            @trigger 'sync', @
     @promise = $.when(promises...)
     @promise.then @onLoad
     @promise.fail @onFail

--- a/app/views/ladder/MainLadderView.coffee
+++ b/app/views/ladder/MainLadderView.coffee
@@ -24,7 +24,7 @@ module.exports = class MainLadderView extends RootView
     @sessions = @supermodel.loadCollection(new LevelSessionsCollection(), 'your_sessions', {cache: false}, 0).model
     @listenToOnce @sessions, 'sync', @onSessionsLoaded
 
-    @getLevelPlayCounts()
+#    @getLevelPlayCounts()
 
   onSessionsLoaded: (e) ->
     for session in @sessions.models

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -1260,6 +1260,9 @@ module.exports = class CampaignView extends RootView
   shouldShow: (what) ->
     isStudentOrTeacher = me.isStudent() or me.isTeacher()
     isIOS = me.get('iosIdentifierForVendor') || application.isIPadApp
+    
+    if what is 'leaderboard'
+      return false
 
     if what is 'classroom-level-play-button'
       isValidStudent = (me.isStudent() and me.get('courseInstances')?.length)

--- a/server/handlers/level_handler.coffee
+++ b/server/handlers/level_handler.coffee
@@ -124,7 +124,8 @@ LevelHandler = class LevelHandler extends Handler
   getMyLeaderboardRank: (req, res, id) ->
     req.query.order = 1
     sessionsQueryParameters = @makeLeaderboardQueryParameters(req, id)
-    Session.count sessionsQueryParameters, (err, count) =>
+    t0 = new Date()
+    Session.count(sessionsQueryParameters).setOptions({maxTimeMS:200}).exec (err, count) =>
       return @sendDatabaseError(res, err) if err
       res.send JSON.stringify(count + 1)
 

--- a/server/middleware/course-instances.coffee
+++ b/server/middleware/course-instances.coffee
@@ -277,7 +277,7 @@ module.exports =
         {creator: req.user.id},
         { $or }
       ]}
-      levelSessions = yield LevelSession.find(query).select(parse.getProjectFromReq(req))
+      levelSessions = yield LevelSession.find(query).setOptions({maxTimeMS:1000}).select(parse.getProjectFromReq(req))
       res.send(session.toObject({req}) for session in levelSessions)
     else
       res.send []

--- a/server/models/Classroom.coffee
+++ b/server/models/Classroom.coffee
@@ -166,7 +166,7 @@ ClassroomSchema.methods.fetchSessionsForMembers = co.wrap (members) ->
         $or.push(_.assign({creator: member.toHexString()}, subQuery))
     if $or.length
       query = { $or }
-      dbqs.push(LevelSession.find(query).select(select).lean().exec())
+      dbqs.push(LevelSession.find(query).setOptions({maxTimeMS:500}).select(select).lean().exec())
   results = yield dbqs
   return _.flatten(results)
 


### PR DESCRIPTION
* disable leaderboard on campaign view
* add timeout to leaderboard rank endpoint, add handling to LadderTabView for it failing
* turn off level play counts on /play/ladder
* add timeout for fetching sessions for teachers and students