### PR TITLE
Prevent additional student links for school admin

### DIFF
--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -252,7 +252,7 @@ mixin allStudentsLevelProgressDot(progress, level, levelNumber)
       - labelText = ''
       - dotClass += ' practice'
 
-  if link
+  if link && !state.get('readOnly')
     a.progress-dot.level-progress-dot(class=dotClass, data-html='true', data-title=view.allStudentsLevelProgressDotTemplate(context), href=link)
       +progressDotLabel(labelText)
   else
@@ -289,7 +289,7 @@ mixin studentLevelProgressDot(progress, level, levelNumber, student)
       - dotClass += ' practice'
 
 
-  if link
+  if link && !state.get('readOnly')
     a.progress-dot.level-progress-dot.student-level-progress-dot(class=dotClass, data-html='true', data-title=view.singleStudentLevelProgressDotTemplate(context) href=link, data-student-id=student.id, data-level-slug=level.get('slug'), data-level-progress=(progress.completed ? 'complete' : progress.started ? 'started' : 'not started'), data-course-id=view.state.get('selectedCourse').id)
       +progressDotLabel(labelText)
   else

--- a/app/views/courses/TeacherClassAssessmentsTable.vue
+++ b/app/views/courses/TeacherClassAssessmentsTable.vue
@@ -14,7 +14,8 @@
           div.table-cell.name
             div
               strong
-                a(:href="studentLink(student._id)") {{ broadName(student) }}
+                a(v-if="!readOnly" :href="studentLink(student._id)") {{ broadName(student) }}
+                span(v-else) {{ broadName(student) }}
             div.student-email {{ student.email || student.name }}
     div.data-column(ref="dataColumn", @scroll="updateArrows" v-if="levels.length > 0")
       div(v-for="(student, index) in students")
@@ -57,7 +58,8 @@
       progress: { default: -> {} }
       course: {}
       courseInstance: {}
-      classroom: {}
+      classroom: {},
+      readOnly: Boolean
     },
     data: ->
       showPrevArrows: false

--- a/app/views/courses/TeacherClassView.coffee
+++ b/app/views/courses/TeacherClassView.coffee
@@ -267,7 +267,8 @@ module.exports = class TeacherClassView extends RootView
         course: course?.toJSON(),
         progress: @state.get('progressData')?.get({ @classroom, course }),
         courseInstance,
-        classroom: @classroom.toJSON()
+        classroom: @classroom.toJSON(),
+        readOnly: @state.get('readOnly')
       }
       new TeacherClassAssessmentsTable({
         el: @$el.find('.assessments-table')[0]


### PR DESCRIPTION
# Issue

There are more links from teacher pages and sub components that should be disabled for school admins.

# Fix

Introduce `readOnly` through props for the sub components and conditionally render remaining links.