### PR TITLE
Ladder configuration

### DIFF
--- a/app/lib/LevelBus.coffee
+++ b/app/lib/LevelBus.coffee
@@ -140,7 +140,8 @@ module.exports = class LevelBus extends Bus
 
   onWinnabilityUpdated: (e) ->
     return unless @onPoint() and e.winnable
-    return unless e.level.get('slug') in ['ace-of-coders', 'elemental-wars', 'the-battle-of-sky-span', 'tesla-tesoro', 'escort-duty', 'treasure-games']  # Mirror matches don't otherwise show victory, so we win here.
+    return unless e.level.get('slug') in ['ace-of-coders', 'elemental-wars', 'the-battle-of-sky-span', 'tesla-tesoro', 'escort-duty', 'treasure-games']  # Mirror matches don't otherwise show victory, so we win here.  # TODO: remove once these levels are configured as mirror matches
+    return unless e.level.get('mirrorMatch')  # Mirror matches don't otherwise show victory, so we win here.
     return if @session.get('state')?.complete
     @onVictory()
 

--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -162,6 +162,9 @@ module.exports = class LevelLoader extends CocoClass
         url += "?course=#{@courseID}"
         if @courseInstanceID
           url += "&courseInstance=#{@courseInstanceID}"
+      if password = utils.getQueryVariable 'password'
+        delimiter = if /\?/.test(url) then '&' else '?'
+        url += delimiter + 'password=' + password
 
     session = new LevelSession().setURL url
     if @headless and not @level.isType('web-dev')

--- a/app/lib/LevelSetupManager.coffee
+++ b/app/lib/LevelSetupManager.coffee
@@ -64,6 +64,10 @@ module.exports = class LevelSetupManager extends CocoClass
 
   loadModals: ->
     # build modals and prevent them from disappearing.
+    # TODO: refactor down to this
+    #if @level.usesConfiguredMultiplayerHero()
+    #  @onInventoryModalPlayClicked()
+    #  return
     if @level.get('slug') is 'zero-sum'
       sorcerer = '52fd1524c7e6cf99160e7bc9'
       if @session.get('creator') is '532dbc73a622924444b68ed9'  # Wizard Dude gets his own avatar

--- a/app/lib/LevelSetupManager.coffee
+++ b/app/lib/LevelSetupManager.coffee
@@ -64,7 +64,6 @@ module.exports = class LevelSetupManager extends CocoClass
 
   loadModals: ->
     # build modals and prevent them from disappearing.
-    # TODO: refactor down to this
     if @level.usesConfiguredMultiplayerHero()
      @onInventoryModalPlayClicked()
      return

--- a/app/lib/LevelSetupManager.coffee
+++ b/app/lib/LevelSetupManager.coffee
@@ -65,42 +65,9 @@ module.exports = class LevelSetupManager extends CocoClass
   loadModals: ->
     # build modals and prevent them from disappearing.
     # TODO: refactor down to this
-    #if @level.usesConfiguredMultiplayerHero()
-    #  @onInventoryModalPlayClicked()
-    #  return
-    if @level.get('slug') is 'zero-sum'
-      sorcerer = '52fd1524c7e6cf99160e7bc9'
-      if @session.get('creator') is '532dbc73a622924444b68ed9'  # Wizard Dude gets his own avatar
-        sorcerer = '53e126a4e06b897606d38bef'
-      @session.set 'heroConfig', {"thangType":sorcerer,"inventory":{"misc-0":"53e2396a53457600003e3f0f","programming-book":"546e266e9df4a17d0d449be5","minion":"54eb5dbc49fa2d5c905ddf56","feet":"53e214f153457600003e3eab","right-hand":"54eab7f52b7506e891ca7202","left-hand":"5463758f3839c6e02811d30f","wrists":"54693797a2b1f53ce79443e9","gloves":"5469425ca2b1f53ce7944421","torso":"546d4a549df4a17d0d449a97","neck":"54693274a2b1f53ce79443c9","eyes":"546941fda2b1f53ce794441d","head":"546d4ca19df4a17d0d449abf"}}
-      @onInventoryModalPlayClicked()
-      return
-    if @level.get('slug') is 'ace-of-coders'
-      goliath = '55e1a6e876cb0948c96af9f8'
-      @session.set 'heroConfig', {"thangType":goliath,"inventory":{"eyes":"53eb99f41a100989a40ce46e","neck":"54693274a2b1f53ce79443c9","wrists":"54693797a2b1f53ce79443e9","feet":"546d4d8e9df4a17d0d449acd","minion":"54eb5bf649fa2d5c905ddf4a","programming-book":"557871261ff17fef5abee3ee"}}
-      @onInventoryModalPlayClicked()
-      return
-    if @level.get('slug') is 'the-battle-of-sky-span'
-      wizard = '52fc1460b2b91c0d5a7b6af3'
-      @session.set 'heroConfig', {
-        "thangType": wizard
-        "inventory":{
-          "eyes": "546941fda2b1f53ce794441d",
-          "feet": "546d4d8e9df4a17d0d449acd",
-          "torso": "546d4a549df4a17d0d449a97",
-          "head": "546d4ca19df4a17d0d449abf",
-          "minion": "54eb5d1649fa2d5c905ddf52",
-          "neck": "54693240a2b1f53ce79443c5",
-          "wrists": "54693830a2b1f53ce79443f1",
-          "programming-book": "557871261ff17fef5abee3ee",
-          "left-ring": "54692d2aa2b1f53ce794438f"
-        }
-      }
-    if @level.get('slug') is 'assembly-speed'
-      raider = '55527eb0b8abf4ba1fe9a107'
-      @session.set 'heroConfig', {"thangType":raider,"inventory":{}}
-      @onInventoryModalPlayClicked()
-      return
+    if @level.usesConfiguredMultiplayerHero()
+     @onInventoryModalPlayClicked()
+     return
 
     if @level.isType('course', 'course-ladder', 'game-dev', 'web-dev') or window.serverConfig.picoCTF
       @onInventoryModalPlayClicked()

--- a/app/schemas/models/level.coffee
+++ b/app/schemas/models/level.coffee
@@ -279,7 +279,7 @@ _.extend LevelSchema.properties,
   practiceThresholdMinutes: {type: 'number', description: 'Players with larger playtimes may be directed to a practice level.'}
   assessment: { type: ['boolean', 'string'], enum: [true, false, 'open-ended', 'cumulative'], description: 'Set to true if this is an assessment level.' }
   assessmentPlacement: { type: 'string', enum: ['middle', 'end'] }
-  
+
   primerLanguage: { type: 'string', enum: ['javascript', 'python'], description: 'Programming language taught by this level.' }
   shareable: { title: 'Shareable', type: ['string', 'boolean'], enum: [false, true, 'project'], description: 'Whether the level is not shareable (false), shareable (true), or a sharing-encouraged project level ("project"). Make sure to use "project" for project levels so they show up correctly in the Teacher Dashboard.' }
 
@@ -350,6 +350,7 @@ _.extend LevelSchema.properties,
   concepts: c.array {title: 'Programming Concepts', description: 'Which programming concepts this level covers.', uniqueItems: true, format: 'concepts-list'}, c.concept
   primaryConcepts: c.array {title: 'Primary Concepts', description: 'The main 1-3 concepts this level focuses on.', uniqueItems: true}, c.concept
   picoCTFProblem: { type: 'string', description: 'Associated picoCTF problem ID, if this is a picoCTF level' }
+  password: { type: 'string', description: 'The password required to create a session for this level' }
 
 
 c.extendBasicProperties LevelSchema, 'level'

--- a/app/schemas/models/level.coffee
+++ b/app/schemas/models/level.coffee
@@ -351,6 +351,7 @@ _.extend LevelSchema.properties,
   primaryConcepts: c.array {title: 'Primary Concepts', description: 'The main 1-3 concepts this level focuses on.', uniqueItems: true}, c.concept
   picoCTFProblem: { type: 'string', description: 'Associated picoCTF problem ID, if this is a picoCTF level' }
   password: { type: 'string', description: 'The password required to create a session for this level' }
+  mirrorMatch: { type: 'boolean', description: 'Whether a multiplayer ladder arena is a mirror match' }
 
 
 c.extendBasicProperties LevelSchema, 'level'

--- a/app/views/editor/level/settings/SettingsTabView.coffee
+++ b/app/views/editor/level/settings/SettingsTabView.coffee
@@ -21,7 +21,7 @@ module.exports = class SettingsTabView extends CocoView
     'helpVideos', 'replayable', 'scoreTypes', 'concepts', 'primaryConcepts', 'picoCTFProblem', 'practice', 'assessment',
     'practiceThresholdMinutes', 'primerLanguage', 'shareable', 'studentPlayInstructions', 'requiredCode', 'suspectCode',
     'requiredGear', 'restrictedGear', 'requiredProperties', 'restrictedProperties', 'recommendedHealth', 'allowedHeroes',
-    'assessmentPlacement', 'password'
+    'assessmentPlacement', 'password', 'mirrorMatch'
   ]
 
   subscriptions:

--- a/app/views/editor/level/settings/SettingsTabView.coffee
+++ b/app/views/editor/level/settings/SettingsTabView.coffee
@@ -21,7 +21,7 @@ module.exports = class SettingsTabView extends CocoView
     'helpVideos', 'replayable', 'scoreTypes', 'concepts', 'primaryConcepts', 'picoCTFProblem', 'practice', 'assessment',
     'practiceThresholdMinutes', 'primerLanguage', 'shareable', 'studentPlayInstructions', 'requiredCode', 'suspectCode',
     'requiredGear', 'restrictedGear', 'requiredProperties', 'restrictedProperties', 'recommendedHealth', 'allowedHeroes',
-    'assessmentPlacement'
+    'assessmentPlacement', 'password'
   ]
 
   subscriptions:

--- a/app/views/ladder/MyMatchesTabView.coffee
+++ b/app/views/ladder/MyMatchesTabView.coffee
@@ -109,7 +109,7 @@ module.exports = class MyMatchesTabView extends CocoView
       placeholder = $(el)
       sessionID = placeholder.data('session-id')
       session = _.find @sessions.models, {id: sessionID}
-      if @level.get('slug') in ['ace-of-coders', 'elemental-wars', 'the-battle-of-sky-span', 'tesla-tesoro', 'escort-duty', 'treasure-games']
+      if @level.get('mirrorMatch') or @level.get('slug') in ['ace-of-coders', 'elemental-wars', 'the-battle-of-sky-span', 'tesla-tesoro', 'escort-duty', 'treasure-games']  # TODO: remove slug list once these levels are configured as mirror matches
         mirrorSession = (s for s in @sessions.models when s.get('team') isnt session.get('team'))[0]
       ladderSubmissionView = new LadderSubmissionView session: session, level: @level, mirrorSession: mirrorSession
       @insertSubView ladderSubmissionView, placeholder

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -375,24 +375,7 @@ module.exports = class PlayLevelView extends RootView
     return if @session
     Backbone.Mediator.publish "ipad:language-chosen", language: e.session.get('codeLanguage') ? "python"
     # Just the level and session have been loaded by the level loader
-    # TODO: remove these multiplayer equipment definitions once usesConfiguredMultiplayerHero is deployed
-    if e.level.get('slug') is 'zero-sum'
-      sorcerer = '52fd1524c7e6cf99160e7bc9'
-      if e.session.get('creator') is '532dbc73a622924444b68ed9'  # Wizard Dude gets his own avatar
-        sorcerer = '53e126a4e06b897606d38bef'
-      e.session.set 'heroConfig', {"thangType":sorcerer,"inventory":{"misc-0":"53e2396a53457600003e3f0f","programming-book":"546e266e9df4a17d0d449be5","minion":"54eb5dbc49fa2d5c905ddf56","feet":"53e214f153457600003e3eab","right-hand":"54eab7f52b7506e891ca7202","left-hand":"5463758f3839c6e02811d30f","wrists":"54693797a2b1f53ce79443e9","gloves":"5469425ca2b1f53ce7944421","torso":"546d4a549df4a17d0d449a97","neck":"54693274a2b1f53ce79443c9","eyes":"546941fda2b1f53ce794441d","head":"546d4ca19df4a17d0d449abf"}}
-    else if e.level.get('slug') is 'ace-of-coders'
-      goliath = '55e1a6e876cb0948c96af9f8'
-      e.session.set 'heroConfig', {"thangType":goliath,"inventory":{
-        "eyes":"53eb99f41a100989a40ce46e","neck":"54693274a2b1f53ce79443c9","wrists":"54693797a2b1f53ce79443e9","feet":"546d4d8e9df4a17d0d449acd","minion":"54eb5bf649fa2d5c905ddf4a","programming-book":"557871261ff17fef5abee3ee"
-      }}
-    else if e.level.get('slug') is 'the-battle-of-sky-span'
-      wizard = '52fc1460b2b91c0d5a7b6af3'
-      e.session.set 'heroConfig', {"thangType":wizard,"inventory":{}}
-    else if e.level.get('slug') is 'assembly-speed'
-      raider = '55527eb0b8abf4ba1fe9a107'
-      e.session.set 'heroConfig', {"thangType":raider,"inventory":{}}
-    else if e.level.isType('hero', 'hero-ladder', 'hero-coop') and not _.size(e.session.get('heroConfig')?.inventory ? {}) and e.level.get('assessment') isnt 'open-ended'
+    if e.level.isType('hero', 'hero-ladder', 'hero-coop') and not _.size(e.session.get('heroConfig')?.inventory ? {}) and e.level.get('assessment') isnt 'open-ended'
       # Delaying this check briefly so LevelLoader.loadDependenciesForSession has a chance to set the heroConfig on the level session
       _.defer =>
         return if _.size(e.session.get('heroConfig')?.inventory ? {})

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -375,6 +375,7 @@ module.exports = class PlayLevelView extends RootView
     return if @session
     Backbone.Mediator.publish "ipad:language-chosen", language: e.session.get('codeLanguage') ? "python"
     # Just the level and session have been loaded by the level loader
+    # TODO: remove these multiplayer equipment definitions once usesConfiguredMultiplayerHero is deployed
     if e.level.get('slug') is 'zero-sum'
       sorcerer = '52fd1524c7e6cf99160e7bc9'
       if e.session.get('creator') is '532dbc73a622924444b68ed9'  # Wizard Dude gets his own avatar

--- a/app/views/play/level/tome/CastButtonView.coffee
+++ b/app/views/play/level/tome/CastButtonView.coffee
@@ -34,7 +34,7 @@ module.exports = class CastButtonView extends CocoView
     # WARNING: CourseVictoryModal does not handle mirror sessions when submitting to ladder; adjust logic if a
     # mirror level is added to
     # Keep server/middleware/levels.coffee mirror list in sync with this one
-    @loadMirrorSession() if @options.levvel.get('mirrorMatch') or @options.level.get('slug') in ['ace-of-coders', 'elemental-wars', 'the-battle-of-sky-span', 'tesla-tesoro', 'escort-duty', 'treasure-games']  # TODO: remove slug list once these levels are configured as mirror matches
+    @loadMirrorSession() if @options.level.get('mirrorMatch') or @options.level.get('slug') in ['ace-of-coders', 'elemental-wars', 'the-battle-of-sky-span', 'tesla-tesoro', 'escort-duty', 'treasure-games']  # TODO: remove slug list once these levels are configured as mirror matches
     @mirror = @mirrorSession?
     @autoSubmitsToLadder = @options.level.isType('course-ladder')
     # Show publish CourseVictoryModal if they've already published

--- a/app/views/play/level/tome/CastButtonView.coffee
+++ b/app/views/play/level/tome/CastButtonView.coffee
@@ -34,7 +34,7 @@ module.exports = class CastButtonView extends CocoView
     # WARNING: CourseVictoryModal does not handle mirror sessions when submitting to ladder; adjust logic if a
     # mirror level is added to
     # Keep server/middleware/levels.coffee mirror list in sync with this one
-    @loadMirrorSession() if @options.level.get('slug') in ['ace-of-coders', 'elemental-wars', 'the-battle-of-sky-span', 'tesla-tesoro', 'escort-duty', 'treasure-games']
+    @loadMirrorSession() if @options.levvel.get('mirrorMatch') or @options.level.get('slug') in ['ace-of-coders', 'elemental-wars', 'the-battle-of-sky-span', 'tesla-tesoro', 'escort-duty', 'treasure-games']  # TODO: remove slug list once these levels are configured as mirror matches
     @mirror = @mirrorSession?
     @autoSubmitsToLadder = @options.level.isType('course-ladder')
     # Show publish CourseVictoryModal if they've already published

--- a/app/views/play/menu/GameMenuModal.coffee
+++ b/app/views/play/menu/GameMenuModal.coffee
@@ -45,7 +45,7 @@ module.exports = class GameMenuModal extends ModalView
   showsChooseHero: ->
     return false if @level?.isType('course', 'course-ladder', 'game-dev', 'web-dev')
     return false if @level?.get('assessment') is 'open-ended'
-    return false if @options.levelID in ['zero-sum', 'ace-of-coders', 'the-battle-of-sky-span']
+    return false if @level?.usesConfiguredMultiplayerHero()
     return true
 
   afterRender: ->

--- a/server/middleware/levels.coffee
+++ b/server/middleware/levels.coffee
@@ -58,8 +58,8 @@ module.exports =
     if session
       return res.send(session.toObject({req: req}))
 
-    mirrorMatches = ['ace-of-coders', 'elemental-wars', 'the-battle-of-sky-span', 'tesla-tesoro', 'escort-duty', 'treasure-games']
-    if sessionQuery.team and level.get('slug') in mirrorMatches
+    mirrorMatches = ['ace-of-coders', 'elemental-wars', 'the-battle-of-sky-span', 'tesla-tesoro', 'escort-duty', 'treasure-games']  # TODO: remove slug list once these levels are configured as mirror matches
+    if sessionQuery.team and (level.get('mirrorMatch') or level.get('slug') in mirrorMatches)
       # Find their other session for this, so that if it exists, we can initialize the new team's session with the mirror code.
       otherTeam = if sessionQuery.team is 'humans' then 'ogres' else 'humans'
       otherSessionQuery = _.defaults {team: otherTeam, code: {$exists: true}}, sessionQuery

--- a/server/middleware/levels.coffee
+++ b/server/middleware/levels.coffee
@@ -87,6 +87,9 @@ module.exports =
     if not req.user.isAnonymous() and level.get('slug') in ['treasure-games', 'escort-duty', 'tesla-tesoro', 'elemental-wars']
       console.log "Allowing session creation for #{level.get('slug')} outside of any course"
       attrs.isForClassroom = true
+    else if level.get('password') and req.query.password isnt level.get('password')
+      # Pretend that the level doesn't exist if the password isn't correct
+      throw new errors.NotFound('Level not found.')
     else if level.get('type') in ['course', 'course-ladder'] or req.query.course?
 
       # Find the course and classroom that has assigned this level, verify access

--- a/server/models/Level.coffee
+++ b/server/models/Level.coffee
@@ -138,6 +138,7 @@ LevelSchema.statics.editableProperties = [
   'primerLanguage'
   'studentPlayInstructions'
   'password'
+  'mirrorMatch'
 ]
 
 module.exports = Level = mongoose.model('level', LevelSchema)

--- a/server/models/Level.coffee
+++ b/server/models/Level.coffee
@@ -67,6 +67,15 @@ LevelSchema.post 'save', (doc) ->
   query["levels.#{doc.get('original')}"] = {$exists: true}
   Campaign.update(query, update, {multi:true}).exec()
 
+# TODO: introduced parallel to User privateProperties filtering for level passwords, but we don't call toObject in the places where we load levels, so this is not active yet.
+LevelSchema.set 'toObject',
+  transform: (doc, ret, options) ->
+    req = options.req
+    includePrivates = req?.user?.isAdmin()
+    delete ret[prop] for prop in LevelSchema.statics.privateProperties unless includePrivates
+    return ret
+
+LevelSchema.statics.privateProperties = ['password']
 LevelSchema.statics.postEditableProperties = ['name']
 LevelSchema.statics.jsonSchema = jsonSchema
 
@@ -128,7 +137,7 @@ LevelSchema.statics.editableProperties = [
   'practiceThresholdMinutes'
   'primerLanguage'
   'studentPlayInstructions'
+  'password'
 ]
-
 
 module.exports = Level = mongoose.model('level', LevelSchema)


### PR DESCRIPTION
1. Add ability to configure `type: "hero-ladder"` levels to use specified hero/equipment, instead of having to hard-code that.
2. Configure mirror match levels via level property instead of hard-coding.
3. Start to add level passwords for restricted level preview.

I need some help on the third part. I am not sure the best way to restrict the `password` property from ever leaving the server except when requested by an admin. See [work in progress here](https://github.com/codecombat/codecombat/commit/1179161b424024e5aa7cfde6e2ec161c66a853c1#diff-13182bfff6e125a033722e291146313cR70). This is needed to control access to arenas before tournaments begin to only our trusted playtesters to whom we've given a password.