### PR TITLE
Prevent space bar from scrolling the page

### DIFF
--- a/app/views/play/level/PlayGameDevLevelView.coffee
+++ b/app/views/play/level/PlayGameDevLevelView.coffee
@@ -161,7 +161,6 @@ module.exports = class PlayGameDevLevelView extends RootView
     }
 
   onClickPlayButton: ->
-    $('#play-btn').blur();
     worldCreationOptions = {spells: @spells, preload: false, realTime: true, justBegin: false, keyValueDb: @session.get('keyValueDb') ? {}, synchronous: true}
     @god.createWorld(worldCreationOptions)
     Backbone.Mediator.publish('playback:real-time-playback-started', {})

--- a/app/views/play/level/PlayGameDevLevelView.coffee
+++ b/app/views/play/level/PlayGameDevLevelView.coffee
@@ -46,7 +46,7 @@ module.exports = class PlayGameDevLevelView extends RootView
       isOwner: false
     })
 
-    $(document).keydown (event) ->
+    $(window).keydown (event) ->
       # prevent space from scrolling on the page since it can be used as a control in the game.
       if (event.keyCode == 32 && event.target == document.body)
         event.preventDefault()
@@ -243,4 +243,5 @@ module.exports = class PlayGameDevLevelView extends RootView
     @goalManager?.destroy()
     @scriptManager?.destroy()
     delete window.world # not sure where this is set, but this is one way to clean it up
+    $(window).off("keydown")
     super()

--- a/app/views/play/level/PlayGameDevLevelView.coffee
+++ b/app/views/play/level/PlayGameDevLevelView.coffee
@@ -46,6 +46,11 @@ module.exports = class PlayGameDevLevelView extends RootView
       isOwner: false
     })
 
+    $(document).keydown (event) ->
+      # prevent space from scrolling on the page since it can be used as a control in the game.
+      if (event.keyCode == 32 && event.target == document.body)
+        event.preventDefault()
+
     if utils.getQueryVariable 'dev'
       @supermodel.shouldSaveBackups = (model) ->  # Make sure to load possibly changed things from localStorage.
         model.constructor.className in ['Level', 'LevelComponent', 'LevelSystem', 'ThangType']
@@ -141,11 +146,6 @@ module.exports = class PlayGameDevLevelView extends RootView
       @god.createWorld(worldCreationOptions)
       @willUpdateFrontEnd = true
 
-      $(document).keydown (event) ->
-        # prevent space from scrolling on the page since it can be used as a control in the game.
-        if (event.keyCode == 32 && event.target == document.body)
-          event.preventDefault()
-
     .catch (e) =>
       throw e if e.stack
       @state.set('errorMessage', e.message)
@@ -161,6 +161,7 @@ module.exports = class PlayGameDevLevelView extends RootView
     }
 
   onClickPlayButton: ->
+    $('#play-btn').blur();
     worldCreationOptions = {spells: @spells, preload: false, realTime: true, justBegin: false, keyValueDb: @session.get('keyValueDb') ? {}, synchronous: true}
     @god.createWorld(worldCreationOptions)
     Backbone.Mediator.publish('playback:real-time-playback-started', {})

--- a/app/views/play/level/PlayGameDevLevelView.coffee
+++ b/app/views/play/level/PlayGameDevLevelView.coffee
@@ -141,6 +141,11 @@ module.exports = class PlayGameDevLevelView extends RootView
       @god.createWorld(worldCreationOptions)
       @willUpdateFrontEnd = true
 
+      $(document).keydown (event) ->
+        # prevent space from scrolling on the page since it can be used as a control in the game.
+        if (event.keyCode == 32 && event.target == document.body)
+          event.preventDefault()
+
     .catch (e) =>
       throw e if e.stack
       @state.set('errorMessage', e.message)


### PR DESCRIPTION
Space bar can be used as a control in the game, so preventing its default behavior of scrolling down the page in PlayGameDevLevelView.