### PR TITLE
Reduce diplomat comment errors

### DIFF
--- a/app/locale/ja.coffee
+++ b/app/locale/ja.coffee
@@ -1282,7 +1282,7 @@ module.exports = nativeDescription: "日本語", englishDescription: "Japanese",
 #    track_concepts8: "to join"
 #    private_require_sub: "Private clans require a subscription to create or join."
 
-#  courses:
+ courses:
 #    create_new_class: "Create New Class"
 #    hoc_blurb1: "Try the"
 #    hoc_blurb2: "Code, Play, Share"

--- a/test/app/core/locale.spec.coffee
+++ b/test/app/core/locale.spec.coffee
@@ -32,3 +32,18 @@ describe 'esper error messages', ->
                 Expected translated placeholders: [#{placeholders}] (#{esper[key]})
                 To match English placeholders: [#{englishPlaceholders}] (#{englishEsper[key]})
               """
+
+describe 'Check keys', ->
+  langs.forEach (language) =>
+    describe "when language is #{language.englishDescription}", ->
+      en = english.translation
+      Object.keys(language.translation or {}).forEach (key) ->
+        Object.keys(language.translation[key] or {}).forEach (keyChild) ->
+          it 'should have the same keys in each entry as in English', ->
+            if en[key][keyChild] == undefined
+              return fail """
+                Expected english to have translation '#{key}.#{keyChild}'
+                This can occur when:
+                  * Parent key for '#{keyChild}' is accidentally commented.
+                  * English translation for '#{key}.#{keyChild}' has been deleted.
+              """


### PR DESCRIPTION
A common error is when a diplomat forgets or accidentally doesn't remove the comment from the parent key of the translation.

I.e.
```
# a:
  b: "translation"
```

When it should be:
```
a:
  b: "translation"
```

When `a` is commented, `b` becomes attached to the wrong parent key. This test catches this issue.

A slight complication introduced by this test is that it will become harder to delete translations from the `en.coffee` file, requiring the translation to be deleted across all languages to make this test pass again. I think this is a fair trade off as more errors are introduced via the translation process than removing translations. 


There is also a translation fix in this pull request.