### PR TITLE
Upgrade Facebook API

### DIFF
--- a/app/core/social-handlers/FacebookHandler.coffee
+++ b/app/core/social-handlers/FacebookHandler.coffee
@@ -70,7 +70,7 @@ module.exports = FacebookHandler = class FacebookHandler extends CocoClass
           channelUrl: document.location.origin + '/channel.html' # Channel File
           cookie: true # enable cookies to allow the server to access the session
           xfbml: true # parse XFBML
-          version: 'v2.9'
+          version: 'v3.2'
         })
         FB.getLoginStatus (response) =>
           if response.status is 'connected'

--- a/app/core/social-handlers/FacebookHandler.coffee
+++ b/app/core/social-handlers/FacebookHandler.coffee
@@ -70,7 +70,7 @@ module.exports = FacebookHandler = class FacebookHandler extends CocoClass
           channelUrl: document.location.origin + '/channel.html' # Channel File
           cookie: true # enable cookies to allow the server to access the session
           xfbml: true # parse XFBML
-          version: 'v2.8'
+          version: 'v2.9'
         })
         FB.getLoginStatus (response) =>
           if response.status is 'connected'

--- a/app/core/social-handlers/FacebookHandler.coffee
+++ b/app/core/social-handlers/FacebookHandler.coffee
@@ -70,7 +70,7 @@ module.exports = FacebookHandler = class FacebookHandler extends CocoClass
           channelUrl: document.location.origin + '/channel.html' # Channel File
           cookie: true # enable cookies to allow the server to access the session
           xfbml: true # parse XFBML
-          version: 'v3.2'
+          version: 'v2.9'
         })
         FB.getLoginStatus (response) =>
           if response.status is 'connected'


### PR DESCRIPTION
# Issue

Facebook API v2.8 is being deprecated.

# Fix

Bump the version number.
See referenced server PR for additional details as this change depends on the server.