### PR TITLE
Remove top padding from style-flat in printable pages

### DIFF
--- a/app/styles/admin/admin-outcomes-report.sass
+++ b/app/styles/admin/admin-outcomes-report.sass
@@ -1,4 +1,7 @@
 #admin-outcomes-report-result-view
+  .style-flat
+    padding-top: 0
+
   font-family: 'Open Sans', sans-serif
   margin-left: auto
   margin-right: auto

--- a/app/styles/teachers/teacher-course-solution-view.sass
+++ b/app/styles/teachers/teacher-course-solution-view.sass
@@ -4,6 +4,11 @@
     .btn a
       color: white
 
+  .style-flat
+    // Required as we disable main-nav for printing.
+    @media print
+      padding-top: 0
+
   #site-content-area
     background-color: white
     color: black


### PR DESCRIPTION
# Issue

Outcomes report and printing course guides had excessive top padding.

## Fix

The cause was due to the redesigned homepage nav bar spacing appearing on the printable versions of these pages.

Thus as these pages hide the nav bar on printing we must also set the padding to 0.

We want the outcome report to always have a `padding-top` of `0` as the preview view is the printable view.

And we want the teacher course page to only have a `padding-top` of `0` when printing as there is a nav bar when not in print view.