### PR TITLE
Cinematics Talking Animation

### DIFF
--- a/app/schemas/models/cinematic.schema.js
+++ b/app/schemas/models/cinematic.schema.js
@@ -76,7 +76,7 @@ const DialogNode = c.object({
   speaker: c.shortString({ enum: ['left', 'right'], title: 'Speaker', description: 'Which character is speaking. Used to select speech bubble.' }),
   text: { type: 'string', title: 'Text', description: 'html text', maxLength: 500 },
   textAnimationLength: c.int({ title: 'Text Animation Length(ms)', description: 'The number of milliseconds it takes for the text to animate out. Defaults to 1000ms.' }),
-  speakingAnimation: c.shortString({ title: 'Speaking Animation', description: 'The animation to play on the lank while the text is being animated.' }),
+  speakingAnimationAction: c.shortString({ title: 'Speaking Animation', description: 'The animation to play on the lank while the text is being animated.' }),
   i18n: { type: 'object', format: 'i18n', props: ['text'], description: 'Help translate this cinematic dialogNode.' },
   textLocation: c.object({ title: 'Text Location', description: 'An {x, y} coordinate point.', format: 'point2d', required: ['x', 'y'] }, {
     x: { title: 'x', description: 'The x coordinate.', type: 'number', 'default': 0 },

--- a/app/schemas/models/cinematic.schema.js
+++ b/app/schemas/models/cinematic.schema.js
@@ -75,6 +75,8 @@ const DialogNode = c.object({
 }, {
   speaker: c.shortString({ enum: ['left', 'right'], title: 'Speaker', description: 'Which character is speaking. Used to select speech bubble.' }),
   text: { type: 'string', title: 'Text', description: 'html text', maxLength: 500 },
+  textAnimationLength: c.int({ title: 'Text Animation Length(ms)', description: 'The number of milliseconds it takes for the text to animate out. Defaults to 1000ms.' }),
+  speakingAnimation: c.shortString({ title: 'Speaking Animation', description: 'The animation to play on the lank while the text is being animated.' }),
   i18n: { type: 'object', format: 'i18n', props: ['text'], description: 'Help translate this cinematic dialogNode.' },
   textLocation: c.object({ title: 'Text Location', description: 'An {x, y} coordinate point.', format: 'point2d', required: ['x', 'y'] }, {
     x: { title: 'x', description: 'The x coordinate.', type: 'number', 'default': 0 },

--- a/app/schemas/selectors/cinematic.js
+++ b/app/schemas/selectors/cinematic.js
@@ -361,4 +361,4 @@ export const getTextAnimationLength = textAnimationLength
  * @param {DialogNode}  dialogNode
  * @returns {string|undefined} Lank action to play
  */
-export const getSpeakingAnimation = dialogNode => (dialogNode || {}).speakingAnimation
+export const getSpeakingAnimationAction = dialogNode => (dialogNode || {}).speakingAnimationAction

--- a/app/schemas/selectors/cinematic.js
+++ b/app/schemas/selectors/cinematic.js
@@ -263,7 +263,7 @@ export const getClearText = dialogNode => (dialogNode || {}).dialogClear || fals
 
 export const getTextPosition = dialogNode => (dialogNode || {}).textLocation
 
-export const getSpeaker = dialogNode => (dialogNode || {}).speaker
+export const getSpeaker = dialogNode => (dialogNode || {}).speaker || 'left'
 
 export const getText = dialogNode => (dialogNode || {}).text
 
@@ -287,6 +287,12 @@ const backgroundObject = triggers => {
 
   return _.merge(DEFAULT_THANGTYPE(), bgObject.thangType)
 }
+
+/**
+ * @param {DialogNode} dialogNode
+ * @returns {number}
+ */
+const textAnimationLength = dialogNode => (dialogNode || {}).textAnimationLength || 1000
 
 /**
  * @param {Object} triggers
@@ -344,3 +350,15 @@ export const getClearBackgroundObject = compose(triggers, clearBackgroundObject)
  * @returns {Object|undefined}
  */
 export const getCamera = compose(shotSetup, camera)
+
+/**
+ * @param {DialogNode} dialogNode
+ * @returns {number} defaults return of 1000
+ */
+export const getTextAnimationLength = textAnimationLength
+
+/**
+ * @param {DialogNode}  dialogNode
+ * @returns {string|undefined} Lank action to play
+ */
+export const getSpeakingAnimation = dialogNode => (dialogNode || {}).speakingAnimation

--- a/app/views/play/cinematic/CinematicLankBoss.js
+++ b/app/views/play/cinematic/CinematicLankBoss.js
@@ -12,7 +12,7 @@ import {
   getClearBackgroundObject,
   getText,
   getTextAnimationLength,
-  getSpeakingAnimation,
+  getSpeakingAnimationAction,
   getSpeaker
 } from '../../../schemas/selectors/cinematic'
 
@@ -141,11 +141,12 @@ export default class CinematicLankBoss {
     }
 
     const text = getText(dialogNode)
-    const animation = getSpeakingAnimation(dialogNode)
+    const animation = getSpeakingAnimationAction(dialogNode)
     if (text && animation) {
       const textLength = getTextAnimationLength(dialogNode)
       const speaker = getSpeaker(dialogNode)
       commands.push(new SequentialCommands([
+        // TODO: Is a minimum time of 100 required to ensure animation always plays?
         new Sleep(Math.min(100, textLength)),
         new SyncFunction(() => {
           this.playActionOnLank(speaker, animation)
@@ -187,11 +188,13 @@ export default class CinematicLankBoss {
    * you need to make the action loop on the ThangType.
    * @param {string} key The lanks unique key
    * @param {string} action The action to queue onto the lank
+   * @return {undefined}
    */
   playActionOnLank (key, action) {
     const lank = this.lanks[key]
     if (!lank) {
-      return console.warn(`Tried to play action '${action}' on non existant lank '${key}'`)
+      console.warn(`Tried to play action '${action}' on non existant lank '${key}'`)
+      return
     }
     lank.queueAction(action)
   }

--- a/app/views/play/cinematic/CinematicLankBoss.js
+++ b/app/views/play/cinematic/CinematicLankBoss.js
@@ -78,7 +78,6 @@ export default class CinematicLankBoss {
       const { enterOnStart, thang: { pos } } = lHero
       moveCharacter('left', original, enterOnStart, pos)
     }
-
     const rHero = getRightHero(shot)
     if (rHero) {
       const { enterOnStart, thang: { pos } } = rHero

--- a/app/views/play/cinematic/CinematicLankBoss.js
+++ b/app/views/play/cinematic/CinematicLankBoss.js
@@ -9,7 +9,11 @@ import {
   getBackground,
   getExitCharacter,
   getBackgroundObject,
-  getClearBackgroundObject
+  getClearBackgroundObject,
+  getText,
+  getTextAnimationLength,
+  getSpeakingAnimation,
+  getSpeaker
 } from '../../../schemas/selectors/cinematic'
 
 // Throws an error if `import ... from ..` syntax.
@@ -135,6 +139,26 @@ export default class CinematicLankBoss {
         })
       ]))
     }
+
+    const text = getText(dialogNode)
+    const animation = getSpeakingAnimation(dialogNode)
+    if (text && animation) {
+      const textLength = getTextAnimationLength(dialogNode)
+      const speaker = getSpeaker(dialogNode)
+      commands.push(new SequentialCommands([
+        new Sleep(Math.min(100, textLength)),
+        new SyncFunction(() => {
+          this.playActionOnLank(speaker, animation)
+        })
+      ]))
+
+      commands.push(new SequentialCommands([
+        new Sleep(textLength),
+        new SyncFunction(() => {
+          this.playActionOnLank(speaker, 'idle')
+        })
+      ]))
+    }
     return commands
   }
 
@@ -156,6 +180,20 @@ export default class CinematicLankBoss {
       // Ensures lank is rendered.
       this.lanks[key].thang.stateChanged = true
     })
+  }
+
+  /**
+   * Plays an action on a lank. If you want an animation to loop, and it isn't,
+   * you need to make the action loop on the ThangType.
+   * @param {string} key The lanks unique key
+   * @param {string} action The action to queue onto the lank
+   */
+  playActionOnLank (key, action) {
+    const lank = this.lanks[key]
+    if (!lank) {
+      return console.warn(`Tried to play action '${action}' on non existant lank '${key}'`)
+    }
+    lank.queueAction(action)
   }
 
   /**

--- a/app/views/play/cinematic/CinematicLankBoss.js
+++ b/app/views/play/cinematic/CinematicLankBoss.js
@@ -78,6 +78,7 @@ export default class CinematicLankBoss {
       const { enterOnStart, thang: { pos } } = lHero
       moveCharacter('left', original, enterOnStart, pos)
     }
+
     const rHero = getRightHero(shot)
     if (rHero) {
       const { enterOnStart, thang: { pos } } = rHero

--- a/app/views/play/cinematic/DialogSystem.js
+++ b/app/views/play/cinematic/DialogSystem.js
@@ -1,6 +1,6 @@
 import anime from 'animejs/lib/anime.es.js'
 import { AnimeCommand, SyncFunction } from './Command/commands'
-import { getClearText, getTextPosition, getSpeaker } from '../../../schemas/selectors/cinematic'
+import { getClearText, getTextPosition, getSpeaker, getTextAnimationLength } from '../../../schemas/selectors/cinematic'
 import { processText } from './dialog-system/dialogSystemHelper'
 
 const SVGNS = 'http://www.w3.org/2000/svg'
@@ -71,7 +71,8 @@ export default class DialogSystem {
         x,
         y,
         shownDialogBubbles: this.shownDialogBubbles,
-        side
+        side,
+        textDuration: getTextAnimationLength(dialogNode)
       })).createBubbleCommand())
     }
     return commands
@@ -102,7 +103,8 @@ class SpeechBubble {
     x,
     y,
     shownDialogBubbles,
-    side
+    side,
+    textDuration
   }) {
     this.id = `speech-${_id++}`
     const parser = new DOMParser()
@@ -154,7 +156,7 @@ class SpeechBubble {
       .add({
         targets: `#${this.id} .letter`,
         opacity: 1,
-        duration: 750,
+        duration: textDuration,
         delay: anime.stagger(50, { easing: 'linear' }),
         easing: 'easeOutQuad',
         complete: () => {

--- a/test/app/models/Cinematic.spec.js
+++ b/test/app/models/Cinematic.spec.js
@@ -15,7 +15,7 @@ import {
   getText,
   getCamera,
   getTextAnimationLength,
-  getSpeakingAnimation
+  getSpeakingAnimationAction
 } from '../../../app/schemas/selectors/cinematic'
 
 /**
@@ -165,11 +165,11 @@ describe('Cinematic', () => {
       expect(result2).toEqual(1000)
     })
 
-    it('getSpeakingAnimation', () => {
-      const result = getSpeakingAnimation(shotFixture1.dialogNodes[1])
+    it('getSpeakingAnimationAction', () => {
+      const result = getSpeakingAnimationAction(shotFixture1.dialogNodes[1])
       expect(result).toEqual('talkyAnimation')
 
-      const result2 = getSpeakingAnimation(shotFixture2.dialogNodes[0])
+      const result2 = getSpeakingAnimationAction(shotFixture2.dialogNodes[0])
       expect(result2).toBeUndefined()
     })
   })
@@ -252,7 +252,7 @@ var shotFixture1 = {
     {
       dialogClear: false,
       textAnimationLength: 42,
-      speakingAnimation: 'talkyAnimation'
+      speakingAnimationAction: 'talkyAnimation'
     }
   ]
 }

--- a/test/app/models/Cinematic.spec.js
+++ b/test/app/models/Cinematic.spec.js
@@ -13,7 +13,9 @@ import {
   getExitCharacter,
   getTextPosition,
   getText,
-  getCamera
+  getCamera,
+  getTextAnimationLength,
+  getSpeakingAnimation
 } from '../../../app/schemas/selectors/cinematic'
 
 /**
@@ -104,10 +106,10 @@ describe('Cinematic', () => {
 
     it('getSpeaker', () => {
       const result = getSpeaker(shotFixture1.dialogNodes[0])
-      expect(result).toBeUndefined()
+      expect(result).toEqual('left')
 
       const result2 = getSpeaker(shotFixture2.dialogNodes[0])
-      expect(result2).toEqual('left')
+      expect(result2).toEqual('right')
     })
 
     it('getBackgroundSlug', () => {
@@ -153,6 +155,22 @@ describe('Cinematic', () => {
       expect(result2).toBeUndefined()
 
       expect(getCamera(undefined)).toBeUndefined()
+    })
+
+    it('getTextAnimationLength', () => {
+      const result = getTextAnimationLength(shotFixture1.dialogNodes[1])
+      expect(result).toEqual(42)
+
+      const result2 = getTextAnimationLength(shotFixture2.dialogNodes[0])
+      expect(result2).toEqual(1000)
+    })
+
+    it('getSpeakingAnimation', () => {
+      const result = getSpeakingAnimation(shotFixture1.dialogNodes[1])
+      expect(result).toEqual('talkyAnimation')
+
+      const result2 = getSpeakingAnimation(shotFixture2.dialogNodes[0])
+      expect(result2).toBeUndefined()
     })
   })
 })
@@ -232,7 +250,9 @@ var shotFixture1 = {
       }
     },
     {
-      dialogClear: false
+      dialogClear: false,
+      textAnimationLength: 42,
+      speakingAnimation: 'talkyAnimation'
     }
   ]
 }
@@ -262,7 +282,7 @@ var shotFixture2 = {
   dialogNodes: [
     {
       triggers: { },
-      speaker: 'left',
+      speaker: 'right',
       textLocation: {
         x: 40,
         y: 10


### PR DESCRIPTION
## Features

Adds text animation length property to the Cinematic schema and the ability for an action to be played over the dialog bubble animation.

This feature is relatively minimal as we're leveraging `Actions` built into Lanks.

Currently the character Lanks can't do any other animation that would be interrupted by talking.
Thus we assume  that after the talking animation concludes the Lanks go back to being idle.

##  Manual testing instructions

1. Navigate to `/editor/cinematic`
2. Make a new cinematic.
3. Create a new shot by clicking  on `shots` and the `+`.
4. Create a setup shot and a left character.
5. Click on the dialog nodes.
6. Create  a dialog node.
7.  Set the text property.
8. Set the textAnimation property.  I  recommend `build` or `move`.
9. Click test Cinematic on the top right.
10. Click on the `Enter` button when it lights up, and observe the lank moving.
