### PR TITLE
Teacher appreciation banner

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1580,6 +1580,10 @@
     code: "__name__'s Code"
     complete_solution: "Complete Solution"
     course_not_started: "Student has not started this course yet."
+    appreciation_week_blurb1: 'For Teacher Appreciation Week 2019, we are offering free 1-week licenses! Email Rob Arevalo (<a href="mailto: robarev@codecombat.com">robarev@codecombat.com</a>) with subject line "<strong>Teacher Appreciation Week</strong>", and include:'
+    appreciation_week_blurb2: "the quantity of 1-week licenses you'd like (1 per student)"
+    appreciation_week_blurb3: "the email address of your CodeCombat teacher account"
+    appreciation_week_blurb4: "whether you'd like licenses for Week 1 (May 6-10) or Week 2 (May 13-17)"
     hoc_happy_ed_week: "Happy Computer Science Education Week!"
     hoc_blurb1: "Learn about the free"
     hoc_blurb2: "Code, Play, Share"

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1580,7 +1580,7 @@
     code: "__name__'s Code"
     complete_solution: "Complete Solution"
     course_not_started: "Student has not started this course yet."
-    appreciation_week_blurb1: 'For <strong>Teacher Appreciation Week 2019</strong>, we are offering free 1-week licenses!<br />Email Rob Arevalo (<a href="mailto: robarev@codecombat.com">robarev@codecombat.com</a>) with subject line "<strong>Teacher Appreciation Week</strong>", and include:'
+    appreciation_week_blurb1: 'For <strong>Teacher Appreciation Week 2019</strong>, we are offering free 1-week licenses!<br />Email Rob Arevalo (<a href="mailto:robarev@codecombat.com?subject=Teacher Appreciation Week">robarev@codecombat.com</a>) with subject line "<strong>Teacher Appreciation Week</strong>", and include:'
     appreciation_week_blurb2: "the quantity of 1-week licenses you'd like (1 per student)"
     appreciation_week_blurb3: "the email address of your CodeCombat teacher account"
     appreciation_week_blurb4: "whether you'd like licenses for Week 1 (May 6-10) or Week 2 (May 13-17)"

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1580,7 +1580,7 @@
     code: "__name__'s Code"
     complete_solution: "Complete Solution"
     course_not_started: "Student has not started this course yet."
-    appreciation_week_blurb1: 'For Teacher Appreciation Week 2019, we are offering free 1-week licenses! Email Rob Arevalo (<a href="mailto: robarev@codecombat.com">robarev@codecombat.com</a>) with subject line "<strong>Teacher Appreciation Week</strong>", and include:'
+    appreciation_week_blurb1: 'For <strong>Teacher Appreciation Week 2019</strong>, we are offering free 1-week licenses!<br />Email Rob Arevalo (<a href="mailto: robarev@codecombat.com">robarev@codecombat.com</a>) with subject line "<strong>Teacher Appreciation Week</strong>", and include:'
     appreciation_week_blurb2: "the quantity of 1-week licenses you'd like (1 per student)"
     appreciation_week_blurb3: "the email address of your CodeCombat teacher account"
     appreciation_week_blurb4: "whether you'd like licenses for Week 1 (May 6-10) or Week 2 (May 13-17)"

--- a/app/styles/courses/courses-view.sass
+++ b/app/styles/courses/courses-view.sass
@@ -6,14 +6,9 @@
     background-color: #cff2fc
     border-radius: 10px
     padding: 20px
-    margin: 0px auto 30px auto
-
+    margin: 20px 80px 40px 80px
     p
-      font-size: 15px
-
-    h3
-      text-align: center
-      font-size: 1.3em
+      margin-bottom: 7px
 
   #main-content
     max-width: 720px

--- a/app/styles/courses/teacher-classes-view.sass
+++ b/app/styles/courses/teacher-classes-view.sass
@@ -21,16 +21,10 @@
     background-color: #cff2fc
     border-radius: 10px
     padding: 20px
-    margin: 10px auto
+    margin: 20px 80px 40px 80px
     text-align: center
-    width: 70%
-
-    p.announcement-button
-      text-align: center
-
-    h3
-      text-align: center
-      font-size: 1.5em
+    p
+      margin-bottom: 7px
 
   .language
     display: inline-block

--- a/app/templates/courses/courses-view.jade
+++ b/app/templates/courses/courses-view.jade
@@ -40,20 +40,17 @@ block content
             .text-center
               h1(data-i18n="courses.welcome_to_page")
 
-            //- TODO: remove temporary HoC 2018 blurb anytime after 2018-12-14
-            if new Date() >= new Date('2018-11-28') && new Date() <= new Date('2018-12-14')
+            //- TODO: remove temporary Teacher appreciation anytime after 2019-05-03
+            //- TODO: remove  always true. Only unpaid teacher should see.
+            if true || new Date() >= new Date('2019-04-29') && new Date() <= new Date('2019-05-03')
               #announcement
-                h3.text-center(data-i18n='teacher.hoc_happy_ed_week')
                 .row
-                  .col-xs-9
-                    p
-                      span(data-i18n='courses.hoc_blurb1')
-                      strong.spr.spl(data-i18n='courses.hoc_blurb2')
-                      span.spr(data-i18n='courses.hoc_blurb3')
-                  .col-xs-3
-                    p.announcement-button
-                      a.btn.btn-navy.btn-lg(href="https://codecombat.com/play/hoc-2018")
-                        span(data-i18n='new_home.play_now')
+                  .col-xs-12
+                    p(data-i18n='[html]teacher.appreciation_week_blurb1')
+                    ul.text-left
+                      li(data-i18n="teacher.appreciation_week_blurb2")
+                      li(data-i18n="teacher.appreciation_week_blurb3")
+                      li(data-i18n="teacher.appreciation_week_blurb4")
 
             if me.showAvatarOnStudentDashboard()
               .current-hero-container.text-center.row

--- a/app/templates/courses/courses-view.jade
+++ b/app/templates/courses/courses-view.jade
@@ -40,19 +40,6 @@ block content
             .text-center
               h1(data-i18n="courses.welcome_to_page")
 
-            //- TODO: remove temporary Teacher appreciation anytime after 2019-05-03
-            //- TODO: remove  always true. Only unpaid teacher should see.
-            if true || new Date() >= new Date('2019-04-29') && new Date() <= new Date('2019-05-03')
-              .container
-                .row
-                  .col-xs-12
-                    #announcement
-                      p(data-i18n='[html]teacher.appreciation_week_blurb1')
-                      ul.text-left
-                        li(data-i18n="teacher.appreciation_week_blurb2")
-                        li(data-i18n="teacher.appreciation_week_blurb3")
-                        li(data-i18n="teacher.appreciation_week_blurb4")
-
             if me.showAvatarOnStudentDashboard()
               .current-hero-container.text-center.row
                 .hero-avatar

--- a/app/templates/courses/courses-view.jade
+++ b/app/templates/courses/courses-view.jade
@@ -43,14 +43,15 @@ block content
             //- TODO: remove temporary Teacher appreciation anytime after 2019-05-03
             //- TODO: remove  always true. Only unpaid teacher should see.
             if true || new Date() >= new Date('2019-04-29') && new Date() <= new Date('2019-05-03')
-              #announcement
+              .container
                 .row
                   .col-xs-12
-                    p(data-i18n='[html]teacher.appreciation_week_blurb1')
-                    ul.text-left
-                      li(data-i18n="teacher.appreciation_week_blurb2")
-                      li(data-i18n="teacher.appreciation_week_blurb3")
-                      li(data-i18n="teacher.appreciation_week_blurb4")
+                    #announcement
+                      p(data-i18n='[html]teacher.appreciation_week_blurb1')
+                      ul.text-left
+                        li(data-i18n="teacher.appreciation_week_blurb2")
+                        li(data-i18n="teacher.appreciation_week_blurb3")
+                        li(data-i18n="teacher.appreciation_week_blurb4")
 
             if me.showAvatarOnStudentDashboard()
               .current-hero-container.text-center.row

--- a/app/templates/courses/teacher-classes-view.jade
+++ b/app/templates/courses/teacher-classes-view.jade
@@ -58,7 +58,7 @@ block content
               a.see-all-office-hours.btn.btn-primary.btn-small.pull-right(data-i18n="general.more") More
 
       //- TODO: remove temporary Teacher appreciation anytime after 2019-05-03
-      if (!view.paidTeacher) && new Date() >= new Date('2019-04-29') && new Date() <= new Date('2019-05-03')
+      if (!view.paidTeacher) && me.get('country') == "united-states" && new Date() >= new Date('2019-04-29') && new Date() <= new Date('2019-05-03')
         .container
           .row
             .col-xs-12

--- a/app/templates/courses/teacher-classes-view.jade
+++ b/app/templates/courses/teacher-classes-view.jade
@@ -60,14 +60,15 @@ block content
       //- TODO: remove temporary Teacher appreciation anytime after 2019-05-03
       //- TODO: remove  always true. Only unpaid teacher should see.
       if true || new Date() >= new Date('2019-04-29') && new Date() <= new Date('2019-05-03')
-        #announcement
+        .container
           .row
             .col-xs-12
-              p(data-i18n='[html]teacher.appreciation_week_blurb1')
-              ul.text-left
-                li(data-i18n="teacher.appreciation_week_blurb2")
-                li(data-i18n="teacher.appreciation_week_blurb3")
-                li(data-i18n="teacher.appreciation_week_blurb4")
+              #announcement
+                p(data-i18n='[html]teacher.appreciation_week_blurb1')
+                ul.text-left
+                  li(data-i18n="teacher.appreciation_week_blurb2")
+                  li(data-i18n="teacher.appreciation_week_blurb3")
+                  li(data-i18n="teacher.appreciation_week_blurb4")
 
     .container
       +teacher-quests

--- a/app/templates/courses/teacher-classes-view.jade
+++ b/app/templates/courses/teacher-classes-view.jade
@@ -57,20 +57,17 @@ block content
             else if view.howManyOfficeHours == 'some' && limited
               a.see-all-office-hours.btn.btn-primary.btn-small.pull-right(data-i18n="general.more") More
 
-      //- TODO: remove temporary HoC 2018 blurb anytime after 2018-12-14
-      if new Date() >= new Date('2018-11-28') && new Date() <= new Date('2018-12-14')
+      //- TODO: remove temporary Teacher appreciation anytime after 2019-05-03
+      //- TODO: remove  always true. Only unpaid teacher should see.
+      if true || new Date() >= new Date('2019-04-29') && new Date() <= new Date('2019-05-03')
         #announcement
-          h3(data-i18n='teacher.hoc_happy_ed_week')
           .row
-            .col-xs-9
-              p
-                span(data-i18n='teacher.hoc_blurb1')
-                strong.spr.spl(data-i18n='teacher.hoc_blurb2')
-                span.spr(data-i18n='teacher.hoc_blurb3')
-            .col-xs-3
-              p.announcement-button
-                a.btn.btn-navy.btn-lg(href="https://codecombat.com/teachers/hour-of-code")
-                  span(data-i18n='teacher.hoc_button_text')
+            .col-xs-12
+              p(data-i18n='[html]teacher.appreciation_week_blurb1')
+              ul.text-left
+                li(data-i18n="teacher.appreciation_week_blurb2")
+                li(data-i18n="teacher.appreciation_week_blurb3")
+                li(data-i18n="teacher.appreciation_week_blurb4")
 
     .container
       +teacher-quests

--- a/app/templates/courses/teacher-classes-view.jade
+++ b/app/templates/courses/teacher-classes-view.jade
@@ -58,8 +58,7 @@ block content
               a.see-all-office-hours.btn.btn-primary.btn-small.pull-right(data-i18n="general.more") More
 
       //- TODO: remove temporary Teacher appreciation anytime after 2019-05-03
-      //- TODO: remove  always true. Only unpaid teacher should see.
-      if true || new Date() >= new Date('2019-04-29') && new Date() <= new Date('2019-05-03')
+      if (!view.paidTeacher) && new Date() >= new Date('2019-04-29') && new Date() <= new Date('2019-05-03')
         .container
           .row
             .col-xs-12

--- a/app/views/courses/TeacherClassesView.coffee
+++ b/app/views/courses/TeacherClassesView.coffee
@@ -156,6 +156,7 @@ module.exports = class TeacherClassesView extends RootView
       req = @administratingTeachers.fetchByIds(administratingTeacherIds)
       @supermodel.trackRequest req
 
+    # TODO: Any reference to paidTeacher can be cleaned up post Teacher Appreciation week (after 2019-05-03)
     @paidTeacher = me.isAdmin() or me.isTeacher() and /@codeninjas.com$/i.test me.get('email')
 
     # Level Sessions loaded after onLoaded to prevent race condition in calculateDots

--- a/app/views/courses/TeacherClassesView.coffee
+++ b/app/views/courses/TeacherClassesView.coffee
@@ -156,6 +156,8 @@ module.exports = class TeacherClassesView extends RootView
       req = @administratingTeachers.fetchByIds(administratingTeacherIds)
       @supermodel.trackRequest req
 
+    @paidTeacher = me.isAdmin() or me.isTeacher() and /@codeninjas.com$/i.test me.get('email')
+
     # Level Sessions loaded after onLoaded to prevent race condition in calculateDots
 
   afterRender: ->
@@ -211,6 +213,7 @@ module.exports = class TeacherClassesView extends RootView
   onLoaded: ->
     helper.calculateDots(@classrooms, @courses, @courseInstances)
     @calculateQuestCompletion()
+    @paidTeacher = @paidTeacher or @prepaids.find((p) => p.get('type') in ['course', 'starter_license'] and p.get('maxRedeemers') > 0)?
 
     if me.isTeacher() and not @classrooms.length
       @openNewClassroomModal()


### PR DESCRIPTION
## Feature

Change adds a temporary banner to run over teacher appreciation week at the route `/teachers/classes`.

I reuse logic that has been used before, and clean up some of the Hour of Code banners that we used to use.

The paidTeacher check is lifted from the TeacherCourseSolutionView (These two lines):
https://github.com/codecombat/codecombat/blob/85bec7768d1bef3f25c7968f15f2d75f8d8a458e/app/views/teachers/TeacherCourseSolutionView.coffee#L42

https://github.com/codecombat/codecombat/blob/85bec7768d1bef3f25c7968f15f2d75f8d8a458e/app/views/teachers/TeacherCourseSolutionView.coffee#L58

CSS changes are scoped to the `announcement` id, and thus safe to change.

## Tests

I ran manual tests on my local teachers.
Paid teachers don't get the banner as per design.
Unpaid teachers do get the design.
User must be in `united-states`.