### PR TITLE
School administrator dashboard project gallery access

### DIFF
--- a/app/templates/courses/project-gallery-view.jade
+++ b/app/templates/courses/project-gallery-view.jade
@@ -1,7 +1,8 @@
 flat-layout
   .container.m-t-3
     p
-      a(v-if="amTeacher", :href="backToClassroomUrl", data-i18n="courses.back_classroom")
+      a(v-if="amTeacher", :href="teacherBackUrl", data-i18n="courses.back_classroom")
+      a(v-else-if="amSchoolAdministrator", :href="schoolAdministratorBackUrl", data-i18n="courses.back_classroom")
       a(v-else, href="/students", data-i18n="courses.back_courses")
     div.text-center.m-t-2
       h2(v-if="classroom")

--- a/app/templates/courses/project-gallery-view.jade
+++ b/app/templates/courses/project-gallery-view.jade
@@ -1,8 +1,8 @@
 flat-layout
   .container.m-t-3
     p
-      a(v-if="amTeacher", :href="teacherBackUrl", data-i18n="courses.back_classroom")
-      a(v-else-if="amSchoolAdministrator", :href="schoolAdministratorBackUrl", data-i18n="courses.back_classroom")
+      a(v-if="amSchoolAdministrator", :href="schoolAdministratorBackUrl", data-i18n="courses.back_classroom")
+      a(v-else-if="amTeacher", :href="teacherBackUrl", data-i18n="courses.back_classroom")
       a(v-else, href="/students", data-i18n="courses.back_courses")
     div.text-center.m-t-2
       h2(v-if="classroom")

--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -252,7 +252,7 @@ mixin allStudentsLevelProgressDot(progress, level, levelNumber)
       - labelText = ''
       - dotClass += ' practice'
 
-  if link && !state.get('readOnly')
+  if link
     a.progress-dot.level-progress-dot(class=dotClass, data-html='true', data-title=view.allStudentsLevelProgressDotTemplate(context), href=link)
       +progressDotLabel(labelText)
   else
@@ -289,7 +289,7 @@ mixin studentLevelProgressDot(progress, level, levelNumber, student)
       - dotClass += ' practice'
 
 
-  if link && !state.get('readOnly')
+  if link
     a.progress-dot.level-progress-dot.student-level-progress-dot(class=dotClass, data-html='true', data-title=view.singleStudentLevelProgressDotTemplate(context) href=link, data-student-id=student.id, data-level-slug=level.get('slug'), data-level-progress=(progress.completed ? 'complete' : progress.started ? 'started' : 'not started'), data-course-id=view.state.get('selectedCourse').id)
       +progressDotLabel(labelText)
   else

--- a/app/views/courses/ProjectGalleryView.coffee
+++ b/app/views/courses/ProjectGalleryView.coffee
@@ -29,7 +29,7 @@ ProjectGalleryComponent = Vue.extend
     amTeacher: -> me.isTeacher()
     amSchoolAdministrator: -> me.isSchoolAdmin()
     teacherBackUrl: -> "/teachers/classes/#{@classroom?._id}"
-    schoolAdministratorBackUrl: -> "/school-administrator/teacher/#{@classroom?.get('ownerID')}/classroom/#{@classroom?.id}"
+    schoolAdministratorBackUrl: -> "/school-administrator/teacher/#{@classroom?.ownerID}/classroom/#{@classroom?._id}"
   created: ->
     Promise.all([
       api.courseInstances.getProjectGallery({ @courseInstanceID }).then((@levelSessions) =>)

--- a/app/views/courses/ProjectGalleryView.coffee
+++ b/app/views/courses/ProjectGalleryView.coffee
@@ -27,7 +27,9 @@ ProjectGalleryComponent = Vue.extend
     levelName: -> @level and utils.i18n(@level, 'name')
     courseName: -> @course and utils.i18n(@course, 'name')
     amTeacher: -> me.isTeacher()
-    backToClassroomUrl: -> "/teachers/classes/#{@classroom?._id}"
+    amSchoolAdministrator: -> me.isSchoolAdmin()
+    teacherBackUrl: -> "/teachers/classes/#{@classroom?._id}"
+    schoolAdministratorBackUrl: -> "/school-administrator/teacher/#{@classroom?.get('ownerID')}/classroom/#{@classroom?.id}"
   created: ->
     Promise.all([
       api.courseInstances.getProjectGallery({ @courseInstanceID }).then((@levelSessions) =>)


### PR DESCRIPTION
# Feature

The school admins should have access to the project gallery and the projects of the students in the classes for the teachers they administer. 

# Implementation

Most of this is done in the server side PR. What is done in this PR is: 

- No more `readOnly` checks to stop the school admin from clicking into these kinds of pages
- Proper "back button" handling, making sure that the back button corresponds to the school admin or the teacher, sending them back to the right view of the classroom