### PR TITLE
Starter license banner display change

### DIFF
--- a/app/views/courses/EnrollmentsView.coffee
+++ b/app/views/courses/EnrollmentsView.coffee
@@ -30,7 +30,7 @@ module.exports = class EnrollmentsView extends RootView
     'click .share-licenses-link': 'onClickShareLicensesLink'
 
   getTitle: -> return $.i18n.t('teacher.enrollments')
-  
+
   i18nData: ->
     starterLicenseCourseList: @state.get('starterLicenseCourseList')
 
@@ -76,11 +76,11 @@ module.exports = class EnrollmentsView extends RootView
     @listenTo(@state, 'all', @debouncedRender)
 
     me.getClientCreatorPermissions()?.then(() => @render?())
-    
+
     leadPriorityRequest = me.getLeadPriority()
     @supermodel.trackRequest leadPriorityRequest
     leadPriorityRequest.then ({ priority }) =>
-      shouldUpsell = (priority is 'low') and (me.get('preferredLanguage') isnt 'nl-BE')
+      shouldUpsell = (priority is 'low') and (me.get('preferredLanguage') isnt 'nl-BE') and @prepaids.length == 0
       @state.set({ shouldUpsell })
       if shouldUpsell
         application.tracker?.trackEvent 'Starter License Upsell: Banner Viewed', {price: @state.get('centsPerStudent'), seats: @state.get('quantityToBuy')}

--- a/app/views/courses/EnrollmentsView.coffee
+++ b/app/views/courses/EnrollmentsView.coffee
@@ -111,12 +111,8 @@ module.exports = class EnrollmentsView extends RootView
     # if we should skip upsell (we ignore the others).
 
     coursePrepaids = @prepaids.filter((p) => p.get('type') == 'course')
-    starterLicensePrepaids = @prepaids.filter((p) => p.get('type') == 'starter_license')
 
-    twoMonthsAgo = moment().subtract('2', 'month')
-    starterLicensesBeforeCutoff = starterLicensePrepaids.filter((p) => moment(p.get('startDate')).isBefore(twoMonthsAgo))
-
-    skipUpsellDueToExistingLicenses = coursePrepaids.length > 0 || starterLicensesBeforeCutoff.length > 0
+    skipUpsellDueToExistingLicenses = coursePrepaids.length > 0
     shouldUpsell = !skipUpsellDueToExistingLicenses and (@state.get('leadPriority') is 'low') and (me.get('preferredLanguage') isnt 'nl-BE')
 
     @state.set({ shouldUpsell })

--- a/test/app/views/courses/EnrollmentsView.spec.coffee
+++ b/test/app/views/courses/EnrollmentsView.spec.coffee
@@ -77,7 +77,7 @@ describe 'EnrollmentsView', ->
 
         expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(1)
 
-      it 'when active starter licenses exist and they are less than two months old', ->
+      it 'when active starter licenses exist', ->
         @view.prepaids.set([])
         @view.prepaids.add(factories.makePrepaid({
           type: 'starter_license'
@@ -90,7 +90,7 @@ describe 'EnrollmentsView', ->
 
         expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(1)
 
-      it 'when expired starter licenses exist and they are less than two months old', ->
+      it 'when expired starter licenses exist', ->
         @view.prepaids.set([])
         @view.prepaids.add(factories.makePrepaid({
           type: 'starter_license'
@@ -126,28 +126,6 @@ describe 'EnrollmentsView', ->
         @view.prepaids.set([])
         @view.prepaids.add(factories.makePrepaid({
           startDate: moment().subtract(2, 'month').toISOString()
-          endDate: moment().add(1, 'month').toISOString()
-        }))
-
-        @view.render()
-        expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(0)
-
-      it 'when expired starter licenses exist that are more than two months old', ->
-        @view.prepaids.set([])
-        @view.prepaids.add(factories.makePrepaid({
-          type: 'starter_license'
-          startDate: moment().subtract(2.5, 'month').toISOString()
-          endDate: moment().subtract(1, 'month').toISOString()
-        }))
-
-        @view.render()
-        expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(0)
-
-      it 'when active starter licenses exist that more than two months old', ->
-        @view.prepaids.set([])
-        @view.prepaids.add(factories.makePrepaid({
-          type: 'starter_license'
-          startDate: moment().subtract(2.5, 'month').toISOString()
           endDate: moment().add(1, 'month').toISOString()
         }))
 

--- a/test/app/views/courses/EnrollmentsView.spec.coffee
+++ b/test/app/views/courses/EnrollmentsView.spec.coffee
@@ -62,12 +62,48 @@ describe 'EnrollmentsView', ->
     beforeEach ->
       leadPriorityRequest = jasmine.Ajax.requests.filter((r)-> r.url == '/db/user/-/lead-priority')[0]
       leadPriorityRequest.respondWith({status: 200, responseText: JSON.stringify({ priority: 'low' })})
-      @view.render()
-    
-    it 'shows the Starter License upsell', ->
-      expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(1)
-    
-  describe 'For low priority leads', ->
+
+    describe 'shows the starter license upsell', ->
+      it 'when only starter licenses exist', ->
+        @view.prepaids.set([])
+        @view.prepaids.add(factories.makePrepaid({
+          type: 'starter_license'
+        }))
+
+        @view.prepaids.trigger('sync')
+
+        @view.render()
+        expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(1)
+
+      it 'when no prepaids exist', ->
+        @view.prepaids.set([])
+        @view.prepaids.trigger('sync')
+
+        @view.render()
+        expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(1)
+
+    describe 'does not show the starter license upsell', ->
+      it 'when full licenses have existed', ->
+        @view.prepaids.set([])
+        @view.prepaids.add(factories.makePrepaid({
+          startDate: moment().subtract(2, 'month').toISOString()
+          endDate: moment().subtract(1, 'month').toISOString()
+        }))
+
+        @view.render()
+        expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(0)
+
+      it 'when full licenses currently exist', ->
+        @view.prepaids.set([])
+        @view.prepaids.add(factories.makePrepaid({
+          startDate: moment().subtract(2, 'month').toISOString()
+          endDate: moment().add(1, 'month').toISOString()
+        }))
+
+        @view.render()
+        expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(0)
+
+  describe 'For high priority leads', ->
     beforeEach ->
       leadPriorityRequest = jasmine.Ajax.requests.filter((r)-> r.url == '/db/user/-/lead-priority')[0]
       leadPriorityRequest.respondWith({status: 200, responseText: JSON.stringify({ priority: 'high' })})
@@ -84,7 +120,7 @@ describe 'EnrollmentsView', ->
 
     it "doesn't show the Starter License upsell", ->
       expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(0)
-  
+
     describe '"Get Licenses" area', ->
 
       describe 'when the teacher has made contact', ->

--- a/test/app/views/courses/EnrollmentsView.spec.coffee
+++ b/test/app/views/courses/EnrollmentsView.spec.coffee
@@ -64,22 +64,51 @@ describe 'EnrollmentsView', ->
       leadPriorityRequest.respondWith({status: 200, responseText: JSON.stringify({ priority: 'low' })})
 
     describe 'shows the starter license upsell', ->
-      it 'when only starter licenses exist', ->
+      it 'when only subscription prepaids exist', ->
         @view.prepaids.set([])
         @view.prepaids.add(factories.makePrepaid({
-          type: 'starter_license'
+          type: 'subscription'
+          startDate: moment().subtract(3, 'weeks').toISOString()
+          endDate: moment().add(2, 'weeks').toISOString()
         }))
 
         @view.prepaids.trigger('sync')
-
         @view.render()
+
+        expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(1)
+
+      it 'when active starter licenses exist and they are less than two months old', ->
+        @view.prepaids.set([])
+        @view.prepaids.add(factories.makePrepaid({
+          type: 'starter_license'
+          startDate: moment().subtract(3, 'weeks').toISOString()
+          endDate: moment().add(2, 'weeks').toISOString()
+        }))
+
+        @view.prepaids.trigger('sync')
+        @view.render()
+
+        expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(1)
+
+      it 'when expired starter licenses exist and they are less than two months old', ->
+        @view.prepaids.set([])
+        @view.prepaids.add(factories.makePrepaid({
+          type: 'starter_license'
+          startDate: moment().subtract(3, 'week').toISOString()
+          endDate: moment().subtract(1, 'week').toISOString()
+        }))
+
+        @view.prepaids.trigger('sync')
+        @view.render()
+
         expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(1)
 
       it 'when no prepaids exist', ->
         @view.prepaids.set([])
-        @view.prepaids.trigger('sync')
 
+        @view.prepaids.trigger('sync')
         @view.render()
+
         expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(1)
 
     describe 'does not show the starter license upsell', ->
@@ -97,6 +126,28 @@ describe 'EnrollmentsView', ->
         @view.prepaids.set([])
         @view.prepaids.add(factories.makePrepaid({
           startDate: moment().subtract(2, 'month').toISOString()
+          endDate: moment().add(1, 'month').toISOString()
+        }))
+
+        @view.render()
+        expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(0)
+
+      it 'when expired starter licenses exist that are more than two months old', ->
+        @view.prepaids.set([])
+        @view.prepaids.add(factories.makePrepaid({
+          type: 'starter_license'
+          startDate: moment().subtract(2.5, 'month').toISOString()
+          endDate: moment().subtract(1, 'month').toISOString()
+        }))
+
+        @view.render()
+        expect(@view.$('a[href="/teachers/starter-licenses"]').length).toBe(0)
+
+      it 'when active starter licenses exist that more than two months old', ->
+        @view.prepaids.set([])
+        @view.prepaids.add(factories.makePrepaid({
+          type: 'starter_license'
+          startDate: moment().subtract(2.5, 'month').toISOString()
           endDate: moment().add(1, 'month').toISOString()
         }))
 


### PR DESCRIPTION
Update logic to determine when a starter license is displayed.  Starter license will now display when:

- The teacher is low priority (selected 1 - 10 students in class)
- The teacher has never had a full license shared with them
- The teacher has never purchased a full license
- The teacher has never purchased a starter license or the teacher has purchased a starter license within the last two months