### PR TITLE
Fix language dropdown positioning when logged in

### DIFF
--- a/app/templates/base-flat.jade
+++ b/app/templates/base-flat.jade
@@ -96,7 +96,7 @@ mixin accountLinks
                       //- string replaced in RootView
                       span.language-dropdown-current Language
                       span.caret
-                    ul.dropdown-menu.language-dropdown
+                    ul(class="dropdown-menu language-dropdown" class=(!me.isAnonymous() ? "pull-right" : ""))
 
                 if me.isAnonymous()
                   ul.nav.navbar-nav.text-p.login-buttons


### PR DESCRIPTION
Leave as is when not logged in.

Before:
<img width="582" alt="Screen Shot 2019-03-21 at 12 21 25 AM" src="https://user-images.githubusercontent.com/1000442/54733772-e3fe6b00-4b71-11e9-824b-f98c4a4a2192.png">

After:
<img width="603" alt="Screen Shot 2019-03-21 at 12 40 43 AM" src="https://user-images.githubusercontent.com/1000442/54733791-07c1b100-4b72-11e9-8cda-a1ea53ee6eb9.png">
