### PR TITLE
Lock node version to 6.14.4 preventing 6.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
   "license": "MIT for the code, and CC-BY for the art and music",
   "private": true,
   "engines": {
-    "node": "^6.12.2",
+    "node": "6.14.4",
     "npm": "^3.10.10"
   }
 }


### PR DESCRIPTION
Version 6.15.0 causes 504's between ELB and EC2 application instance.

This fixes the node version to 6.14.4 which has been working.