### PR TITLE
Update find next assessment level logic

### DIFF
--- a/app/core/utils.coffee
+++ b/app/core/utils.coffee
@@ -486,8 +486,8 @@ createLevelNumberMap = (levels) ->
   levelNumberMap
 
 findNextLevel = (levels, currentIndex, needsPractice) ->
-  # TODO: Fully account for skipping assessments
-  # levels = [{practice: true/false, complete: true/false}]
+  # Find next available incomplete level, depending on whether practice is needed
+  # levels = [{practice: true/false, complete: true/false, assessment: true/false}]
   index = currentIndex
   index++
   if needsPractice
@@ -518,6 +518,7 @@ findNextAssessmentForLevel = (levels, currentIndex, needsPractice) ->
   # Find assessment level immediately after current level (and its practice levels)
   # Only return assessment if it's the next level
   # Skip over practice levels unless practice neeeded
+  # levels = [{practice: true/false, complete: true/false, assessment: true/false}]
   # eg: l*,p,p,a*,a',l,...
   # given index l*, return index a*
   # given index a*, return index a'

--- a/app/core/utils.coffee
+++ b/app/core/utils.coffee
@@ -514,21 +514,27 @@ findNextLevel = (levels, currentIndex, needsPractice) ->
     index++ while index < levels.length and (levels[index].practice or levels[index].complete or levels[index].assessment)
   index
 
-findNextAssessmentForLevel = (levels, currentIndex) ->
-  # Assessments are placed immediately after a level (and possibly its practice levels)
-  # eg: l*,p,p,a*,a',l,... (if we ever do multiple assessments later)
+findNextAssessmentForLevel = (levels, currentIndex, needsPractice) ->
+  # Find assessment level immediately after current level (and its practice levels)
+  # Only return assessment if it's the next level
+  # Skip over practice levels unless practice neeeded
+  # eg: l*,p,p,a*,a',l,...
   # given index l*, return index a*
   # given index a*, return index a'
   index = currentIndex
   index++
   while index < levels.length
-    if levels[index].complete or levels[index].practice # It's a practice level or completed, keep looking
-      index++
+    if levels[index].practice
+      return -1 if needsPractice and not levels[index].complete
+      index++ # It's a practice level but do not need practice, keep looking
     else if levels[index].assessment
+      return -1 if levels[index].complete
       return index
+    else if levels[index].complete # It's completed, keep looking
+      index++
     else # we got to a normal level; we didn't find an assessment for the given level.
-      return false
-  return false # we got to the end of the list and found nothing
+      return -1
+  return -1 # we got to the end of the list and found nothing
 
 needsPractice = (playtime=0, threshold=5) ->
   playtime / 60 > threshold

--- a/app/templates/teachers/hovers/progress-dot-single-student-level.jade
+++ b/app/templates/teachers/hovers/progress-dot-single-student-level.jade
@@ -27,7 +27,7 @@ mixin assessmentLines()
       span(data-i18n="teacher.concepts_used")
     for goal in conceptGoals
       .small-details
-        if goalStates[goal.id].status === 'success'
+        if goalStates && goalStates[goal.id].status === 'success'
           i.glyphicon.glyphicon-ok
         else
           i.glyphicon.glyphicon-remove

--- a/app/views/courses/StudentLevelProgressDot.vue
+++ b/app/views/courses/StudentLevelProgressDot.vue
@@ -111,7 +111,7 @@
       conceptGoals: ->
         return (@level.goals || []).filter((g) => g.concepts?.length)
       conceptGoalsCompleted: ->
-        return @conceptGoals.filter((g) => @progress.session?.state.goalStates[g.id].status is 'success').length
+        return @conceptGoals.filter((g) => @progress.session?.state.goalStates?[g.id].status is 'success').length
       percentConceptsCompleted: ->
         res = 100 * @conceptGoalsCompleted / @conceptGoals.length
         return if _.isNaN(res) then 0 else res

--- a/server/middleware/course-instances.coffee
+++ b/server/middleware/course-instances.coffee
@@ -117,7 +117,7 @@ module.exports =
 
     course = yield Course.findById courseId
     throw new errors.NotFound('Course referenced by course instance not found') unless course
-    
+
     userObjectIDs = (mongoose.Types.ObjectId(userID) for userID in userIDs)
 
     courseInstance = yield CourseInstance.findByIdAndUpdate(
@@ -130,7 +130,7 @@ module.exports =
       { _id: { $in: userObjectIDs } },
       { $pull: { courseInstances: courseInstance._id } }
     )
-    
+
     res.status(200).send(courseInstance.toObject({ req }))
 
   fetchNextLevels: wrap (req, res) ->
@@ -170,7 +170,7 @@ module.exports =
         ]}, project))
     levelSessions = _.flatten(yield queries)
     levelCompleteMap = {}
-    
+
     for levelSession in levelSessions
       currentLevelSession = levelSession if levelSession.id is sessionID
       levelCompleteMap[levelSession.get('level')?.original] = levelSession.get('state')?.complete
@@ -191,7 +191,7 @@ module.exports =
     unless currentIndex >= 0 then throw new errors.NotFound('Level original ObjectId not found in Classroom courses')
     nextLevelIndex = utils.findNextLevel(levels, currentIndex, needsPractice)
     nextLevelOriginal = courseLevels[nextLevelIndex]?.original
-    nextAssessmentIndex = utils.findNextAssessmentForLevel(levels, currentIndex)
+    nextAssessmentIndex = utils.findNextAssessmentForLevel(levels, currentIndex, needsPractice)
     nextAssessmentOriginal = courseLevels[nextAssessmentIndex]?.original
     unless nextLevelOriginal then return res.status(200).send({
       level: {}
@@ -206,7 +206,7 @@ module.exports =
       dbq.select(parse.getProjectFromReq(req))
       level = yield dbq
       level = level.toObject({req: req})
-    
+
     assessment = {}
     if nextAssessmentOriginal
       # Fetch full Assessment Level object
@@ -215,7 +215,7 @@ module.exports =
       dbq.select(parse.getProjectFromReq(req))
       assessment = yield dbq
       assessment = assessment.toObject({req: req})
-    
+
     res.status(200).send({ level, assessment })
 
   fetchClassroom: wrap (req, res) ->

--- a/test/app/core/utils.spec.coffee
+++ b/test/app/core/utils.spec.coffee
@@ -120,10 +120,16 @@ describe 'Utility library', ->
       levelNumberMap = utils.createLevelNumberMap(levels)
       expect((val.toString() for key, val of levelNumberMap)).toEqual(['1', '1a', '1b', '1c', '2', '2a', '2b', '3', '4', '4a', '5'])
 
-  describe 'find next level and assessment', ->
+  describe 'findNextLevel and findNextAssessmentForLevel', ->
     # r=required p=practice c=complete *=current a=assessment
     # utils.findNextLevel returns next level 0-based index
     # utils.findNextAssessmentForLevel returns next level 0-based index
+
+    # Find next available incomplete level, depending on whether practice is needed
+    # Find assessment level immediately after current level (and its practice levels)
+    # Only return assessment if it's the next level
+    # Skip over practice levels unless practice neeeded
+    # levels = [{practice: true/false, complete: true/false, assessment: true/false}]
 
     describe 'when no practice needed', ->
       needsPractice = false

--- a/test/app/core/utils.spec.coffee
+++ b/test/app/core/utils.spec.coffee
@@ -1,22 +1,22 @@
 describe 'Utility library', ->
   utils = require 'core/utils'
-  
+
   describe 'getQueryVariable(param, defaultValue)', ->
     beforeEach ->
       spyOn(utils, 'getDocumentSearchString').and.returnValue(
         '?key=value&bool1=false&bool2=true&email=test%40email.com'
       )
-    
+
     it 'returns the query parameter', ->
       expect(utils.getQueryVariable('key')).toBe('value')
-      
+
     it 'returns Boolean types if the value is "true" or "false"', ->
       expect(utils.getQueryVariable('bool1')).toBe(false)
       expect(utils.getQueryVariable('bool2')).toBe(true)
-      
+
     it 'decodes encoded strings', ->
       expect(utils.getQueryVariable('email')).toBe('test@email.com')
-      
+
     it 'returns the given default value if the key is not present', ->
       expect(utils.getQueryVariable('key', 'other-value')).toBe('value')
       expect(utils.getQueryVariable('NaN', 'other-value')).toBe('other-value')
@@ -120,67 +120,250 @@ describe 'Utility library', ->
       levelNumberMap = utils.createLevelNumberMap(levels)
       expect((val.toString() for key, val of levelNumberMap)).toEqual(['1', '1a', '1b', '1c', '2', '2a', '2b', '3', '4', '4a', '5'])
 
-  describe 'findNextlevel', ->
-    # r=required p=practice c=complete *=current
+  describe 'find next level and assessment', ->
+    # r=required p=practice c=complete *=current a=assessment
     # utils.findNextLevel returns next level 0-based index
+    # utils.findNextAssessmentForLevel returns next level 0-based index
+
     describe 'when no practice needed', ->
       needsPractice = false
-      it 'returns next level when rc* p', (done) ->
+      it 'returns correct next levels when rc* p', ->
         levels = [
           {practice: false, complete: true}
           {practice: true, complete: false}
         ]
         expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(2)
-        done()
-      it 'returns next level when pc* p r', (done) ->
+        expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when pc* p r', ->
         levels = [
           {practice: true, complete: true}
           {practice: true, complete: false}
           {practice: false, complete: false}
         ]
         expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(2)
-        done()
-      it 'returns next level when pc* p p', (done) ->
+        expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when pc* p p', ->
         levels = [
           {practice: true, complete: true}
           {practice: true, complete: false}
           {practice: true, complete: false}
         ]
         expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(3)
-        done()
-      it 'returns next level when rc* p rc', (done) ->
+        expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc* p rc', ->
         levels = [
           {practice: false, complete: true}
           {practice: true, complete: false}
           {practice: false, complete: true}
         ]
         expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(3)
-        done()
+        expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc* r p p p a r p p p a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(1)
+        expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc rc* p p p a r p p p a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 1, needsPractice)).toEqual(6)
+        expect(utils.findNextAssessmentForLevel(levels, 1, needsPractice)).toEqual(5)
+      it 'returns correct next levels when rc rc pc* p p a r p p p a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 2, needsPractice)).toEqual(6)
+        expect(utils.findNextAssessmentForLevel(levels, 2, needsPractice)).toEqual(5)
+      it 'returns correct next levels when rc rc pc pc pc* a r p p p a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 4, needsPractice)).toEqual(6)
+        expect(utils.findNextAssessmentForLevel(levels, 4, needsPractice)).toEqual(5)
+      it 'returns correct next levels when rc rc pc pc pc ac* r p p p a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {assessment: true, complete: true}
+          {practice: false, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 5, needsPractice)).toEqual(6)
+        expect(utils.findNextAssessmentForLevel(levels, 5, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc rc pc pc pc ac rc* p p p a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {assessment: true, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 6, needsPractice)).toEqual(11)
+        expect(utils.findNextAssessmentForLevel(levels, 6, needsPractice)).toEqual(10)
+      it 'returns correct next levels when rc rc* p p p a rc p p p a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: true}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 2, needsPractice)).toEqual(11)
+        expect(utils.findNextAssessmentForLevel(levels, 2, needsPractice)).toEqual(5)
+      it 'returns correct next levels when rc rc pc pc pc* a rc p p p a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {assessment: true, complete: false}
+          {practice: false, complete: true}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 4, needsPractice)).toEqual(11)
+        expect(utils.findNextAssessmentForLevel(levels, 4, needsPractice)).toEqual(5)
+      it 'returns correct next levels when rc rc* p p p ac rc p p p a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 2, needsPractice)).toEqual(11)
+        expect(utils.findNextAssessmentForLevel(levels, 2, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc rc pc pc pc* a rc p p p a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {assessment: true, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 4, needsPractice)).toEqual(11)
+        expect(utils.findNextAssessmentForLevel(levels, 4, needsPractice)).toEqual(-1)
+
     describe 'when needs practice', ->
       needsPractice = true
-      it 'returns next level when rc* p', (done) ->
+      it 'returns correct next levels when rc* p', ->
         levels = [
           {practice: false, complete: true}
           {practice: true, complete: false}
         ]
         expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(1)
-        done()
-      it 'returns next level when rc* rc', (done) ->
+        expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc* rc', ->
         levels = [
           {practice: false, complete: true}
           {practice: false, complete: true}
         ]
         expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(2)
-        done()
-      it 'returns next level when rc p rc*', (done) ->
+        expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc p rc*', ->
         levels = [
           {practice: false, complete: true}
           {practice: true, complete: false}
           {practice: false, complete: true}
         ]
         expect(utils.findNextLevel(levels, 2, needsPractice)).toEqual(1)
-        done()
-      it 'returns next level when rc pc p rc*', (done) ->
+        expect(utils.findNextAssessmentForLevel(levels, 2, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc pc p rc*', ->
         levels = [
           {practice: false, complete: true}
           {practice: true, complete: true}
@@ -188,8 +371,8 @@ describe 'Utility library', ->
           {practice: false, complete: true}
         ]
         expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(2)
-        done()
-      it 'returns next level when rc pc p rc* p', (done) ->
+        expect(utils.findNextAssessmentForLevel(levels, 3, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc pc p rc* p', ->
         levels = [
           {practice: false, complete: true}
           {practice: true, complete: true}
@@ -198,8 +381,8 @@ describe 'Utility library', ->
           {practice: true, complete: false}
         ]
         expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(4)
-        done()
-      it 'returns next level when rc pc p rc* pc', (done) ->
+        expect(utils.findNextAssessmentForLevel(levels, 3, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc pc p rc* pc', ->
         levels = [
           {practice: false, complete: true}
           {practice: true, complete: true}
@@ -208,8 +391,8 @@ describe 'Utility library', ->
           {practice: true, complete: true}
         ]
         expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(5)
-        done()
-      it 'returns next level when rc pc p rc* pc p', (done) ->
+        expect(utils.findNextAssessmentForLevel(levels, 3, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc pc p rc* pc p', ->
         levels = [
           {practice: false, complete: true}
           {practice: true, complete: true}
@@ -219,8 +402,8 @@ describe 'Utility library', ->
           {practice: true, complete: false}
         ]
         expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(5)
-        done()
-      it 'returns next level when rc pc p rc* pc r', (done) ->
+        expect(utils.findNextAssessmentForLevel(levels, 3, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc pc p rc* pc r', ->
         levels = [
           {practice: false, complete: true}
           {practice: true, complete: true}
@@ -230,8 +413,8 @@ describe 'Utility library', ->
           {practice: false, complete: false}
         ]
         expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(5)
-        done()
-      it 'returns next level when rc pc p rc* pc p r', (done) ->
+        expect(utils.findNextAssessmentForLevel(levels, 3)).toEqual(-1)
+      it 'returns correct next levels when rc pc p rc* pc p r', ->
         levels = [
           {practice: false, complete: true}
           {practice: true, complete: true}
@@ -242,8 +425,50 @@ describe 'Utility library', ->
           {practice: false, complete: false}
         ]
         expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(5)
-        done()
-      it 'returns next level when rc pc p a rc* pc p r', (done) ->
+        expect(utils.findNextAssessmentForLevel(levels, 3)).toEqual(-1)
+      it 'returns correct next levels when rc pc pc rc* r p', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {practice: false, complete: true}
+          {practice: false, complete: false}
+          {practice: true, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(4)
+        expect(utils.findNextAssessmentForLevel(levels, 3, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc* pc rc', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: false, complete: true}
+        ]
+        expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(3)
+        expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc pc p rc* r p', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: false}
+          {practice: false, complete: true}
+          {practice: false, complete: false}
+          {practice: true, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(2)
+        expect(utils.findNextAssessmentForLevel(levels, 3, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc pc p a rc* r p', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: false}
+          {practice: false, complete: false, assessment: true}
+          {practice: false, complete: true}
+          {practice: false, complete: false}
+          {practice: true, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 4, needsPractice)).toEqual(2)
+        expect(utils.findNextAssessmentForLevel(levels, 4, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc pc p a rc* pc p r', ->
         levels = [
           {practice: false, complete: true}
           {practice: true, complete: true}
@@ -255,46 +480,166 @@ describe 'Utility library', ->
           {practice: false, complete: false}
         ]
         expect(utils.findNextLevel(levels, 4, needsPractice)).toEqual(6)
-        done()
-      it 'returns next level when rc pc pc rc* r p', (done) ->
+        expect(utils.findNextAssessmentForLevel(levels, 4, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc rc* p p p a r p p p a r r', ->
         levels = [
           {practice: false, complete: true}
-          {practice: true, complete: true}
-          {practice: true, complete: true}
           {practice: false, complete: true}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
           {practice: false, complete: false}
           {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
         ]
-        expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(4)
-        done()
-      it 'returns next level when rc* pc rc', (done) ->
+        expect(utils.findNextLevel(levels, 1, needsPractice)).toEqual(2)
+        expect(utils.findNextAssessmentForLevel(levels, 1, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc rc pc* p p a r p p p a r r', ->
         levels = [
           {practice: false, complete: true}
-          {practice: true, complete: true}
-          {practice: false, complete: true}
-        ]
-        expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(3)
-        done()
-      it 'returns next level when rc pc p rc* r p', (done) ->
-        levels = [
           {practice: false, complete: true}
           {practice: true, complete: true}
           {practice: true, complete: false}
-          {practice: false, complete: true}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
           {practice: false, complete: false}
           {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
         ]
-        expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(2)
-        done()
-      it 'returns next level when rc pc p a rc* r p', (done) ->
+        expect(utils.findNextLevel(levels, 2, needsPractice)).toEqual(3)
+        expect(utils.findNextAssessmentForLevel(levels, 2, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc rc pc pc pc* a r p p p a r r', ->
         levels = [
           {practice: false, complete: true}
-          {practice: true, complete: true}
-          {practice: true, complete: false}
-          {practice: false, complete: false, assessment: true}
           {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {assessment: true, complete: false}
           {practice: false, complete: false}
           {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
         ]
-        expect(utils.findNextLevel(levels, 4, needsPractice)).toEqual(2)
-        done()
+        expect(utils.findNextLevel(levels, 4, needsPractice)).toEqual(6)
+        expect(utils.findNextAssessmentForLevel(levels, 4, needsPractice)).toEqual(5)
+      it 'returns correct next levels when rc rc pc pc pc ac* r p p p a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {assessment: true, complete: true}
+          {practice: false, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 5, needsPractice)).toEqual(6)
+        expect(utils.findNextAssessmentForLevel(levels, 5, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc rc pc pc pc ac rc* p p p a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {assessment: true, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 6, needsPractice)).toEqual(7)
+        expect(utils.findNextAssessmentForLevel(levels, 6, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc rc pc pc pc* ac rc p p p a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {assessment: true, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 4, needsPractice)).toEqual(7)
+        expect(utils.findNextAssessmentForLevel(levels, 4, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc rc pc pc pc* a rc p p p a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {assessment: true, complete: false}
+          {practice: false, complete: true}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 4, needsPractice)).toEqual(7)
+        expect(utils.findNextAssessmentForLevel(levels, 4, needsPractice)).toEqual(5)
+      it 'returns correct next levels when rc rc pc pc pc* ac rc pc pc pc a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {assessment: true, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 4, needsPractice)).toEqual(11)
+        expect(utils.findNextAssessmentForLevel(levels, 4, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc rc pc pc pc ac* r p p p a r r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {practice: true, complete: true}
+          {assessment: true, complete: true}
+          {practice: false, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {practice: true, complete: false}
+          {assessment: true, complete: false}
+          {practice: false, complete: false}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 5, needsPractice)).toEqual(6)
+        expect(utils.findNextAssessmentForLevel(levels, 5, needsPractice)).toEqual(-1)


### PR DESCRIPTION
Only return next assessment level if it’s incomplete and immediately
following current level.
Next practice level takes precedence over next assessment level.
Add automated tests for utils.findNextAssessmentForLevel

Fixing goalStates null check in student assessment progress UI.