### PR TITLE
Created a custom Context Menu for the Surface element of PlayLevelView.coffee

### DIFF
--- a/app/lib/surface/Surface.coffee
+++ b/app/lib/surface/Surface.coffee
@@ -156,8 +156,8 @@ module.exports = Surface = class Surface extends CocoClass
   initCoordinates: ->
     @coordinateGrid ?= new CoordinateGrid {camera: @camera, layer: @gridLayer, textLayer: @surfaceTextLayer}, @world.size()
     @coordinateGrid.showGrid() if @world.showGrid or @options.grid
-    showCoordinates = if @options.coords? then @options.coords else @world.showCoordinates
-    @coordinateDisplay ?= new CoordinateDisplay camera: @camera, layer: @surfaceTextLayer if showCoordinates
+    @showCoordinates = if @options.coords? then @options.coords else @world.showCoordinates
+    @coordinateDisplay ?= new CoordinateDisplay camera: @camera, layer: @surfaceTextLayer if @showCoordinates
 
   hookUpChooseControls: ->
     chooserOptions = stage: @webGLStage, surfaceLayer: @surfaceTextLayer, camera: @camera, restrictRatio: @options.choosing is 'ratio-region'

--- a/app/schemas/subscriptions/play.coffee
+++ b/app/schemas/subscriptions/play.coffee
@@ -181,6 +181,14 @@ module.exports =
 
   'level:contact-button-pressed': c.object {title: 'Contact Pressed', description: 'Dispatched when the contact button is pressed in a level.'}
 
+  'level:surface-context-menu-pressed': c.object {required: ['posX', 'posY', 'wopX', 'wopY']},
+    posX: {type: 'number'}
+    posY: {type: 'number'}
+    wopX: {type: 'number'}
+    wopY: {type: 'number'}
+
+  'level:surface-context-menu-hide': c.object {}
+
   'level:license-required': c.object {}
 
   'level:open-items-modal': c.object {}

--- a/app/styles/play/level/surface-context-menu.sass
+++ b/app/styles/play/level/surface-context-menu.sass
@@ -1,0 +1,23 @@
+@import "app/styles/mixins"
+
+#surface-context-menu-view.surface-context-menu
+  z-index: 10
+  position: absolute
+  width: 170px
+  background: transparent
+  border: 1px solid transparent
+  box-shadow: 0 4px 5px 3px rgba(0, 0, 0, 0.2)
+
+  .menu-options
+    list-style: none
+    padding: 10px 0
+    background-color: rgb(211,211,211)
+
+    .menu-option 
+      font-weight: 500
+      font-size: 14px
+      padding: 10px 40px 10px 20px
+      cursor: pointer
+
+      &:hover 
+        background: rgba(0, 0, 0, 0.2)

--- a/app/templates/play/level/surface-context-menu.jade
+++ b/app/templates/play/level/surface-context-menu.jade
@@ -1,0 +1,5 @@
+
+
+ul.menu-options
+  li: #copy.menu-option!= view.copyMessage
+  li: #other.menu-option Other

--- a/app/templates/play/play-level-view.jade
+++ b/app/templates/play/play-level-view.jade
@@ -56,6 +56,8 @@ include game-dev-goals.jade
 
       button.btn.btn-lg.btn-primary.banner.header-font#stop-cinematic-playback-button(data-i18n="[title]common.continue;common.continue")
 
+    #surface-context-menu-view
+
     if features.codePlay
       a(href=document.location.protocol+"//lenovogamestate.com/pages/products/")
         - var url = "/images/common/codeplay/NA_InLevelPage_Y700_1132X283_ingameProduct.png"

--- a/app/views/play/level/SurfaceContextMenuView.coffee
+++ b/app/views/play/level/SurfaceContextMenuView.coffee
@@ -1,0 +1,69 @@
+require('app/styles/play/level/surface-context-menu')
+CocoView = require 'views/core/CocoView'
+
+module.exports = class SurfaceContextMenuView extends CocoView
+  id: 'surface-context-menu-view'
+  className: 'surface-context-menu'
+  template: require('templates/play/level/surface-context-menu')
+
+  events:
+    'click #copy': 'onClickCopy'
+
+  subscriptions:
+    'level:surface-context-menu-pressed': 'showView'
+    'level:surface-context-menu-hide': 'hideView'
+    
+  constructor: (options) ->
+    @supermodel = options.supermodel # Has to go before super so events are hooked up
+    super options
+    @level = options.level
+    @session = options.session
+    
+
+  destroy: ->
+    super()
+
+  afterRender: ->
+    super()
+
+  onClickCopy: (e) ->
+    if navigator.clipboard
+      navigator.clipboard.writeText( @coordinates )
+    else if document.queryCommandSupported('copy')
+      textArea = document.createElement("textarea")
+      textArea.value = @coordinates
+      document.body.appendChild(textArea)
+      textArea.focus()
+      textArea.select()
+      document.execCommand('copy')
+      document.body.removeChild(textArea)
+    else
+      console.log "Copy Coordinates not supported"
+
+  
+
+  setPosition: (e) ->
+    @$el.css('left', e.posX)
+    @$el.css('top', e.posY)
+    #margin = 20
+    #width = @$levelInfo.outerWidth()
+    #@$levelInfo.css('left', Math.min(Math.max(margin, mapX - width / 2), @$map.width() - width - margin))
+    #height = @$levelInfo.outerHeight()
+    #top = mapY - @$levelInfo.outerHeight() - 60
+    #if top < 100
+    #  top = mapY + 60
+    #@$levelInfo.css('top', top)
+
+  setCoordinates: (e) ->
+    @coordinates = "#{e.wopX}, #{e.wopY}"
+    message = "copy #{@coordinates}"
+    @copyMessage = message
+
+  hideView: ->
+    @$el.hide()
+
+  showView: (e) ->
+    @$el.show()
+    @setCoordinates(e)
+    @setPosition(e)
+    @render()


### PR DESCRIPTION
This pull request is a continuation of a previous pull request I created #4864 , and is for a new custom Context Menu that shows up when you clicked the right mouse button on the Surface element of the PlayLevelView. When you mouse over the surface element now the CoordinateDisplay element shows up and displays the given coordinates of the game world that the mouse is pointing too. With my new Context Menu a user can now press the right mouse button to display the Context Menu that holds and option to copy the given coordinates of CoordinateDisplay and pass them to the clipboard so they can be pasted into the editor.

An example of this feature is shown below:
![contextmenu_1280-720](https://user-images.githubusercontent.com/7968842/47053690-f576bd80-d162-11e8-9cc0-fa721b25cf91.gif)

Some things that may need to be addressed before this feature is fully implemented are:
1. The Context Menu goes away if the left mouse button is clicked anywhere on the screen, but remains if the right mouse button is clicked outside of the Surface element.
2. Finalize the Styling of the Context Menu
3. There is a second list element titled "other" that acts as a placeholder for any other functionality we wish to add to the Context Menu.

