### PR TITLE
Add polyfill for 'includes' to support IE11

### DIFF
--- a/app/vendor.js
+++ b/app/vendor.js
@@ -37,6 +37,21 @@ window.Vuex = require('vuex').default
 
 window.algoliasearch = require('algoliasearch')
 
+// polyfill to support IE11
+if (!String.prototype.includes) {
+  String.prototype.includes = function(search, start) {
+    'use strict';
+    if (typeof start !== 'number') {
+      start = 0;
+    }
+    if (start + search.length > this.length) {
+      return false;
+    } else {
+      return this.indexOf(search, start) !== -1;
+    }
+  };
+}
+
 function loadScript (url) {
   var script = document.createElement('script');
   script.src = url;


### PR DESCRIPTION
Polyfill for String.prototype.includes
Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Polyfill