### PR TITLE
:bug:Fix utils.findNextLevel assessment bug

### DIFF
--- a/app/core/utils.coffee
+++ b/app/core/utils.coffee
@@ -505,6 +505,7 @@ createLevelNumberMap = (levels) ->
 findNextLevel = (levels, currentIndex, needsPractice) ->
   # Find next available incomplete level, depending on whether practice is needed
   # levels = [{practice: true/false, complete: true/false, assessment: true/false}]
+  # Skip over assessment levels
   index = currentIndex
   index++
   if needsPractice
@@ -513,7 +514,7 @@ findNextLevel = (levels, currentIndex, needsPractice) ->
       # May leave earlier practice levels incomplete and reach end of course
       index++ while index < levels.length and (levels[index].complete or levels[index].assessment)
     else
-      # Needs practice, current level is required, next level is required; return the first incomplete level of previous practice chain
+      # Needs practice, current level is required, next level is required or assessment; return the first incomplete level of previous practice chain
       index--
       index-- while index >= 0 and not levels[index].practice
       if index >= 0
@@ -525,7 +526,7 @@ findNextLevel = (levels, currentIndex, needsPractice) ->
             return index
       # Last set of practice levels is complete; return the next incomplete normal level instead.
       index = currentIndex + 1
-      index++ while index < levels.length and levels[index].complete and not levels[index].assessment
+      index++ while index < levels.length and (levels[index].complete or levels[index].assessment)
   else
     # No practice needed; return the next required incomplete level
     index++ while index < levels.length and (levels[index].practice or levels[index].complete or levels[index].assessment)

--- a/test/app/core/utils.spec.coffee
+++ b/test/app/core/utils.spec.coffee
@@ -194,6 +194,16 @@ describe 'Utility library', ->
         ]
         expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(3)
         expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc rc rc* a r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: false, complete: false, assessment: true}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 2, needsPractice)).toEqual(4)
+        expect(utils.findNextAssessmentForLevel(levels, 2, needsPractice)).toEqual(3)
       it 'returns correct next levels when rc* r p p p a r p p p a r r', ->
         levels = [
           {practice: false, complete: true}
@@ -408,6 +418,16 @@ describe 'Utility library', ->
         ]
         expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(2)
         expect(utils.findNextAssessmentForLevel(levels, 3, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when rc rc rc* a r', ->
+        levels = [
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: false, complete: true}
+          {practice: false, complete: false, assessment: true}
+          {practice: false, complete: false}
+        ]
+        expect(utils.findNextLevel(levels, 2, needsPractice)).toEqual(4)
+        expect(utils.findNextAssessmentForLevel(levels, 2, needsPractice)).toEqual(3)
       it 'returns correct next levels when rc pc p rc* p', ->
         levels = [
           {practice: false, complete: true}


### PR DESCRIPTION
Correctly skip over assessments when needing a practice level but one
isn’t available.