### PR TITLE
Speed up adding and removing courses from large classroom

### DIFF
--- a/app/views/courses/TeacherClassView.coffee
+++ b/app/views/courses/TeacherClassView.coffee
@@ -101,7 +101,7 @@ module.exports = class TeacherClassView extends RootView
 
     @urls = require('core/urls')
 
-    @debouncedRender = _.debounce @render, 300
+    @debouncedRender = _.debounce @render
     @calculateProgressAndLevels = _.debounce @calculateProgressAndLevelsAux, 800
 
     @state = new State(@getInitialState())

--- a/app/views/courses/TeacherClassView.coffee
+++ b/app/views/courses/TeacherClassView.coffee
@@ -296,6 +296,7 @@ module.exports = class TeacherClassView extends RootView
     @classroom?.loaded and @classroom?.get('members')?.length is 0 or (@students?.loaded and @classroom?.sessions?.loaded)
 
   calculateProgressAndLevelsAux: ->
+    return if @destroyed
     return unless @supermodel.progress is 1 and @allStatsLoaded()
     userLevelCompletedMap = @classroom.sessions.models.reduce((map, session) =>
       if session.completed()

--- a/test/app/views/teachers/TeacherClassView.spec.coffee
+++ b/test/app/views/teachers/TeacherClassView.spec.coffee
@@ -180,6 +180,7 @@ describe 'TeacherClassView', ->
                   expect(simplerLine).toMatch /0,0,0/
               done()
             reader.readAsText(blob);
+          @view.calculateProgressAndLevelsAux()
           @view.$el.find('.export-student-progress-btn').click()
 
     describe 'when javascript classroom', ->
@@ -240,6 +241,7 @@ describe 'TeacherClassView', ->
                   expect(simplerLine).toMatch /0,0,0/
               done()
             reader.readAsText(blob);
+          @view.calculateProgressAndLevelsAux()
           @view.$el.find('.export-student-progress-btn').click()
 
     describe '.assignCourse(courseID, members)', ->


### PR DESCRIPTION
## Issue

Prior to this change, `calculateProgressAndLevels` method is called in response to all sorts of state changes. This is problematic as `calculateProgressAndLevels` is expensive.
The outcome is operations on large class sizes becoming unreasonably slow.

Adding or removing a course from a student can cause progress to be calculated > 20 times. This leads to a lot of repeated work.

## Why the debounce fix

An alternative way of fixing this issue is streamlining the various call sites. Identifying wasteful calls and refactoring them.
I chose not to pursue this as certain `calculateProgressAndLevels` calls had been committed due to historic UI bugs.

Hence I opted to keep the call sites the same, instead debouncing repeated calls.
This means that the functionality should be the same but with much less work.

## Testing

I manually tested this against large classes and there was a noticeable improvement. Instead of `calculateProgressAndLevels` being called >20 times. It was only called twice.

Although there are still a few render calls slowing down the page. The overall behavior is much improved.