### PR TITLE
Facebook Pixel teacher conversion tracking added

### DIFF
--- a/app/views/core/CreateAccountModal/teacher/TeacherRolePanel.coffee
+++ b/app/views/core/CreateAccountModal/teacher/TeacherRolePanel.coffee
@@ -24,6 +24,8 @@ TeacherRolePanel = Vue.extend
         return
       @commitValues()
       window.tracker?.trackEvent 'CreateAccountModal Teacher TeacherRolePanel Continue Success', category: 'Teachers'
+      # Facebook Pixel tracking for Teacher conversions.
+      window.fbq?('trackCustom', 'UniqueTeacherSignup')
       @$emit('continue')
       
     clickBack: ->


### PR DESCRIPTION
Triggers when the `CreateAccountModal Teacher TeacherRolePanel Continue Success` google analytics event is triggered.