### PR TITLE
Teacher class code and class url made read only on Teacher Dashboard.

### DIFF
--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -489,14 +489,14 @@ mixin progressDotLabel(label)
 mixin copyCodes
   div.copy-button-group.form-inline.m-b-3
     .form-group
-      input.text-h4.semibold#join-code-input(value=state.get('classCode'))
+      input.text-h4.semibold#join-code-input(value=state.get('classCode'), readonly)
     button#copy-code-btn.form-control.btn.btn-lg.btn-forest
       span(data-i18n='teacher.copy_class_code')
     div.text-center.small.class-code-blurb(data-i18n='teacher.class_code_blurb')
 
   div.copy-button-group.form-inline.m-b-3
     .form-group
-      input.form-control.text-h4.semibold#join-url-input(value=state.get('joinURL'), dir="ltr")
+      input.text-h4.semibold#join-url-input(value=state.get('joinURL'), dir="ltr", readonly)
     button#copy-url-btn.form-control.btn.btn-lg.btn-forest
       span(data-i18n='teacher.copy_class_url')
     div.text-center.small.class-code-blurb(data-i18n='teacher.class_join_url_blurb')


### PR DESCRIPTION
Enforce readonly property of input fields.

Remove `form-control` class because it changes the cursor to a `not-allowed` cursor.