### PR TITLE
Fix printing certificates on landscape pages

### DIFF
--- a/app/styles/user/certificates-view.sass
+++ b/app/styles/user/certificates-view.sass
@@ -1,3 +1,6 @@
+.style-flat
+  padding-top: 0
+
 #certificates-view
   background-color: white
   text-align: center
@@ -12,6 +15,9 @@
 
   @media print
     -webkit-print-color-adjust: exact
+    html, body
+      height: 100%
+      overflow: hidden
 
   .menu
     position: fixed


### PR DESCRIPTION
# Issue

The certificates have top padding making room for the nav that isn't required.
This is causing certificates to not fit on a single landscape page.

# Fix

Remove the padding-top from the `.style-flat` div on the Certificates View.
On manual testing the page was still leaking off the page. This is fixed with the `print` media query additions.

Manually tested on Chrome and Firefox. Firefox adds white space which can't be removed on my computer. I believe this fixes the issue on Chrome and improves printing on other browsers by reducing top white space.