### PR TITLE
Add StandardJS tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,20 @@
     "multicore": "coffee multicore.coffee",
     "proxy": "COCO_PROXY='true' nodemon",
     "proxy-win": "cross-env COCO_PROXY='true' nodemon",
-    "analyzer": "COCO_ANALYZER_BUNDLE=1 webpack --profile --json > stats.json"
+    "analyzer": "COCO_ANALYZER_BUNDLE=1 webpack --profile --json > stats.json",
+    "standard": "standard",
+    "fix": "standard --fix"
   },
   "main": "index.js",
+  "standard": {
+    "ignore": [
+      "node_modules/**",
+      "bower_components/**",
+      "vendor/**",
+      "spec/**",
+      "public/**"
+    ]
+  },
   "keywords": [
     "learning",
     "live coding",
@@ -157,8 +168,8 @@
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
-    "babel-preset-env": "^1.7.0",
     "babel-polyfill": "^6.26.0",
+    "babel-preset-env": "^1.7.0",
     "bower": "~1.6.4",
     "bundle-loader": "^0.5.5",
     "commonjs-require-definition": "0.2.0",
@@ -189,6 +200,7 @@
     "recursive-readdir-sync": "^1.0.6",
     "requirejs": "~2.1.10",
     "sass-loader": "^6.0.6",
+    "standard": "^12.0.1",
     "uglifyjs-webpack-plugin": "^1.3.0",
     "webpack-bundle-analyzer": "^2.9.0",
     "webpack-livereload-plugin": "https://github.com/codecombat/webpack-livereload-plugin/tarball/master"

--- a/package.json
+++ b/package.json
@@ -50,12 +50,16 @@
   },
   "main": "index.js",
   "standard": {
+    "plugins": [
+      "script-tags"
+    ],
     "ignore": [
       "node_modules/**",
       "bower_components/**",
       "vendor/**",
       "spec/**",
-      "public/**"
+      "public/**",
+      "**/styles/**"
     ]
   },
   "keywords": [
@@ -164,6 +168,7 @@
   },
   "devDependencies": {
     "@vue/test-utils": "^1.0.0-beta.28",
+    "acorn": "^6.1.1",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
@@ -177,6 +182,7 @@
     "copy-webpack-plugin": "^4.0.1",
     "country-data": "0.0.24",
     "cross-env": "^5.2.0",
+    "eslint-plugin-script-tags": "^0.5.0",
     "exports-loader": "^0.6.3",
     "faker": "^3.1.0",
     "file-loader": "^0.11.2",


### PR DESCRIPTION
We want a standard to follow for writing JavaScript. There should be adequate tooling, low config and some benefit to the style we choose.

We've chosen [standardJS](https://standardjs.com/), or JavaScript Standard Style. This is a zero config tool that formats and lints our code. standard also has editor extensions, plugins and a CLI.

This PR introduces a new npm script: `npm run standard` that is detailed below.

This script will format your code and print linting errors to the console.
**It is recommended that you install an editor [plugin](https://standardjs.com/#are-there-text-editor-plugins) to get a much better experience** as this script runs slowly.

The commands were tested on files ending with `.js` and `.vue`.

The plugin `eslint-plugin-script-tags` is required to use standard on JavaScript within vue `<script>` tags. There is also a peer dependency on `acorn` that must be installed.

## Commands reference

`npm run fix` will run `standard --fix` on the entire codebase ignoring certain directories.

`npm run fix <filename>` will run `standard --fix` on a single file.

`npm run standard` will provide linting info for the entire project.

`npm run standard <filename>` will provide standard linting info for a single file.
