### PR TITLE
Clarify numbering to web dev 2 solutions guide

### DIFF
--- a/app/templates/courses/teacher-courses-view.jade
+++ b/app/templates/courses/teacher-courses-view.jade
@@ -103,10 +103,6 @@ mixin course-info(course)
         a.guide-btn.btn.btn-primary(disabled=disableButtons href=("/teachers/course-solution/" + course.id + "/html") data-course-id=course.id data-course-name=course.get('name') data-event-action="Classes Guides Guide JavaScript" class=(me.isTeacher() || me.isAdmin() ? '': 'disabled'))
           span(data-i18n="courses.view_guide_online")
           |  &mdash; HTML
-      else if course.id === view.utils.courseIDs.WEB_DEVELOPMENT_2
-        a.guide-btn.btn.btn-primary(disabled=disableButtons href=("/teachers/course-solution/" + course.id + "/html") data-course-id=course.id data-course-name=course.get('name') data-event-action="Classes Guides Guide JavaScript" class=(me.isTeacher() || me.isAdmin() ? '': 'disabled'))
-          span(data-i18n="courses.view_guide_online")
-          |  &mdash; HTML / JavaScript
       else
         a.guide-btn.btn.btn-primary(disabled=disableButtons href=("/teachers/course-solution/" + course.id + "/javascript") data-course-id=course.id data-course-name=course.get('name') data-event-action="Classes Guides Guide JavaScript" class=(me.isTeacher() || me.isAdmin() ? '': 'disabled'))
           span(data-i18n="courses.view_guide_online")

--- a/app/views/teachers/TeacherCourseSolutionView.coffee
+++ b/app/views/teachers/TeacherCourseSolutionView.coffee
@@ -89,7 +89,7 @@ module.exports = class TeacherCourseSolutionView extends RootView
         assessment: level.get('assessment') ? false
       })
     @levelNumberMap = utils.createLevelNumberMap(levels)
-    if @course?.attributes?.slug == "web-development-2"
+    if @course?.id == utils.courseIDs.WEB_DEVELOPMENT_2
       # Filter out non numbered levels.
       @levels.models = @levels.models.filter((l) => l.get('original') of @levelNumberMap)
     @render?()

--- a/app/views/teachers/TeacherCourseSolutionView.coffee
+++ b/app/views/teachers/TeacherCourseSolutionView.coffee
@@ -89,6 +89,9 @@ module.exports = class TeacherCourseSolutionView extends RootView
         assessment: level.get('assessment') ? false
       })
     @levelNumberMap = utils.createLevelNumberMap(levels)
+    if @course?.attributes?.slug == "web-development-2"
+      # Filter out non numbered levels.
+      @levels.models = @levels.models.filter((l) => l.get('original') of @levelNumberMap)
     @render?()
 
   afterRender: ->


### PR DESCRIPTION
Instead of a single `HTM`L guide for both JS and Python `web-dev-2` classes, now there are two pages.