### PR TITLE
Additional Tarena ladder course ID workaround to go with #5227

### DIFF
--- a/app/views/play/level/modal/CourseVictoryModal.coffee
+++ b/app/views/play/level/modal/CourseVictoryModal.coffee
@@ -26,7 +26,7 @@ module.exports = class CourseVictoryModal extends ModalView
     @courseInstanceID = options.courseInstanceID or utils.getQueryVariable('course-instance') or utils.getQueryVariable('league')
     if features.china and not @courseID and not @courseInstanceID   #just for china tarena hackthon 2019 classroom RestPoolLeaf
       @courseID = '560f1a9f22961295f9427742'
-      @courseInstanceID = '5c97112804d9bd0042a211ff'
+      @courseInstanceID = '5cb8403a60778e004634ee6e'
     @views = []
 
     @session = options.session

--- a/app/views/play/level/modal/CourseVictoryModal.coffee
+++ b/app/views/play/level/modal/CourseVictoryModal.coffee
@@ -24,6 +24,9 @@ module.exports = class CourseVictoryModal extends ModalView
   initialize: (options) ->
     @courseID = options.courseID
     @courseInstanceID = options.courseInstanceID or utils.getQueryVariable('course-instance') or utils.getQueryVariable('league')
+    if features.china and not @courseID and not @courseInstanceID   #just for china tarena hackthon 2019 classroom RestPoolLeaf
+      @courseID = '560f1a9f22961295f9427742'
+      @courseInstanceID = '5c97112804d9bd0042a211ff'
     @views = []
 
     @session = options.session


### PR DESCRIPTION
@wjllance can you test this to see if it works?

The idea is that when we did #5227 to make it so that Tarena hackathon players play in the global leaderboard, we nullified the `leagueID`, which passed through all the way to the CourseVictoryModal, which assumes it has a `courseID` or `courseInstanceID` but doesn't. So, if we don't have those, in China, for now, we can fill in the values we would have had.