### PR TITLE
Camera control from the game

### DIFF
--- a/app/lib/surface/Surface.coffee
+++ b/app/lib/surface/Surface.coffee
@@ -95,6 +95,7 @@ module.exports = Surface = class Surface extends CocoClass
     @options = _.clone(@defaults)
     @options = _.extend(@options, givenOptions) if givenOptions
     @handleEvents = @options.handleEvents ? true
+    @zoomToHero = @options.levelType isnt "game-dev" # In game-dev levels the hero is gameReferee
     @gameUIState = @options.gameUIState or new GameUIState({
       canDragCamera: true
     })
@@ -256,7 +257,7 @@ module.exports = Surface = class Surface extends CocoClass
   updateState: (frameChanged) ->
     # world state must have been restored in @restoreWorldState
     if @handleEvents
-      if @playing and @currentFrame < @world.frames.length - 1 and @heroLank and not @mouseIsDown and @camera.newTarget isnt @heroLank.sprite and @camera.target isnt @heroLank.sprite
+      if @zoomToHero and @playing and @currentFrame < @world.frames.length - 1 and @heroLank and not @mouseIsDown and @camera.newTarget isnt @heroLank.sprite and @camera.target isnt @heroLank.sprite
         @camera.zoomTo @heroLank.sprite, @camera.zoom, 750
     @lankBoss.update frameChanged
     @camera.updateZoom()  # Make sure to do this right after the LankBoss updates, not before, so it can properly target sprite positions.

--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -378,9 +378,11 @@ module.exports = class World
     return unless @goalManager
     @goalManager.submitWorldGenerationEvent(channel, event, @frames.length)
 
-  publishGlobalEvent: (channel, event={}) ->
+  publishCameraEvent: (eventName, event) ->
     return if not Backbone?.Mediator # headless mode don't have this
-    Backbone.Mediator.publish(channel, event) # Feel the force, young jedi
+    event ?= {}
+    channel = 'camera:' + channel
+    Backbone.Mediator.publish(eventName, event)
 
   getGoalState: (goalID) ->
     @goalManager.getGoalState(goalID)

--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -378,6 +378,10 @@ module.exports = class World
     return unless @goalManager
     @goalManager.submitWorldGenerationEvent(channel, event, @frames.length)
 
+  publishGlobalEvent: (channel, event={}) ->
+    return if not Backbone?.Mediator # headless mode don't have this
+    Backbone.Mediator.publish(channel, event) # Feel the force, young jedi
+
   getGoalState: (goalID) ->
     @goalManager.getGoalState(goalID)
 

--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -381,7 +381,7 @@ module.exports = class World
   publishCameraEvent: (eventName, event) ->
     return if not Backbone?.Mediator # headless mode don't have this
     event ?= {}
-    channel = 'camera:' + eventName
+    eventName = 'camera:' + eventName
     Backbone.Mediator.publish(eventName, event)
 
   getGoalState: (goalID) ->

--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -381,7 +381,7 @@ module.exports = class World
   publishCameraEvent: (eventName, event) ->
     return if not Backbone?.Mediator # headless mode don't have this
     event ?= {}
-    channel = 'camera:' + channel
+    channel = 'camera:' + eventName
     Backbone.Mediator.publish(eventName, event)
 
   getGoalState: (goalID) ->


### PR DESCRIPTION
# Issue

We need to control the camera (bounds, target, zoom) from the game codebase.

# Fix

Added world's method to trigger client code events from the world lib.
Unbound the camera from the hero thang on game-dev levels (we don't hero there).