### PR TITLE
Remove commas from stats definition in user schema

### DIFF
--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -203,20 +203,18 @@ _.extend UserSchema.properties,
     courseMiscPatches: c.int()
     courseEdits: c.int()
     concepts: {type: 'object', additionalProperties: c.int(), description: 'Number of levels completed using each programming concept.'}
-
     licenses: c.object {}, {
       usage: c.object {}, {
         used: c.int()
         total: c.int()
       }
-    },
-
+    }
     students: c.object {}, {
       count: c.object {}, {
         active: c.int()
         inactive: c.int()
       }
-    },
+    }
 
   earned: c.RewardSchema 'earned by achievements'
   purchased: c.RewardSchema 'purchased with gems or money'


### PR DESCRIPTION
Fixes parsing error causing schema definition to be incorrect