### PR TITLE
Fix for memory consumption issue from Victory Modal

### DIFF
--- a/app/lib/LevelSetupManager.coffee
+++ b/app/lib/LevelSetupManager.coffee
@@ -109,7 +109,8 @@ module.exports = class LevelSetupManager extends CocoClass
 
     lastHeroesEarned = me.get('earned')?.heroes ? []
     lastHeroesPurchased = me.get('purchased')?.heroes ? []
-    @options.parent.openModalView(firstModal)
+    window.currentView.openModalView(firstModal)
+
     @trigger 'open'
     #    @inventoryModal.onShown() # replace?
 
@@ -119,7 +120,7 @@ module.exports = class LevelSetupManager extends CocoClass
      @inventoryModal.setHero(e.hero) if window.currentModal is @inventoryModal
 
   onHeroesModalConfirmClicked: (e) ->
-    @options.parent.openModalView(@inventoryModal)
+    window.currentView.openModalView(@inventoryModal)
     @inventoryModal.render()
     @inventoryModal.didReappear()
     @inventoryModal.onShown()
@@ -127,7 +128,7 @@ module.exports = class LevelSetupManager extends CocoClass
     window.tracker?.trackEvent 'Choose Inventory', category: 'Play Level'
 
   onChooseHeroClicked: ->
-    @options.parent.openModalView(@heroesModal)
+    window.currentView.openModalView(@heroesModal)
     @heroesModal.render()
     @heroesModal.didReappear()
     @inventoryModal.endHighlight()

--- a/app/views/play/level/modal/CourseVictoryComponent.vue
+++ b/app/views/play/level/modal/CourseVictoryComponent.vue
@@ -103,7 +103,7 @@
   
   module.exports = Vue.extend({
     # TODO: Move these props to vuex
-    props: ['nextLevel', 'nextAssessment', 'session', 'course', 'courseInstanceID', 'stats', 'supermodel', 'parent', 'codeLanguage'],
+    props: ['nextLevel', 'nextAssessment', 'level', 'session', 'course', 'courseInstanceID', 'codeLanguage'],
     components: {
       PieChart
     }
@@ -205,7 +205,7 @@
         )
         if me.showHeroAndInventoryModalsToStudents()
             @setupManager?.destroy()
-            @setupManager = new LevelSetupManager supermodel: @supermodel, levelID: @nextLevel.slug, levelPath: "level", hadEverChosenHero: true, parent: @parent, courseID: @course._id, courseInstanceID: @courseInstanceID, codeLanguage:@codeLanguage
+            @setupManager = new LevelSetupManager levelID: @nextLevel.slug, levelPath: "level", hadEverChosenHero: true, courseID: @course._id, courseInstanceID: @courseInstanceID, codeLanguage:@codeLanguage
             unless @setupManager?.navigatingToPlay
               @setupManager.open()
                  

--- a/app/views/play/level/modal/CourseVictoryModal.coffee
+++ b/app/views/play/level/modal/CourseVictoryModal.coffee
@@ -170,9 +170,6 @@ module.exports = class CourseVictoryModal extends ModalView
       session: @session.toJSON(),
       course: @course.toJSON(),
       @courseInstanceID,
-      stats: @classroom?.statsForSessions(@levelSessions, @course.id)
-      supermodel: @supermodel,
-      parent: @options.parent
       codeLanguage: @session.get('codeLanguage')
     }
     new CourseVictoryComponent({


### PR DESCRIPTION
The following parameters sent to CourseVictory vue component were taking up too much memory, memory consumption reduced considerably after removing these - 

**stats**  (existed from pre-china classroom, it is not used in the vue component at all, can be removed)

**supermodel**  (added for china classroom items implementation, need to test thoroughly as I remember adding this at a later stage to resolve an issue)

**parent** (added for china classroom items implementation for using as parent view that opens the inventory modal, we can use window.currentView instead as parent)



Before merging this I want to test the following - 
- Test the workflow with china classroom items on
- Go through the bugs we fixed after implementing china classroom items and retest them
- **### _level_** is used in the vue component in some places and it was never passed from CourseVictoryModal.coffee. I added this now as part of this fix. Need to investigate how it worked before.