### PR TITLE
Improve simulation sampling

### DIFF
--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -264,7 +264,6 @@ module.exports = class LevelLoader extends CocoClass
         languageModuleResource = @supermodel.addSomethingResource "language_module_#{codeLanguage}"
         resources.push(languageModuleResource)
         loadAetherLanguage(codeLanguage).then (aetherLang) =>
-          console.log "Marking lang loaded:", aetherLang
           languageModuleResource.markLoaded()
     return resources
 
@@ -390,7 +389,7 @@ module.exports = class LevelLoader extends CocoClass
     reason = @getReasonForNotYetLoaded()
     console.debug('LevelLoader: Reason not loaded:', reason)
     return !reason
-    
+
   getReasonForNotYetLoaded: ->
     return 'worldNecessities still loading' unless _.filter(@worldNecessities).length is 0
     return 'thang names need to load' unless @thangNamesLoaded

--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -669,7 +669,10 @@ module.exports = class World
 
   teamForPlayer: (n) ->
     playableTeams = @playableTeams ? ['humans']
-    playableTeams[n % playableTeams.length]
+    if n?
+      playableTeams[n % playableTeams.length]
+    else
+      _.sample playableTeams  # Pick at random for good distribution
 
   getScores: ->
     time: @age

--- a/app/views/ladder/LadderTabView.coffee
+++ b/app/views/ladder/LadderTabView.coffee
@@ -188,7 +188,7 @@ module.exports = class LadderTabView extends CocoView
       histogramData = null
       $.when(
         level = "#{@level.get('original')}.#{@level.get('version').major}"
-        url = "/db/level/#{level}/histogram_data?team=#{team.name.toLowerCase()}"
+        url = "/db/level/#{level}/histogram_data?team=#{team.name.toLowerCase()}&levelSlug=#{@level.get('slug')}"
         url += '&leagues.leagueID=' + @options.league.id if @options.league
         $.get url, (data) -> histogramData = data
       ).then =>
@@ -353,7 +353,7 @@ module.exports.LeaderboardData = LeaderboardData = class LeaderboardData extends
         promises.push @playersBelow.fetch cache: false
         level = "#{@level.get('original')}.#{@level.get('version').major}"
         success = (@myRank) =>
-        loadURL = "/db/level/#{level}/leaderboard_rank?scoreOffset=#{score}&team=#{@team}"
+        loadURL = "/db/level/#{level}/leaderboard_rank?scoreOffset=#{score}&team=#{@team}&levelSlug=#{@level.get('slug')}"
         loadURL += '&leagues.leagueID=' + @league.id if @league
         promises.push $.ajax(loadURL, cache: false, success: success)
     @promise = $.when(promises...)

--- a/app/views/ladder/SimulateTabView.coffee
+++ b/app/views/ladder/SimulateTabView.coffee
@@ -24,7 +24,7 @@ module.exports = class SimulateTabView extends CocoView
   onLoaded: ->
     super()
     @render()
-    if (document.location.hash is '#simulate' or @options.level.isType('course-ladder')) and not @simulator
+    if not @simulator and (document.location.hash is '#simulate' or @options.level.get('slug') not in ['ace-of-coders', 'zero-sum'])
       @startSimulating()
 
   afterRender: ->

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -223,7 +223,8 @@ module.exports = class PlayLevelView extends RootView
     console.debug('PlayLevelView: world necessities loaded')
     # Called when we have enough to build the world, but not everything is loaded
     @grabLevelLoaderData()
-    team = utils.getQueryVariable('team') ?  @session.get('team') ? @world?.teamForPlayer(0) ? 'humans'
+    randomTeam = @world?.teamForPlayer()  # If no team is set, then we will want to equally distribute players to teams
+    team = utils.getQueryVariable('team') ?  @session.get('team') ? randomTeam ? 'humans'
     @loadOpponentTeam(team)
     @setupGod()
     @setTeam team

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -8,6 +8,7 @@ ThangType = require 'models/ThangType'
 utils = require 'core/utils'
 storage = require 'core/storage'
 {createAetherOptions} = require 'lib/aether_utils'
+loadAetherLanguage = require 'lib/loadAetherLanguage'
 
 # tools
 Surface = require 'lib/surface/Surface'
@@ -535,14 +536,13 @@ module.exports = class PlayLevelView extends RootView
 
   perhapsStartSimulating: ->
     return unless @shouldSimulate()
-    return console.error "Should not auto-simulate until we fix how these languages are loaded"
-    # TODO: how can we not require these as part of /play bundle?
-    #require 'bower_components/aether/build/javascript'
-    #require 'bower_components/aether/build/python'
-    #require 'bower_components/aether/build/coffeescript'
-    #require 'bower_components/aether/build/lua'
-    #require 'bower_components/aether/build/java'
-    @simulateNextGame()
+    languagesToLoad = ['javascript', 'python', 'coffeescript', 'lua']  # java
+    for language in languagesToLoad
+      do (language) =>
+        loadAetherLanguage(language).then (aetherLang) =>
+          languagesToLoad = _.without languagesToLoad, language
+          if not languagesToLoad.length
+            @simulateNextGame()
 
   simulateNextGame: ->
     return @simulator.fetchAndSimulateOneGame() if @simulator
@@ -564,7 +564,6 @@ module.exports = class PlayLevelView extends RootView
   shouldSimulate: ->
     return true if utils.getQueryVariable('simulate') is true
     return false if utils.getQueryVariable('simulate') is false
-    stillBuggy = true  # Keep this true while we still haven't fixed the zombie worker problem when simulating the more difficult levels on Chrome
     defaultCores = 2
     cores = window.navigator.hardwareConcurrency or defaultCores  # Available on Chrome/Opera, soon Safari
     defaultHeapLimit = 793000000
@@ -575,30 +574,27 @@ module.exports = class PlayLevelView extends RootView
     return false if $.browser?.msie or $.browser?.msedge
     return false if $.browser.linux
     return false if me.level() < 8
+    return false if @level.get('slug') in ['zero-sum', 'ace-of-coders']
     if @level.isType('course', 'game-dev', 'web-dev')
       return false
     else if @level.isType('hero') and gamesSimulated
-      return false if stillBuggy
       return false if cores < 8
       return false if heapLimit < defaultHeapLimit
       return false if @loadDuration > 10000
     else if @level.isType('hero-ladder') and gamesSimulated
-      return false if stillBuggy
       return false if cores < 4
       return false if heapLimit < defaultHeapLimit
       return false if @loadDuration > 15000
     else if @level.isType('hero-ladder') and not gamesSimulated
-      return false if stillBuggy
       return false if cores < 8
       return false if heapLimit <= defaultHeapLimit
-      return false if @loadDuration > 20000
+      return false if @loadDuration > 12000
     else if @level.isType('course-ladder')
       return false if cores <= defaultCores
       return false if heapLimit < defaultHeapLimit
       return false if @loadDuration > 18000
     else
       console.warn "Unwritten level type simulation heuristics; fill these in for new level type #{@level.get('type')}?"
-      return false if stillBuggy
       return false if cores < 8
       return false if heapLimit < defaultHeapLimit
       return false if @loadDuration > 10000

--- a/app/views/play/level/tome/CastButtonView.coffee
+++ b/app/views/play/level/tome/CastButtonView.coffee
@@ -35,7 +35,7 @@ module.exports = class CastButtonView extends CocoView
     # mirror level is added to
     @loadMirrorSession() if @options.level.get('slug') in ['ace-of-coders', 'elemental-wars', 'the-battle-of-sky-span', 'tesla-tesoro', 'escort-duty']
     @mirror = @mirrorSession?
-    @autoSubmitsToLadder = @options.level.get('slug') in ['wakka-maul']
+    @autoSubmitsToLadder = @options.level.isType('course-ladder')
     # Show publish CourseVictoryModal if they've already published
     if options.session.get('published')
       Backbone.Mediator.publish 'level:show-victory', { showModal: true, manual: false }

--- a/server/handlers/level_handler.coffee
+++ b/server/handlers/level_handler.coffee
@@ -12,6 +12,7 @@ Campaign = require '../models/Campaign'
 Course = require  '../models/Course'
 CourseInstance = require '../models/CourseInstance'
 Classroom = require '../models/Classroom'
+simpleCache = require '../lib/simpleCache'
 
 LevelHandler = class LevelHandler extends Handler
   modelClass: Level
@@ -80,6 +81,7 @@ LevelHandler = class LevelHandler extends Handler
         valueArray = _.pluck data, (session) -> _.find(session.leagues, leagueID: league)?.stats?.totalScore or 10
       else
         valueArray = _.pluck data, 'totalScore'
+        simpleCache.setLadderScores req.query.levelSlug, match.team, valueArray
       @sendSuccess res, valueArray
 
   checkExistence: (req, res, slugOrID) ->
@@ -124,9 +126,11 @@ LevelHandler = class LevelHandler extends Handler
   getMyLeaderboardRank: (req, res, id) ->
     req.query.order = 1
     sessionsQueryParameters = @makeLeaderboardQueryParameters(req, id)
-    Session.count(sessionsQueryParameters).setOptions({maxTimeMS:1000}).exec (err, count) =>
+    Session.count(sessionsQueryParameters).setOptions({maxTimeMS:200}).exec (err, count) =>
       if err and err.message is 'operation exceeded time limit'
         rank = "unknown"
+        if not sessionsQueryParameters['leagues.leagueID'] and req.query.levelSlug
+          rank = simpleCache.getLadderRank(req.query.levelSlug, req.query.team, req.query.scoreOffset) or rank
       else if err
         return @sendDatabaseError(res, err)
       else

--- a/server/lib/simpleCache.coffee
+++ b/server/lib/simpleCache.coffee
@@ -1,0 +1,20 @@
+_ = require 'lodash'
+
+module.exports = simpleCache = 
+  # We use mongoose-cache to aggressively cache requests for ladder score distributions for the histograms.
+  # We'd like access to those results outside of that same query for ladder simulations and leaderboard rank indexing.
+  # This simple cache is another place to put the latest score distributions for those purposes.
+  ladderScores: {}
+
+  getLadderScores: (levelSlug, team) ->
+    simpleCache.ladderScores[levelSlug]?[team]
+
+  setLadderScores: (levelSlug, team, scores) ->
+    simpleCache.ladderScores[levelSlug] ?= {}
+    simpleCache.ladderScores[levelSlug][team] = scores
+
+  getLadderRank: (levelSlug, team, totalScore) ->
+    scores = simpleCache.getLadderScores levelSlug, team
+    return null unless scores
+    sessionIndex = _.sortedIndex scores, totalScore, (index) -> -index  # Descending order
+    sessionIndex + 1

--- a/server/queues/scoring/getTwoGames.coffee
+++ b/server/queues/scoring/getTwoGames.coffee
@@ -4,6 +4,7 @@ errors = require '../../commons/errors'
 scoringUtils = require './scoringUtils'
 LevelSession = require '../../models/LevelSession'
 Mandate = require '../../models/Mandate'
+simpleCache = require '../../lib/simpleCache'
 
 module.exports = getTwoGames = (req, res) ->
   #return errors.unauthorized(res, 'You need to be logged in to get games.') unless req.user?.get('email')
@@ -19,7 +20,8 @@ module.exports = getTwoGames = (req, res) ->
       background: req.body.background
       levelID: req.body.levelID
       leagueID: req.body.leagueID
-    getRandomSessions req.user, options, sendSessionsResponse(res)
+      user: req.user
+    getRandomSessions options, sendSessionsResponse(res)
 
 sessionSelectionString = 'team totalScore submittedCode submittedCodeLanguage teamSpells levelID creatorName creator submitDate leagues'
 
@@ -41,40 +43,54 @@ getSpecificSession = (sessionID, callback) ->
     if err? then return callback "Couldn\'t find target simulation session #{sessionID}"
     callback null, session
 
-getRandomSessions = (user, options, callback) ->
+getRandomSessions = (options, callback) ->
   # Determine whether to play a random match, an internal league match, or an external league match.
   # Only people in a league will end up simulating internal league matches (for leagues they're in) except by dumb chance.
   # If we don't like that, we can rework sampleByLevel to have an opportunity to switch to internal leagues if the first session had a league affiliation.
   if not leagueID = options.leagueID
-    leagueIDs = user?.get('clans') or []
-    leagueIDs = leagueIDs.concat user?.get('courseInstances') or []
+    leagueIDs = options.user?.get('clans') or []
+    leagueIDs = leagueIDs.concat options.user?.get('courseInstances') or []
     leagueIDs = (leagueID + '' for leagueID in leagueIDs)  # Make sure to fetch them as strings.
     return sampleByLevel options, callback unless leagueIDs.length and Math.random() > 1 / leagueIDs.length
-    leagueID = _.sample leagueIDs
-  queryParameters = {'leagues.leagueID': leagueID}
+    options.leagueID = _.sample leagueIDs
+  queryParameters = {'leagues.leagueID': options.leagueID}
   queryParameters.levelID = options.levelID if options.levelID
-  findRandomSession queryParameters, (err, session) ->
+  nextStep = makeGetSecondRandomLeagueSession options, callback
+  if Math.random() < 0.5 and options.user and not options.user.isTeacher()
+    # Prioritize simulating own games
+    LevelSession.find(_.assign({creator: options.user._id + ''}, queryParameters)).select(sessionSelectionString).lean().exec (err, sessions) ->
+      if err then return callback err
+      if sessions.length
+        nextStep null, _.sample sessions
+      else
+        # Didn't have our own session, so find someone else's
+        findRandomSession {query: queryParameters}, nextStep
+  else
+    findRandomSession {query: queryParameters}, nextStep
+
+makeGetSecondRandomLeagueSession = (options, callback) ->
+  (err, session) ->
     if err then return callback err
     unless session then return sampleByLevel options, callback
     otherTeam = scoringUtils.calculateOpposingTeam session.team
-    queryParameters = team: otherTeam, levelID: session.levelID
+    queryParameters = team: otherTeam, levelID: session.levelID, creator: {$ne: session.creator + ''}
     if Math.random() < 0.5
       # Try to play a match on the internal league ladder for this level
-      queryParameters['leagues.leagueID'] = leagueID
+      queryParameters['leagues.leagueID'] = options.leagueID
       findNextLeagueOpponent session, queryParameters, (err, otherSession) ->
         if err then return callback err
         if otherSession
-          session.shouldUpdateLastOpponentSubmitDateForLeague = leagueID
+          session.shouldUpdateLastOpponentSubmitDateForLeague = options.leagueID
           return callback null, [session, otherSession]
         # No opposing league session found; try to play an external match
         delete queryParameters['leagues.leagueID']
         delete queryParameters.submitDate
-        findRandomSession queryParameters, (err, otherSession) ->
+        findRandomSession {session: session, query: queryParameters}, (err, otherSession) ->
           if err then return callback err
           callback null, [session, otherSession]
     else
       # Play what will probably end up being an external match
-      findRandomSession queryParameters, (err, otherSession) ->
+      findRandomSession {session: session, query: queryParameters}, (err, otherSession) ->
         if err then return callback err
         callback null, [session, otherSession]
 
@@ -84,8 +100,25 @@ ladderLevelIDs = ['dueling-grounds', 'cavern-survival', 'multiplayer-treasure-gr
 backgroundLadderLevelIDs = _.without ladderLevelIDs, 'zero-sum', 'ace-of-coders'
 sampleByLevel = (options, callback) ->
   levelID = options.levelID or _.sample(if options.background then backgroundLadderLevelIDs else ladderLevelIDs)
-  favorRecentHumans = Math.random() < 0.5  # We pick one session favoring recent submissions, then find another one uniformly to play against
-  async.map [{levelID: levelID, team: 'humans', favorRecent: favorRecentHumans}, {levelID: levelID, team: 'ogres', favorRecent: not favorRecentHumans}], findRandomSession, callback
+  if Math.random() < 0.5 and options.user and not options.user.isTeacher()
+    # Prioritize simulating own games
+    LevelSession.find({creator: options.user._id + '', submitted: true, levelID: levelID}).select(sessionSelectionString).lean().exec (err, sessions) ->
+      if err then return callback err
+      if sessions.length
+        session = _.sample sessions
+        otherTeam = if session.team is 'humans' then 'ogres' else 'humans'
+        findRandomSession {session: session, query: {levelID: levelID, team: otherTeam}}, (err, otherSession) ->
+          if err then return callback err
+          callback null, [session, otherSession]
+      else
+        delete options.user
+        sampleByLevel options, callback
+  else
+    favorRecentHumans = Math.random() < 0.5  # We pick one session favoring recent submissions, then find another one uniformly to play against
+    async.map [
+      {query: {levelID: levelID, team: 'humans'}, favorRecent: favorRecentHumans},
+      {query: {levelID: levelID, team: 'ogres'}, favorRecent: not favorRecentHumans}
+    ], findRandomSession, callback
 
 findNextLeagueOpponent = (session, queryParams, callback) ->
   queryParams.submitted = true
@@ -95,46 +128,63 @@ findNextLeagueOpponent = (session, queryParams, callback) ->
   sort = submitDate: -1
   LevelSession.findOne(queryParams).sort(sort).select(sessionSelectionString).lean().exec (err, otherSession) ->
     return callback err if err
-    if otherSession and otherSession.creator + '' is session.creator + ''
-      queryParams.submitDate.$lt = new Date(new Date(queryParams.submitDate.$lt) - 1)
-      return LevelSession.findOne(queryParams).sort(sort).select(sessionSelectionString).lean().exec callback
     callback null, otherSession
 
-findRandomSession = (queryParams, callback) ->
+findRandomSession = (options, callback) ->
   # In MongoDB 3.2, we will be able to easily get a random document with aggregate $sample: https://jira.mongodb.org/browse/SERVER-533
-  queryParams.submitted = true
-  favorRecent = queryParams.favorRecent
-  delete queryParams.favorRecent
-  if favorRecent
-    return findRecentRandomSession queryParams, callback
-  queryParams.randomSimulationIndex = $lte: Math.random()
+  query = options.query
+  query.submitted = true
+  if options.favorRecent
+    return findRecentRandomSession query, callback
+  if query.team and options.session
+    ladderScores = simpleCache.getLadderScores query.levelID, options.session.team
+    if ladderScores and Math.random() < 0.5
+      # Try to find some match near this one in score
+      return findComparableSession {session: options.session, query: query, scores: ladderScores}, callback
+  query.randomSimulationIndex = $lte: Math.random()
   sort = randomSimulationIndex: -1
-  LevelSession.findOne(queryParams).sort(sort).select(sessionSelectionString).lean().exec (err, session) ->
+  LevelSession.findOne(query).sort(sort).select(sessionSelectionString).lean().exec (err, session) ->
     return callback err if err
     return callback null, session if session
-    delete queryParams.randomSimulationIndex  # Just find the highest-indexed session, if our randomSimulationIndex was lower than the lowest one.
-    LevelSession.findOne(queryParams).sort(sort).select(sessionSelectionString).lean().exec (err, session) ->
+    delete query.randomSimulationIndex  # Just find the highest-indexed session, if our randomSimulationIndex was lower than the lowest one.
+    LevelSession.findOne(query).sort(sort).select(sessionSelectionString).lean().exec (err, session) ->
       return callback err if err
       callback null, session
 
-findRecentRandomSession = (queryParams, callback) ->
+findRecentRandomSession = (query, callback) ->
   # We pick a random submitDate between the first submit date for the level and now, then do a $lt fetch to find a session to simulate.
   # We bias it towards recently submitted sessions.
-  findEarliestSubmission queryParams, (err, startDate) ->
+  findEarliestSubmission query, (err, startDate) ->
     return callback err, null unless startDate
     now = new Date()
     interval = now - startDate
     cutoff = new Date now - Math.pow(Math.random(), 4) * interval
-    queryParams.submitDate = $gte: startDate, $lt: cutoff
-    LevelSession.findOne(queryParams).sort(submitDate: -1).select(sessionSelectionString).lean().exec (err, session) ->
+    query.submitDate = $gte: startDate, $lt: cutoff
+    LevelSession.findOne(query).sort(submitDate: -1).select(sessionSelectionString).lean().exec (err, session) ->
       return callback err if err
       callback null, session
 
 earliestSubmissionCache = {}
-findEarliestSubmission = (queryParams, callback) ->
-  cacheKey = JSON.stringify queryParams
+findEarliestSubmission = (query, callback) ->
+  cacheKey = JSON.stringify query
   return callback null, cached if cached = earliestSubmissionCache[cacheKey]
-  LevelSession.findOne(queryParams).sort(submitDate: 1).lean().exec (err, earliest) ->
+  LevelSession.findOne(query).sort(submitDate: 1).lean().exec (err, earliest) ->
     return callback err if err
     result = earliestSubmissionCache[cacheKey] = earliest?.submitDate
     callback null, result
+
+findComparableSession = (options, callback) ->
+  # We pick a random session kind of close in score to the target session
+  scores = options.scores
+  sessionRank = _.sortedIndex scores, options.session.totalScore, (index) -> -index  # Descending order
+  range = Math.max 100, Math.round(scores.length / 500)
+  maxScoreIndex = Math.max 0, sessionRank - range
+  minScoreIndex = Math.min scores.length - 1, sessionRank + range
+  possibleScores = scores.slice(maxScoreIndex, minScoreIndex)
+  targetScore = _.sample possibleScores
+  #console.log 'trying to find something with score close to', options.session.totalScore, 'of', scores.slice(0, 5), '... where we are ranked', sessionRank, ' and found', targetScore, 'between', maxScoreIndex, scores[maxScoreIndex], 'and', minScoreIndex, scores[minScoreIndex]
+  options.query.totalScore = $lte: targetScore
+  sort = totalScore: -1
+  LevelSession.findOne(options.query).sort(sort).select(sessionSelectionString).lean().exec (err, session) ->
+    return callback err if err
+    callback null, session


### PR DESCRIPTION
Random game simulation will now never play you against yourself.

It will often target an opponent near your skill level for better games.

It will often play one of your games so that you can get faster results for games you care about if you are simulating.

Improved simulation display of what's going on while simulating.

Added a simple cached fallback for calculating leaderboard ranks based on ladder score distributions we may already have cached, and reduced the max query timeout before falling back to that.