### PR TITLE
NCES grouping fixes

### DIFF
--- a/app/views/admin/AdministerUserModal.coffee
+++ b/app/views/admin/AdministerUserModal.coffee
@@ -357,7 +357,7 @@ module.exports = class AdministerUserModal extends ModalView
           <td>#{_.escape(teacher.email)}</td>
           <td>#{teacher.firstName or 'No first name'}</td>
           <td>#{teacher.lastName or 'No last name'}</td>
-          <td>#{teacher.schoolName or 'No school name'}</td>
+          <td>#{teacher.schoolName or 'Other'}</td>
           <td>Verified teacher: #{teacher.verifiedTeacher or 'false'}</td>
         </tr>
       "
@@ -417,7 +417,7 @@ module.exports = class AdministerUserModal extends ModalView
   administratedSchools: (teachers) ->
     schools = {}
     _.forEach teachers, (teacher) =>
-      school = teacher?._trialRequest?.organization or "No school found"
+      school = teacher?._trialRequest?.organization or "Other"
       if not schools[school]
         schools[school] = [teacher]
       else

--- a/app/views/admin/AdministerUserModal.coffee
+++ b/app/views/admin/AdministerUserModal.coffee
@@ -405,7 +405,7 @@ module.exports = class AdministerUserModal extends ModalView
 
       return "
         <tr>
-          <h6>#{schoolName}</h6>
+          <th>#{schoolName}</th>
           #{teachers.join('\n')}
         </tr>
       "

--- a/app/views/school-administrator/teachers/SchoolAdminTeacherListView.vue
+++ b/app/views/school-administrator/teachers/SchoolAdminTeacherListView.vue
@@ -91,7 +91,10 @@
           const groupedTeachers = {}
 
           for (const teacher of this.administratedTeachers) {
-            const trialRequest = teacher._trialRequest || { organization: 'No school found' }
+            const trialRequest = teacher._trialRequest || {}
+            if (!trialRequest.organization) {
+              trialRequest.organization = 'No school found'
+            }
 
             groupedTeachers[trialRequest.organization] = groupedTeachers[trialRequest.organization] || []
             groupedTeachers[trialRequest.organization].push(teacher)

--- a/app/views/school-administrator/teachers/SchoolAdminTeacherListView.vue
+++ b/app/views/school-administrator/teachers/SchoolAdminTeacherListView.vue
@@ -91,7 +91,7 @@
           const groupedTeachers = {}
 
           for (const teacher of this.administratedTeachers) {
-            const trialRequest = teacher._trialRequest || {}
+            const trialRequest = teacher._trialRequest || { organization: 'No school found' }
 
             groupedTeachers[trialRequest.organization] = groupedTeachers[trialRequest.organization] || []
             groupedTeachers[trialRequest.organization].push(teacher)

--- a/app/views/school-administrator/teachers/SchoolAdminTeacherListView.vue
+++ b/app/views/school-administrator/teachers/SchoolAdminTeacherListView.vue
@@ -39,7 +39,7 @@
                         v-for="(teachers, groupName) of groupedTeachers"
                 >
                     <li class="group-title">
-                        <h4 v-if="groupName !== 'undefined'">{{ groupName }}</h4>
+                        <h4 v-if="groupName">{{ groupName }}</h4>
                         <h4 v-else>{{ $t('school_administrator.other') }}</h4>
                     </li>
 
@@ -92,9 +92,6 @@
 
           for (const teacher of this.administratedTeachers) {
             const trialRequest = teacher._trialRequest || {}
-            if (!trialRequest.organization) {
-              trialRequest.organization = 'No school found'
-            }
 
             groupedTeachers[trialRequest.organization] = groupedTeachers[trialRequest.organization] || []
             groupedTeachers[trialRequest.organization].push(teacher)


### PR DESCRIPTION
# Issue

We were not grouping teachers by `No school found` and the table headers were not `th` but rather `h6`, popping above the table.

# Fix

Add default `No school found` and properly use `th`.