### PR TITLE
Refactor, test classroom and course instance handler endpoints

### DIFF
--- a/server/middleware/classrooms.coffee
+++ b/server/middleware/classrooms.coffee
@@ -425,3 +425,14 @@ module.exports =
       throw new errors.Forbidden('You do not have access to this classroom')
     res.status(200).send(classroom.toObject({req}))
     
+  put: wrap (req, res) ->
+    classroom = yield database.getDocFromHandle(req, Classroom)
+    if not classroom
+      throw new errors.NotFound('Classroom not found.')
+
+    unless classroom.isOwner(req.user._id)
+      throw new errors.Forbidden('You may not edit this classroom')
+    database.assignBody(req, classroom)
+    database.validateDoc(classroom)
+    classroom = yield classroom.save()
+    res.status(200).send(classroom.toObject({req}))

--- a/server/middleware/classrooms.coffee
+++ b/server/middleware/classrooms.coffee
@@ -416,3 +416,12 @@ module.exports =
       query = {$and: [{_id: {$lt: beforeId}}, query]}
     classrooms = yield Classroom.find(query).sort({_id: -1}).limit(limit).select('ownerID members').lean()
     res.status(200).send(classrooms)
+
+  getByHandle: wrap (req, res) ->
+    classroom = yield database.getDocFromHandle(req, Classroom)
+    if not classroom
+      throw new errors.NotFound('Classroom not found.')
+    unless classroom.isOwner(req.user._id) or classroom.isMember(req.user._id) or req.user.isAdmin()
+      throw new errors.Forbidden('You do not have access to this classroom')
+    res.status(200).send(classroom.toObject({req}))
+    

--- a/server/models/CourseInstance.coffee
+++ b/server/models/CourseInstance.coffee
@@ -36,5 +36,9 @@ CourseInstanceSchema.methods.isMember = (userId) ->
   for memberId in @get('members')
     return true if memberId.equals(userId)
   return false
+  
+CourseInstanceSchema.methods.isOwner = (userId) ->
+  return userId.equals(@get('ownerID'))
+
 
 module.exports = CourseInstance = mongoose.model 'course.instance', CourseInstanceSchema, 'course.instances'

--- a/server/routes/index.coffee
+++ b/server/routes/index.coffee
@@ -172,6 +172,7 @@ module.exports.setup = (app) ->
   app.post('/db/course/:handle/patch', mw.auth.checkLoggedIn(), mw.patchable.postPatch(Course, 'course'))
   app.get('/db/course/:handle/patches', mw.patchable.patches(Course))
 
+  app.post('/db/course_instance', mw.auth.checkLoggedIn(), mw.courseInstances.post)
   app.get('/db/course_instance/-/non-hoc', mw.auth.checkHasPermission(['admin']), mw.courseInstances.fetchNonHoc)
   app.post('/db/course_instance/-/recent', mw.auth.checkHasPermission(['admin']), mw.courseInstances.fetchRecent)
   app.get('/db/course_instance/:handle/levels/:levelOriginal/sessions/:sessionID/next', mw.courseInstances.fetchNextLevels)

--- a/server/routes/index.coffee
+++ b/server/routes/index.coffee
@@ -173,15 +173,20 @@ module.exports.setup = (app) ->
   app.get('/db/course/:handle/patches', mw.patchable.patches(Course))
 
   app.post('/db/course_instance', mw.auth.checkLoggedIn(), mw.courseInstances.post)
+  app.get('/db/course_instance', mw.courseInstances.getByOwner, mw.courseInstances.getByMember, mw.courseInstances.getByClassroom)
   app.get('/db/course_instance/-/non-hoc', mw.auth.checkHasPermission(['admin']), mw.courseInstances.fetchNonHoc)
   app.post('/db/course_instance/-/recent', mw.auth.checkHasPermission(['admin']), mw.courseInstances.fetchRecent)
+  app.get('/db/course_instance/:handle', mw.auth.checkLoggedIn(), mw.courseInstances.getByHandle)
   app.get('/db/course_instance/:handle/levels/:levelOriginal/sessions/:sessionID/next', mw.courseInstances.fetchNextLevels)
+  app.get('/db/course_instance/:handle/members', mw.auth.checkLoggedIn(), mw.courseInstances.fetchMembers)
   app.post('/db/course_instance/:handle/members', mw.auth.checkLoggedIn(), mw.courseInstances.addMembers)
   app.delete('/db/course_instance/:handle/members', mw.auth.checkLoggedIn(), mw.courseInstances.removeMembers)
   app.get('/db/course_instance/:handle/classroom', mw.auth.checkLoggedIn(), mw.courseInstances.fetchClassroom)
   app.get('/db/course_instance/:handle/course', mw.auth.checkLoggedIn(), mw.courseInstances.fetchCourse)
   app.get('/db/course_instance/:handle/my-course-level-sessions', mw.auth.checkLoggedIn(), mw.courseInstances.fetchMyCourseLevelSessions)
   app.get('/db/course_instance/:handle/peer-projects', mw.auth.checkLoggedIn(), mw.courseInstances.fetchPeerProjects)
+  app.get('/db/course_instance/:handle/level_sessions', mw.auth.checkLoggedIn(), mw.courseInstances.getLevelSessions)
+  app.get('/db/course_instance/-/find_by_level/:levelOriginal', mw.auth.checkLoggedIn(), mw.courseInstances.findByLevel)
 
   EarnedAchievement = require '../models/EarnedAchievement'
   app.post('/db/earned_achievement', mw.auth.checkHasUser(), mw.earnedAchievements.post)

--- a/server/routes/index.coffee
+++ b/server/routes/index.coffee
@@ -136,6 +136,7 @@ module.exports.setup = (app) ->
 
   app.post('/db/classroom', mw.classrooms.post)
   app.get('/db/classroom', mw.classrooms.getByCode, mw.classrooms.getByOwner, mw.classrooms.getByMember)
+  app.get('/db/classroom/:handle', mw.classrooms.getByHandle)
   app.get('/db/classroom/:handle/levels', mw.classrooms.fetchAllLevels)
   app.get('/db/classroom/:handle/courses/:courseID/levels', mw.classrooms.fetchLevelsForCourse)
 #  app.post('/db/classroom/:handle/invite-members', mw.classrooms.inviteMembers)

--- a/server/routes/index.coffee
+++ b/server/routes/index.coffee
@@ -137,6 +137,7 @@ module.exports.setup = (app) ->
   app.post('/db/classroom', mw.classrooms.post)
   app.get('/db/classroom', mw.classrooms.getByCode, mw.classrooms.getByOwner, mw.classrooms.getByMember)
   app.get('/db/classroom/:handle', mw.classrooms.getByHandle)
+  app.put('/db/classroom/:handle', mw.classrooms.put)
   app.get('/db/classroom/:handle/levels', mw.classrooms.fetchAllLevels)
   app.get('/db/classroom/:handle/courses/:courseID/levels', mw.classrooms.fetchLevelsForCourse)
 #  app.post('/db/classroom/:handle/invite-members', mw.classrooms.inviteMembers)

--- a/spec/server/functional/classrooms.spec.coffee
+++ b/spec/server/functional/classrooms.spec.coffee
@@ -439,7 +439,7 @@ describe 'POST /db/classroom/-/members', ->
     expect(res.statusCode).toBe(201)
     @classroom = yield Classroom.findById(body._id)
     [res, body] = yield request.postAsync({uri: getURL('/db/course_instance'), json: { courseID: @course.id, classroomID: @classroom.id }})
-    expect(res.statusCode).toBe(200)
+    expect(res.statusCode).toBe(201)
     @courseInstance = yield CourseInstance.findById(res.body._id)
     @student = yield utils.initUser()
     done()

--- a/spec/server/functional/course_instance.spec.coffee
+++ b/spec/server/functional/course_instance.spec.coffee
@@ -45,8 +45,12 @@ describe 'POST /db/course_instance', ->
       classroomID: @classroom.id
     }
     [res, body] = yield request.postAsync {uri: url, json: data}
-    expect(res.statusCode).toBe(200)
+    expect(res.statusCode).toBe(201)
     expect(body.classroomID).toBeDefined()
+    courseInstance = yield CourseInstance.findById(body._id)
+    expect(courseInstance.get('classroomID').equals(@classroom._id)).toBe(true)
+    expect(courseInstance.get('courseID').equals(@course._id)).toBe(true)
+    expect(courseInstance.get('ownerID').equals(@teacher._id)).toBe(true)
     done()
 
   it 'returns the same CourseInstance if you POST twice', utils.wrap (done) ->
@@ -56,7 +60,7 @@ describe 'POST /db/course_instance', ->
       classroomID: @classroom.id
     }
     [res, body] = yield request.postAsync {uri: url, json: data}
-    expect(res.statusCode).toBe(200)
+    expect(res.statusCode).toBe(201)
     expect(body.classroomID).toBeDefined()
     firstID = body._id
     [res, body] = yield request.postAsync {uri: url, json: data}
@@ -477,12 +481,12 @@ describe 'GET /db/course_instance/:handle/levels/:levelOriginal/sessions/:sessio
 
       dataA = { name: 'Some Name', courseID: @courseA.id, classroomID: @classroom.id }
       [res, body] = yield request.postAsync {uri: url, json: dataA}
-      expect(res.statusCode).toBe(200)
+      expect(res.statusCode).toBe(201)
       @courseInstanceA = yield CourseInstance.findById(res.body._id)
 
       dataB = { name: 'Some Other Name', courseID: @courseB.id, classroomID: @classroom.id }
       [res, body] = yield request.postAsync {uri: url, json: dataB}
-      expect(res.statusCode).toBe(200)
+      expect(res.statusCode).toBe(201)
       @courseInstanceB = yield CourseInstance.findById(res.body._id)
 
       done()
@@ -527,12 +531,12 @@ describe 'GET /db/course_instance/:handle/levels/:levelOriginal/sessions/:sessio
 
       dataA = { name: 'Some Name', courseID: @courseA.id, classroomID: @classroom.id }
       [res, body] = yield request.postAsync {uri: url, json: dataA}
-      expect(res.statusCode).toBe(200)
+      expect(res.statusCode).toBe(201)
       @courseInstanceA = yield CourseInstance.findById(res.body._id)
 
       dataB = { name: 'Some Other Name', courseID: @courseB.id, classroomID: @classroom.id }
       [res, body] = yield request.postAsync {uri: url, json: dataB}
-      expect(res.statusCode).toBe(200)
+      expect(res.statusCode).toBe(201)
       @courseInstanceB = yield CourseInstance.findById(res.body._id)
 
       done()
@@ -615,7 +619,7 @@ describe 'GET /db/course_instance/:handle/levels/:levelOriginal/sessions/:sessio
 
       dataA = { name: 'Some Name', courseID: @courseA.id, classroomID: @classroom.id }
       [res, body] = yield request.postAsync {uri: url, json: dataA}
-      expect(res.statusCode).toBe(200)
+      expect(res.statusCode).toBe(201)
       @courseInstanceA = yield CourseInstance.findById(res.body._id)
 
       done()

--- a/spec/server/utils.coffee
+++ b/spec/server/utils.coffee
@@ -374,7 +374,7 @@ module.exports = mw =
       data.classroomID = sources.classroom.id
 
     [res, body] = yield request.postAsync({ uri: getURL('/db/course_instance'), json: data })
-    expect(res.statusCode).toBe(200)
+    expect(res.statusCode).toBe(201)
     courseInstance = yield CourseInstance.findById(res.body._id)
     if sources.members
       userIDs = _.map(sources.members, 'id')


### PR DESCRIPTION
Refactored all of the classroom and course instance handlers. This is too big to integrate all at once! I'm pulling endpoints gradually, rebasing out pieces of the commit to be evaluated and merged in.

ON DECK:
* Refactor, test GET /db/classroom?memberID=:id

This endpoint is only used in the Student Courses page. This is tested in smoke tests already, and I've tested locally to make sure it still works. This replaces [this code](https://github.com/codecombat/codecombat/blob/aace80037a7c439a40aafc66bc1fd33d5145dd53/server/handlers/classroom_handler.coffee#L58-L65).