### PR TITLE
Remove Java from the arena language options

### DIFF
--- a/app/views/ladder/LadderPlayModal.coffee
+++ b/app/views/ladder/LadderPlayModal.coffee
@@ -36,7 +36,8 @@ module.exports = class LadderPlayModal extends ModalView
       {id: 'javascript', name: 'JavaScript'}
       {id: 'coffeescript', name: 'CoffeeScript (Experimental)'}
       {id: 'lua', name: 'Lua'}
-      {id: 'java', name: 'Java'}
+      # TODO: Bring java back once it's supported
+      # {id: 'java', name: 'Java'}
     ]
     @myName = me.get('name') || 'Newcomer'
 


### PR DESCRIPTION
Fix for #5157 

Removes Java from the arena drop down menu as it's not currently supported.