### PR TITLE
Homepage A/B testing

### DIFF
--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -137,10 +137,12 @@ module.exports = class Tracker extends CocoClass
       gaFieldObject.eventLabel = properties.label if properties.label?
       gaFieldObject.eventValue = properties.value if properties.value?
 
-      # Add label for tracking home page A/B testing results on GA
-      # TODO: what if label already exists, as of now there is no label for the events for which trackABResult is true.
-      if properties.trackABResult and not properties.label and me.getHomePageTestGroup()
-        gaFieldObject.eventLabel = "testGroup"+ me.getHomePageTestGroup()
+      # Adding label for tracking home page A/B testing group on GA for analyzing results
+      # TODO: what if gaFieldObject.label already exists and we still want to track a/b results
+      # As of now gaFieldObject.label doesnt exist for the specific events which are relevant for a/b test results, so not a concern for now
+      # Probably add multiple labels as keys in gaFieldObject.label in the future, if required.
+      if properties.trackABResult and not gaFieldObject.label and me.getHomePageTestGroup()
+        gaFieldObject.eventLabel = "{testGroup:"+ me.getHomePageTestGroup() + "}"  # {testGroup:A} / {testGroup:B} / {testGroup:C}
 
       ga? 'send', gaFieldObject
       ga? 'codeplay.send', gaFieldObject if features.codePlay

--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -81,7 +81,7 @@ module.exports = class Tracker extends CocoClass
     @explicitTraits ?= {}
     @explicitTraits[key] = value for key, value of traits
 
-    traitsToReport = ['email', 'anonymous', 'dateCreated', 'hourOfCode', 'name', 'referrer', 'testGroupNumber', 'gender', 'lastLevel', 'siteref', 'ageRange', 'schoolName', 'coursePrepaidID', 'role']
+    traitsToReport = ['email', 'anonymous', 'dateCreated', 'hourOfCode', 'name', 'referrer', 'testGroupNumber', 'testGroupNumberUS', 'gender', 'lastLevel', 'siteref', 'ageRange', 'schoolName', 'coursePrepaidID', 'role']
     if me.isTeacher(true)
       traitsToReport.push('firstName', 'lastName')
     for userTrait in traitsToReport
@@ -136,6 +136,12 @@ module.exports = class Tracker extends CocoClass
         eventAction: action
       gaFieldObject.eventLabel = properties.label if properties.label?
       gaFieldObject.eventValue = properties.value if properties.value?
+
+      # Add label for tracking home page A/B testing results on GA
+      # TODO: what if label already exists, as of now there is no label for the events for which trackABResult is true.
+      if properties.trackABResult and not properties.label and me.getHomePageTestGroup()
+        gaFieldObject.eventLabel = "testGroup"+ me.getHomePageTestGroup()
+
       ga? 'send', gaFieldObject
       ga? 'codeplay.send', gaFieldObject if features.codePlay
 

--- a/app/core/auth.coffee
+++ b/app/core/auth.coffee
@@ -12,6 +12,10 @@ init = ->
     # Assign testGroupNumber to returning visitors; new ones in server/routes/auth
     me.set 'testGroupNumber', Math.floor(Math.random() * 256)
     me.patch()
+  if me and me.get("country") == 'united-states' and not me.get('testGroupNumberUS')?
+    # Assign testGroupNumberUS to returning visitors; new ones in server/models/User
+    me.set 'testGroupNumberUS', Math.floor(Math.random() * 256)
+    me.patch()
   preferredLanguage = getQueryVariable('preferredLanguage')
   if me and features.codePlay and preferredLanguage
     me.set('preferredLanguage', preferredLanguage)

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -145,6 +145,8 @@
     view_progress: "View Progress"
     go_to_courses: "Go to My Courses"
     want_coco: "Want CodeCombat at your school?"
+    educator: "Educator"
+    student: "Student"
 
   nav:
     educators: "Educators"

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -235,6 +235,17 @@ module.exports = class User extends CocoModel
     return 0 unless numVideos > 0
     return me.get('testGroupNumber') % numVideos
 
+  getHomePageTestGroup: () ->
+    return unless me.get('country') == 'united-states'
+    groupNumber = me.get('testGroupNumberUS')
+    # testGroupNumberUS is a random number from 0-255, dividing into 40%-40%-20%
+    if groupNumber >= 0 and groupNumber < 102  # first 40% of 256
+      return "A"
+    else if groupNumber >= 102 and groupNumber < 204  # next 40% of 256
+      return "B"
+    else  # remaining 20% of 256 
+      return "C"
+
   hasSubscription: ->
     return false if me.isStudent() or me.isTeacher()
     if payPal = @get('payPal')

--- a/app/schemas/events/identify.json
+++ b/app/schemas/events/identify.json
@@ -17,6 +17,7 @@
 				"ageRange": {"type": "string", "pattern":"^\\d+-\\d+"},
 				"lastLevel": {"type": "string"},
 				"testGroupNumber": {"type": "integer"},
+				"testGroupNumberUS": {"type": "integer"},
 				"name": {"type": "string"},
 				"dateCreated": {"type": "string", "format": "date-time"},
 				"email": {"type": "string", "format": "email"},

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -126,6 +126,7 @@ _.extend UserSchema.properties,
   dateCreated: c.date({title: 'Date Joined'})
   anonymous: {type: 'boolean' }
   testGroupNumber: {type: 'integer', minimum: 0, maximum: 256, exclusiveMaximum: true}
+  testGroupNumberUS: {type: 'integer', minimum: 0, maximum: 256, exclusiveMaximum: true}
   mailChimp: {type: 'object'}
   hourOfCode: {type: 'boolean'}
   hourOfCodeComplete: {type: 'boolean'}

--- a/app/templates/base-flat.jade
+++ b/app/templates/base-flat.jade
@@ -101,9 +101,9 @@ mixin accountLinks
                 if me.isAnonymous()
                   ul.nav.navbar-nav.text-p.login-buttons
                     li
-                      a#create-account-link.signup-button(data-event-action="Header Sign Up CTA", data-i18n="signup.sign_up")
+                      a#create-account-link.signup-button.track-ab-result(data-event-action="Header Sign Up CTA", data-i18n="signup.sign_up")
                     li
-                      a#login-link.login-button(data-event-action="Header Login CTA", data-i18n="signup.login")
+                      a#login-link.login-button.track-ab-result(data-event-action="Header Login CTA", data-i18n="signup.login")
 
 
   block page_nav

--- a/app/templates/home-view.jade
+++ b/app/templates/home-view.jade
@@ -7,10 +7,25 @@ block content
         h1.text-white(data-i18n="new_home.slogan")
         div.button-section
           if me.isAnonymous()
-            p
-              button.btn.btn-lg.btn-primary.signup-button.signup-home-btn(data-event-action="Homepage Get Started CTA", data-i18n="new_home.get_started")
-            p
-              a.btn.btn-lg.btn-primary-alt.play-btn(href="/play", data-event-action="Homepage Play Now CTA", data-i18n="new_home.try_the_game")
+            if me.getHomePageTestGroup() == "A"
+              p
+                button.btn.btn-lg.btn-primary.teacher-btn(data-event-action="Homepage Click Teacher Button #1 CTA", data-i18n="new_home.educator")
+              p
+                button.btn.btn-lg.btn-primary.student-btn(data-event-action="Homepage Click Student Button CTA", data-i18n="new_home.student")
+              p
+                a.btn.btn-lg.btn-primary-alt.track-ab-result(href="/play", data-i18n="common.play")
+            else if me.getHomePageTestGroup() == "B"
+              p
+                button.btn.btn-lg.btn-primary.teacher-btn(data-event-action="Homepage Click Teacher Button #1 CTA", data-i18n="new_home.im_a_teacher", style="text-transform: none")
+              p
+                button.btn.btn-lg.btn-primary.student-btn(data-event-action="Homepage Click Student Button CTA", data-i18n="new_home.im_a_student", style="text-transform: none")
+              p
+                a.btn.btn-lg.btn-primary-alt.track-ab-result(href="/play", data-i18n="common.play", style="text-transform: none")
+            else
+              p
+                button.btn.btn-lg.btn-primary.signup-button.signup-home-btn.track-ab-result(data-event-action="Homepage Get Started CTA", data-i18n="new_home.get_started")
+              p
+                a.btn.btn-lg.btn-primary-alt.play-btn.track-ab-result(href="/play", data-event-action="Homepage Play Now CTA", data-i18n="new_home.try_the_game")
           else
             p
               if me.isTeacher()
@@ -27,7 +42,7 @@ block content
             if me.isAnonymous()
               br
               p
-                a.btn.btn-lg.btn-primary.play-btn(href="/play", data-event-action="Homepage Try The Game CTA", data-i18n="new_home.try_the_game")
+                a.btn.btn-lg.btn-primary.play-btn.track-ab-result(href="/play", data-event-action="Homepage Try The Game CTA", data-i18n="new_home.try_the_game")
         .col-md-7
           .game-based-image
             img(src="/images/pages/home/type_real_code.gif"
@@ -59,7 +74,7 @@ block content
                   span.text-p(data-i18n="new_home.classroom_in_box_blurb3")
           if me.isAnonymous()
             .row.signup_btn
-              button.btn.btn-lg.btn-primary.signup-button.signup-home-btn(data-event-action="Homepage Sign Up #2 CTA", data-i18n="signup.sign_up")
+              button.btn.btn-lg.btn-primary.signup-button.signup-home-btn.track-ab-result(data-event-action="Homepage Sign Up #2 CTA", data-i18n="signup.sign_up")
 
     .row#creativity-rigor
       .col-lg-12
@@ -216,7 +231,7 @@ block content
                 p.text-navy(data-i18n="new_home.for_teachers_subblurb4")
         if me.isAnonymous()
           .text-center
-            button.btn.btn-lg.btn-primary.signup-button.signup-home-btn(data-event-action="Homepage Sign Up #3 CTA", data-i18n="signup.sign_up")
+            button.btn.btn-lg.btn-primary.teacher-btn(data-event-action="Homepage Sign Up #3 CTA", data-i18n="signup.sign_up")
 
     .row.row-dark.text-center#teachers-love-codecombat
       .col-lg-12

--- a/app/views/HomeView.coffee
+++ b/app/views/HomeView.coffee
@@ -48,7 +48,7 @@ module.exports = class HomeView extends RootView
     @playSound 'menu-button-click'
     e.preventDefault()
     e.stopImmediatePropagation()
-    @homePageEvent($(e.target).data('event-action'))
+    @homePageEvent($(e.target).data('event-action'), {trackABResult: true})
     if me.isTeacher()
       application.router.navigate '/teachers/update-account', trigger: true
     else
@@ -59,15 +59,19 @@ module.exports = class HomeView extends RootView
     application.router.navigate("/teachers/classes", { trigger: true })
 
   onClickStudentButton: (e) ->
-    @homePageEvent($(e.target).data('event-action'))
+    @homePageEvent('Started Signup', {trackABResult: true})
+    @homePageEvent($(e.target).data('event-action'), {trackABResult: true})
     @openModalView(new CreateAccountModal({startOnPath: 'student'}))
 
   onClickTeacherButton: (e) ->
-    @homePageEvent($(e.target).data('event-action'))
+    @homePageEvent('Started Signup', {trackABResult: true})
+    @homePageEvent($(e.target).data('event-action'), {trackABResult: true})
     @openModalView(new CreateAccountModal({startOnPath: 'teacher'}))
 
   onClickTrackEvent: (e) ->
-    @homePageEvent($(e.target).data('event-action'))
+    if $(e.target)?.hasClass('track-ab-result')
+      properties = {trackABResult: true}
+    @homePageEvent($(e.target).data('event-action'), properties || {})
 
   # Provides a uniform interface for collecting information from the homepage.
   # Always provides the category Homepage and includes the user role.
@@ -91,10 +95,17 @@ module.exports = class HomeView extends RootView
       anchorText = $.i18n.t(translationKey, {lng: 'en-US'})
     else
       anchorText = anchor.text
+
+    if $(e.target)?.hasClass('track-ab-result')
+      properties = {trackABResult: true}
+
     if anchorText
-      @homePageEvent("Link: #{anchorText}", {}, ['Google Analytics'])
+      @homePageEvent("Link: #{anchorText}", properties || {}, ['Google Analytics'])
     else
-      @homePageEvent("Link:", {clicked: e?.currentTarget?.host or "unknown"}, ['Google Analytics'])
+      _.extend(properties || {}, {
+        clicked: e?.currentTarget?.host or "unknown"
+      })
+      @homePageEvent("Link:", properties, ['Google Analytics'])
 
   afterRender: ->
     if !me.showChinaVideo()

--- a/app/views/core/CreateAccountModal/BasicInfoView.coffee
+++ b/app/views/core/CreateAccountModal/BasicInfoView.coffee
@@ -198,7 +198,7 @@ module.exports = class BasicInfoView extends CocoView
 
   onSubmitForm: (e) ->
     if @signupState.get('path') is 'teacher'
-      window.tracker?.trackEvent 'CreateAccountModal Teacher BasicInfoView Submit Clicked', category: 'Teachers'
+      window.tracker?.trackEvent 'CreateAccountModal Teacher BasicInfoView Submit Clicked', { category: 'Teachers', trackABResult: true }
     if @signupState.get('path') is 'student'
       window.tracker?.trackEvent 'CreateAccountModal Student BasicInfoView Submit Clicked', category: 'Students'
     if @signupState.get('path') is 'individual'

--- a/app/views/core/CreateAccountModal/CreateAccountModal.coffee
+++ b/app/views/core/CreateAccountModal/CreateAccountModal.coffee
@@ -53,6 +53,7 @@ startSignupTracking = ->
   properties =
     category: 'Homepage'
     user: me.get('role') || (me.isAnonymous() && "anonymous") || "homeuser"
+    trackABResult: true
   window.tracker?.trackEvent(
     'Teacher signup started',
     properties)
@@ -225,6 +226,7 @@ module.exports = class CreateAccountModal extends ModalView
     properties =
       category: 'Homepage'
       subview: @signupState.get('path') || "choosetype"
+      trackABResult: true
     window.tracker?.trackEvent('Log in from CreateAccount', properties)
     @openModalView(new AuthModal({ initialValues: @signupState.get('authModalInitialValues'), subModalContinue: @signupState.get('subModalContinue') }))
 

--- a/app/views/core/CreateAccountModal/teacher/SchoolInfoPanel.coffee
+++ b/app/views/core/CreateAccountModal/teacher/SchoolInfoPanel.coffee
@@ -67,7 +67,7 @@ SchoolInfoPanel =
 
     clickContinue: ->
       # Make sure to add conditions if we change this to be used on non-teacher path
-      window.tracker?.trackEvent 'CreateAccountModal Teacher SchoolInfoPanel Continue Clicked', category: 'Teachers'
+      window.tracker?.trackEvent 'CreateAccountModal Teacher SchoolInfoPanel Continue Clicked', { category: 'Teachers', trackABResult: true }
       requiredAttrs = _.pick(@, 'district', 'city', 'state', 'country')
       unless _.all(requiredAttrs)
         @showRequired = true

--- a/app/views/core/CreateAccountModal/teacher/TeacherRolePanel.coffee
+++ b/app/views/core/CreateAccountModal/teacher/TeacherRolePanel.coffee
@@ -17,7 +17,7 @@ TeacherRolePanel = Vue.extend
   methods:
     clickContinue: ->
       # Make sure to add conditions if we change this to be used on non-teacher path
-      window.tracker?.trackEvent 'CreateAccountModal Teacher TeacherRolePanel Continue Clicked', category: 'Teachers'
+      window.tracker?.trackEvent 'CreateAccountModal Teacher TeacherRolePanel Continue Clicked', { category: 'Teachers', trackABResult: true }
       requiredAttrs = _.pick(@, 'role', 'numStudents')
       unless _.all(requiredAttrs)
         @showRequired = true

--- a/app/views/core/RootView.coffee
+++ b/app/views/core/RootView.coffee
@@ -78,9 +78,13 @@ module.exports = class RootView extends CocoView
     CreateAccountModal = require 'views/core/CreateAccountModal'
     switch @id
       when 'home-view'
-        window.tracker?.trackEvent('Started Signup', category: 'Homepage', label: 'Homepage')
+        properties = {
+          category: 'Homepage'
+          trackABResult: true
+        }
+        window.tracker?.trackEvent('Started Signup', properties, [])
         eventAction = $(e.target)?.data('event-action')
-        window.tracker?.trackEvent(eventAction, category: 'Homepage', []) if eventAction
+        window.tracker?.trackEvent(eventAction, properties, []) if eventAction
       when 'world-map-view'
         # TODO: add campaign data
         window.tracker?.trackEvent 'Started Signup', category: 'World Map', label: 'World Map'
@@ -91,9 +95,13 @@ module.exports = class RootView extends CocoView
   onClickLoginButton: (e) ->
     AuthModal = require 'views/core/AuthModal'
     if @id is 'home-view'
-      window.tracker?.trackEvent 'Login', category: 'Homepage', ['Google Analytics'] 
+      properties = { category: 'Homepage' }
+      window.tracker?.trackEvent 'Login', properties, ['Google Analytics'] 
+      
       eventAction = $(e.target)?.data('event-action')
-      window.tracker?.trackEvent(eventAction, category: 'Homepage', []) if eventAction
+      if $(e.target)?.hasClass('track-ab-result')
+        _.extend(properties, { trackABResult: true })
+      window.tracker?.trackEvent(eventAction, properties, []) if eventAction
     @openModalView new AuthModal()
 
   showLoading: ($el) ->

--- a/app/views/courses/TeacherClassesView.coffee
+++ b/app/views/courses/TeacherClassesView.coffee
@@ -126,7 +126,7 @@ module.exports = class TeacherClassesView extends RootView
           @calculateQuestCompletion()
           @render()
 
-    window.tracker?.trackEvent 'Teachers Classes Loaded', category: 'Teachers', ['Mixpanel']
+    window.tracker?.trackEvent 'Teachers Classes Loaded', { category: 'Teachers', trackABResult: true }, ['Mixpanel']
 
     @courses = new Courses()
     @courses.fetch()
@@ -220,7 +220,7 @@ module.exports = class TeacherClassesView extends RootView
 
   openNewClassroomModal: ->
     return unless me.id is @teacherID # Viewing page as admin
-    window.tracker?.trackEvent 'Teachers Classes Create New Class Started', category: 'Teachers', ['Mixpanel']
+    window.tracker?.trackEvent 'Teachers Classes Create New Class Started', { category: 'Teachers', trackABResult: true }, ['Mixpanel']
     classroom = new Classroom({ ownerID: me.id })
     modal = new ClassroomSettingsModal({ classroom: classroom })
     @openModalView(modal)

--- a/static-mock.coffee
+++ b/static-mock.coffee
@@ -32,6 +32,7 @@ exports.me =
   hideFooter: -> false
   useGoogleAnalytics: -> true
   showChinaVideo: -> false
+  getHomePageTestGroup: -> undefined
 
 exports.view =
   forumLink: () -> 'http://discourse.codecombat.com/'


### PR DESCRIPTION
- Adding `testGroupNumberUS` to the users belonging to `united-states` since this test is only for US customers.
- Dividing users by `testGroupNumberUS` into 40%, 40%, 20% for UI variation A,B,C respectively.
- Added UI variation on the homepage for test group A,B,C.
- Added support to track certain events for a/b test results, i.e. their events will have a label pointing to the test group that triggered the event.

Also, includes a minor change to open the teacher signup modal instead of the generic signup modal when clicked on `Sign Up` button from `For Teachers` section on the homepage.