### PR TITLE
Abort and show code errors while in game dev test level

### DIFF
--- a/app/lib/God.coffee
+++ b/app/lib/God.coffee
@@ -83,7 +83,7 @@ module.exports = class God extends CocoClass
 
     # We only want one world being simulated, so we abort other angels, unless we had one preloading this very code.
     hadPreloader = false
-    for angel in @angelsShare.busyAngels
+    for angel in @angelsShare.busyAngels.slice()
       isPreloading = angel.running and angel.work.preload and _.isEqual angel.work.userCodeMap, userCodeMap, (a, b) ->
         return a.raw is b.raw if a?.raw? and b?.raw?
         undefined  # Let default equality test suffice.

--- a/app/views/play/level/tome/ProblemAlertView.coffee
+++ b/app/views/play/level/tome/ProblemAlertView.coffee
@@ -68,7 +68,7 @@ module.exports = class ProblemAlertView extends CocoView
       @hint = format @problem.hint
 
   onShowProblemAlert: (data) ->
-    return unless $('#code-area').is(":visible")
+    return unless $('#code-area').is(":visible") or @level.isType('game-dev')
     if @problem?
       if @$el.hasClass "alert-#{@problem.level}"
         @$el.removeClass "alert-#{@problem.level}"

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -1036,6 +1036,7 @@ module.exports = class SpellView extends CocoView
     @spell.hasChangedSignificantly @getSource(), null, (hasChanged) =>
       return if hasChanged
       @spell.thang.aether.addProblem e.problem
+      @spell.thang.castAether?.addProblem e.problem
       @lastUpdatedAetherSpellThang = null  # force a refresh without a re-transpile
       @updateAether false, false
 

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -872,10 +872,10 @@ module.exports = class SpellView extends CocoView
       for i in [0...problem.row]
         lineOffsetPx += @aceSession.getRowLength(i) * @ace.renderer.lineHeight
       lineOffsetPx -= @ace.session.getScrollTop()
-    Backbone.Mediator.publish 'tome:show-problem-alert', problem: problem, lineOffsetPx: Math.max lineOffsetPx, 0
     if problem.level not in ['info', 'warning']
       Backbone.Mediator.publish 'playback:stop-cinematic-playback', {}
       # TODO: find a way to also show problem alert if it's compile-time, and/or not enter cinematic mode at all
+    Backbone.Mediator.publish 'tome:show-problem-alert', problem: problem, lineOffsetPx: Math.max lineOffsetPx, 0
 
   # Gets the number of lines before the start of <script> content in the usercode
   # Because Errors report their line number relative to the <script> tag
@@ -1035,8 +1035,10 @@ module.exports = class SpellView extends CocoView
     return unless @spell.thang?.thang.id is e.problem.userInfo.thangID
     @spell.hasChangedSignificantly @getSource(), null, (hasChanged) =>
       return if hasChanged
-      @spell.thang.aether.addProblem e.problem
-      @spell.thang.castAether?.addProblem e.problem
+      if e.problem.type is 'runtime'
+        @spellThang.castAether?.addProblem e.problem
+      else
+        @spell.thang.aether.addProblem e.problem
       @lastUpdatedAetherSpellThang = null  # force a refresh without a re-transpile
       @updateAether false, false
 


### PR DESCRIPTION
The changes in Angel.coffee should be fine; we just weren't handling the runtime errors from user code.

The change in SpellView... why did we not have the runtime version of the `aether` having the error before, or how do runtime errors still work in normal game modes? Not sure if that will change any behavior anywhere else, although in my tests it didn't. Might be worth a little more QA comparing various error behaviors.