### PR TITLE
Restrict student page links for school admins

### DIFF
--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -59,7 +59,10 @@ mixin studentRow(student)
         if student.get('deleted')
           em (deleted)
         - var url = '/teachers/classes/' + view.classroom.id + '/' + student.id;
-        a(href=url)
+        if !state.get('readOnly')
+          a(href=url)
+            div.student-name= student.broadName()
+        else
           div.student-name= student.broadName()
         div.student-email.small-details= student.get('email') || student.get('name')
     td.hidden

--- a/app/templates/teachers/teacher-student-view.jade
+++ b/app/templates/teachers/teacher-student-view.jade
@@ -10,7 +10,9 @@ block content
   else
     .container
       +breadcrumbs
-      if view.classroom && view.classroom.get('ownerID') === me.id || me.isAdmin()
+      if !view.classroom || view.classroom.get('ownerID') !== me.id || !me.isAdmin()
+        h3.m-t-2 Not available
+      else
         h3.m-t-2
           span(data-i18n="teacher.student_profile")
           span.spr :

--- a/app/templates/teachers/teacher-student-view.jade
+++ b/app/templates/teachers/teacher-student-view.jade
@@ -10,7 +10,7 @@ block content
   else
     .container
       +breadcrumbs
-      if !view.classroom || view.classroom.get('ownerID') !== me.id || !me.isAdmin()
+      if view.canViewStudentProfile()
         h3.m-t-2 Not available
       else
         h3.m-t-2

--- a/app/templates/teachers/teacher-student-view.jade
+++ b/app/templates/teachers/teacher-student-view.jade
@@ -10,7 +10,7 @@ block content
   else
     .container
       +breadcrumbs
-      if view.canViewStudentProfile()
+      if !view.canViewStudentProfile()
         h3.m-t-2 Not available
       else
         h3.m-t-2

--- a/app/views/teachers/TeacherStudentView.coffee
+++ b/app/views/teachers/TeacherStudentView.coffee
@@ -406,7 +406,7 @@ module.exports = class TeacherStudentView extends RootView
     date = if expires? then moment(expires).utc().format('l') else ''
     utils.formatStudentLicenseStatusDate(status, date)
 
-  canViewStudentProfile: () -> !@classroom || (@classroom.get('ownerID') != me.id && !me.isAdmin())
+  canViewStudentProfile: () -> @classroom && (@classroom.get('ownerID') == me.id || me.isAdmin())
 
   # TODO: Hookup enroll/assign functionality
 

--- a/app/views/teachers/TeacherStudentView.coffee
+++ b/app/views/teachers/TeacherStudentView.coffee
@@ -406,6 +406,7 @@ module.exports = class TeacherStudentView extends RootView
     date = if expires? then moment(expires).utc().format('l') else ''
     utils.formatStudentLicenseStatusDate(status, date)
 
+  canViewStudentProfile: () -> !@classroom || (@classroom.get('ownerID') != me.id && !me.isAdmin())
 
   # TODO: Hookup enroll/assign functionality
 


### PR DESCRIPTION
# Issue

There was still a link into student pages that both school admins and teachers were seeing. Going to this student page for a school admin would simply display an empty page. 

# Fix

Remove the link, and give a more useful "Not available" message to the school admin that somehow gets to a student page.