### PR TITLE
Fix: Duplicated home page text

### DIFF
--- a/app/templates/home-view.jade
+++ b/app/templates/home-view.jade
@@ -231,7 +231,7 @@ block content
               .width-320
                 h1.text-gold 94%
                 img(src="/images/pages/home/pink_rectangle.png")
-                h4.text-white(data-i18n="new_home.teachers_love_codecombat_blurb1")
+                h4.text-white(data-i18n="new_home.teachers_love_codecombat_blurb3")
           p.mcrel-blurb(data-i18n="new_home.teachers_love_codecombat_subblurb")
 
     //- TODO: this is really similar to quad above


### PR DESCRIPTION
## Issue

The text used in the statistics overview is duplicated. 

## Fix

The reference to the first section was used twice. I just updated it to use the third section text instead. 