### PR TITLE
Cinematic Lank Boss Priority Functionality

### DIFF
--- a/app/core/api/cinematic.js
+++ b/app/core/api/cinematic.js
@@ -6,7 +6,7 @@ import fetchJson from './fetch-json'
  * @async
  * @return {Promise<import('../../schemas/selectors/cinematic').Cinematic} raw Cinematic object
  */
-export const get = (slug) => {
+export const getCinematic = (slug) => {
   if (!slug) {
     throw new Error(`No slug supplied`)
   }
@@ -24,14 +24,14 @@ export const get = (slug) => {
  * @async
  * @returns {Promise<CinematicName[]>} - Sorted by slug
  */
-export const getAll = () => fetchJson('/db/cinematic/all')
+export const getAllCinematics = () => fetchJson('/db/cinematic/all')
 
 /**
  * Updates a cinematic in the database.
  * @async
  * @returns {Promise<import('../../schemas/selectors/cinematic').Cinematic>} raw Cinematic object
  */
-export const put = ({ data }, options = {}) => {
+export const putCinematic = ({ data }, options = {}) => {
   if (!data) {
     throw new Error('Please pass in a data property.')
   }
@@ -50,7 +50,7 @@ export const put = ({ data }, options = {}) => {
  * @async
  * @returns {Promise<import('../../schemas/selectors/cinematic').Cinematic} raw Cinematic object
  */
-export const create = ({ name }, options = {}) =>
+export const createCinematic = ({ name }, options = {}) =>
   fetchJson('/db/cinematic', _.assign({}, options, {
     method: 'POST',
     json: { name }

--- a/app/core/api/thang-types.js
+++ b/app/core/api/thang-types.js
@@ -30,6 +30,19 @@ export const getThang = (options = {}) => {
   return fetchJson(`/db/thang.type/${options.slug}`, { data })
 }
 
+/**
+ * Retrieves a thangType from the database by original.
+ * @param {string} original The ThangType original
+ * @async
+ * @returns {Promise<Object>} - the ThangType object
+ */
+export const getThangTypeOriginal = original => {
+  if (!original) {
+    throw new Error('You must pass an \'original\' property into getThangOriginal')
+  }
+  return fetchJson(`/db/thang.type/${original}/version`)
+}
+
 export const getHeroes = (options) => {
   const data = {
     view: 'heroes'

--- a/app/views/CinematicCanvas.vue
+++ b/app/views/CinematicCanvas.vue
@@ -18,14 +18,14 @@ import { CinematicController } from './play/cinematic/cinematicController'
 
 export default {
   props: {
-    slug: {
-      type: String,
+    cinematicData: {
+      type: Object,
       required: true
     }
   },
   data: () => ({
     controller: null,
-    enterDisabled: true
+    enterDisabled: false
   }),
   mounted: function() {
     if (!me.hasCinematicAccess()) {
@@ -37,7 +37,7 @@ export default {
     this.controller = new CinematicController({
       canvas,
       canvasDiv,
-      slug: this.slug,
+      cinematicData: this.cinematicData,
       handlers: {
         onPlay: this.handlePlay,
         onPause: this.handleWait,
@@ -75,6 +75,7 @@ export default {
   position: relative;
   font-size: 1.5em;
   height: 514px;
+  width: 800px;
 }
 
 #cinematic-div canvas {

--- a/app/views/CinematicViewComponent.vue
+++ b/app/views/CinematicViewComponent.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-if="inputting">
+    <div v-if="inputting && !loading">
       <p>Input the slug of your cinematic here. Make a new cinematic <a href="/editor/cinematic">here.</a>
       <p>The slug is the end bit of the url.</p>
       <div class="form-group">
@@ -8,8 +8,8 @@
         <button v-on:click="playCinematic()">Load+Play Cinematic</button>
       </div>
     </div>
-    <div v-else>
-      <cinematic-canvas :slug="slugInput" />
+    <div v-if="cinematicData">
+      <cinematic-canvas :cinematicData="cinematicData" />
     </div>
   </div>
 
@@ -21,11 +21,14 @@
  * Allows manual input of cinematic slug and play button.
  */
 import CinematicCanvas from "./CinematicCanvas.vue";
+import { get } from '../core/api/cinematic';
+
 module.exports = Vue.extend({
   components: { CinematicCanvas },
   data: () => ({
-    inputting: true,
-    slugInput: ''
+    slugInput: '',
+    loading: false,
+    cinematicData: null
   }),
   mounted: function() {
     if (!me.hasCinematicAccess()) {
@@ -35,7 +38,19 @@ module.exports = Vue.extend({
   },
   methods: {
     playCinematic: function() {
-      this.inputting = false
+      this.loading = true
+      get(this.slugInput)
+        .then(d => {
+          this.cinematicData = d
+        })
+        .then(() => {
+          this.loading = false
+        })
+    }
+  },
+  computed: {
+    inputting: function() {
+      return !this.cinematicData
     }
   }
 });

--- a/app/views/CinematicViewComponent.vue
+++ b/app/views/CinematicViewComponent.vue
@@ -37,15 +37,11 @@ module.exports = Vue.extend({
     }
   },
   methods: {
-    playCinematic: function() {
+    playCinematic: async function() {
       this.loading = true
-      get(this.slugInput)
-        .then(d => {
-          this.cinematicData = d
-        })
-        .then(() => {
-          this.loading = false
-        })
+      const data = await get(this.slugInput)
+      this.cinematicData = data
+      this.loading = false
     }
   },
   computed: {

--- a/app/views/CinematicViewComponent.vue
+++ b/app/views/CinematicViewComponent.vue
@@ -21,7 +21,7 @@
  * Allows manual input of cinematic slug and play button.
  */
 import CinematicCanvas from "./CinematicCanvas.vue";
-import { get } from '../core/api/cinematic';
+import { getCinematic } from '../core/api/cinematic';
 
 module.exports = Vue.extend({
   components: { CinematicCanvas },
@@ -39,8 +39,7 @@ module.exports = Vue.extend({
   methods: {
     playCinematic: async function() {
       this.loading = true
-      const data = await get(this.slugInput)
-      this.cinematicData = data
+      this.cinematicData = await getCinematic(this.slugInput)
       this.loading = false
     }
   },

--- a/app/views/editor/cinematic/CinematicEditorComponent.vue
+++ b/app/views/editor/cinematic/CinematicEditorComponent.vue
@@ -26,13 +26,17 @@
         <div class="col-md-4">
           <span>There is no autosave. Please click this button often.</span>
           <button v-on:click="saveCinematic" :disabled="state.saving || !cinematic">save</button>
+          <button v-on:click="runCinematic">Test Cinematic</button>
           <button><a href="/cinematic">Play View (please save first)</a></button>
         </div>
       </div>
 
       <div class="row">
-        <div class="col-md-12">
+        <div class="col-md-6">
           <div id="treema-editor" ref="treemaEditor" v-once></div>
+        </div>
+        <div class="col-md-6" v-if="rawData">
+          <cinematic-canvas :cinematicData="rawData" :key="rerenderKey" />
         </div>
       </div>
 
@@ -44,6 +48,7 @@
 import { get, put, create, getAll } from 'core/api/cinematic'
 import Cinematic from 'app/models/Cinematic'
 import ListItem from 'app/components/cinematic/editor/ListItem'
+import CinematicCanvas from 'app/views/CinematicCanvas'
 
 require('lib/setupTreema')
 
@@ -55,12 +60,15 @@ module.exports = Vue.extend({
     cinematic: null,
     treema: null,
     cinematicList: null,
+    rawData: null,
     state: {
       saving: false
-    }
+    },
+    rerenderKey: 0
   }),
   components: {
-    'editor-list': ListItem
+    'editor-list': ListItem,
+    'cinematic-canvas': CinematicCanvas
   },
   mounted () {
     if (!me.isAdmin()) {
@@ -127,9 +135,22 @@ module.exports = Vue.extend({
      */
     async saveCinematic() {
       this.state.saving = true
+      try {
       await put({ data: this.cinematic.toJSON() })
       noty({ text: 'Saved', type: 'success', timeout: 1000 })
+      } catch (e) {
+        noty({ text: e.message, type: 'error', timeout: 1000 })
+      }
       this.state.saving = false
+    },
+
+    /**
+     * Runs the cinematic on the right hand side of the editor.
+     */
+    runCinematic() {
+      this.rerenderKey += 1;
+      this.rawData = this.rawData || {}
+      this.rawData.shots = this.treema.data.shots
     },
 
     async createCinematic() {

--- a/app/views/editor/cinematic/CinematicEditorComponent.vue
+++ b/app/views/editor/cinematic/CinematicEditorComponent.vue
@@ -45,7 +45,7 @@
 </template>
 
 <script>
-import { get, put, create, getAll } from 'core/api/cinematic'
+import { getCinematic, putCinematic, createCinematic, getAllCinematics } from 'core/api/cinematic'
 import Cinematic from 'app/models/Cinematic'
 import ListItem from 'app/components/cinematic/editor/ListItem'
 import CinematicCanvas from 'app/views/CinematicCanvas'
@@ -88,7 +88,7 @@ module.exports = Vue.extend({
      */
     async fetchCinematic(slug) {
       try {
-        this.cinematic = new Cinematic(await get(slug))
+        this.cinematic = new Cinematic(await getCinematic(slug))
       } catch (e) {
         return noty({
           text: `Error finding slug '${slug}'.`,
@@ -119,7 +119,7 @@ module.exports = Vue.extend({
      * Fetch all names and slugs of cinematics from the database.
      */
     async fetchList() {
-      this.cinematicList = await getAll();
+      this.cinematicList = await getAllCinematics();
     },
     /**
      * Pushes changes from treema to the cinematic model.
@@ -136,8 +136,8 @@ module.exports = Vue.extend({
     async saveCinematic() {
       this.state.saving = true
       try {
-      await put({ data: this.cinematic.toJSON() })
-      noty({ text: 'Saved', type: 'success', timeout: 1000 })
+        await putCinematic({ data: this.cinematic.toJSON() })
+        noty({ text: 'Saved', type: 'success', timeout: 1000 })
       } catch (e) {
         noty({ text: e.message, type: 'error', timeout: 1000 })
       }
@@ -157,7 +157,7 @@ module.exports = Vue.extend({
       const name = window.prompt("Name of new cinematic?")
       if (!name) { return }
 
-      const result = await create({ name })
+      const result = await createCinematic({ name })
       return this.fetchList()
     }
   },

--- a/app/views/play/cinematic/CinematicLankBoss.js
+++ b/app/views/play/cinematic/CinematicLankBoss.js
@@ -22,6 +22,7 @@ Promise.config({
 
 const BACKGROUND_OBJECT = 'backgroundObject'
 const BACKGROUND = 'background'
+const RIGHT = Math.PI
 
 /**
  * @typedef {import(./Command/CinematicParser).System} System
@@ -284,7 +285,7 @@ export default class CinematicLankBoss {
           x: this.stageBounds.bottomRight.x + 4,
           y: this.stageBounds.bottomRight.y
         },
-        rotation: Math.PI
+        rotation: RIGHT
       })
     } else if (key === 'left' && !thang) {
       thang = createThang({
@@ -313,14 +314,12 @@ export default class CinematicLankBoss {
 
 /**
  * Creates a mock thang. Looking left by default.
- * You can pass in options to override default thang properties.
+ * You can pass in a thang to override default thang properties.
  *
- * A rotation of `Math.PI` is looking right.
- *
- * @param {Object} options - is merged onto default thang options
- * @returns {Object} thang object
+ * @param {Object} thang - is merged onto default thang settings.
+ * @returns {Object} thang object literal
  */
-const createThang = (options) => {
+const createThang = thang => {
   const defaults = {
     health: 10.0,
     maxHealth: 10.0,
@@ -336,18 +335,16 @@ const createThang = (options) => {
     //  Looking left
     rotation: 0
   }
-  return _.merge(defaults, options)
+  return _.merge(defaults, thang)
 }
 
 /**
- * A modified AnimeCommand that updates thang state ensuring lanks are correctly
- * rendered.
+ * A modified AnimeCommand that updates thang state ensuring lanks are correctly rendered.
  */
 class MoveLank extends AbstractCommand {
   /**
-   * Runs an anime js animation with some helper methods ensuring the lanks are
-   * properly rendered on the canvas.
-   * @param {Function} animationFn
+   * @param {Function} animationFn Function that returns a run function, animation tween
+   *                               and a function to update the state of the lank.
    */
   constructor (animationFn) {
     super()
@@ -362,7 +359,6 @@ class MoveLank extends AbstractCommand {
   }
 
   cancel (promise) {
-    // Bound by the `runFn`.
     const animation = this.animation
     if (!animation) {
       throw new Error('Incorrect use of MoveLank. Must attach animation.')

--- a/app/views/play/cinematic/CinematicLankBoss.js
+++ b/app/views/play/cinematic/CinematicLankBoss.js
@@ -77,6 +77,7 @@ export default class CinematicLankBoss {
       const { enterOnStart, thang: { pos } } = lHero
       moveCharacter('left', original, enterOnStart, pos)
     }
+
     const rHero = getRightHero(shot)
     if (rHero) {
       const { enterOnStart, thang: { pos } } = rHero
@@ -104,6 +105,7 @@ export default class CinematicLankBoss {
     if (char === 'left' || char === 'both') {
       commands.push(this.moveLankCommand({ key: 'left', pos: { x: -20 } }))
     }
+
     if (char === 'right' || char === 'both') {
       commands.push(this.moveLankCommand({ key: 'right', pos: { x: 20 } }))
     }
@@ -274,13 +276,12 @@ export default class CinematicLankBoss {
       }
     }
 
-    console.log('adding lank', key)
-
     // Initial coordinates for thangs being created offscreen.
+    // This feels like it could be refactored to be nicer.
     if (key === 'right' && !thang) {
       thang = createThang({
         pos: {
-          x: this.stageBounds.bottomRight.x + 2,
+          x: this.stageBounds.bottomRight.x + 4,
           y: this.stageBounds.bottomRight.y
         },
         rotation: Math.PI
@@ -288,7 +289,7 @@ export default class CinematicLankBoss {
     } else if (key === 'left' && !thang) {
       thang = createThang({
         pos: {
-          x: this.stageBounds.topLeft.x - 2,
+          x: this.stageBounds.topLeft.x - 4,
           y: this.stageBounds.bottomRight.y
         }
       })

--- a/app/views/play/cinematic/CinematicLankBoss.js
+++ b/app/views/play/cinematic/CinematicLankBoss.js
@@ -7,7 +7,7 @@ import {
   getLeftHero,
   getRightHero,
   getBackground,
-  exitCharacter,
+  getExitCharacter,
   getBackgroundObject,
   getClearBackgroundObject
 } from '../../../schemas/selectors/cinematic'
@@ -102,13 +102,15 @@ export default class CinematicLankBoss {
 
   parseDialogNode (dialogNode) {
     const commands = []
-    const char = exitCharacter(dialogNode)
-    if (char === 'left' || char === 'both') {
-      commands.push(this.moveLankCommand({ key: 'left', pos: { x: -20 } }))
-    }
 
+    // TODO: Do we need to give the designers more access to where the characters should exit?
+    //       Currently characters start 4 meters off the respective side of the camera bounds.
+    const char = getExitCharacter(dialogNode)
+    if (char === 'left' || char === 'both') {
+      commands.push(this.moveLankCommand({ key: 'left', pos: { x: this.stageBounds.topLeft.x - 4 } }))
+    }
     if (char === 'right' || char === 'both') {
-      commands.push(this.moveLankCommand({ key: 'right', pos: { x: 20 } }))
+      commands.push(this.moveLankCommand({ key: 'right', pos: { x: this.stageBounds.bottomRight.x + 4 } }))
     }
 
     const bgObject = getBackgroundObject(dialogNode)
@@ -137,6 +139,8 @@ export default class CinematicLankBoss {
 
   /**
    * Moves either the left or right lank to a given co-ordinates **instantly**.
+   *
+   * TODO: Refactor into the moveLankCommand method. Make it handle a delay of 0ms.
    * @param {'left'|'right'} side - the lank being moved.
    * @param {{x, y}} pos - the position in meters to move towards.
    */
@@ -166,7 +170,6 @@ export default class CinematicLankBoss {
       }
       pos = pos || {}
       // normalize parameters
-      console.log('have the key', key)
       pos.x = pos.x !== undefined ? pos.x : this.lanks[key].thang.pos.x
       pos.y = pos.y !== undefined ? pos.y : this.lanks[key].thang.pos.y
       if (this.lanks[key].thang.pos.x === pos.x && this.lanks[key].thang.pos.y === pos.y) {
@@ -201,6 +204,8 @@ export default class CinematicLankBoss {
    * Sets the background.
    *
    * Handles backgrounds that may already exist or are simply being moved.
+   * TODO: Refactor and fold into the moveLankCommand method. Make it handle delay of 0ms.
+   *       This method is a special case of the moveLank method.
    * @param {Object} background Background object.
    */
   setBackgroundCommand ({ slug, thang: { scaleX, scaleY, pos: { x, y } } }) {

--- a/app/views/play/cinematic/Loader.js
+++ b/app/views/play/cinematic/Loader.js
@@ -48,9 +48,10 @@ export default class Loader {
 
     this.loadingThangTypes.set(
       original,
-      getThangTypeOriginal(original)
-        .then(attr => new ThangType(attr))
-        .then(t => this.loadedThangTypes.set(original, t))
+      (async () => {
+        const attr = await getThangTypeOriginal(original)
+        this.loadedThangTypes.set(original, new ThangType(attr))
+      })()
     )
   }
 
@@ -111,9 +112,10 @@ export default class Loader {
   queueThangType (slug) {
     this.loadingThangTypes.set(
       slug,
-      getThang({ slug })
-        .then(attr => new ThangType(attr))
-        .then(t => this.loadedThangTypes.set(slug, t))
+      (async () => {
+        const attr = await getThang({ slug })
+        this.loadedThangTypes.set(slug, new ThangType(attr))
+      })()
     )
   }
 

--- a/app/views/play/cinematic/Loader.js
+++ b/app/views/play/cinematic/Loader.js
@@ -1,5 +1,5 @@
-import { get } from 'core/api/cinematic'
-import { getThang } from '../../../core/api/thang-types'
+import { getThang, getThangTypeOriginal } from '../../../core/api/thang-types'
+import { getBackgroundSlug, getBackgroundObject, getRightCharacterThangTypeSlug, getLeftCharacterThangTypeSlug } from '../../../schemas/selectors/cinematic';
 
 /**
  * @typedef {import('../../../schemas/selectors/cinematic')} Cinematic
@@ -13,9 +13,8 @@ const ThangType = require('models/ThangType')
  */
 
 export default class Loader {
-  constructor ({ slug }) {
-    this.slug = slug
-
+  constructor ({ data }) {
+    this.data = data
     // Stores thangType with slug as the key.
     this.loadedThangTypes = new Map()
     // Stores the thangType loading promise with slug as key.
@@ -27,10 +26,49 @@ export default class Loader {
    * @returns {Cinematic} The raw JSON object with Cinematic data.
    */
   async loadAssets () {
-    this.data = await get(this.slug)
     this.loadThangTypes(this.data.shots)
+    this.loadPlayerThangType()
+    this.loadBackgroundObjects(this.data.shots)
     await this.load()
     return this.data
+  }
+
+  /**
+   * Loads the player thangType from the global `me` object if accessible.
+   * Has a side effect of storing the players thangType by original as a resource.
+   */
+  loadPlayerThangType () {
+    if ((me || {}) && !me.get('heroConfig')) {
+      return
+    }
+    const original = me.get('heroConfig').thangType
+    if (!original) {
+      return
+    }
+
+    this.loadingThangTypes.set(
+      original,
+      getThangTypeOriginal(original)
+        .then(attr => new ThangType(attr))
+        .then(t => this.loadedThangTypes.set(original, t))
+    )
+  }
+
+  /**
+   * Queues up the background objects
+   * @param {Shot[]} shots
+   */
+  loadBackgroundObjects (shots) {
+    shots
+      .filter(shot => (shot.dialogNodes || []).length > 0)
+      .map(({ dialogNodes }) =>
+        dialogNodes
+          .map(dialogNode => getBackgroundObject(dialogNode))
+          .filter(bgObject => bgObject)
+          .map(({ type: { slug } }) => slug)
+          .filter(slug => slug)
+          .forEach(slug => this.queueThangType(slug))
+      )
   }
 
   /**
@@ -40,32 +78,43 @@ export default class Loader {
    * TODO: Add retry logic to the getThang function.
    */
   loadThangTypes (shots) {
-    const characterArray = []
+    const slugs = []
     shots
-      .map(({ shotSetup }) => shotSetup)
-      .filter(setup => setup)
-      .forEach(({ leftThangType, rightThangType }) => {
-        if (leftThangType) {
-          characterArray.push(leftThangType)
+      .forEach(shot => {
+        const { slug } = getLeftCharacterThangTypeSlug(shot) || {}
+        if (slug) {
+          slugs.push(slug)
         }
-        if (rightThangType) {
-          characterArray.push(rightThangType)
+        const { slug: slug2 } = getRightCharacterThangTypeSlug(shot) || {}
+        if (slug2) {
+          slugs.push(slug2)
+        }
+
+        const backgroundSlug = getBackgroundSlug(shot) || {}
+        if (backgroundSlug) {
+          slugs.push(backgroundSlug)
         }
       })
-    // Now we have a list of only character objects, we can fetch the data,
+    // Now we have a list of only slugs, we can fetch the data,
     // storing the promise in our `loadedThangTypes` Map.
-    characterArray
+    slugs
       .filter(character => character)
-      .filter(({ type = undefined, slug = undefined }) => type === 'slug' && slug)
-      .filter(({ slug }) => !(this.loadedThangTypes.has(slug) || this.loadingThangTypes.has(slug)))
-      .map(({ slug }) => slug)
-      .forEach(slug =>
-        this.loadingThangTypes.set(
-          slug,
-          getThang({ slug })
-            .then(attr => new ThangType(attr))
-            .then(t => this.loadedThangTypes.set(slug, t))
-        ))
+      .filter(slug => typeof slug === 'string')
+      .filter(slug => !(this.loadedThangTypes.has(slug) || this.loadingThangTypes.has(slug)))
+      .forEach(slug => this.queueThangType(slug))
+  }
+
+  /**
+   * Queues a ThangType resource for async loading.
+   * @param {string} slug ThangType slug.
+   */
+  queueThangType (slug) {
+    this.loadingThangTypes.set(
+      slug,
+      getThang({ slug })
+        .then(attr => new ThangType(attr))
+        .then(t => this.loadedThangTypes.set(slug, t))
+    )
   }
 
   /**
@@ -84,11 +133,13 @@ export default class Loader {
   /**
    * Get a loaded thangType by slug.
    * @param {string} slug - Slug of a thangType
+   * @returns {object|undefined} May return thangType or undefined
    */
   getThangType (slug) {
     const thangType = this.loadedThangTypes.get(slug)
     if (!thangType) {
-      throw new Error(`Make sure '${slug}' thangType is loaded before getting`)
+      console.error(`Make sure '${slug}' thangType is loaded before getting`)
+      return
     }
     return thangType
   }

--- a/app/views/play/cinematic/Loader.js
+++ b/app/views/play/cinematic/Loader.js
@@ -15,9 +15,9 @@ const ThangType = require('models/ThangType')
 export default class Loader {
   constructor ({ data }) {
     this.data = data
-    // Stores thangType with slug as the key.
+    // Stores thangType with slug or original as the key.
     this.loadedThangTypes = new Map()
-    // Stores the thangType loading promise with slug as key.
+    // Stores the thangType loading promise with slug or original as key.
     this.loadingThangTypes = new Map()
   }
 
@@ -62,7 +62,7 @@ export default class Loader {
   loadBackgroundObjects (shots) {
     shots
       .filter(shot => (shot.dialogNodes || []).length > 0)
-      .map(({ dialogNodes }) =>
+      .forEach(({ dialogNodes }) =>
         dialogNodes
           .map(dialogNode => getBackgroundObject(dialogNode))
           .filter(bgObject => bgObject)

--- a/app/views/play/cinematic/cinematicController.js
+++ b/app/views/play/cinematic/cinematicController.js
@@ -18,7 +18,7 @@ export class CinematicController {
   constructor ({
     canvas,
     canvasDiv,
-    slug,
+    cinematicData,
     handlers: {
       onPlay,
       onPause,
@@ -37,24 +37,13 @@ export class CinematicController {
     this.stubRequiredLayer = new LayerAdapter({ name: 'Ground', webGL: true, camera: camera })
 
     this.layerAdapter = new LayerAdapter({ name: 'Default', webGL: true, camera: camera })
+    this.backgroundAdapter = new LayerAdapter({ name: 'Background', webGL: true, camera: camera })
+    this.stage.addChild(this.backgroundAdapter.container)
     this.stage.addChild(this.layerAdapter.container)
 
-    // Count the number of times we are making a new spritesheet
-    let count = 0
-    this.startupLocks = []
-    this.startupLocks.push(new Promise((resolve, reject) => {
-      this.layerAdapter.on('new-spritesheet', (_spritesheet) => {
-        // This should trigger for each ThangType being loaded and turned into a Lank.
-        // Behavior is still unknown so keeping logging.
-        // TODO: Eventually remove this logging when we understand the exact behavior.
-        console.log('Got a new spritesheet. Count:', ++count)
-        resolve()
-      })
-    }))
-
     // TODO: Will be moved to camera commands.
-    this.systems.camera.zoomTo({ x: 0, y: 0 }, 7, 0)
-    this.systems.loader = new Loader({ slug })
+    this.systems.camera.zoomTo({ x: 0, y: 0 }, 6, 0)
+    this.systems.loader = new Loader({ data: cinematicData })
 
     this.systems.dialogSystem = new DialogSystem({
       canvasDiv,
@@ -68,6 +57,7 @@ export class CinematicController {
     this.systems.cinematicLankBoss = new CinematicLankBoss({
       groundLayer: this.stubRequiredLayer,
       layerAdapter: this.layerAdapter,
+      backgroundAdapter: this.backgroundAdapter,
       camera: this.systems.camera,
       loader: this.systems.loader
     })
@@ -80,9 +70,6 @@ export class CinematicController {
   /**
    * Method that loads and initializes the cinematic.
    *
-   * We load cinematic data and initialize the Lank creation. Creating a lank causes a
-   * new spritesheet to be built so we wait for at least one spritesheet to be built.
-   *  TODO: Have a reasonable timeout so we don't lock forever in an edge case.
    *
    * Finally we run the cinematic runner.
    */
@@ -94,14 +81,9 @@ export class CinematicController {
       .filter(commands => commands.length > 0)
       .reduce((acc, commands) => [...acc, ...commands], [])
 
-    // TODO: There must be a better way than an array of locks! In future add reasonable timeout with `Promise.race`.
-    await Promise.all(this.startupLocks)
-
     attachListener({ cinematicLankBoss: this.systems.cinematicLankBoss, stage: this.stage })
 
-    // This is hot start. We don't need to start immediately.
     this.commands = commands
-    this.runShot()
   }
 
   /**


### PR DESCRIPTION
Brings functionality back to Cinematics.
I feel there are some better abstractions and refactorings that can be done but unsure how to proceed for the moment.
I feel that the design is sufficiently decoupled that the improvements could be added later.

## Features

 - Backgrounds can be set between shots
 - Background objects can be placed.
 - Background objects can be removed with a trigger delay.
 - Player Hero can be shown as the left or right character.
 - Add Cinematic View to the Cinematic Editor for easier testing.

Depends on the changes from #5282 

This was tested manually as I can't think of how to test the side effects without creating some kind of Cinematic Verifier environment. To assist with rapid feedback the cinematic editor environment improvement at least allows you to immediately view  the cinematic being worked on.