### PR TITLE
Group NCES data correctly with headers

### DIFF
--- a/app/views/admin/AdministerUserModal.coffee
+++ b/app/views/admin/AdministerUserModal.coffee
@@ -405,7 +405,7 @@ module.exports = class AdministerUserModal extends ModalView
 
       return "
         <tr>
-          <h6>#{schoolName}</h6>
+          <th>#{schoolName}</th>
           #{teachers.join('\n')}
         </tr>
       "


### PR DESCRIPTION
# Issue

The headers for the school admin teacher table were not `th` but rather `h6`, popping above the table.

# Fix

Properly use `th` instead.