### PR TITLE
School admin access granting for coco admins

### DIFF
--- a/app/core/api/users.coffee
+++ b/app/core/api/users.coffee
@@ -83,4 +83,13 @@ module.exports = {
       method: 'GET'
     }))
 
+  fetchByIds: ({ fetchByIds, teachersOnly, includeTrialRequests }) ->
+    fetchJson("/db/user", {
+      method: 'GET',
+      data: {
+        fetchByIds
+        teachersOnly
+        includeTrialRequests
+      }
+    })
 }

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -26,11 +26,19 @@ module.exports = class User extends CocoModel
   @schema: require 'schemas/models/user'
   urlRoot: '/db/user'
   notyErrors: false
+  PERMISSIONS: {
+    COCO_ADMIN: 'admin',
+    SCHOOL_ADMINISTRATOR: 'schoolAdministrator',
+    ARTISAN: 'artisan',
+    GOD_MODE: 'godmode',
+    LICENSOR: 'licensor'
+  }
 
-  isAdmin: -> 'admin' in @get('permissions', true)
-  isLicensor: -> 'licensor' in @get('permissions', true)
-  isArtisan: -> 'artisan' in @get('permissions', true)
-  isInGodMode: -> 'godmode' in @get('permissions', true)
+  isAdmin: -> @PERMISSIONS.COCO_ADMIN in @get('permissions', true)
+  isLicensor: -> @PERMISSIONS.LICENSOR in @get('permissions', true)
+  isArtisan: -> @PERMISSIONS.ARTISAN in @get('permissions', true)
+  isInGodMode: -> @PERMISSIONS.GOD_MODE in @get('permissions', true)
+  isSchoolAdmin: -> @PERMISSIONS.SCHOOL_ADMINISTRATOR in @get('permissions', true)
   isAnonymous: -> @get('anonymous', true)
   isSmokeTestUser: -> User.isSmokeTestUser(@attributes)
   displayName: -> @get('name', true)

--- a/app/styles/admin/administer-user-modal.sass
+++ b/app/styles/admin/administer-user-modal.sass
@@ -4,3 +4,6 @@
 
   .user-props
     font-size: 11px
+
+#edit-school-admins-link
+  text-decoration: underline

--- a/app/templates/admin/administer-user-modal.jade
+++ b/app/templates/admin/administer-user-modal.jade
@@ -41,6 +41,13 @@ block modal-header-content
       input#verified-teacher-checkbox(type='checkbox', checked=view.userIsVerifiedTeacher())
       span.p-l-1
         | APCSP Verified Teacher (has access to private forum)
+    br
+    label
+      input#school-admin-checkbox(type='checkbox', checked=view.userIsSchoolAdmin())
+      span.p-l-1
+        | Enable School Administrator
+      span.p-l-1
+        a(href="#edit-school-admins-link")#edit-school-admins-link edit teachers
     div
       if view.userSaveState == 'saving'
         | Saving...
@@ -50,6 +57,25 @@ block modal-header-content
         | &nbsp;
 
 block modal-body-content
+  if view.editingSchoolAdmins
+    h3.m-t-3#school-admins-title Edit School Admin Teacher Access
+    h5 Add teacher
+    table.table.table-condensed
+      .form-horizontal
+        form#teacher-search-form.form-group
+        .col-sm-4
+          input.form-control#teacher-search(type="text")
+        .col-sm-1
+          button.btn.btn-primary.btn-large#teacher-search-button Search
+        .col-sm-1
+          button.btn.btn-large#clear-teacher-search-button Clear results
+      #teacher-search-result
+    br
+    h5 Edit teachers
+    br
+    table.table.table-condensed
+      #school-admin-result
+
 
   if view.prepaids.size()
     h3.m-t-3#prepaids Existing Prepaids


### PR DESCRIPTION
## Feature

We want to give our admins the ability to grant School Administrator access through the admin modal dialog. This requires a new search, state management before and after storing user ID's in the db and interacting with the new API endpoints in https://github.com/codecombat/codecombat-server/pull/57/files.

## Asks

- How would you manage state in this situation? It quickly grew complex, and the current structure is more a result of debugging and pulling together all the pieces - rather than by intentional design. 
- What is a good approach for testing this? My focus has been on understanding the systems, interactions and data models. Now that the pieces are interacting the expected way, could this be done in a more testable way? 

## Todo

- [x] Fix current issue with removing teachers
- [ ] Improve state management
- [ ] Tests