### PR TITLE
Fix navigation height with Partner logo

### DIFF
--- a/app/styles/style-flat.sass
+++ b/app/styles/style-flat.sass
@@ -150,20 +150,15 @@ body[lang='ru'], body[lang='uk'], body[lang='bg'], body[lang^='mk'], body[lang='
       #logo-img
         height: 40px
 
-        &.code-ninjas-powered-by
-          width: 150px
-          height: auto
-          margin-top: -10px
+        &.powered-by
+          height: 30px
+          width: auto
+          margin-top: -5px
 
-      .code-ninjas-logo
-        width: 150px
+      .code-ninjas-logo, #tarena-logo
+        height: 40px
+        width: auto
         margin-right: 10px
-        margin-top: 6px
-        margin-bottom: 10px
-
-      #tarena-logo
-        width: 150px
-        margin: 5px 10px 0 10px
 
     .navbar-toggle
       color: black

--- a/app/templates/base-flat.jade
+++ b/app/templates/base-flat.jade
@@ -33,11 +33,11 @@ mixin accountLinks
                 span.icon-bar
               if me.useTarenaLogo()
                 a.navbar-brand(href="http://kidtts.tmooc.cn/ttsPage/login.html")
-                  img#logo-img(src="/images/pages/base/logo.png")
+                  img#logo-img.powered-by(src="/images/pages/base/logo.png")
                   img#tarena-logo(src="/images/pages/base/logo-tarena.png")
               else if serverConfig.codeNinjas
                 a.navbar-brand(href="/home")
-                  img#logo-img.code-ninjas-powered-by(src="/images/pages/base/logo.png")
+                  img#logo-img.powered-by(src="/images/pages/base/logo.png")
                   img.code-ninjas-logo(src="/images/pages/base/code-ninjas-logo-right.png")
               else
                 a.navbar-brand(href="/home")


### PR DESCRIPTION
# Issue

When the CodeCombat logo is sharing the navigation with another logo the nav resizes and thus covers the teacher dashboard.

The nav must be 70px tall, and a third party logo causes the nav to have a height of ~90px.

# Fix

Ensure that partner logos are set by height instead of width.
The issue was fixed for CodeNinja's logo but also fixed the Tarena logo.

Because we shrink the CodeCombat logo when it's with a partner logo, I shrunk it slightly more to compensate for the slightly smaller third party logos. It's also been centered vertically.