### PR TITLE
:bug: Fix css for unequipped items moving

### DIFF
--- a/app/styles/play/menu/inventory-modal.sass
+++ b/app/styles/play/menu/inventory-modal.sass
@@ -350,14 +350,11 @@ $itemSlotGridHeight: 51px
         cursor: pointer
 
         &:hover
-          padding: 0
-          img
-            margin: 1px
           button
             //margin-top: -2px
             //height: 19px
-            font-size: 12px
-            margin: -1px 1px 1px 1px
+            position: relative
+            top: -1px
 
             &:active, &.active
               background-position: -57px * 2 0


### PR DESCRIPTION
Fix bug where unequipped items jump around when hovered over.

Bug caused because the box size changing and disrupting the floating icons beneath.

This fix maintains the original behavior of the button slightly moving on hover over.