### PR TITLE
Dropdown menu will truncate very long names

### DIFF
--- a/app/styles/style-flat.sass
+++ b/app/styles/style-flat.sass
@@ -177,6 +177,10 @@ body[lang='ru'], body[lang='uk'], body[lang='bg'], body[lang^='mk'], body[lang='
       #navbar-collapse
         float: right
 
+      .dropdown-menu
+        max-width: 330px
+        overflow-x: auto
+
     .language-dropdown
       max-height: 60vh
       overflow-y: auto


### PR DESCRIPTION
# Issue

Very long names cause the "My Account" dropdown menu to shift off the users screen making it hard it impossible to read buttons. 

# Fix

Set a max width and set overflow-x.