### PR TITLE
Concept tagging

### DIFF
--- a/app/core/application.coffee
+++ b/app/core/application.coffee
@@ -75,6 +75,7 @@ Application = {
     preferredLanguage = me.get('preferredLanguage') or 'en'
     $(document).bind 'keydown', preventBackspace
     preload(COMMON_FILES)
+    moment.relativeTimeThreshold('ss', 1) # do not return 'a few seconds' when calling 'humanize' 
     CocoModel.pollAchievements()
     unless me.get('anonymous')
       # TODO: Remove logging later, once this system has proved stable

--- a/app/lib/SolutionConceptTagger.coffee
+++ b/app/lib/SolutionConceptTagger.coffee
@@ -1,18 +1,21 @@
 concepts = require 'schemas/concepts'
 
-module.exports = TagSolution = (solution) ->
-  code = solution.source
+module.exports = TagSolution = ({source, ast, language}) ->
   engine = new esper.Engine()
-  engine.load(code)
-  ast = engine.evaluator.ast
+  if source
+    engine.load(source)
+  else if ast
+    engine.loadAST(ast)
+  esperAST = engine.evaluator.ast
+  if language is 'python'
+    # remove the first variable assignment, which appears to be added by skulpty in the transpilation
+    esperAST.body.shift() 
   result = []
   for key of concepts
     tkn = concepts[key].tagger
     continue unless tkn
     if typeof tkn is 'function'
-      result.push concepts[key].concept if tkn(ast)
+      result.push concepts[key].concept if tkn(esperAST)
     else
-      result.push concepts[key].concept if ast.find(tkn).length > 0
-   
-  console.log result
+      result.push concepts[key].concept if esperAST.find(tkn).length > 0
   result

--- a/app/lib/coursesHelper.coffee
+++ b/app/lib/coursesHelper.coffee
@@ -159,7 +159,7 @@ module.exports =
             numStarted: 0
             # numCompleted: 0
           }
-          isPractice = level.get('practice')
+          isOptional = level.get('practice') or level.get('assessment')
           sessionsForLevel = _.filter classroom.sessions.models, (session) ->
             session.get('level').original is levelID
 
@@ -174,37 +174,38 @@ module.exports =
             courseProgress[levelID][userID].session = _.find(sessions, (s) -> s.completed()) or _.first(sessions)
 
             if _.size(sessions) is 0 # haven't gotten to this level yet, but might have completed others before
-              courseProgress.started ||= false unless isPractice #no-op
-              courseProgress.completed = false unless isPractice
-              courseProgress[userID].started ||= false unless isPractice #no-op
-              courseProgress[userID].completed = false unless isPractice
+              courseProgress.started ||= false unless isOptional #no-op
+              courseProgress.completed = false unless isOptional
+              courseProgress[userID].started ||= false unless isOptional #no-op
+              courseProgress[userID].completed = false unless isOptional
               courseProgress[levelID].started ||= false #no-op
-              courseProgress[levelID].completed = false unless isPractice
+              courseProgress[levelID].completed = false unless isOptional
               courseProgress[levelID][userID].started = false
               courseProgress[levelID][userID].completed = false
 
             if _.size(sessions) > 0 # have gotten to the level and at least started it
-              courseProgress.started = true unless isPractice
-              courseProgress[userID].started = true unless isPractice
+              courseProgress.started = true unless isOptional
+              courseProgress[userID].started = true unless isOptional
               courseProgress[levelID].started = true
               courseProgress[levelID][userID].started = true
               dates = _.map(sessions, (s) -> new Date(s.get('changed')))
               courseProgress[levelID][userID].lastPlayed = new Date(Math.max(dates...))
               courseProgress[levelID].numStarted += 1
+              courseProgress[levelID][userID].codeConcepts = _.flatten(_.map(sessions, (s) -> s.get('codeConcepts') or []))
 
             if _.find(sessions, (s) -> s.completed()) # have finished this level
-              courseProgress.completed &&= true unless isPractice #no-op
-              courseProgress[userID].completed &&= true unless isPractice #no-op
-              courseProgress[userID].levelsCompleted += 1 unless isPractice
+              courseProgress.completed &&= true unless isOptional #no-op
+              courseProgress[userID].completed &&= true unless isOptional #no-op
+              courseProgress[userID].levelsCompleted += 1 unless isOptional
               courseProgress[levelID].completed &&= true #no-op
               # courseProgress[levelID].numCompleted += 1
               courseProgress[levelID][userID].completed = true
               dates = (new Date(s.get('dateFirstCompleted') || s.get('changed')) for s in sessions)
               courseProgress[levelID][userID].dateFirstCompleted = new Date(Math.max(dates...))
             else # level started but not completed
-              courseProgress.completed = false unless isPractice
-              courseProgress[userID].completed = false unless isPractice
-              if isPractice
+              courseProgress.completed = false unless isOptional
+              courseProgress[userID].completed = false unless isOptional
+              if isOptional
                 # Weird behavior! Since practice levels are optional, the level is considered 'incomplete'
                 # for the class as a whole only if any started-but-not-completed sessions exist
                 courseProgress[levelID].completed = false if courseProgress[levelID][userID].started
@@ -214,7 +215,7 @@ module.exports =
               courseProgress[levelID].dateFirstCompleted = null
               courseProgress[levelID][userID].dateFirstCompleted = null
 
-          if isPractice and courseProgress and not courseProgress[levelID].started
+          if isOptional and courseProgress and not courseProgress[levelID].started
             courseProgress[levelID].completed = false # edge for practice levels, not considered complete if never started either
 
     _.assign(progressData, progressMixin)

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1446,7 +1446,9 @@
     challenge_level: "Challenge Level:"
     status: "Status:"
     assessments: "Assessments"
-    play_again: "Play Again"
+    challenges: "Challenges"
+    level_name: "Level Name:"
+    play_again: "Replay" # {change}
     keep_trying: "Keep Trying"
     start_challenge: "Start Challenge"
     locked: "Locked"
@@ -1508,6 +1510,8 @@
     latest_completed: "Latest completed:"
     sort_by: "Sort by"
     progress: "Progress"
+    concepts_used: "Concepts used by Student:"
+    concept_checked: "Concept checked:"
     completed: "Completed"
     practice: "Practice"
     started: "Started"
@@ -1742,6 +1746,12 @@
     success: "Success"
     in_progress: "In Progress"
     not_started: "Not Started"
+    mid_course: "Mid-Course"
+    end_course: "End of Course"
+    none: "None detected yet"
+    explain_open_ended: "Note: Students are encouraged to solve this level creatively — one possible solution is provided below."
+    level_label: "Level:"
+    time_played_label: "Time Played:"
 
   share_licenses:
     share_licenses: "Share Licenses"

--- a/app/locale/locale.coffee
+++ b/app/locale/locale.coffee
@@ -3,6 +3,9 @@
 # Sort according to language popularity on Internet
 # http://en.wikipedia.org/wiki/Languages_used_on_the_Internet
 
+utils = require('../core/utils')
+
+
 module.exports =
   'en': require('./en') # Include these in the main bundle
   'en-US': require('./en-US')
@@ -139,7 +142,11 @@ Object.defineProperties module.exports,
             opts.ns = ns
           Vue.util.extend opts, options
           i18n.t key, opts
-
+          
+        Vue::$dbt = (source, key, options) ->
+          options ?= {}
+          utils.i18n(source, key, options.language, options.fallback)
+          
         return
 
       Vue.use(VueI18Next)

--- a/app/models/Classroom.coffee
+++ b/app/models/Classroom.coffee
@@ -52,7 +52,7 @@ module.exports = class Classroom extends CocoModel
         levels = []
         for level in course.levels when level.original
           continue if language? and level.primerLanguage is language
-          levels.push({key: level.original, practice: level.practice ? false})
+          levels.push({key: level.original, practice: level.practice ? false, assessment: level.assessment ? false})
         _.assign(@levelNumberMap, utils.createLevelNumberMap(levels))
     @levelNumberMap[levelID] ? defaultNumber
 
@@ -75,7 +75,7 @@ module.exports = class Classroom extends CocoModel
     }
 
   getLevels: (options={}) ->
-    # options: courseID, withoutLadderLevels, projectLevels
+    # options: courseID, withoutLadderLevels, projectLevels, assessmentLevels
     # TODO: find a way to get the i18n in here so that level names can be translated (Courses don't include in their denormalized copy of levels)
     Levels = require 'collections/Levels'
     courses = @get('courses')

--- a/app/models/LevelSession.coffee
+++ b/app/models/LevelSession.coffee
@@ -85,7 +85,7 @@ module.exports = class LevelSession extends CocoModel
       oldTopScore = _.find oldTopScores, type: scoreType
       newScore = scores[scoreType]
       unless newScore?
-        newTopScores.push oldTopScore
+        newTopScores.push oldTopScore if oldTopScore
         continue
       newScore *= -1 if scoreType in LevelConstants.lowerIsBetterScoreTypes  # Index relies on "top" scores being higher numbers
       if not oldTopScore? or newScore > oldTopScore.score

--- a/app/schemas/models/campaign.schema.coffee
+++ b/app/schemas/models/campaign.schema.coffee
@@ -96,6 +96,7 @@ CampaignSchema.denormalizedLevelProperties = [
   'original'
   'adventurer'
   'assessment'
+  'assessmentPlacement'
   'practice'
   'practiceThresholdMinutes'
   'primerLanguage'

--- a/app/schemas/models/classroom.schema.coffee
+++ b/app/schemas/models/classroom.schema.coffee
@@ -23,7 +23,8 @@ _.extend ClassroomSchema.properties,
   courses: c.array { title: 'Courses' }, c.object { title: 'Course' }, {
     _id: c.objectId()
     levels: c.array { title: 'Levels' }, c.object { title: 'Level' }, {
-      assessment: {type: 'boolean'}
+      assessment: {type: ['boolean', 'string']}
+      assessmentPlacement: { type: 'string' }
       practice: {type: 'boolean'}
       practiceThresholdMinutes: {type: 'number'}
       primerLanguage: { type: 'string', enum: ['javascript', 'python'] }

--- a/app/schemas/models/level.coffee
+++ b/app/schemas/models/level.coffee
@@ -278,6 +278,8 @@ _.extend LevelSchema.properties,
   practice: { type: 'boolean' }
   practiceThresholdMinutes: {type: 'number', description: 'Players with larger playtimes may be directed to a practice level.'}
   assessment: { type: ['boolean', 'string'], enum: [true, false, 'open-ended'], description: 'Set to true if this is an assessment level.' }
+  assessmentPlacement: { type: 'string', enum: ['middle', 'end'] }
+  
   primerLanguage: { type: 'string', enum: ['javascript', 'python'], description: 'Programming language taught by this level.' }
   shareable: { title: 'Shareable', type: ['string', 'boolean'], enum: [false, true, 'project'], description: 'Whether the level is not shareable (false), shareable (true), or a sharing-encouraged project level ("project"). Make sure to use "project" for project levels so they show up correctly in the Teacher Dashboard.' }
 

--- a/app/schemas/models/level_session.coffee
+++ b/app/schemas/models/level_session.coffee
@@ -155,6 +155,11 @@ _.extend LevelSessionSchema.properties,
 
   codeLanguage:
     type: 'string'
+    
+  codeConcepts:
+    type: 'array'
+    items:
+      type: 'string'    
 
   playtime:
     type: 'number'

--- a/app/styles/courses/student-assessments-view.sass
+++ b/app/styles/courses/student-assessments-view.sass
@@ -1,9 +1,19 @@
-#student-assessments-view
+#student-assessments-view .style-flat
   .assessments-list
     list-style: none
 
-  .play-level-btn
+  .btn
     min-width: 140px
+    margin-top: 7px
 
   .table-header
     font-weight: bold
+
+  .row
+    padding: 4px 0
+    
+  font-size: 16px
+  line-height: 27px
+
+  .level-row
+    border-bottom: 1px solid #ccc

--- a/app/styles/courses/teacher-class-view.sass
+++ b/app/styles/courses/teacher-class-view.sass
@@ -34,6 +34,10 @@
   .classroom-info-row[dir="rtl"] > div
     float: right
 
+  .student-code
+    font-weight: bold
+    font-style: italic
+
   .concept
     & span
       white-space: nowrap
@@ -429,3 +433,7 @@
       
     td, th
       text-align: center
+
+    .student-name
+      text-overflow: ellipsis
+      overflow: hidden

--- a/app/templates/courses/student-assessments-view.jade
+++ b/app/templates/courses/student-assessments-view.jade
@@ -2,47 +2,64 @@ flat-layout
   .container.m-t-3
     p
       a(href="/students", data-i18n="courses.back_courses")
-    div.text-center.m-t-2
-      h2
-        | {{ $t('courses.assessments') }}
-      h1(v-if="classroom")
+    div.m-t-2
+      h2.text-center
+        | {{ $t('courses.challenges') }}
+      h1(v-if="classroom").text-center
         | {{ classroom.name }}
-      ul.assessments-list.m-t-3
-        li
-          .row
-            .col-xs-5.col-xs-offset-1
-              span.table-header.pull-left
-                | {{ $t('courses.challenge_level') }}
-            .status-column.col-xs-3
-              span.table-header.pull-left
-                | {{ $t('courses.status') }}
-        li(v-for="level in levels")
-          .row
-            .col-xs-5.col-xs-offset-1
-              span.level-name.pull-left
-                span(v-if="level.primaryConcepts")
-                  | {{ $t('concepts.' + (level.primaryConcepts && level.primaryConcepts[0])) }} ({{ level.name }})
-                span(v-else)
-                  | ({{ level.name }})
-            .col-xs-3
-              div.level-status.pull-left
-                span(v-if="sessionMap[level.original] && sessionMap[level.original].state.complete")
-                  span.glyphicon.glyphicon-ok-sign.success-symbol.text-forest
-                  | {{ $t('teacher.success') }}
-                span(v-else-if="sessionMap[level.original]")
-                  span.glyphicon.glyphicon-question-sign.in-progress-symbol.text-gold
-                  | {{ $t('teacher.in_progress') }}
-                span(v-else)
-                  span.glyphicon.glyphicon-question-sign.not-started-symbol.text-gray
-                  | {{ $t('teacher.not_started') }}
-            .col-xs-2
-              div(v-if="levelUnlockedMap[level.original] && playLevelUrlMap[level.original]")
-                a.play-level-btn.btn.btn-lg.btn-gray(v-if="sessionMap[level.original] && sessionMap[level.original].state.complete", :href="playLevelUrlMap[level.original]")
-                  | {{ $t('courses.play_again') }}
-                a.play-level-btn.btn.btn-lg.btn-forest(v-else-if="sessionMap[level.original]", :href="playLevelUrlMap[level.original]")
-                  | {{ $t('courses.keep_trying') }}
-                a.play-level-btn.btn.btn-lg.btn-navy(v-else, :href="playLevelUrlMap[level.original]")
-                  | {{ $t('courses.start_challenge') }}
-              div(v-else)
-                a.btn.btn-lg.btn-gray-alt(disabled)
-                  | {{ $t('courses.locked') }}
+      div.assessments-list.m-t-3(v-for="chunk in levelsByCourse" v-if="chunk.assessmentLevels.length && inCourses[chunk.course._id]")
+        .row
+          .col-xs-5
+            span.table-header
+              | {{ $dbt(chunk.course, 'name') }}
+          .status-column.col-xs-5
+            span.table-header
+              | {{ $t('courses.status') }}
+        .row.level-row(v-for="level in chunk.assessmentLevels")
+          .col-xs-5
+            div.level-type
+              span(v-if="level.assessment === 'open-ended' && level.assessmentPlacement === 'middle'")
+                | {{ $t('teacher.mid_course') }}
+              span(v-else-if="level.assessment === 'open-ended' && level.assessmentPlacement === 'end'")
+                | {{ $t('teacher.end_course') }}
+              span(v-else-if="level.primaryConcepts")
+                | {{ $t('concepts.' + (level.primaryConcepts && level.primaryConcepts[0])) }}
+                
+            div.small
+              strong {{$t('courses.level_name')}}
+              =" "
+              span {{ $dbt(level, 'name') }}
+          .col-xs-5
+            div.level-status
+              span(v-if="sessionMap[level.original] && sessionMap[level.original].state.complete")
+                span.glyphicon.glyphicon-ok-sign.success-symbol.text-forest
+                =" "
+                | {{ $t('teacher.success') }}
+              span(v-else-if="sessionMap[level.original]")
+                span.glyphicon.glyphicon-question-sign.in-progress-symbol.text-gold
+                =" "
+                | {{ $t('teacher.in_progress') }}
+              span(v-else)
+                span.glyphicon.glyphicon-question-sign.not-started-symbol.text-gray
+                =" "
+                | {{ $t('teacher.not_started') }}
+            div.small(v-if="level.assessment === 'open-ended' && sessionMap[level.original]")
+              strong {{ $t('teacher.concepts_used') }}
+              =" "
+              span(v-for="(concept, i) in sessionMap[level.original].codeConcepts || []")
+                span(v-if="i > 0")
+                  =", "
+                span {{ $t("concepts." + concept) }}
+              span(v-if="!(sessionMap[level.original].codeConcepts && sessionMap[level.original].codeConcepts.length)")
+                | {{ $t("teacher.none") }}
+          .col-xs-2
+            div(v-if="levelUnlockedMap[level.original] && playLevelUrlMap[level.original]")
+              a.play-level-btn.btn.btn-navy-alt(v-if="sessionMap[level.original] && sessionMap[level.original].state.complete", :href="playLevelUrlMap[level.original]")
+                | {{ $t('courses.play_again') }}
+              a.play-level-btn.btn.btn-forest(v-else-if="sessionMap[level.original]", :href="playLevelUrlMap[level.original]")
+                | {{ $t('courses.keep_trying') }}
+              a.play-level-btn.btn.btn-navy(v-else, :href="playLevelUrlMap[level.original]")
+                | {{ $t('courses.start_challenge') }}
+            div(v-else)
+              a.btn.btn-gray-alt(disabled)
+                | {{ $t('courses.locked') }}

--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -271,7 +271,7 @@ mixin studentRow(student)
           - var instance = view.courseInstances.findWhere({ courseID: course.id, classroomID: classroom.id })
           if instance && instance.hasMember(student)
             - var progress = state.get('progressData').get({ classroom: view.classroom, course: course, user: student })
-            - var levelsTotal = _.reject(trimCourse.levels, 'practice').length
+            - var levelsTotal = _.reject(_.reject(trimCourse.levels, 'practice'), 'assessment').length
             - var label = courseLabelsArray[index];
             +studentCourseProgressDot(progress, levelsTotal, label)
     td
@@ -363,6 +363,7 @@ mixin courseOverview(course)
     .course-overview-progress
       if state.get('progressData')
         each level, index in levels
+          - if (level.get('assessment')) continue;
           - var progress = state.get('progressData').get({ classroom: view.classroom, course: course, level: level })
           - var levelNumber = view.classroom.getLevelNumber(level.get('original'), index + 1)
           +allStudentsLevelProgressDot(progress, level, levelNumber)
@@ -377,6 +378,7 @@ mixin studentLevelsRow(student)
       - var levels = view.classroom.getLevels({courseID: course.id}).models
       if state.get('progressData')
         each level, index in levels
+          - if (level.get('assessment')) continue;
           - var progress = state.get('progressData').get({ classroom: view.classroom, course: course, level: level, user: student })
           - var levelNumber = view.classroom.getLevelNumber(level.get('original'), index + 1)
           +studentLevelProgressDot(progress, level, levelNumber, student)
@@ -427,7 +429,7 @@ mixin studentLevelProgressDot(progress, level, levelNumber, student)
   //- TODO: Refactor with TeacherClassesView jade
   - dotClass = progress.completed ? 'forest' : (progress.started ? 'gold' : '');
   - levelName = i18n(level.attributes, 'name')
-  - context = _.merge(progress, { levelName: levelName, levelNumber: levelNumber, moment: moment, practice: level.get('practice'), isLadder: level.isLadder(), isProject: level.isProject() })
+  - context = _.merge(progress, { levelName: levelName, levelNumber: levelNumber, moment: moment, practice: level.get('practice'), isLadder: level.isLadder(), isProject: level.isProject(), assessment: level.get('assessment'), primaryConcept: _.first(level.get('primaryConcepts')) })
   - var link = null;
   if dotClass
     //- TODO: these anchor links do not navigate to the anchor in destination page
@@ -505,6 +507,16 @@ mixin bulkAssignControls
 
 mixin assessmentsTab
   #assessments-tab
+    .text-center.m-t-3
+      span(data-i18n='teacher.select_course')
+      span.spr :
+      select.course-select
+        each course in view.latestReleasedCourses
+          option(value=course.id selected=(course === state.get('selectedCourse')))
+            = i18n(course.attributes, 'name')
+            if !view.availableCourseMap[course.id]
+              = " " + translate('teacher.paren_new')
+    
     h4.m-b-2.m-t-3(data-i18n="teacher.progress_color_key")
     #progress-color-key-row.row.m-b-3
       .col.col-md-2.col-xs-4
@@ -524,21 +536,32 @@ mixin assessmentsTab
         .clearfix
     table.table.table-condensed.assessments-table
       if view.classroom && state.get('progressData')
-        thead
-          th
-          each pair in view.courseAssessmentPairs
-            each level in pair[1]
-              - var concept = level.get('primaryConcepts') && level.get('primaryConcepts')[0]
-              th(data-i18n="concepts." + concept)
-        tbody
-          each student in state.get('students').models
-            tr
-              td.student-name
-                = student.broadName()
-              each pair in view.courseAssessmentPairs
-                each level in pair[1]
+        - var course = state.get('selectedCourse');
+        - var levels = []
+        if course
+          - levels = _.find(view.courseAssessmentPairs, function (pair) { return pair[0] === course })[1];
+        if levels.length === 0
+          h4(data-i18n="TODO") No assessment levels available for this course yet.
+        else
+          thead
+            th
+            each level in levels
+              if level.get('assessment') === 'open-ended'
+                if level.get('assessmentPlacement') === 'middle'
+                  th(data-i18n="teacher.mid_course")
+                else
+                  th(data-i18n="teacher.end_course")
+              else
+                - var concept = level.get('primaryConcepts') && level.get('primaryConcepts')[0]
+                th(data-i18n="concepts." + concept)
+          tbody
+            each student in state.get('students').models
+              tr
+                td.student-name
+                  = student.broadName()
+                each level in levels
                   td
-                    - var progress = state.get('progressData').get({ classroom: view.classroom, course: pair[0], level: level, user: student })
+                    - var progress = state.get('progressData').get({ classroom: view.classroom, course: course, level: level, user: student })
                     +studentLevelProgressDot(progress, level, null, student)
 
 mixin enrollmentStatusTab

--- a/app/templates/play/campaign-view.jade
+++ b/app/templates/play/campaign-view.jade
@@ -116,6 +116,8 @@ if showGameDevAlert
               else
                 img.item-portrait.item-portrait-on-banner(src="/file/db/thang.type/#{level.unlocksItem}/portrait.png")
               img.treasure-chest(src="/images/pages/play/#{level.requiresSubscription?'silver':'bronze'}-chest.png")
+            else if levelStatusMap[level.slug] !== 'complete' && level.assessment
+              img.banner(src="/images/pages/play/level-banner-unstarted-subscriber.png")
             else if levelStatusMap[level.slug] === 'started'
               img.banner(src="/images/pages/play/level-banner-started.png")
             else if levelStatusMap[level.slug] !== 'complete'

--- a/app/templates/teachers/hovers/progress-dot-single-student-level.jade
+++ b/app/templates/teachers/hovers/progress-dot-single-student-level.jade
@@ -1,48 +1,74 @@
 if practice
-  span.text-uppercase.small-details(data-i18n='teacher.practice')
+  span.text-uppercase.small-details.spr(data-i18n='teacher.practice')
 
 mixin timePlayed()
   if session.get('playtime') > 0
-    .small-details.nowrap
+    .small-details.nowrap 
+      span(data-i18n="teacher.time_played_label")
+      =" "
       span.spr(data-i18n='teacher.time_played')
       span= moment.duration({ seconds: session.get('playtime') }).humanize()
+    
+mixin header()
+  strong.small-details.nowrap
+    if assessment
+      span(data-i18n="courses.challenge")
+    else
+      span(data-i18n="teacher.level_label")
+    =" "
+    if levelNumber
+      span= levelNumber
+      span.spr . 
+    span= levelName
+    
+mixin assessmentLines()
+  if assessment === 'open-ended'
+    .small-details.nowrap
+      span(data-i18n="teacher.concepts_used")
+    em.small-details
+      for concept, i in codeConcepts
+        if i > 0
+          =", "
+        span(data-i18n="concepts." + concept)
+      if !codeConcepts.length
+        span(data-i18n="teacher.none")
+  else
+    .small-details.nowrap
+      span(data-i18n="teacher.concept_checked")
+    em.small-details
+      span(data-i18n="concepts." + primaryConcept)
 
 if completed
+  +header
   .small-details.nowrap
-    if levelNumber
-      span= levelNumber
-      span.spr . 
-    span= levelName
-  .small-details.nowrap
-    span.spr(data-i18n='teacher.completed')
+    span(data-i18n='teacher.completed')
+    =": "
     - var dateCompleted = session.get('dateFirstCompleted') || session.get('created') || session.get('changed');
     if dateCompleted
-      span= new Date(dateCompleted).toLocaleString()
+      span= moment(dateCompleted).format('lll')
     +timePlayed
+  if assessment
+    +assessmentLines
   if !isProject && !isLadder
-    .small-details.nowrap
+    .small-details.nowrap.m-t-1
       //- TODO: data-i18n doesn't work here
-      strong Click to view student code
+      .student-code Click to view student code
 else if started
+  +header
   .small-details.nowrap
-    if levelNumber
-      span= levelNumber
-      span.spr . 
-    span= levelName
-  .small-details.nowrap
-    span.spr(data-i18n='teacher.last_played')
-    span= new Date(session.get('changed')).toLocaleString()
+    span(data-i18n='user.last_played')
+    =": "
+    span= moment(session.get('changed')).format('lll')
     +timePlayed
+  if assessment
+    +assessmentLines
+        
   if !isProject && !isLadder
-    .small-details.nowrap
-      strong Click to view student code
+    .small-details.nowrap.m-t-1
+      .student-code Click to view student code
 else
-  .small-details.nowrap
-    if levelNumber
-      span= levelNumber
-      span.spr . 
-    span= levelName
+  +header
   if practice
-    span.small-details.nowrap(data-i18n='teacher.not_required')
+    .small-details.nowrap(data-i18n='teacher.not_required')
   else
-    span.small-details.nowrap(data-i18n='teacher.no_progress')
+    .small-details.nowrap(data-i18n='teacher.no_progress')

--- a/app/templates/teachers/teacher-course-solution-view.jade
+++ b/app/templates/teachers/teacher-course-solution-view.jade
@@ -33,13 +33,13 @@ block content
         if level.get('assessment') && !me.get('verifiedTeacher')
           - continue
         .small
-          a(href="##{view.levelNumberMap[level.get('original')]}") #{view.levelNumberMap[level.get('original')]}. #{i18n(level.attributes, 'name')}
+          a(href="##{level.get('slug')}") #{view.levelNumberMap[level.get('original')]}. #{i18n(level.attributes, 'name')}
       br
 
       each level, index in view.levels.models
         if level.get('assessment') && !me.get('verifiedTeacher')
           - continue
-        h2.page-break-before(id=view.levelNumberMap[level.get('original')]) ##{view.levelNumberMap[level.get('original')]}. #{i18n(level.attributes, 'name')}
+        h2.page-break-before(id=level.get('slug')) ##{view.levelNumberMap[level.get('original')]}. #{i18n(level.attributes, 'name')}
         h3(data-i18n="teacher.level_overview_solutions")
         i #{i18n(level.attributes, 'description')}
         div
@@ -68,6 +68,8 @@ block content
             span= level.get('name')
             span.spl(data-i18n="common.solution")
           if level.get('solution')
+            if level.get('assessment') === 'open-ended'
+              em(data-i18n="teacher.explain_open_ended")
             pre
               code= level.get('solution')
           else

--- a/app/views/courses/TeacherClassView.coffee
+++ b/app/views/courses/TeacherClassView.coffee
@@ -135,7 +135,7 @@ module.exports = class TeacherClassView extends RootView
     @supermodel.trackRequest @courseInstances.fetchForClassroom(classroomID)
 
     @levels = new Levels()
-    @supermodel.trackRequest @levels.fetchForClassroom(classroomID, {data: {project: 'original,name,primaryConcepts,concepts,primerLanguage,practice,shareable,i18n'}})
+    @supermodel.trackRequest @levels.fetchForClassroom(classroomID, {data: {project: 'original,name,primaryConcepts,concepts,primerLanguage,practice,shareable,i18n,assessment,assessmentPlacement,slug'}})
 
     @attachMediatorEvents()
     window.tracker?.trackEvent 'Teachers Class Loaded', category: 'Teachers', classroomID: @classroom.id, ['Mixpanel']
@@ -405,6 +405,7 @@ module.exports = class TeacherClassView extends RootView
         if instance and instance.hasMember(student)
           for trimLevel in trimCourse.levels
             level = @levels.findWhere({ original: trimLevel.original })
+            continue if level.get('assessment')
             progress = @state.get('progressData').get({ classroom: @classroom, course: course, level: level, user: student })
             concepts.push(level.get('concepts') ? []) if progress?.completed
       concepts = _.union(_.flatten(concepts))
@@ -416,6 +417,8 @@ module.exports = class TeacherClassView extends RootView
         continue unless session.get('creator') is student.id
         continue unless session.get('state')?.complete
         continue if levelPracticeMap[session.get('level')?.original]
+        level = @levels.findWhere({ original: session.get('level')?.original })
+        continue if level?.get('assessment')
         levels++
         playtime += session.get('playtime') or 0
         if courseID = levelCourseIdMap[session.get('level')?.original]

--- a/app/views/editor/level/settings/SettingsTabView.coffee
+++ b/app/views/editor/level/settings/SettingsTabView.coffee
@@ -20,7 +20,8 @@ module.exports = class SettingsTabView extends CocoView
     'type', 'kind', 'terrain', 'banner', 'loadingTip', 'requiresSubscription', 'adventurer', 'adminOnly',
     'helpVideos', 'replayable', 'scoreTypes', 'concepts', 'primaryConcepts', 'picoCTFProblem', 'practice', 'assessment',
     'practiceThresholdMinutes', 'primerLanguage', 'shareable', 'studentPlayInstructions', 'requiredCode', 'suspectCode',
-    'requiredGear', 'restrictedGear', 'requiredProperties', 'restrictedProperties', 'recommendedHealth', 'allowedHeroes'
+    'requiredGear', 'restrictedGear', 'requiredProperties', 'restrictedProperties', 'recommendedHealth', 'allowedHeroes',
+    'assessmentPlacement'
   ]
 
   subscriptions:

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -1268,8 +1268,15 @@ module.exports = class CampaignView extends RootView
           level.locked = found
           level.hidden = false
 
-      level.color = 'rgb(193, 193, 193)' if level.locked
       level.noFlag = !level.next
+      if level.locked
+        level.color = 'rgb(193, 193, 193)'
+      else if level.practice
+        level.color = 'rgb(45, 145, 81)'
+      else if level.assessment
+        level.color = '#AD62F8'
+        if playerState isnt 'complete'
+          level.noFlag = false
       level.unlocksHero = false
       level.unlocksItem = false
       prev = level

--- a/app/views/play/level/LevelGoalsView.coffee
+++ b/app/views/play/level/LevelGoalsView.coffee
@@ -160,6 +160,7 @@ module.exports = class LevelGoalsView extends CocoView
   # Score display
 
   shouldShowScores: ->
+    return false # Disable scores for now (WIP)
     shouldShow = @level.get('assessment') in ['open-ended'] and @hasMainScore
     if shouldShow isnt @showingScores
       @showingScores = shouldShow

--- a/app/views/play/level/tome/Spell.coffee
+++ b/app/views/play/level/tome/Spell.coffee
@@ -147,6 +147,7 @@ module.exports = class Spell
       source = @getSource()
     unless @language is 'html'
       @thang?.aether.transpile source
+      @session.lastAST = @thang?.aether.ast
     null
 
   # NOTE: By default, I think this compares the current source code with the source *last saved to the server* (not the last time it was run)

--- a/bower.json
+++ b/bower.json
@@ -43,7 +43,7 @@
     "fastclick": "~1.0.3",
     "three.js": "~0.71.0",
     "lscache": "~1.0.5",
-    "esper.js": "http://files.codecombat.com/esper.tar.gz",
+    "esper.js": "http://files.codecombat.com/esper-2018-01-16.tar.gz",
     "algoliasearch": "^3.13.1",
     "algolia-autocomplete.js": "^0.17.0",
     "algolia-autocomplete-no-conflict": "1.0.0",

--- a/server/models/Classroom.coffee
+++ b/server/models/Classroom.coffee
@@ -79,6 +79,7 @@ ClassroomSchema.methods.generateCoursesData = co.wrap ({isAdmin, includeAssessme
         'slug',
         'name',
         'assessment',
+        'assessmentPlacement'
         'practice',
         'practiceThresholdMinutes',
         'primerLanguage',
@@ -165,7 +166,7 @@ ClassroomSchema.methods.fetchSessionsForMembers = co.wrap (members) ->
       memberCoursesMap[userID.toHexString()] ?= []
       memberCoursesMap[userID.toHexString()].push(courseInstance.courseID)
   dbqs = []
-  select = 'state.complete level creator playtime changed created dateFirstCompleted submitted published code'
+  select = 'state.complete level creator playtime changed created dateFirstCompleted submitted published code codeConcepts'
   $or = []
   for member in members
     for courseID in memberCoursesMap[member.toHexString()] ? []

--- a/server/models/Level.coffee
+++ b/server/models/Level.coffee
@@ -91,6 +91,7 @@ LevelSchema.statics.editableProperties = [
   'adventurer'
   'practice'
   'assessment'
+  'assessmentPlacement'
   'shareable'
   'adminOnly'
   'disableSpaces'

--- a/server/models/LevelSession.coffee
+++ b/server/models/LevelSession.coffee
@@ -85,7 +85,7 @@ LevelSessionSchema.pre 'save', (next) ->
     next()
 
 LevelSessionSchema.statics.privateProperties = ['code', 'submittedCode', 'unsubscribed']
-LevelSessionSchema.statics.editableProperties = ['players', 'code', 'codeLanguage', 'completed', 'state',
+LevelSessionSchema.statics.editableProperties = ['players', 'code', 'codeLanguage', 'codeConcepts', 'completed', 'state',
                                                  'levelName', 'creatorName', 'levelID',
                                                  'chat', 'teamSpells', 'submitted', 'submittedCodeLanguage',
                                                  'unsubscribed', 'playtime', 'heroConfig', 'team',


### PR DESCRIPTION
Add `codeConcepts` to level sessions. This lists all concepts used in player code, including default code. Does not retroactively apply them to existing sessions, and only works with Python and JavaScript. For `'open-ended'` assessment levels, the teacher class assessment tab bubbles show which concepts were used in the student code, and for other levels they list the primary concept for that level.

Also fixed a couple bugs found along the way:

* Fix "Last Played" string in bubble
* Fix student assessment page if they are in another
  classroom w/out assessments

Still TODO:
* Confirm wording, then translate
* Consider what to show in assessment tab when a course does not have assessments