### PR TITLE
Don't throw errors in production under other domain names

### DIFF
--- a/app/core/initialize.coffee
+++ b/app/core/initialize.coffee
@@ -114,6 +114,7 @@ watchForErrors = ->
 
   showError = (text) ->
     return if currentErrors >= 3
+    return if app.isProduction() and not me.isAdmin() # Don't show noty error messages in production when not an admin
     return unless me.isAdmin() or document.location.href.search(/codecombat.com/) is -1 or document.location.href.search(/\/editor\//) isnt -1
     ++currentErrors
     unless webkit?.messageHandlers  # Don't show these notys on iPad


### PR DESCRIPTION
# Issue

Some third party vendors using CodeCombat are seeing errors. This is due to our code not recognizing that it's in production.

# Fix

Add an additional condition to the problem area. Instead of checking for `codecombat.com` domain. Instead check for the lack of `localhost`.
We still want admins to see errors.