### PR TITLE
Show computed health in inventory dialog

### DIFF
--- a/app/models/ThangType.coffee
+++ b/app/models/ThangType.coffee
@@ -392,6 +392,12 @@ module.exports = class ThangType extends CocoModel
     props = _.without props, 'canCast', 'spellNames', 'spells'
     for stat, modifiers of itemConfig.stats ? {}
       stats[stat] = @formatStatDisplay stat, modifiers
+      if @heroStatModifier? and stats['maxHealth']? and !isNaN(stats['maxHealth'].display)
+        healthModifier = @heroStatModifier.health.absolute
+        totalHealth = Math.round(healthModifier * stats['maxHealth'].display)
+        modifiedHealth = Math.round(totalHealth - stats['maxHealth'].display)
+        stats['maxHealth'].display +=  "  (#{modifiedHealth})"
+        stats['maxHealth'].tooltipDisplay = "#{totalHealth} total health after x#{healthModifier} modifier from the selected hero"
     for stat in itemConfig.extraHUDProperties ? []
       stats[stat] ?= null  # Find it in the other Components.
     for component in components
@@ -400,6 +406,12 @@ module.exports = class ThangType extends CocoModel
         value = config[stat]
         continue unless value?
         stats[stat] = @formatStatDisplay stat, setTo: value
+        if @heroStatModifier? and (stat is 'attackDamage' or  stat is 'bashDamage' or  stat is 'throwDamage')
+          damageModifier = @heroStatModifier.attack.absolute
+          totalDamage = Math.round(damageModifier * stats[stat].display)
+          modifiedDamage = Math.round(totalDamage - stats[stat].display)
+          stats[stat].display += "  (#{modifiedDamage})"
+          stats[stat].tooltipDisplay = "#{totalDamage} damage after x#{damageModifier} from the selected hero"
         if stat is 'attackDamage'
           dps = (value / (config.cooldown or 0.5)).toFixed(1)
           stats[stat].display += " (#{dps} DPS)"

--- a/app/templates/play/modal/item-details-view.jade
+++ b/app/templates/play/modal/item-details-view.jade
@@ -15,8 +15,8 @@
         if !me.isStudent()
           for stat in stats
             div(class="stat-row big-font" + (/^en/.test(me.get('preferredLanguage')) && stat.matchedShortName ? " short-name" : ""))
-              div.stat-label= stat.name
-              div.stat= stat.display
+              div.stat-label(title=stat.tooltipDisplay)= stat.name
+              div.stat(title=stat.tooltipDisplay)= stat.display
             img.hr(src="/images/pages/play/modal/hr.png", class=stat.isLast ? "" : "faded", draggable="false")
 
         if item.description

--- a/app/views/play/menu/InventoryModal.coffee
+++ b/app/views/play/menu/InventoryModal.coffee
@@ -418,6 +418,7 @@ module.exports = class InventoryModal extends ModalView
 
 
   showItemDetails: (item, showExtra) ->
+    item.heroStatModifier = @selectedHero.getHeroStats()
     @itemDetailsView.setItem(item)
     @$el.find('#item-details-extra > *').addClass('secret')
     @$el.find("##{showExtra}-item-viewed").removeClass('secret')

--- a/app/views/play/modal/ItemDetailsView.coffee
+++ b/app/views/play/modal/ItemDetailsView.coffee
@@ -27,6 +27,9 @@ module.exports = class ItemDetailsView extends CocoView
       @componentConfigs = (c.config for c in @item.get('components') when c.config)
 
       stats = @item.getFrontFacingStats()
+      if stats.tooltipDisplay?
+        @$el.find('.stat-label').addClass('has-tooltip').tooltip()
+        @$el.find('.stat').addClass('has-tooltip').tooltip()
       props = (p for p in stats.props when not @propDocs[p])
       if props.length > 0 or ('cast' in stats.props)
 


### PR DESCRIPTION
Addressing issue #2171, Show computed health in inventory dialog. We showed computed health and damage. In addition we added tooltips to both for more information, as described in the slack channel.

I have already signed the CFA agreement.