### PR TITLE
:bug:Fix student level complete on teacher dashboard

### DIFF
--- a/app/models/LevelSession.coffee
+++ b/app/models/LevelSession.coffee
@@ -41,7 +41,7 @@ module.exports = class LevelSession extends CocoModel
     @get('submittedCodeLanguage')? and @get('team')?
 
   completed: ->
-    @get('state')?.complete || @get('submitted') || false
+    @get('state')?.complete || false
 
   shouldAvoidCorruptData: (attrs) ->
     return false unless me.team is 'humans'


### PR DESCRIPTION
LevelSession.submitted property shouldn't be used for level completeness in classroom dashboards.  More applicable to arena ladder logic.