### PR TITLE
All levels unlocked when no course instance

### DIFF
--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -100,7 +100,6 @@ module.exports = class CampaignView extends RootView
     'shift+s': 'onShiftS'
 
   constructor: (options, @terrain) ->
-    debugger
     super options
     @terrain = 'picoctf' if window.serverConfig.picoCTF
     @editorMode = options?.editorMode
@@ -634,9 +633,6 @@ module.exports = class CampaignView extends RootView
       if @isClassroom()
         level.locked = true
         level.hidden = true
-        if @classroom?
-          level.unlocksItem = false
-          level.unlocksPet = false
       else
         level.position ?= { x: 10, y: 10 }
         level.locked = not me.ownsLevel(level.original)

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -1295,7 +1295,7 @@ module.exports = class CampaignView extends RootView
     @campaign?.get('levels')
 
   applyCourseLogicToLevels: (orderedLevels) ->
-      nextSlug = @courseStats.levels.next?.get('slug')
+    nextSlug = @courseStats.levels.next?.get('slug')
     nextSlug ?= @courseStats.levels.first?.get('slug')
     return unless nextSlug
 

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -658,10 +658,6 @@ module.exports = class CampaignView extends RootView
         level.unlocksItem = _.find(level.rewards, 'item')?.item
         level.unlocksPet = utils.petThangIDs.indexOf(level.unlocksItem) isnt -1
 
-        if @classroom?
-          level.unlocksItem = false
-          level.unlocksPet = false
-
         if window.serverConfig.picoCTF
           if problem = _.find(@picoCTFProblems or [], pid: level.picoCTFProblem)
             level.locked = false if problem.unlocked or level.slug is 'digital-graffiti'

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -631,7 +631,6 @@ module.exports = class CampaignView extends RootView
 
     for level, levelIndex in orderedLevels
       if @isClassroom()
-        console.log("locking level")
         level.locked = true
         level.hidden = true
       else

--- a/test/app/views/play/CampaignView.spec.coffee
+++ b/test/app/views/play/CampaignView.spec.coffee
@@ -22,8 +22,15 @@ describe 'CampaignView', ->
         @levels[2].practice = true
         @campaignView.annotateLevels(@levels)
       it 'does not hide the not-really-practice level', ->
-        expect(@levels[2].hidden).toEqual(false)
-        expect(@levels[3].hidden).toEqual(false)
+        if me.isStudent() or me.isTeacher()
+          expect(@levels[2].locked).toEqual(true)
+          expect(@levels[3].locked).toEqual(true)
+          expect(@levels[2].hidden).toEqual(true)
+          expect(@levels[3].hidden).toEqual(true)
+        else 
+          expect(@levels[2].locked).toEqual(false)
+          expect(@levels[3].locked).toEqual(false)
+
 
     describe 'and 2nd rewards a practice a non-practice level', ->
       beforeEach ->


### PR DESCRIPTION
As a quick fix, we are locking and hiding all levels when courseInstance-Id is not available. As an improvement, created a task to tackle in future to query for courseInstanceId if it is missing and direct the user to the right course instance in this scenario - 
Redirect user to right course Instance when courseInstanceId is removed from query variable in the url

Now we are locking and hiding all levels before the code for unlocking the right levels is executed. So, the flashing of unlocked levels before the map gets loaded completely does not happen anymore!