### PR TITLE
Responsive /account/prepaid page

### DIFF
--- a/app/styles/account/account-prepaid-view.sass
+++ b/app/styles/account/account-prepaid-view.sass
@@ -1,3 +1,17 @@
+@media (min-width: 320px) and (max-width: 480px)
+  .site-chrome
+    #site-nav
+      min-width: 0
+
+#prepaidViewContainer
+  // We do this as a hack because we've fixed the nav bar for desktop only.
+  // Consider a rewrite of this page with the new flat layout.
+  width: 96vw
+  margin-left: 0
+  max-width: 970px
+
+  button
+    width: 100%
 
 #users-input, #months-input
   max-width: 100px

--- a/app/styles/account/account-prepaid-view.sass
+++ b/app/styles/account/account-prepaid-view.sass
@@ -1,8 +1,3 @@
-@media (min-width: 320px) and (max-width: 480px)
-  .site-chrome
-    #site-nav
-      min-width: 0
-
 #prepaidViewContainer
   // We do this as a hack because we've fixed the nav bar for desktop only.
   // Consider a rewrite of this page with the new flat layout.

--- a/app/templates/account/prepaid-view.jade
+++ b/app/templates/account/prepaid-view.jade
@@ -6,7 +6,7 @@ block content
     p(data-i18n="account_settings.not_logged_in") Log in or create an account to change your settings.
 
   else
-    .container#prepaidViewContainer
+    .container-fluid#prepaidViewContainer
       ol.breadcrumb
         li
           a(href="/")

--- a/app/templates/account/prepaid-view.jade
+++ b/app/templates/account/prepaid-view.jade
@@ -6,83 +6,86 @@ block content
     p(data-i18n="account_settings.not_logged_in") Log in or create an account to change your settings.
 
   else
-    ol.breadcrumb
-      li
-        a(href="/")
-          span.glyphicon.glyphicon-home
-      li
-        a(href="/account", data-i18n="nav.account")
-      li.active(data-i18n="account.prepaid_codes")
+    .container#prepaidViewContainer
+      ol.breadcrumb
+        li
+          a(href="/")
+            span.glyphicon.glyphicon-home
+        li
+          a(href="/account", data-i18n="nav.account")
+        li.active(data-i18n="account.prepaid_codes")
 
-    .row
-      .col-md-12
-        .panel.panel-default
-          .panel-heading
-            .panel-title
-              a(data-toggle="collapse" href="#purchasepanel")
-                span(data-i18n="account_prepaid.purchase_code")
-          .panel-collapse.collapse(class=view.ppcQuery ? "": "in")#purchasepanel
-            .panel-body
-              p Prepaids are no longer available for purchase.
-    .row
-      .col-md-12
-        .panel.panel-default
-          .panel-heading
-            .panel-title
-              a(data-toggle="collapse" href="#redeempanel")
-                span(data-i18n="account_prepaid.redeem_codes")
-          .panel-collapse.collapse.in#redeempanel
-            .panel-body
-              p
-                span(data-i18n="account_prepaid.prepaid_code")
-                span.spr :
-                input.input-ppc(name="ppc", type="text", value="#{view.ppc}", required)
-              if view.ppcInfo && view.ppcInfo.length > 0
-                p
-                  each info in view.ppcInfo
-                    div
-                      != info
-              p
-                span.spr
-                  button#lookup-code-btn.btn.btn-info(data-i18n="account_prepaid.lookup_code")
-                span
-                  button#redeem-code-btn.btn.btn-success(data-i18n="account_prepaid.apply_account")
-    .row
-      .col-md-12
-        #codes-panel.panel.panel-default
-          .panel-heading
-            .panel-title
-              a(data-toggle="collapse" href="#codeslist")
-                span(data-i18n="account_prepaid.your_codes")
-          .panel-collapse.collapse.in#codeslist
-            .panel-body
-              if view.codes && view.codes.length
-                table.table.table-striped
-                  tr
-                    th 
-                      span.spr(data-i18n="[title]account_prepaid.copy_link;general.code", title="You can copy the code's link and send it to someone.")
-                        span.glyphicon.glyphicon-question-sign(aria-hidden="true")
-                    th(data-i18n="account_prepaid.months")
-                    th Remaining Users
-                    th Total Users
-                    th(data-i18n="user.status")
-                  for code in view.codes.models
-                    if code.get('type') === 'terminal_subscription'
-                      - var owner = (code.get('creator') == me.id ? true : false)
-                      - var properties = code.get('properties')
-                      - var redeemers = code.get('redeemers')
-                      - var redeemed = redeemers ? redeemers.length : 0
-                      tr
-                        td
-                          a(href="/account/prepaid?_ppc=#{code.get('code')}")= code.get('code')
-                        td= properties.months || '-'
-                        if owner
-                          td= code.get('maxRedeemers') - redeemed
-                          td= code.get('maxRedeemers')
-                          td(data-i18n="account.purchased")
-                        else
-                          td -
-                          td -
-                          td(data-i18n="account_prepaid.redeemed")
-              else
-                p(data-i18n="account_prepaid.no_codes")
+      .row
+        .col-md-12
+          .panel.panel-default
+            .panel-heading
+              .panel-title
+                a(data-toggle="collapse" href="#purchasepanel")
+                  span(data-i18n="account_prepaid.purchase_code")
+            .panel-collapse.collapse(class=view.ppcQuery ? "": "in")#purchasepanel
+              .panel-body
+                p Prepaids are no longer available for purchase.
+      .row
+        .col-md-12
+          .panel.panel-default
+            .panel-heading
+              .panel-title
+                a(data-toggle="collapse" href="#redeempanel")
+                  span(data-i18n="account_prepaid.redeem_codes")
+            .panel-collapse.collapse.in#redeempanel
+              .panel-body
+                .form-group
+                  label(for="ppc code" data-i18n="account_prepaid.prepaid_code")
+                  span.spr :
+                  input.input-ppc.form-control(name="ppc", type="text", value="#{view.ppc}", required)
+                if view.ppcInfo && view.ppcInfo.length > 0
+                  p
+                    each info in view.ppcInfo
+                      div
+                        != info
+                .row
+                  .col-xs-6
+                    span.spr
+                      button#lookup-code-btn.btn.btn-info.btn-block(data-i18n="account_prepaid.lookup_code")
+                  .col-xs-6
+                    span
+                      button#redeem-code-btn.btn.btn-success.btn-block(data-i18n="account_prepaid.apply_account")
+      .row
+        .col-md-12
+          #codes-panel.panel.panel-default
+            .panel-heading
+              .panel-title
+                a(data-toggle="collapse" href="#codeslist")
+                  span(data-i18n="account_prepaid.your_codes")
+            .panel-collapse.collapse.in#codeslist
+              .panel-body
+                if view.codes && view.codes.length
+                  table.table.table-striped
+                    tr
+                      th(scope="col") 
+                        span.spr(data-i18n="[title]account_prepaid.copy_link;general.code", title="You can copy the code's link and send it to someone.")
+                          span.glyphicon.glyphicon-question-sign(aria-hidden="true")
+                      th(scope="col" data-i18n="account_prepaid.months")
+                      th(scope="col") Remaining Users
+                      th(scope="col") Total Users
+                      th(scope="col" data-i18n="user.status")
+                    for code in view.codes.models
+                      if code.get('type') === 'terminal_subscription'
+                        - var owner = (code.get('creator') == me.id ? true : false)
+                        - var properties = code.get('properties')
+                        - var redeemers = code.get('redeemers')
+                        - var redeemed = redeemers ? redeemers.length : 0
+                        tr
+                          td
+                            a(href="/account/prepaid?_ppc=#{code.get('code')}")= code.get('code')
+                          td= properties.months || '-'
+                          if owner
+                            td= code.get('maxRedeemers') - redeemed
+                            td= code.get('maxRedeemers')
+                            td(data-i18n="account.purchased")
+                          else
+                            td -
+                            td -
+                            td(data-i18n="account_prepaid.redeemed")
+                else
+                  p(data-i18n="account_prepaid.no_codes")

--- a/app/views/account/PrepaidView.coffee
+++ b/app/views/account/PrepaidView.coffee
@@ -18,6 +18,8 @@ module.exports = class PrepaidView extends RootView
     'click #redeem-code-btn': 'onClickRedeemCodeButton'
 
   initialize: ->
+    # HACK: Make this one specific page responsive on mobile.
+    $('head').append('<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">');
 
     @codes = new CocoCollection([], { url: '/db/user/'+me.id+'/prepaid_codes', model: Prepaid })
     @codes.on 'sync', (code) => @render?()


### PR DESCRIPTION
Requirements was to make this page behave better on phones.

There is a meta tag in our `layout.static.pug` that sets viewport to `width=1024`. This needs to be overwritten to allow the page to scale on smaller screens. This ended up being the cleanest way I could think of doing this without risking side effects.

If we want this page to be a better experience it requires a re-design & rewrite.

