### PR TITLE
Fix verifier dev=true mode

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -177,9 +177,13 @@ module.exports = class CocoRouter extends Backbone.Router
     'play/game-dev-level/:sessionID': go('play/level/PlayGameDevLevelView')
     'play/web-dev-level/:sessionID': go('play/level/PlayWebDevLevelView')
     'play/game-dev-level/:levelID/:sessionID': (levelID, sessionID, queryString) ->
-      @navigate("play/game-dev-level/#{sessionID}?#{queryString}", { trigger: true, replace: true })
+      url = "play/game-dev-level/#{sessionID}"
+      url += "?#{queryString}" if queryString
+      @navigate(url, { trigger: true, replace: true })
     'play/web-dev-level/:levelID/:sessionID': (levelID, sessionID, queryString) ->
-      @navigate("play/web-dev-level/#{sessionID}?#{queryString}", { trigger: true, replace: true })
+      url = "play/web-dev-level/#{sessionID}"
+      url += "?#{queryString}" if queryString
+      @navigate(url, { trigger: true, replace: true })
     'play/spectate/:levelID': go('play/SpectateView')
     'play/:map': go('play/CampaignView')
 
@@ -278,6 +282,9 @@ module.exports = class CocoRouter extends Backbone.Router
       locale.load(me.get('preferredLanguage', true))
     ]).then ([ViewClass]) =>
       return go('NotFoundView') if not ViewClass
+      # Convert to Array and remove query string params (Backbone 1.1.1+ includes them as routing params)
+      queryVariables = utils.getQueryVariables()
+      args = Array.prototype.slice.call(args, 0, args.length - Object.keys(queryVariables).length)
       view = new ViewClass(options, args...)  # options, then any path fragment args
       view.render()
       if window.alreadyLoadedView

--- a/app/core/utils.coffee
+++ b/app/core/utils.coffee
@@ -366,6 +366,7 @@ getDocumentSearchString = ->
   return document.location.search
 
 getQueryVariables = ->
+  return {} if _.isEmpty(module.exports.getDocumentSearchString())
   query = module.exports.getDocumentSearchString().substring(1) # use module.exports so spy is used in testing
   pairs = (pair.split('=') for pair in query.split '&')
   variables = {}


### PR DESCRIPTION
Upgrading to Backbone 1.1.1 for https://github.com/codecombat/codecombat/commit/320150f56740f225e40b1392b202e31fb1ece6e8 introduced different routing param behavior.  Query strings are appended to the routing params, which messes up our use of optional wildcards.

To fix, we strip those back out in our routing `go` method which should get us back to the expected behavior in general and leave @shubhi1092's fix in place.