### PR TITLE
modify China ICP info

### DIFF
--- a/app/templates/base-flat.jade
+++ b/app/templates/base-flat.jade
@@ -136,7 +136,8 @@ mixin accountLinks
                       li
                         a(href="http://blog.codecombat.com/", data-i18n="nav.blog")
                       if features.china
-                        li 京ICP备16061132号
+                        li
+                          a(href="http://www.miitbeian.gov.cn/") 京ICP备19012263号
                   .col-lg-3
                     if !me.isStudent()
                       h3(data-i18n="nav.educators")


### PR DESCRIPTION
change 京ICP备16061132号 to 京ICP备19012263号 with href to MIIT of China