### PR TITLE
Add margin to the bottom of the subscribe dialog

### DIFF
--- a/app/styles/modal/subscribe-modal.sass
+++ b/app/styles/modal/subscribe-modal.sass
@@ -287,6 +287,7 @@
     border: 5px solid gray
 
 .support-blurb
+  margin-bottom: 10px
   margin-top: 10px
 
 body[lang='fr']


### PR DESCRIPTION
There wasn't whitespace at the bottom of the dialog, so this change adds the whitespace.

Before:
![screen shot 2018-12-13 at 8 13 23 pm](https://user-images.githubusercontent.com/933422/49982813-9c819680-ff13-11e8-9c9b-d4b52ce58c66.png)

After:
![screen shot 2018-12-13 at 8 13 38 pm](https://user-images.githubusercontent.com/933422/49982826-b4591a80-ff13-11e8-8747-6f7aa3596d5e.png)
