### PR TITLE
Refactor allowing modal to start music

### DIFF
--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -263,8 +263,8 @@ module.exports = class CampaignView extends RootView
     $(window).on 'resize', @onWindowResize
     @probablyCachedMusic = storage.load("loaded-menu-music")
     musicDelay = if @probablyCachedMusic then 1000 else 10000
-    delayedMusicStart = => _.delay (=> @playMusic() unless @destroyed), musicDelay
-    @playMusicTimeout = delayedMusicStart()
+    delayMusicStart = => _.delay (=> @playMusic() unless @destroyed), musicDelay
+    @playMusicTimeout = delayMusicStart()
     @hadEverChosenHero = me.get('heroConfig')?.thangType
     @listenTo me, 'change:purchased', -> @renderSelectors('#gems-count')
     @listenTo me, 'change:spent', -> @renderSelectors('#gems-count')
@@ -278,7 +278,7 @@ module.exports = class CampaignView extends RootView
         setTimeout(=>
             @openModalView new HoCModal({
               showVideo: @terrain is "hoc-2018",
-              onDestroy: ->delayedMusicStart(),
+              onDestroy: ->delayMusicStart(),
             })
         , 0)
 

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -278,7 +278,7 @@ module.exports = class CampaignView extends RootView
         setTimeout(=>
             @openModalView new HoCModal({
               showVideo: @terrain is "hoc-2018",
-              onDestroy: ->delayMusicStart(),
+              onDestroy: delayMusicStart,
             })
         , 0)
 

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -114,12 +114,6 @@ module.exports = class CampaignView extends RootView
 
     if @terrain is "hoc-2018"
       $('body').append($("<img src='https://code.org/api/hour/begin_codecombat_play.png' style='visibility: hidden;'>"))
-    if utils.getQueryVariable('hour_of_code') or @terrain is "hoc-2018"
-      if not sessionStorage.getItem(@terrain)
-        sessionStorage.setItem(@terrain, "seen-modal")
-        setTimeout(() =>
-            @openModalView new HoCModal({showVideo: @terrain is "hoc-2018"})
-        , 0)
 
     if utils.getQueryVariable('hour_of_code')
       if me.isStudent() or me.isTeacher()
@@ -269,12 +263,25 @@ module.exports = class CampaignView extends RootView
     $(window).on 'resize', @onWindowResize
     @probablyCachedMusic = storage.load("loaded-menu-music")
     musicDelay = if @probablyCachedMusic then 1000 else 10000
-    @playMusicTimeout = _.delay (=> @playMusic() unless @destroyed), musicDelay
+    delayedMusicStart = => _.delay (=> @playMusic() unless @destroyed), musicDelay
+    @playMusicTimeout = delayedMusicStart()
     @hadEverChosenHero = me.get('heroConfig')?.thangType
     @listenTo me, 'change:purchased', -> @renderSelectors('#gems-count')
     @listenTo me, 'change:spent', -> @renderSelectors('#gems-count')
     @listenTo me, 'change:earned', -> @renderSelectors('#gems-count')
     @listenTo me, 'change:heroConfig', -> @updateHero()
+
+    if utils.getQueryVariable('hour_of_code') or @terrain is "hoc-2018"
+      if not sessionStorage.getItem(@terrain)
+        sessionStorage.setItem(@terrain, "seen-modal")
+        clearTimeout(@playMusicTimeout)
+        setTimeout(=>
+            @openModalView new HoCModal({
+              showVideo: @terrain is "hoc-2018",
+              onDestroy: ->delayedMusicStart(),
+            })
+        , 0)
+
     window.tracker?.trackEvent 'Loaded World Map', category: 'World Map', label: @terrain
 
   destroy: ->

--- a/app/views/special_event/HoC2018InterstitialModal.coffee
+++ b/app/views/special_event/HoC2018InterstitialModal.coffee
@@ -17,3 +17,8 @@ module.exports = class HoC2018InterstitialModal extends ModalComponent
   constructor: (options) ->
     super(options)
     @propsData.showVideo = options?.showVideo or false
+    @onDestroy = options?.onDestroy
+
+  destroy: ->
+    @onDestroy?()
+    super()


### PR DESCRIPTION
Adds an `onDestroy` callback to the modal allowing it to start the music once it has been destroyed.