### PR TITLE
End a/b test on homepage

### DIFF
--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -137,12 +137,13 @@ module.exports = class Tracker extends CocoClass
       gaFieldObject.eventLabel = properties.label if properties.label?
       gaFieldObject.eventValue = properties.value if properties.value?
 
-      # Adding label for tracking home page A/B testing group on GA for analyzing results
-      # TODO: what if gaFieldObject.label already exists and we still want to track a/b results
+      # Send trackABResult as true in the properties to track a/b test results in GA as the event label
+      # TODO: what if gaFieldObject.label already exists
       # As of now gaFieldObject.label doesnt exist for the specific events which are relevant for a/b test results, so not a concern for now
       # Probably add multiple labels as keys in gaFieldObject.label in the future, if required.
-      if properties.trackABResult and not gaFieldObject.label and me.getHomePageTestGroup()
-        gaFieldObject.eventLabel = "{testGroup:"+ me.getHomePageTestGroup() + "}"  # {testGroup:A} / {testGroup:B} / {testGroup:C}
+      if properties.trackABResult and not gaFieldObject.label
+        if me.getHomePageTestGroup()
+          gaFieldObject.eventLabel = "{testGroup:"+ me.getHomePageTestGroup() + "}"  # {testGroup:A} / {testGroup:B} / {testGroup:C}
 
       ga? 'send', gaFieldObject
       ga? 'codeplay.send', gaFieldObject if features.codePlay

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -86,6 +86,7 @@
     classroom_edition: "Classroom Edition:"
     learn_to_code: "Learn to code:"
     play_now: "Play Now"
+    im_an_educator: "I'm an Educator"
     im_a_teacher: "I'm a Teacher"
     im_a_student: "I'm a Student"
     learn_more: "Learn more"

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -282,15 +282,9 @@ module.exports = class User extends CocoModel
     return me.get('testGroupNumber') % numVideos
 
   getHomePageTestGroup: () ->
+    return  # ending A/B test on homepage for now.
     return unless me.get('country') == 'united-states'
-    groupNumber = me.get('testGroupNumberUS')
-    # testGroupNumberUS is a random number from 0-255, dividing into 40%-40%-20%
-    if groupNumber >= 0 and groupNumber < 102  # first 40% of 256
-      return "A"
-    else if groupNumber >= 102 and groupNumber < 204  # next 40% of 256
-      return "B"
-    else  # remaining 20% of 256 
-      return "C"
+    # testGroupNumberUS is a random number from 0-255, use it to run A/B tests for US users.
 
   hasSubscription: ->
     return false if me.isStudent() or me.isTeacher()

--- a/app/templates/base-flat.jade
+++ b/app/templates/base-flat.jade
@@ -104,9 +104,9 @@ mixin accountLinks
                 if me.isAnonymous()
                   ul.nav.navbar-nav.text-p.login-buttons
                     li
-                      a#create-account-link.signup-button.track-ab-result(data-event-action="Header Sign Up CTA", data-i18n="signup.sign_up")
+                      a#create-account-link.signup-button(data-event-action="Header Sign Up CTA", data-i18n="signup.sign_up")
                     li
-                      a#login-link.login-button.track-ab-result(data-event-action="Header Login CTA", data-i18n="signup.login")
+                      a#login-link.login-button(data-event-action="Header Login CTA", data-i18n="signup.login")
 
 
   block page_nav

--- a/app/templates/home-view.jade
+++ b/app/templates/home-view.jade
@@ -7,25 +7,12 @@ block content
         h1.text-white(data-i18n="new_home.slogan")
         div.button-section
           if me.isAnonymous()
-            if me.getHomePageTestGroup() == "A"
-              p
-                button.btn.btn-lg.btn-primary.teacher-btn(data-event-action="Homepage Click Teacher Button #1 CTA", data-i18n="new_home.educator")
-              p
-                button.btn.btn-lg.btn-primary.student-btn(data-event-action="Homepage Click Student Button CTA", data-i18n="new_home.student")
-              p
-                a.btn.btn-lg.btn-primary-alt.track-ab-result(href="/play", data-i18n="common.play")
-            else if me.getHomePageTestGroup() == "B"
-              p
-                button.btn.btn-lg.btn-primary.teacher-btn(data-event-action="Homepage Click Teacher Button #1 CTA", data-i18n="new_home.im_a_teacher", style="text-transform: none")
-              p
-                button.btn.btn-lg.btn-primary.student-btn(data-event-action="Homepage Click Student Button CTA", data-i18n="new_home.im_a_student", style="text-transform: none")
-              p
-                a.btn.btn-lg.btn-primary-alt.track-ab-result(href="/play", data-i18n="common.play", style="text-transform: none")
-            else
-              p
-                button.btn.btn-lg.btn-primary.signup-button.signup-home-btn.track-ab-result(data-event-action="Homepage Get Started CTA", data-i18n="new_home.get_started")
-              p
-                a.btn.btn-lg.btn-primary-alt.play-btn.track-ab-result(href="/play", data-event-action="Homepage Play Now CTA", data-i18n="new_home.try_the_game")
+            p
+              button.btn.btn-lg.btn-primary.teacher-btn(data-event-action="Homepage Click Teacher Button #1 CTA", data-i18n="new_home.im_an_educator", style="text-transform: none")
+            p
+              button.btn.btn-lg.btn-primary.student-btn(data-event-action="Homepage Click Student Button CTA", data-i18n="new_home.im_a_student", style="text-transform: none")
+            p
+              a.btn.btn-lg.btn-primary-alt.play-btn(href="/play", data-i18n="common.play", data-event-action="Homepage Play Now CTA", style="text-transform: none")
           else
             p
               if me.isTeacher()
@@ -42,7 +29,7 @@ block content
             if me.isAnonymous()
               br
               p
-                a.btn.btn-lg.btn-primary.play-btn.track-ab-result(href="/play", data-event-action="Homepage Try The Game CTA", data-i18n="new_home.try_the_game")
+                a.btn.btn-lg.btn-primary.play-btn(href="/play", data-event-action="Homepage Try The Game CTA", data-i18n="new_home.try_the_game")
         .col-md-7
           .game-based-image
             img(src="/images/pages/home/type_real_code_logo.gif"
@@ -74,7 +61,7 @@ block content
                   span.text-p(data-i18n="new_home.classroom_in_box_blurb3")
           if me.isAnonymous()
             .row.signup_btn
-              button.btn.btn-lg.btn-primary.signup-button.signup-home-btn.track-ab-result(data-event-action="Homepage Sign Up #2 CTA", data-i18n="signup.sign_up")
+              button.btn.btn-lg.btn-primary.signup-button.signup-home-btn(data-event-action="Homepage Sign Up #2 CTA", data-i18n="signup.sign_up")
 
     .row#creativity-rigor
       .col-lg-12

--- a/app/views/HomeView.coffee
+++ b/app/views/HomeView.coffee
@@ -48,7 +48,7 @@ module.exports = class HomeView extends RootView
     @playSound 'menu-button-click'
     e.preventDefault()
     e.stopImmediatePropagation()
-    @homePageEvent($(e.target).data('event-action'), {trackABResult: true})
+    @homePageEvent($(e.target).data('event-action'))
     if me.isTeacher()
       application.router.navigate '/teachers/update-account', trigger: true
     else
@@ -59,13 +59,13 @@ module.exports = class HomeView extends RootView
     application.router.navigate("/teachers/classes", { trigger: true })
 
   onClickStudentButton: (e) ->
-    @homePageEvent('Started Signup', {trackABResult: true})
-    @homePageEvent($(e.target).data('event-action'), {trackABResult: true})
+    @homePageEvent('Started Signup')
+    @homePageEvent($(e.target).data('event-action'))
     @openModalView(new CreateAccountModal({startOnPath: 'student'}))
 
   onClickTeacherButton: (e) ->
-    @homePageEvent('Started Signup', {trackABResult: true})
-    @homePageEvent($(e.target).data('event-action'), {trackABResult: true})
+    @homePageEvent('Started Signup')
+    @homePageEvent($(e.target).data('event-action'))
     @openModalView(new CreateAccountModal({startOnPath: 'teacher'}))
 
   onClickTrackEvent: (e) ->

--- a/app/views/core/CreateAccountModal/BasicInfoView.coffee
+++ b/app/views/core/CreateAccountModal/BasicInfoView.coffee
@@ -198,7 +198,7 @@ module.exports = class BasicInfoView extends CocoView
 
   onSubmitForm: (e) ->
     if @signupState.get('path') is 'teacher'
-      window.tracker?.trackEvent 'CreateAccountModal Teacher BasicInfoView Submit Clicked', { category: 'Teachers', trackABResult: true }
+      window.tracker?.trackEvent 'CreateAccountModal Teacher BasicInfoView Submit Clicked', category: 'Teachers'
     if @signupState.get('path') is 'student'
       window.tracker?.trackEvent 'CreateAccountModal Student BasicInfoView Submit Clicked', category: 'Students'
     if @signupState.get('path') is 'individual'

--- a/app/views/core/CreateAccountModal/CreateAccountModal.coffee
+++ b/app/views/core/CreateAccountModal/CreateAccountModal.coffee
@@ -53,7 +53,6 @@ startSignupTracking = ->
   properties =
     category: 'Homepage'
     user: me.get('role') || (me.isAnonymous() && "anonymous") || "homeuser"
-    trackABResult: true
   window.tracker?.trackEvent(
     'Teacher signup started',
     properties)
@@ -226,7 +225,6 @@ module.exports = class CreateAccountModal extends ModalView
     properties =
       category: 'Homepage'
       subview: @signupState.get('path') || "choosetype"
-      trackABResult: true
     window.tracker?.trackEvent('Log in from CreateAccount', properties)
     @openModalView(new AuthModal({ initialValues: @signupState.get('authModalInitialValues'), subModalContinue: @signupState.get('subModalContinue') }))
 

--- a/app/views/core/CreateAccountModal/teacher/SchoolInfoPanel.coffee
+++ b/app/views/core/CreateAccountModal/teacher/SchoolInfoPanel.coffee
@@ -67,7 +67,7 @@ SchoolInfoPanel =
 
     clickContinue: ->
       # Make sure to add conditions if we change this to be used on non-teacher path
-      window.tracker?.trackEvent 'CreateAccountModal Teacher SchoolInfoPanel Continue Clicked', { category: 'Teachers', trackABResult: true }
+      window.tracker?.trackEvent 'CreateAccountModal Teacher SchoolInfoPanel Continue Clicked', category: 'Teachers'
       requiredAttrs = _.pick(@, 'district', 'city', 'state', 'country')
       unless _.all(requiredAttrs)
         @showRequired = true

--- a/app/views/core/CreateAccountModal/teacher/TeacherRolePanel.coffee
+++ b/app/views/core/CreateAccountModal/teacher/TeacherRolePanel.coffee
@@ -17,7 +17,7 @@ TeacherRolePanel = Vue.extend
   methods:
     clickContinue: ->
       # Make sure to add conditions if we change this to be used on non-teacher path
-      window.tracker?.trackEvent 'CreateAccountModal Teacher TeacherRolePanel Continue Clicked', { category: 'Teachers', trackABResult: true }
+      window.tracker?.trackEvent 'CreateAccountModal Teacher TeacherRolePanel Continue Clicked', category: 'Teachers'
       requiredAttrs = _.pick(@, 'role', 'numStudents')
       unless _.all(requiredAttrs)
         @showRequired = true

--- a/app/views/core/RootView.coffee
+++ b/app/views/core/RootView.coffee
@@ -80,7 +80,6 @@ module.exports = class RootView extends CocoView
       when 'home-view'
         properties = {
           category: 'Homepage'
-          trackABResult: true
         }
         window.tracker?.trackEvent('Started Signup', properties, [])
         eventAction = $(e.target)?.data('event-action')

--- a/app/views/courses/TeacherClassesView.coffee
+++ b/app/views/courses/TeacherClassesView.coffee
@@ -127,7 +127,7 @@ module.exports = class TeacherClassesView extends RootView
           @calculateQuestCompletion()
           @render()
 
-    window.tracker?.trackEvent 'Teachers Classes Loaded', { category: 'Teachers', trackABResult: true }, ['Mixpanel']
+    window.tracker?.trackEvent 'Teachers Classes Loaded', category: 'Teachers', ['Mixpanel']
 
     @courses = new Courses()
     @courses.fetch()
@@ -232,7 +232,7 @@ module.exports = class TeacherClassesView extends RootView
 
   openNewClassroomModal: ->
     return unless me.id is @teacherID # Viewing page as admin
-    window.tracker?.trackEvent 'Teachers Classes Create New Class Started', { category: 'Teachers', trackABResult: true }, ['Mixpanel']
+    window.tracker?.trackEvent 'Teachers Classes Create New Class Started', category: 'Teachers', ['Mixpanel']
     classroom = new Classroom({ ownerID: me.id })
     modal = new ClassroomSettingsModal({ classroom: classroom })
     @openModalView(modal)


### PR DESCRIPTION
Ending A/B test on the homepage and replacing with the test winner - https://app.asana.com/0/654820789891907/1120659490583466

Left the support to implement and track a/b test in the future. We can use the user property `testGroupNumberUS` to implement a/b test for US users, or `testGroupNumber` for worldwide users, and use `trackABResult` to track the results in google analytics.