### PR TITLE
:bug:Fix IE11 level background raster image loading

### DIFF
--- a/app/core/utils.coffee
+++ b/app/core/utils.coffee
@@ -250,6 +250,11 @@ getByPath = (target, path) ->
 
 isID = (id) -> _.isString(id) and id.length is 24 and id.match(/[a-f0-9]/gi)?.length is 24
 
+isIE = ->
+  return false unless navigator? # Only relevant on client-side
+  # http://stackoverflow.com/questions/19999388/jquery-check-if-user-is-using-ie
+  navigator.userAgent.indexOf('MSIE') > 0 or !!navigator.userAgent.match(/Trident.*rv\:11\./)
+
 isRegionalSubscription = (name) -> /_basic_subscription/.test(name)
 
 isSmokeTestEmail = (email) ->
@@ -700,6 +705,7 @@ module.exports = {
   injectCSS
   inEU
   isID
+  isIE
   isRegionalSubscription
   isSmokeTestEmail
   keepDoingUntil

--- a/app/core/utils.coffee
+++ b/app/core/utils.coffee
@@ -250,10 +250,7 @@ getByPath = (target, path) ->
 
 isID = (id) -> _.isString(id) and id.length is 24 and id.match(/[a-f0-9]/gi)?.length is 24
 
-isIE = ->
-  return false unless navigator? # Only relevant on client-side
-  # http://stackoverflow.com/questions/19999388/jquery-check-if-user-is-using-ie
-  navigator.userAgent.indexOf('MSIE') > 0 or !!navigator.userAgent.match(/Trident.*rv\:11\./)
+isIE = -> $?.browser?.msie ? false
 
 isRegionalSubscription = (name) -> /_basic_subscription/.test(name)
 

--- a/app/models/ThangType.coffee
+++ b/app/models/ThangType.coffee
@@ -49,7 +49,10 @@ module.exports = class ThangType extends CocoModel
   loadRasterImage: ->
     return if @loadingRaster or @loadedRaster
     return unless raster = @get('raster')
-    @rasterImage = $("<img crossOrigin='Anonymous', src='/file/#{raster}' />")
+    # IE11 does not support CORS for images in the canvas element
+    # https://caniuse.com/#feat=cors
+    @rasterImage = if utils.isIE() then $("<img src='/file/#{raster}' />")
+    else $("<img crossOrigin='Anonymous', src='/file/#{raster}' />")
     @loadingRaster = true
     @rasterImage.one('load', =>
       @loadingRaster = false

--- a/app/views/core/CocoView.coffee
+++ b/app/views/core/CocoView.coffee
@@ -505,9 +505,7 @@ module.exports = class CocoView extends Backbone.View
     ua = navigator.userAgent or navigator.vendor or window.opera
     return mobileRELong.test(ua) or mobileREShort.test(ua.substr(0, 4))
 
-  isIE: ->
-    # http://stackoverflow.com/questions/19999388/jquery-check-if-user-is-using-ie
-    navigator.userAgent.indexOf('MSIE') > 0 or !!navigator.userAgent.match(/Trident.*rv\:11\./)
+  isIE: utils.isIE
 
   isMac: ->
     navigator.platform.toUpperCase().indexOf('MAC') isnt -1


### PR DESCRIPTION
IE11 does not support crossorigin img attribute within a canvas element.