### PR TITLE
Fix verifier dev=true mode (2nd attempt)

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -127,10 +127,8 @@ module.exports = class CocoRouter extends Backbone.Router
     'editor/campaign/:campaignID': go('editor/campaign/CampaignEditorView')
     'editor/poll': go('editor/poll/PollSearchView')
     'editor/poll/:articleID': go('editor/poll/PollEditView')
-    'editor/verifier': go('editor/verifier/VerifierView')
-    'editor/verifier/:levelID': go('editor/verifier/VerifierView')
-    'editor/i18n-verifier/:levelID': go('editor/verifier/i18nVerifierView')
-    'editor/i18n-verifier': go('editor/verifier/i18nVerifierView')
+    'editor/verifier(/:levelID)': go('editor/verifier/VerifierView')
+    'editor/i18n-verifier(/:levelID)': go('editor/verifier/i18nVerifierView')
     'editor/course': go('editor/course/CourseSearchView')
     'editor/course/:courseID': go('editor/course/CourseEditView')
 

--- a/app/views/HomeView.coffee
+++ b/app/views/HomeView.coffee
@@ -49,11 +49,8 @@ module.exports = class HomeView extends RootView
       @trialRequests.fetchOwn()
       @supermodel.loadCollection(@trialRequests)
 
-    isHourOfCodeWeek = false  # Temporary: default to hourOfCode flow during the main event week
     @playURL = if me.isStudent()
       '/students'
-    else if isHourOfCodeWeek
-      '/play?hour_of_code=true'
     else
       '/play'
 


### PR DESCRIPTION
Upgrading to Backbone 1.1.1 for https://github.com/codecombat/codecombat/commit/320150f56740f225e40b1392b202e31fb1ece6e8 introduced different routing param behavior.  Query strings are appended to the routing params, which messes up our use of optional wildcards.

This URL routing pattern is broken and we shouldn't use it anymore:
'/somepage': go('SomeView')
'/somepage/:param1': go('SomeView')

Because, query strings on the base route will be passed in as the optional param (param1) instead.

Instead, use a single route with optional param via parenthesis:
'/somepage(/:param1)': go('SomeView')

Did not update /play CampaignView routing because it was unclear what Facebook integration would break and it's not quite broken, just very fragile.  Can't use query strings on world map selector (/play), but we don't currently.

I looked through all the *view* files with getQueryVariable calls and didn't see any others that needed to be fixed.