### PR TITLE
Fix for effects when objects are reused

### DIFF
--- a/app/lib/surface/Lank.coffee
+++ b/app/lib/surface/Lank.coffee
@@ -606,6 +606,7 @@ module.exports = Lank = class Lank extends CocoClass
   updateEffectMarks: ->
     return if _.isEqual @thang.effectNames, @previousEffectNames
     return if @stopped
+    @thang.effectNames ?= []
     for effect in @thang.effectNames
       mark = @addMark effect, @options.floatingLayer, effect
       mark.statusEffect = true


### PR DESCRIPTION
It's possible that a Lank has previousEffectNames and the thang doesn't have effectNames anymore (GD levels with dynamical components).