### PR TITLE
Make markdown links always jump to the top

### DIFF
--- a/app/views/teachers/MarkdownResourceView.coffee
+++ b/app/views/teachers/MarkdownResourceView.coffee
@@ -35,7 +35,7 @@ module.exports = class MarkdownResourceView extends RootView
           else
             align = if me.get('preferredLanguage') in ['he', 'ar', 'fa', 'ur'] then 'left' else 'right'
             buttonText = $.i18n.t 'teacher.back_to_top'
-            "<a class='pull-#{align} btn btn-md btn-navy back-to-top' href='#logo-img'>#{buttonText}</a></h5"
+            "<a class='pull-#{align} btn btn-md btn-navy back-to-top' href='#top'>#{buttonText}</a></h5"
 
       if @name is 'cs1'
         $('body').append($("<img src='https://code.org/api/hour/begin_code_combat_teacher.png' style='visibility: hidden;'>"))


### PR DESCRIPTION
# Issue

Our markdown links that jump to the top of the page were pointing to an outdated `#logo-img` anchor, and were not jumping anywhere.

# Fix

There was no natural place to link this to, because we already have `href` set for this image at the top of the page in our nav bar. Instead, replace with a simple `href="#"` so it always jumps to the top. 