### PR TITLE
Exclude ladder level on both student and teacher completeness check

### DIFF
--- a/app/lib/coursesHelper.coffee
+++ b/app/lib/coursesHelper.coffee
@@ -178,7 +178,7 @@ module.exports =
             numStarted: 0
             # numCompleted: 0
           }
-          isOptional = level.get('practice') or level.get('assessment')
+          isOptional = level.get('practice') or level.get('assessment') or level.isLadder()
           sessionsForLevel = _.filter classroom.sessions.models, (session) ->
             session.get('level').original is levelID
 


### PR DESCRIPTION
Checked the following test cases manually and cases in the comments on Asana.

The teacher calculation remains unchanged and still shows 100%.
The student 18/19 correctly displays as 18/18 as ladder is not a required level.
This is correctly displayed on the /students page as well as the world map for the student.