### PR TITLE
Add mousemove event transferring in game systems

### DIFF
--- a/app/lib/surface/Surface.coffee
+++ b/app/lib/surface/Surface.coffee
@@ -100,6 +100,8 @@ module.exports = Surface = class Surface extends CocoClass
     })
     @realTimeInputEvents = @gameUIState.get('realTimeInputEvents')
     @listenTo(@gameUIState, 'sprite:mouse-down', @onSpriteMouseDown)
+    if @world.trackMouseMove
+      @listenTo(@gameUIState, 'surface:stage-mouse-move', @onWorldMouseMove)
     @onResize = _.debounce @onResize, resizeDelay
     @initEasel()
     @initAudio()
@@ -549,6 +551,14 @@ module.exports = Surface = class Surface extends CocoClass
       pos: @camera.screenToWorld x: e.originalEvent.stageX, y: e.originalEvent.stageY
       time: @world.dt * @world.frames.length
       thangID: e.sprite.thang.id
+    })
+
+  onWorldMouseMove: (e) =>
+    return unless @realTime
+    @realTimeInputEvents.add({
+      type: 'mousemove'
+      pos: @camera.screenToWorld x: e.originalEvent.stageX, y: e.originalEvent.stageY
+      time: @world.dt * @world.frames.length
     })
 
   onMouseUp: (e) =>

--- a/app/lib/surface/Surface.coffee
+++ b/app/lib/surface/Surface.coffee
@@ -100,7 +100,7 @@ module.exports = Surface = class Surface extends CocoClass
     })
     @realTimeInputEvents = @gameUIState.get('realTimeInputEvents')
     @listenTo(@gameUIState, 'sprite:mouse-down', @onSpriteMouseDown)
-    if @world.trackMouseMove
+    if @world.trackMouseMove # This is defined as a parameter of Systems.UI and setup there for a level
       @listenTo(@gameUIState, 'surface:stage-mouse-move', @onWorldMouseMove)
     @onResize = _.debounce @onResize, resizeDelay
     @initEasel()


### PR DESCRIPTION
# Issue

For some levels we need track mousemove event.

# Fix
If world's parameter `trackMouseMove` is true then we send all mousemove events to realtTimeInputEvents which is processed in Systems.UI