### PR TITLE
Remove the focus from restart level button in PlayGameDevLevelView.

### DIFF
--- a/app/views/play/level/PlayGameDevLevelView.coffee
+++ b/app/views/play/level/PlayGameDevLevelView.coffee
@@ -156,6 +156,7 @@ module.exports = class PlayGameDevLevelView extends RootView
     }
 
   onClickPlayButton: ->
+    $('#play-btn').blur()   # Removes focus from the button after clicking on it.
     worldCreationOptions = {spells: @spells, preload: false, realTime: true, justBegin: false, keyValueDb: @session.get('keyValueDb') ? {}, synchronous: true}
     @god.createWorld(worldCreationOptions)
     Backbone.Mediator.publish('playback:real-time-playback-started', {})


### PR DESCRIPTION
Clicking on restart level keeps the focus on the button, so pressing space bar restarts the level even though it might be one of the game controls as well. So removing the focus from the button after its clicked.