### PR TITLE
Update spectate.sass

### DIFF
--- a/app/styles/play/spectate.sass
+++ b/app/styles/play/spectate.sass
@@ -129,6 +129,7 @@
     left: 0
     right: 0
     background: linear-gradient(to top, rgba(0,0,0,0) 0%,rgba(0,0,0,0.8*$GI) 100%)
+    z-index: 4
 
   #hud-left-gradient
     background: linear-gradient(to right, rgba(0,0,0,$GI) 0%,rgba(0,0,0,0) 100%)


### PR DESCRIPTION
[Weird shadow in spectate mode: Issue #3005](https://github.com/codecombat/codecombat/issues/3005)

When looking at the issue, we noticed that the canvas-top-gradient z-index was too high, and that lowering it removed the shadow and seemingly fixed the issue. 

The contributor license agreement has also been signed.