### PR TITLE
Fix Tracked Properties Undefined

### DIFF
--- a/app/views/play/level/GameDevTrackView.coffee
+++ b/app/views/play/level/GameDevTrackView.coffee
@@ -37,10 +37,11 @@ module.exports = class GameDevTrackView extends CocoView
         trackedPropNamesIndex = thangState.trackedPropertyKeys.indexOf 'uiTrackedProperties'
         unless trackedPropNamesIndex is -1
           trackedPropNames = thangState.props[trackedPropNamesIndex]
-          for name in trackedPropNames
-            propIndex = thangState.trackedPropertyKeys.indexOf name
-            continue if propIndex is -1
-            @listings[overrideLabel ? name] = thangState.props[propIndex]
+          if trackedPropNames
+            for name in trackedPropNames
+              propIndex = thangState.trackedPropertyKeys.indexOf name
+              continue if propIndex is -1
+              @listings[overrideLabel ? name] = thangState.props[propIndex]
         continue unless key is 'Hero Placeholder'
         trackedObjNamesIndex = thangState.trackedPropertyKeys.indexOf 'objTrackedProperties'
         continue if trackedObjNamesIndex is -1


### PR DESCRIPTION
Without this check the transpiled coffeescript can check the length of undefined in the for statement.