### PR TITLE
Anchor links for View Student Code broken in Student Profile View

### DIFF
--- a/app/views/teachers/TeacherStudentView.coffee
+++ b/app/views/teachers/TeacherStudentView.coffee
@@ -81,16 +81,12 @@ module.exports = class TeacherStudentView extends RootView
       @updateSolutions()
       @render()
 
-      # Navigate to anchor after loading complete, update selectedCourseId for progress dropdown
-      if window.location.hash
-        # Ensures the jump to fragment occurs after other queued async events.
-        setTimeout(=>
-          levelSlug = window.location.hash.substring(1)
-          @updateSelectedCourseProgress(levelSlug)
-          window.location.href = window.location.href 
-        , 0)
-
     super()
+    # Navigate to anchor after loading complete, update selectedCourseId for progress dropdown
+    if window.location.hash
+      levelSlug = window.location.hash.substring(1)
+      @updateSelectedCourseProgress(levelSlug)
+      window.location.href = window.location.href 
 
   afterRender: ->
     super(arguments...)

--- a/app/views/teachers/TeacherStudentView.coffee
+++ b/app/views/teachers/TeacherStudentView.coffee
@@ -80,12 +80,15 @@ module.exports = class TeacherStudentView extends RootView
       @calculateStandardDev()
       @updateSolutions()
       @render()
-      
+
       # Navigate to anchor after loading complete, update selectedCourseId for progress dropdown
       if window.location.hash
-        levelSlug = window.location.hash.substring(1)
-        @updateSelectedCourseProgress(levelSlug)
-        window.location.href = window.location.href 
+        # Ensures the jump to fragment occurs after other queued async events.
+        setTimeout(=>
+          levelSlug = window.location.hash.substring(1)
+          @updateSelectedCourseProgress(levelSlug)
+          window.location.href = window.location.href 
+        , 0)
 
     super()
 


### PR DESCRIPTION
# Issue

tl;dr: `super` renders the page. Move logic after the super call to ensure page is rendered when we try to jump to the fragment heading.

For full repo of bug report see linked ticket.

I was able to reproduce the issue on Chrome but not Firefox.
The issue seems to be the page not being rendered when the fragment `if` condition is being run. 

# Fix

~The change forces the `@updateSelectedCourseProgress`method to run after other synchronous and async methods earlier in the event queue. Ensuring we can jump to a fragment that has been  rendered.~ (retracted after second commit)

`CocoView.coffee`'s `onLoaded` method calls [`@render`](https://github.com/codecombat/codecombat/blob/dfe2860fcb4768462cc38fa4f947a558dc2af4c7/app/views/core/CocoView.coffee#L231) synchronously. This occurs when `super()` is called.

Thus by moving the fragment logic after the `super()` call. We ensure the page is rendered before jumping to the  fragment.

## Testing

Manually tested on Chrome and Firefox with a test teacher.
