### PR TITLE
Make percentage level completion more granular on progress dots.

### DIFF
--- a/app/templates/courses/teacher-classes-view.jade
+++ b/app/templates/courses/teacher-classes-view.jade
@@ -140,8 +140,9 @@ mixin progressDot(classroom, course, label)
   if courseInstance && !_.isEmpty(courseInstance.get('members'))
     - complete = courseInstance.numCompleted
     - started = courseInstance.started
+    - percentLevelCompletion = courseInstance.percentLevelCompletion
     - dotClass = complete === total ? 'forest' : started ? 'gold' : '';
-    - var progressDotContext = {total: total, complete: complete, loading: !courseInstance.sessionsLoaded};
+    - var progressDotContext = {total: total, complete: complete, loading: !courseInstance.sessionsLoaded, percentLevelCompletion: percentLevelCompletion};
     .progress-dot(class=dotClass, data-title=view.progressDotTemplate(progressDotContext))
       +progressDotLabel(label)
 

--- a/app/templates/teachers/hovers/progress-dot-whole-course.jade
+++ b/app/templates/teachers/hovers/progress-dot-whole-course.jade
@@ -12,7 +12,7 @@ else
     span.spl(data-i18n='courses.students')
       | Students
   .percent-students.small-details
-    = Math.floor(complete / total * 100)
+    = percentLevelCompletion || Math.floor(complete / total * 100)
     | %
     span.spl(data-i18n='clans.complete_2')
       | Complete

--- a/test/app/lib/CoursesHelper.spec.coffee
+++ b/test/app/lib/CoursesHelper.spec.coffee
@@ -169,26 +169,37 @@ describe 'CoursesHelper', ->
 
   describe 'hasUserCompletedCourse', ->
     it 'user completed a single level but hasn\'t completed all levels', ->
-      [userStarted, allComplete] = helper.hasUserCompletedCourse({'a': true}, new Set(['a', 'b']))
+      [userStarted, allComplete, levelsCompleted] = helper.hasUserCompletedCourse({'a': true}, new Set(['a', 'b']))
       expect(userStarted).toBe true
       expect(allComplete).toBe false
+      expect(levelsCompleted).toEqual 1
 
     it 'user completed all levels', ->
-      [userStarted, allComplete] = helper.hasUserCompletedCourse({'a': true, 'b': true}, new Set(['a', 'b']))
+      [userStarted, allComplete, levelsCompleted] = helper.hasUserCompletedCourse({'a': true, 'b': true}, new Set(['a', 'b']))
       expect(userStarted).toBe true
       expect(allComplete).toBe true
+      expect(levelsCompleted).toEqual 2
 
     it 'undefined user state passed in', ->
-      [userStarted, allComplete] = helper.hasUserCompletedCourse(undefined, new Set(['a']))
+      [userStarted, allComplete, levelsCompleted] = helper.hasUserCompletedCourse(undefined, new Set(['a']))
       expect(userStarted).toBe false
       expect(allComplete).toBe false
+      expect(levelsCompleted).toEqual 0
 
     it "User hasn't completed all levels", ->
-      [userStarted, allComplete] = helper.hasUserCompletedCourse({'a': true, 'b': false}, new Set(['a', 'b']))
+      [userStarted, allComplete, levelsCompleted] = helper.hasUserCompletedCourse({'a': true, 'b': false}, new Set(['a', 'b']))
       expect(userStarted).toBe true
       expect(allComplete).toBe false
+      expect(levelsCompleted).toEqual 1
 
     it "User has completed required levels", ->
-      [userStarted, allComplete] = helper.hasUserCompletedCourse({'a': true, 'b': false}, new Set(['a']))
+      [userStarted, allComplete, levelsCompleted] = helper.hasUserCompletedCourse({'a': true, 'b': false}, new Set(['a']))
       expect(userStarted).toBe true
       expect(allComplete).toBe true
+      expect(levelsCompleted).toEqual 1
+
+    it "User has completed different levels", ->
+      [userStarted, allComplete, levelsCompleted] = helper.hasUserCompletedCourse({'a': true, 'b': true}, new Set(['c']))
+      expect(userStarted).toBe false
+      expect(allComplete).toBe false
+      expect(levelsCompleted).toEqual 0


### PR DESCRIPTION
Calculation was number of students that completed the course divided by total students.

Now completion percentage is the progress of the entire class by counting all the completed levels against summation of all required levels per student.


## Effect:

If the class has one student in a course with 10 required levels. Prior to this change the percent completion would change from 0% to 100% immediately when the student completes all required levels.

With the change the percentage will improve gradually as students complete required levels.
Once the student as completed 1 level, the new percentage will be 10%.

With two students there are now 20 required levels between them. If one student completes a single level, the total class progress is only 5% or `1/20`.
