### PR TITLE
Tiny whitespace fix for school admin notification

### DIFF
--- a/app/templates/courses/teacher-classes-view.jade
+++ b/app/templates/courses/teacher-classes-view.jade
@@ -102,7 +102,7 @@ block content
                 = teacher.get('email')
               | )
               if index !== view.administratingTeachers.models.length - 1
-                | ,
+                | &nbsp;,
 
 
     +createClassButton


### PR DESCRIPTION
# Issue

Pug/Jade does not consider spacing in the beginning of a text block like `| My text`.

# Fix

Added `&nbsp;` to force spacing in the rendered HTML.