### PR TITLE
Spectate View precondition error log

### DIFF
--- a/app/views/play/SpectateView.coffee
+++ b/app/views/play/SpectateView.coffee
@@ -135,7 +135,7 @@ module.exports = class SpectateLevelView extends RootView
   loadOpponentTeam: (myTeam) ->
     if myTeam != @session.get('team')
       console.error("Team mismatch. Expected session one to be '#{myTeam}'. Got '#{@session.get('team')}'");
-    
+
     opponentSpells = []
     for spellTeam, spells of @session.get('teamSpells') ? @otherSession?.get('teamSpells') ? {}
       continue if spellTeam is myTeam or not myTeam

--- a/app/views/play/SpectateView.coffee
+++ b/app/views/play/SpectateView.coffee
@@ -133,6 +133,9 @@ module.exports = class SpectateLevelView extends RootView
     @levelLoader = null
 
   loadOpponentTeam: (myTeam) ->
+    if myTeam != @session.get('team')
+      console.error("Team mismatch. Expected session one to be '#{myTeam}'. Got '#{@session.get('team')}'");
+    
     opponentSpells = []
     for spellTeam, spells of @session.get('teamSpells') ? @otherSession?.get('teamSpells') ? {}
       continue if spellTeam is myTeam or not myTeam


### PR DESCRIPTION
This `console.error` highlights an important precondition that must be satisfied for Spectate Mode to work.

May help uncover and diagnose other Spectate bugs which are intermittent.