### PR TITLE
Have game dev levels use modern esper when possible

### DIFF
--- a/app/templates/static/layout.static.pug
+++ b/app/templates/static/layout.static.pug
@@ -27,7 +27,8 @@ html(lang='en')
       var DEXECURE_URL = "/dexecure-c167a5675c.js";
       "serviceWorker"in navigator&&navigator.serviceWorker.register(DEXECURE_URL,{scope:'/'}).then(function(e){"/"!=new URL(e.scope).pathname&&console.log("Service worker scope is not /")})["catch"](function(e){console.log("Unable to register service worker.");console.log(e)});
       // Placeholder for iPad, which inspects the user object at the bottom of an injected page.
-    script(src='/' + shaTag + '/javascripts/esper.js', defer='')
+    script.
+      window.javascriptsPath = '/#{shaTag}/javascripts/';
     if chunkPaths[viewName]
       script(src=chunkPaths[viewName], defer='')
     script(src='/' + shaTag + '/javascripts/app.js', defer='', async='', data-ace-base='/javascripts/ace') // This data tag needs to be on SOME script with a src for Ace to work

--- a/app/vendor.js
+++ b/app/vendor.js
@@ -34,7 +34,21 @@ window.Vuex = require('vuex').default
 
 window.algoliasearch = require('algoliasearch')
 
-
+function loadScript (url) {
+  var script = document.createElement('script');
+  script.src = url;
+  document.head.appendChild(script);
+}
+try {
+  //Detect very modern javascript support.
+  (0,eval("'use strict'; let test = WeakMap && (class Test { *gen(a=7) { yield yield * () => true ; } });"));
+  console.log("Modern javascript detected, aw yeah!");
+  loadScript(window.javascriptsPath + 'esper.modern.js')
+  
+} catch (e) {
+  console.log("Legacy javascript detected, falling back...", e.message);
+  loadScript(window.javascriptsPath + 'esper.js');
+}
 
 // All the rest of Vendor...
 require('vendor/scripts/css.js')


### PR DESCRIPTION
Currently legacy esper is loaded on the main thread and the modern version is loaded in the web worker when possible. However, this means loading the engine twice for modern browsers and, more importantly, game dev levels play slower because they are running on the slower engine. This change has the modern engine loaded on the main thread when possible.