### PR TITLE
Voyager world map placeholder data support

### DIFF
--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -524,6 +524,8 @@ module.exports = class User extends CocoModel
   useGoogleAnalytics: -> not (features?.chinaInfra ? false)
   # This flag is set globally for our China server.
   showChinaVideo: -> features?.china ? false
+  # Voyager flags
+  showVoyagerCampaign: -> @isAdmin()
 
 
 tiersByLevel = [-1, 0, 0.05, 0.14, 0.18, 0.32, 0.41, 0.5, 0.64, 0.82, 0.91, 1.04, 1.22, 1.35, 1.48, 1.65, 1.78, 1.96, 2.1, 2.24, 2.38, 2.55, 2.69, 2.86, 3.03, 3.16, 3.29, 3.42, 3.58, 3.74, 3.89, 4.04, 4.19, 4.32, 4.47, 4.64, 4.79, 4.96,

--- a/app/schemas/models/level.coffee
+++ b/app/schemas/models/level.coffee
@@ -264,7 +264,7 @@ _.extend LevelSchema.properties,
   i18n: {type: 'object', format: 'i18n', props: ['name', 'description', 'loadingTip', 'studentPlayInstructions'], description: 'Help translate this level'}
   banner: {type: 'string', format: 'image-file', title: 'Banner'}
   goals: c.array {title: 'Goals', description: 'An array of goals which are visible to the player and can trigger scripts.'}, GoalSchema
-  type: c.shortString(title: 'Type', description: 'What type of level this is.', 'enum': ['campaign', 'ladder', 'ladder-tutorial', 'hero', 'hero-ladder', 'hero-coop', 'course', 'course-ladder', 'game-dev', 'web-dev'])
+  type: c.shortString(title: 'Type', description: 'What type of level this is.', 'enum': ['campaign', 'ladder', 'ladder-tutorial', 'hero', 'hero-ladder', 'hero-coop', 'course', 'course-ladder', 'game-dev', 'web-dev', 'intro'])
   kind: c.shortString(title: 'Kind', description: 'Similar to type, but just for our organization.', enum: ['demo', 'usage', 'mastery', 'advanced', 'practice', 'challenge'])
   terrain: c.terrainString
   requiresSubscription: {title: 'Requires Subscription', description: 'Whether this level is available to subscribers only.', type: 'boolean'}

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -110,6 +110,12 @@ module.exports = class CampaignView extends RootView
     @terrain = 'picoctf' if window.serverConfig.picoCTF
     @editorMode = options?.editorMode
     @requiresSubscription = not me.isPremium()
+    # Only admins can view the voyager campaign until the final content is ready
+    # Assuming, the voyager placeholder campaigns will start with 'voyager'
+    # TODO: Remove this check before final voyager launch
+    if _.string.startsWith(@terrain, "voyager") and (not me.showVoyagerCampaign() or not @editorMode)
+      console.error("voyager dummy campaign, only editor mode is available for admins!")
+      return
     if @editorMode
       @terrain ?= 'dungeon'
     @levelStatusMap = {}


### PR DESCRIPTION
- Adding a new level type for "intro"
- Allowing only admins to view voyager dummy campaigns in edit mode.
- Dummy campaigns will be created by the script on the server side - https://github.com/codecombat/codecombat-server/pull/65