### PR TITLE
Fix recommendedHealth

### DIFF
--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -3,6 +3,7 @@ LevelComponent = require 'models/LevelComponent'
 LevelSystem = require 'models/LevelSystem'
 Article = require 'models/Article'
 LevelSession = require 'models/LevelSession'
+{me} = require 'core/auth'
 ThangType = require 'models/ThangType'
 ThangNamesCollection = require 'collections/ThangNamesCollection'
 LZString = require 'lz-string'
@@ -547,6 +548,8 @@ module.exports = class LevelLoader extends CocoClass
     if @observing
       @world.difficulty = Math.max 0, @world.difficulty - 1  # Show the difficulty they won, not the next one.
     serializedLevel = @level.serialize {@supermodel, @session, @opponentSession, @headless, @sessionless}
+    if me.tryClampHeroHealth()
+      serializedLevel.clampHeroHealth = true
     @world.loadFromLevel serializedLevel, false
     console.debug 'World has been initialized from level loader.' if LOG
 

--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -548,8 +548,8 @@ module.exports = class LevelLoader extends CocoClass
     if @observing
       @world.difficulty = Math.max 0, @world.difficulty - 1  # Show the difficulty they won, not the next one.
     serializedLevel = @level.serialize {@supermodel, @session, @opponentSession, @headless, @sessionless}
-    if me.tryClampHeroHealth()
-      serializedLevel.clampHeroHealth = true
+    if me.constrainHeroHealth()
+      serializedLevel.constrainHeroHealth = true
     @world.loadFromLevel serializedLevel, false
     console.debug 'World has been initialized from level loader.' if LOG
 

--- a/app/lib/surface/Lank.coffee
+++ b/app/lib/surface/Lank.coffee
@@ -488,7 +488,7 @@ module.exports = Lank = class Lank extends CocoClass
     return unless @thang and @thang.health isnt @lastHealth
     @lastHealth = @thang.health
     if bar = @healthBar
-      debugger
+      console.debug "[filter1]Setting healthBar", healthPct, @thang.health, @thang.maxHealth, @thang
       healthPct = Math.max(@thang.health / @thang.maxHealth, 0)
       bar.scaleX = healthPct / @options.floatingLayer.resolutionFactor
     if @thang.showsName

--- a/app/lib/surface/Lank.coffee
+++ b/app/lib/surface/Lank.coffee
@@ -518,7 +518,6 @@ module.exports = Lank = class Lank extends CocoClass
     return unless @thang?.health? and 'health' in (@thang?.hudProperties ? []) and @options.floatingLayer
     team = @thang?.team or 'neutral'
     key = "#{team}-health-bar"
-    debugger
     unless key in @options.floatingLayer.spriteSheet.animations
       healthColor = healthColors[team]
       bar = createProgressBar(healthColor)

--- a/app/lib/surface/Lank.coffee
+++ b/app/lib/surface/Lank.coffee
@@ -488,7 +488,6 @@ module.exports = Lank = class Lank extends CocoClass
     return unless @thang and @thang.health isnt @lastHealth
     @lastHealth = @thang.health
     if bar = @healthBar
-      console.debug "[filter1]Setting healthBar", healthPct, @thang.health, @thang.maxHealth, @thang
       healthPct = Math.max(@thang.health / @thang.maxHealth, 0)
       bar.scaleX = healthPct / @options.floatingLayer.resolutionFactor
     if @thang.showsName

--- a/app/lib/surface/Lank.coffee
+++ b/app/lib/surface/Lank.coffee
@@ -518,6 +518,7 @@ module.exports = Lank = class Lank extends CocoClass
     return unless @thang?.health? and 'health' in (@thang?.hudProperties ? []) and @options.floatingLayer
     team = @thang?.team or 'neutral'
     key = "#{team}-health-bar"
+
     unless key in @options.floatingLayer.spriteSheet.animations
       healthColor = healthColors[team]
       bar = createProgressBar(healthColor)

--- a/app/lib/surface/Lank.coffee
+++ b/app/lib/surface/Lank.coffee
@@ -488,6 +488,7 @@ module.exports = Lank = class Lank extends CocoClass
     return unless @thang and @thang.health isnt @lastHealth
     @lastHealth = @thang.health
     if bar = @healthBar
+      debugger
       healthPct = Math.max(@thang.health / @thang.maxHealth, 0)
       bar.scaleX = healthPct / @options.floatingLayer.resolutionFactor
     if @thang.showsName
@@ -518,7 +519,7 @@ module.exports = Lank = class Lank extends CocoClass
     return unless @thang?.health? and 'health' in (@thang?.hudProperties ? []) and @options.floatingLayer
     team = @thang?.team or 'neutral'
     key = "#{team}-health-bar"
-
+    debugger
     unless key in @options.floatingLayer.spriteSheet.animations
       healthColor = healthColors[team]
       bar = createProgressBar(healthColor)

--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -692,11 +692,6 @@ module.exports = class World
     'defeated': @getSystem('Combat')?.defeatedByTeam 'humans'
 
   clampHeroHealth: (level) ->
-    stackTrace = () ->
-      errThingy = new Error()
-      console.debug("clampHeroHealth called from:")
-      console.debug(errThingy.stack)
-    
     hero = _.find @thangs, id: 'Hero Placeholder'
     if hero? and level.clampHeroHealth?
       if level.recommendedHealth?
@@ -704,10 +699,3 @@ module.exports = class World
       if level.maximumHealth?
         hero.maxHealth = Math.min(hero.maxHealth, level.maximumHealth)
       hero.health = hero.maxHealth
-      console.error("We have done clamping to health #{hero.health} / #{hero.maxHealth}")
-      stackTrace()
-    # if hero?
-    #   # hero.health = 500
-    #   hero.maxHealth = 500
-    #   hero.health = hero.maxHealth
-      # stackTrace()

--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -250,8 +250,7 @@ module.exports = class World
     @thangTypes = level.thangTypes
     @loadScriptsFromLevel level
     @loadSystemsFromLevel level
-    @loadThangsFromLevel level, willSimulate
-    
+    @loadThangsFromLevel level, willSimulate    
     @showsCountdown = @levelID in COUNTDOWN_LEVELS or _.any(@thangs, (t) -> (t.programmableProperties and 'findFlags' in t.programmableProperties) or t.inventory?.flag)
     @picoCTFProblem = level.picoCTFProblem if level.picoCTFProblem
     if @picoCTFProblem?.instances and not @picoCTFProblem.flag_sha1

--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -250,7 +250,7 @@ module.exports = class World
     @thangTypes = level.thangTypes
     @loadScriptsFromLevel level
     @loadSystemsFromLevel level
-    @loadThangsFromLevel level, willSimulate    
+    @loadThangsFromLevel level, willSimulate
     @showsCountdown = @levelID in COUNTDOWN_LEVELS or _.any(@thangs, (t) -> (t.programmableProperties and 'findFlags' in t.programmableProperties) or t.inventory?.flag)
     @picoCTFProblem = level.picoCTFProblem if level.picoCTFProblem
     if @picoCTFProblem?.instances and not @picoCTFProblem.flag_sha1

--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -691,8 +691,9 @@ module.exports = class World
     'defeated': @getSystem('Combat')?.defeatedByTeam 'humans'
 
   constrainHeroHealth: (level) ->
+    return unless level.constrainHeroHealth
     hero = _.find @thangs, id: 'Hero Placeholder'
-    if hero? and level.constrainHeroHealth
+    if hero?
       if level.recommendedHealth?
         hero.maxHealth = Math.max(hero.maxHealth, level.recommendedHealth)
       if level.maximumHealth?

--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -251,6 +251,7 @@ module.exports = class World
     @loadScriptsFromLevel level
     @loadSystemsFromLevel level
     @loadThangsFromLevel level, willSimulate
+    
     @showsCountdown = @levelID in COUNTDOWN_LEVELS or _.any(@thangs, (t) -> (t.programmableProperties and 'findFlags' in t.programmableProperties) or t.inventory?.flag)
     @picoCTFProblem = level.picoCTFProblem if level.picoCTFProblem
     if @picoCTFProblem?.instances and not @picoCTFProblem.flag_sha1
@@ -260,8 +261,7 @@ module.exports = class World
         system.start @thangs
       catch err
         console.error "Error starting system!", system, err
-    if level.type is 'course'
-      @clampHeroHealth(level)
+    @clampHeroHealth(level)
 
   loadSystemsFromLevel: (level) ->
     # Remove old Systems
@@ -692,10 +692,22 @@ module.exports = class World
     'defeated': @getSystem('Combat')?.defeatedByTeam 'humans'
 
   clampHeroHealth: (level) ->
+    stackTrace = () ->
+      errThingy = new Error()
+      console.debug("clampHeroHealth called from:")
+      console.debug(errThingy.stack)
+    
     hero = _.find @thangs, id: 'Hero Placeholder'
-    if hero?
+    if hero? and level.clampHeroHealth?
       if level.recommendedHealth?
         hero.maxHealth = Math.max(hero.maxHealth, level.recommendedHealth)
       if level.maximumHealth?
         hero.maxHealth = Math.min(hero.maxHealth, level.maximumHealth)
       hero.health = hero.maxHealth
+      console.error("We have done clamping to health #{hero.health} / #{hero.maxHealth}")
+      stackTrace()
+    # if hero?
+    #   # hero.health = 500
+    #   hero.maxHealth = 500
+    #   hero.health = hero.maxHealth
+      # stackTrace()

--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -260,7 +260,7 @@ module.exports = class World
         system.start @thangs
       catch err
         console.error "Error starting system!", system, err
-    @clampHeroHealth(level)
+    @constrainHeroHealth(level)
 
   loadSystemsFromLevel: (level) ->
     # Remove old Systems
@@ -690,9 +690,9 @@ module.exports = class World
     'survival-time': @age
     'defeated': @getSystem('Combat')?.defeatedByTeam 'humans'
 
-  clampHeroHealth: (level) ->
+  constrainHeroHealth: (level) ->
     hero = _.find @thangs, id: 'Hero Placeholder'
-    if hero? and level.clampHeroHealth?
+    if hero? and level.constrainHeroHealth
       if level.recommendedHealth?
         hero.maxHealth = Math.max(hero.maxHealth, level.recommendedHealth)
       if level.maximumHealth?

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -504,6 +504,7 @@ module.exports = class User extends CocoModel
   showGemsAndXp: -> features?.classroomItems ? false
   showHeroAndInventoryModalsToStudents: -> features?.classroomItems and @isStudent()
   skipHeroSelectOnStudentSignUp: -> features?.classroomItems ? false
+  tryClampHeroHealth: -> features?.classroomItems ? false
   useDexecure: -> not (features?.chinaInfra ? false)
   useSocialSignOn: -> not (features?.chinaUx ? false)
 

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -504,7 +504,7 @@ module.exports = class User extends CocoModel
   showGemsAndXp: -> features?.classroomItems ? false
   showHeroAndInventoryModalsToStudents: -> features?.classroomItems and @isStudent()
   skipHeroSelectOnStudentSignUp: -> features?.classroomItems ? false
-  tryClampHeroHealth: -> features?.classroomItems ? false
+  constrainHeroHealth: -> features?.classroomItems ? false
   useDexecure: -> not (features?.chinaInfra ? false)
   useSocialSignOn: -> not (features?.chinaUx ? false)
 

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -146,8 +146,8 @@ module.exports = class PlayLevelView extends RootView
     @supermodel.shouldSaveBackups = givenSupermodel.shouldSaveBackups
 
     serializedLevel = @level.serialize {@supermodel, @session, @otherSession, headless: false, sessionless: false}
-    if me.tryClampHeroHealth()
-      serializedLevel.clampHeroHealth = true
+    if me.constrainHeroHealth()
+      serializedLevel.constrainHeroHealth = true
     @god?.setLevel serializedLevel
     if @world
       @world.loadFromLevel serializedLevel, false
@@ -299,8 +299,8 @@ module.exports = class PlayLevelView extends RootView
     return @waitingToSetUpGod = true unless @god
     @waitingToSetUpGod = undefined
     serializedLevel = @level.serialize {@supermodel, @session, @otherSession, headless: false, sessionless: false}
-    if me.tryClampHeroHealth()
-      serializedLevel.clampHeroHealth = true
+    if me.constrainHeroHealth()
+      serializedLevel.constrainHeroHealth = true
     @god.setLevel serializedLevel
     @god.setLevelSessionIDs if @otherSession then [@session.id, @otherSession.id] else [@session.id]
     @god.setWorldClassMap @world.classMap

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -146,6 +146,8 @@ module.exports = class PlayLevelView extends RootView
     @supermodel.shouldSaveBackups = givenSupermodel.shouldSaveBackups
 
     serializedLevel = @level.serialize {@supermodel, @session, @otherSession, headless: false, sessionless: false}
+    if me.tryClampHeroHealth()
+      serializedLevel.clampHeroHealth = true
     @god?.setLevel serializedLevel
     if @world
       @world.loadFromLevel serializedLevel, false
@@ -296,7 +298,10 @@ module.exports = class PlayLevelView extends RootView
     return if @level.isType('web-dev')
     return @waitingToSetUpGod = true unless @god
     @waitingToSetUpGod = undefined
-    @god.setLevel @level.serialize {@supermodel, @session, @otherSession, headless: false, sessionless: false}
+    serializedLevel = @level.serialize {@supermodel, @session, @otherSession, headless: false, sessionless: false}
+    if me.tryClampHeroHealth()
+      serializedLevel.clampHeroHealth = true
+    @god.setLevel serializedLevel
     @god.setLevelSessionIDs if @otherSession then [@session.id, @otherSession.id] else [@session.id]
     @god.setWorldClassMap @world.classMap
 


### PR DESCRIPTION
 - Had local health bar anomalies. Suspect caching.
   - The cache seemed to be setting maxHealth lower.
   - Tested using proxy and everything worked.
   - Worked locally after clearing cache.

Bug: Only clamped health if level type was `course`. Most have type `hero`. The fix injects additional data into the `level` data object to inform when to clamp.