### PR TITLE
Fix school admin checkbox responsivity

### DIFF
--- a/app/views/admin/AdministerUserModal.coffee
+++ b/app/views/admin/AdministerUserModal.coffee
@@ -261,10 +261,7 @@ module.exports = class AdministerUserModal extends ModalView
           @renderSelectors('#'+prepaidId)
         return
 
-  userIsSchoolAdmin: ->
-    console.log(@user.isSchoolAdmin())
-    console.log(@user.get('permissions'))
-    @user.isSchoolAdmin()
+  userIsSchoolAdmin: -> @user.isSchoolAdmin()
 
   onClickSchoolAdminCheckbox: (e) ->
     checked = @$(e.target).prop('checked')
@@ -284,14 +281,10 @@ module.exports = class AdministerUserModal extends ModalView
       else if not checked and res.schoolAdministrator == 1
         _.remove(permissions, (p) -> p == 'schoolAdministrator')
       else
-        @userSaveState = 'Something went wrong...'
+        @userSaveState = 'Checkbox and server state mismatch. Close and open this dialog again to refresh.'
 
       @user.set('permissions', permissions)
       @render()
-      setTimeout((()=>
-        @userSaveState = null
-        @render()
-      ), 2000)
     null
 
   onClickEditSchoolAdmins: (e) ->

--- a/app/views/admin/AdministerUserModal.coffee
+++ b/app/views/admin/AdministerUserModal.coffee
@@ -261,7 +261,10 @@ module.exports = class AdministerUserModal extends ModalView
           @renderSelectors('#'+prepaidId)
         return
 
-  userIsSchoolAdmin: -> @user.isSchoolAdmin()
+  userIsSchoolAdmin: ->
+    console.log(@user.isSchoolAdmin())
+    console.log(@user.get('permissions'))
+    @user.isSchoolAdmin()
 
   onClickSchoolAdminCheckbox: (e) ->
     checked = @$(e.target).prop('checked')
@@ -274,6 +277,16 @@ module.exports = class AdministerUserModal extends ModalView
       }
     }).then (res) =>
       @userSaveState = 'saved'
+      permissions = @user.get('permissions')
+
+      if checked and res.schoolAdministrator == 0
+          permissions.push('schoolAdministrator')
+      else if not checked and res.schoolAdministrator == 1
+        _.remove(permissions, (p) -> p == 'schoolAdministrator')
+      else
+        @userSaveState = 'Something went wrong...'
+
+      @user.set('permissions', permissions)
       @render()
       setTimeout((()=>
         @userSaveState = null


### PR DESCRIPTION
# Issue

The school admin checkbox was not responsive because the local `user` was not updated after the `put` call to the server. 

# Fix

Modify the local permissions of the user model after receiving the `res`.