### PR TITLE
Fix artillery not rendering in Last Guardian

### DIFF
--- a/app/models/ThangType.coffee
+++ b/app/models/ThangType.coffee
@@ -509,15 +509,16 @@ module.exports = class ThangType extends CocoModel
 
   getPrerenderedSpriteSheet: (colorConfig, defaultSpriteType) ->
     return unless @prerenderedSpriteSheets
-    if @noRawData()
-      return @prerenderedSpriteSheets.first() # there can only be one
     spriteType = @get('spriteType') or defaultSpriteType
-    @prerenderedSpriteSheets.find (pss) ->
+    result = @prerenderedSpriteSheets.find (pss) ->
       return false if pss.get('spriteType') isnt spriteType
       otherColorConfig = pss.get('colorConfig')
       return true if _.isEmpty(colorConfig) and _.isEmpty(otherColorConfig)
       getHue = (config) -> _.result(_.result(config, 'team'), 'hue')
       return getHue(colorConfig) is getHue(otherColorConfig)
+    if (not result) and @noRawData()
+      return @prerenderedSpriteSheets.first() # there can only be one
+    return result
 
   getPrerenderedSpriteSheetToLoad: ->
     return unless @prerenderedSpriteSheets

--- a/server/commons/Handler.coffee
+++ b/server/commons/Handler.coffee
@@ -248,7 +248,7 @@ module.exports = class Handler
 
     # Hack: levels loading thang types need the components returned as well.
     # Need a way to specify a projection for a query.
-    project = {name: 1, original: 1, kind: 1, components: 1, prerenderedSpriteSheetData: 1}
+    project = {name: 1, original: 1, kind: 1, components: 1, prerenderedSpriteSheetData: 1, spriteType: 1}
     sort = if nonVersioned then {} else {'version.major': -1, 'version.minor': -1}
 
     makeFunc = (id) =>


### PR DESCRIPTION
This commit makes it so when you go to [The Last Guardian](https://codecombat.com/editor/level/last-guardian),
the artillery sprite correctly displays. This may also fix other
prerendered sprite sheet issues. Two changes:

1. Have the names endpoint return spriteType so
`getPrerenderedSpriteSheet` can use it to figure out what sprite sheet
 needs to be rendered.
2. Don't let a lack of `raw` property get in the way of searching for
 the right spritesheet to use.