### PR TITLE
Set country and geo for returning users

### DIFF
--- a/app/core/api/users.coffee
+++ b/app/core/api/users.coffee
@@ -92,4 +92,9 @@ module.exports = {
         includeTrialRequests
       }
     })
+  
+  setCountryGeo: (options = {}) -> 
+    fetchJson("/db/user/setUserCountryGeo", _.assign({}, options, {
+      method: 'PUT'
+    }))
 }

--- a/app/core/auth.coffee
+++ b/app/core/auth.coffee
@@ -55,10 +55,8 @@ trackFirstArrival = ->
   storage.save(BEEN_HERE_BEFORE_KEY, true)
 
 setTestGroupNumberUS = ->
-  console.log("setting test group")
   if me and me.get("country") == 'united-states' and not me.get('testGroupNumberUS')?
     # Assign testGroupNumberUS to returning visitors; new ones in server/models/User
-    console.log("setting testgroup in if")
     me.set 'testGroupNumberUS', Math.floor(Math.random() * 256)
     me.patch()
 

--- a/app/core/auth.coffee
+++ b/app/core/auth.coffee
@@ -8,14 +8,16 @@ init = ->
   module.exports.me = window.me = new User(window.userObject) # inserted into main.html
   module.exports.me.onLoaded()
   trackFirstArrival()
+  # set country and geo fields for returning users if not set during account creation (/server/models/User - makeNew)
+  if not me.get('country')
+    $.ajax('/db/user/setUserCountryGeo', {method: 'PUT'}).then (res) ->
+      me.set(res)
+      setTestGroupNumberUS()
   if me and not me.get('testGroupNumber')?
     # Assign testGroupNumber to returning visitors; new ones in server/routes/auth
     me.set 'testGroupNumber', Math.floor(Math.random() * 256)
     me.patch()
-  if me and me.get("country") == 'united-states' and not me.get('testGroupNumberUS')?
-    # Assign testGroupNumberUS to returning visitors; new ones in server/models/User
-    me.set 'testGroupNumberUS', Math.floor(Math.random() * 256)
-    me.patch()
+  setTestGroupNumberUS()
   preferredLanguage = getQueryVariable('preferredLanguage')
   if me and features.codePlay and preferredLanguage
     me.set('preferredLanguage', preferredLanguage)
@@ -48,5 +50,11 @@ trackFirstArrival = ->
   return if beenHereBefore
   window.tracker?.trackEvent 'First Arrived'
   storage.save(BEEN_HERE_BEFORE_KEY, true)
+
+setTestGroupNumberUS = ->
+  if me and me.get("country") == 'united-states' and not me.get('testGroupNumberUS')?
+    # Assign testGroupNumberUS to returning visitors; new ones in server/models/User
+    me.set 'testGroupNumberUS', Math.floor(Math.random() * 256)
+    me.patch()
 
 init()

--- a/app/core/auth.coffee
+++ b/app/core/auth.coffee
@@ -3,6 +3,7 @@ User = require 'models/User'
 storage = require 'core/storage'
 BEEN_HERE_BEFORE_KEY = 'beenHereBefore'
 { getQueryVariable } = require('core/utils')
+api = require('core/api')
 
 init = ->
   module.exports.me = window.me = new User(window.userObject) # inserted into main.html
@@ -10,9 +11,11 @@ init = ->
   trackFirstArrival()
   # set country and geo fields for returning users if not set during account creation (/server/models/User - makeNew)
   if not me.get('country')
-    $.ajax('/db/user/setUserCountryGeo', {method: 'PUT'}).then (res) ->
+    api.users.setCountryGeo()
+    .then (res) ->
       me.set(res)
       setTestGroupNumberUS()
+    .catch((e) => console.error("Error in setting country and geo:", e))
   if me and not me.get('testGroupNumber')?
     # Assign testGroupNumber to returning visitors; new ones in server/routes/auth
     me.set 'testGroupNumber', Math.floor(Math.random() * 256)
@@ -52,8 +55,10 @@ trackFirstArrival = ->
   storage.save(BEEN_HERE_BEFORE_KEY, true)
 
 setTestGroupNumberUS = ->
+  console.log("setting test group")
   if me and me.get("country") == 'united-states' and not me.get('testGroupNumberUS')?
     # Assign testGroupNumberUS to returning visitors; new ones in server/models/User
+    console.log("setting testgroup in if")
     me.set 'testGroupNumberUS', Math.floor(Math.random() * 256)
     me.patch()
 


### PR DESCRIPTION
Setting country and geo for returning users so that any code paths that don't set the country/geo when the user is created can be covered.

Related server PR: https://github.com/codecombat/codecombat-server/pull/79