### PR TITLE
Fix classroom course progress dots

### DIFF
--- a/app/lib/coursesHelper.coffee
+++ b/app/lib/coursesHelper.coffee
@@ -1,10 +1,11 @@
 Levels = require 'collections/Levels'
 utils = require 'core/utils'
 
-# Returns whether a user has started and completed all the levels in a course.
+# Returns whether a user has started a course as well as if they've completed
+# all the required levels in the course.
 #
-# @param {Object<Key=string, Value=bool> | undefined} userLevels - Key value store of level original string and completion state.
-# @param {Set<string>} levelsInCourse - Set of the levels in the course.
+# @param {Object<key=string, value=bool> | undefined} userLevels - Key value store of level original and completion state.
+# @param {Set<string>} levelsInCourse - Required level originals in the course.
 # @return {[bool, bool]} - user started value and allcomplete state. 
 hasUserCompletedCourse = (userLevels, levelsInCourse) ->
   userStarted = false

--- a/app/lib/coursesHelper.coffee
+++ b/app/lib/coursesHelper.coffee
@@ -27,6 +27,7 @@ module.exports =
         for userID in instance.get('members')
           userStarted = false
           allComplete = true
+          userLevelsSeen = if userLevelsCompleted[userID] then Object.keys(userLevelsCompleted[userID]).filter((l) -> levelsInVersionedCourse.has(l)).length else 0
           for level, complete of userLevelsCompleted[userID] when levelsInVersionedCourse.has level
             userStarted = true
             if not complete
@@ -34,7 +35,7 @@ module.exports =
               break
           allComplete = false unless userStarted
           instance.started ||= userStarted
-          ++instance.numCompleted if allComplete
+          ++instance.numCompleted if allComplete and userLevelsSeen == levelsInVersionedCourse.size
 
   calculateEarliestIncomplete: (classroom, courses, courseInstances, students) ->
     # Loop through all the combinations of things, return the first one that somebody hasn't finished

--- a/app/lib/coursesHelper.coffee
+++ b/app/lib/coursesHelper.coffee
@@ -235,7 +235,7 @@ module.exports =
 
   courseLabelsArray: (courses) ->
     courses.map((course) -> course.acronym())
-  
+
   hasUserCompletedCourse: hasUserCompletedCourse
 
 progressMixin =

--- a/test/app/lib/CoursesHelper.spec.coffee
+++ b/test/app/lib/CoursesHelper.spec.coffee
@@ -166,3 +166,29 @@ describe 'CoursesHelper', ->
         progress = progressData.get {@classroom, @course, level: @practiceLevel}
         expect(progress.completed).toBe false
         expect(progress.started).toBe true
+
+  describe 'hasUserCompletedCourse', ->
+    it 'user completed a single level but hasn\'t completed all levels', ->
+      [userStarted, allComplete] = helper.hasUserCompletedCourse({'a': true}, new Set(['a', 'b']))
+      expect(userStarted).toBe true
+      expect(allComplete).toBe false
+
+    it 'user completed all levels', ->
+      [userStarted, allComplete] = helper.hasUserCompletedCourse({'a': true, 'b': true}, new Set(['a', 'b']))
+      expect(userStarted).toBe true
+      expect(allComplete).toBe true
+
+    it 'undefined user state passed in', ->
+      [userStarted, allComplete] = helper.hasUserCompletedCourse(undefined, new Set(['a']))
+      expect(userStarted).toBe false
+      expect(allComplete).toBe false
+
+    it "User hasn't completed all levels", ->
+      [userStarted, allComplete] = helper.hasUserCompletedCourse({'a': true, 'b': false}, new Set(['a', 'b']))
+      expect(userStarted).toBe true
+      expect(allComplete).toBe false
+
+    it "User has completed required levels", ->
+      [userStarted, allComplete] = helper.hasUserCompletedCourse({'a': true, 'b': false}, new Set(['a']))
+      expect(userStarted).toBe true
+      expect(allComplete).toBe true


### PR DESCRIPTION
Fix required the number of levels in the user state to be compared with the number of required levels in the course.

Otherwise a user could have a single completed level incorrectly marking them as completing the course.


Also tested against a teacher with a large classroom. This seems to fix all of the wrong progress on the account.