### PR TITLE
Fix: Always show classes section on outcomes report

### DIFF
--- a/app/templates/admin/outcome-report-result-view.jade
+++ b/app/templates/admin/outcome-report-result-view.jade
@@ -113,20 +113,19 @@ div.style-flat
           small standalone game and web projects
 
 
-  if view.options.insightsHtml
-    div.dont-break.block
-      div.rob-row
-        div.left-col
+  div.dont-break.block
+    div.rob-row
+      div.left-col
+        h1 Classes
+        for clazz in view.options.classrooms
+          b= clazz.name
+          ul
+            li Language: #{clazz.aceConfig.language}
+            li #{clazz.members.length} students
+      if view.options.insightsHtml
+        div.right-col
           h1 Insights
           != view.options.insightsHtml
-        
-        div.right-col
-          h1 Classes
-          for clazz in view.options.classrooms
-            b= clazz.name
-            ul
-              li Language: #{clazz.aceConfig.language}
-              li #{clazz.members.length} students
 
   div.dont-break
     img.anya(src="/images/pages/admin/outcomes-report/anya.png")


### PR DESCRIPTION
## Issue

The outcomes reports would only show the overview of the class, the classes section, if there was custom markdown manually added to the report. 

## Fix

Always show the classes section regardless of whether the markdown was present or not. To keep the report consistent when generated with/without the custom markdown, the classes section was moved to the left.