### PR TITLE
[Prototype] Backbone Sub Vue

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -312,7 +312,7 @@ module.exports = class CocoRouter extends Backbone.Router
         console.debug("Skipping route in Backbone - delegating to Vue app")
         return
       else if options.vueRoute  # Routing to a vue component using VueComponentView
-        vueComponentView = require 'views/core/VueComponentView'
+        vueComponentView = require 'app/views/core/VueComponentView'
         view = new vueComponentView(ViewClass.default, options, args...)
       else
         view = new ViewClass(options, args...)  # options, then any path fragment args

--- a/app/views/core/SubVueComponentView.js
+++ b/app/views/core/SubVueComponentView.js
@@ -1,0 +1,55 @@
+
+// This is the base backbone view to render any VueComponent.
+// Pass the vue component, propsData, base template into the constructor
+
+import CocoView from 'views/core/CocoView'
+import store from 'core/store'
+
+const silentStore = { commit: _.noop, dispatch: _.noop }
+
+export default class VueComponentView extends CocoView {
+  constructor (options) {
+    super(options)
+
+    this.props = {}
+  }
+
+  getMountPoint() {
+    return this.$el[0]
+  }
+
+  buildVueComponent() {
+    return new this.VueComponent({
+      el: this.getMountPoint(),
+      propsData: this.props,
+      store: store
+    })
+  }
+
+  setState (state = {})  {
+    for (const key of Object.keys(state)) {
+      Vue.set(
+        this.props,
+        key,
+        state[key]
+      )
+    }
+  }
+
+  afterRender() {
+    if (!this.vueComponent) {
+      this.vueComponent = this.buildVueComponent()
+    }
+
+    this.props = this.vueComponent.$props
+
+    super.afterRender()
+  }
+
+  destroy() {
+    super.destroy()
+
+    this.vueComponent.$destroy()
+    this.vueComponent.$store = silentStore
+  }
+}

--- a/app/views/core/SubVueComponentView.js
+++ b/app/views/core/SubVueComponentView.js
@@ -11,6 +11,10 @@ export default class VueComponentView extends CocoView {
   constructor (options) {
     super(options)
 
+    if (!this.VueComponent) {
+      throw new Error('Class must be initialized with VueComponent')
+    }
+
     this.props = {}
   }
 

--- a/app/views/core/SubVueComponentView.js
+++ b/app/views/core/SubVueComponentView.js
@@ -1,7 +1,3 @@
-
-// This is the base backbone view to render any VueComponent.
-// Pass the vue component, propsData, base template into the constructor
-
 import CocoView from 'views/core/CocoView'
 import store from 'core/store'
 
@@ -40,7 +36,7 @@ export default class VueComponentView extends CocoView {
     }
   }
 
-  afterRender() {
+  afterRender () {
     if (!this.vueComponent) {
       this.vueComponent = this.buildVueComponent()
     }

--- a/app/views/core/VueComponentView.js
+++ b/app/views/core/VueComponentView.js
@@ -43,6 +43,8 @@ module.exports = class VueComponentView extends RootView {
   }
 
   destroy() {
+    super.destroy()
+
     this.vueComponent.$destroy()
     this.vueComponent.$store = silentStore
   }

--- a/app/views/core/VueComponentView.js
+++ b/app/views/core/VueComponentView.js
@@ -1,4 +1,3 @@
-
 // This is the base backbone view to render any VueComponent.
 // Pass the vue component, propsData, base template into the constructor
 
@@ -10,14 +9,16 @@ const silentStore = { commit: _.noop, dispatch: _.noop }
 module.exports = class VueComponentView extends RootView {
   constructor (component, options) {
     super(options)
+
     const baseTemplate = options.baseTemplate || 'base-flat'  //base template, by default using base-flat
     this.id = 'vue-component-view'
+
     try {
       this.template = require('templates/'+ baseTemplate)
-    }
-    catch (err) {
+    } catch (err) {
       console.error("Error in importing the base template.", err)
     }
+
     this.VueComponent = component
     this.propsData = options.propsData
   }
@@ -30,19 +31,30 @@ module.exports = class VueComponentView extends RootView {
     })
   }
 
+  setState (state = {})  {
+    for (const key of Object.keys(state)) {
+      Vue.set(
+        this.props,
+        key,
+        state[key]
+      )
+    }
+  }
+
   afterRender() {
     if (this.vueComponent) {
       this.$el.find('#site-content-area').replaceWith(this.vueComponent.$el)
-    }
-    else{
+    } else {
       this.vueComponent = this.buildVueComponent()
       window.rootComponent = this.vueComponent
     }
 
+    this.propsData = this.vueComponent.$props
+
     super.afterRender()
   }
 
-  destroy() {
+  destroy () {
     super.destroy()
 
     this.vueComponent.$destroy()

--- a/app/views/play/level/LevelGoals.vue
+++ b/app/views/play/level/LevelGoals.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
   div
-    // TODO: Split this into two components, one the ul, the other the goals-status 
+    // TODO: Split this into two components, one the ul, the other the goals-status
     ul#primary-goals-list(dir="auto")
       level-goal(
         v-for="goal in levelGoals",
@@ -18,7 +18,7 @@
         :goal="goal",
         :state="goalStates[goal.id]",
       )
-      
+
     div.goals-status.rtl-allowed(v-if="showStatus")
       span {{ $t("play_level.goals") }}
       span.spr :
@@ -36,16 +36,32 @@
   LevelGoal = require('./LevelGoal').default
 
   module.exports = Vue.extend({
-    props: ['showStatus']
-    
-    data: -> {
-      overallStatus: ''
-      timedOut: false
-      goals: [] # TODO: Get goals, goalStates from vuex
-      goalStates: {}
-      casting: false
-    },
-    
+    props: {
+        showStatus:
+          type: Boolean
+          default: false
+
+        overallStatus:
+          type: String
+          default: ''
+
+        timedOut:
+          type: Boolean
+          default: false
+
+        goals:
+          type: Array
+          default: []
+
+        goalStates:
+          type: Object
+          default: {}
+
+        casting:
+          type: Boolean
+          default: false
+    }
+
     computed: {
       classToShow: ->
         classToShow = 'success' if @overallStatus is 'success'
@@ -94,7 +110,7 @@
       color: rgb(245, 170, 49)
     .running
       color: rgb(200, 200, 200)
-  
+
   ul
     padding-left: 0
     margin-bottom: 0
@@ -102,7 +118,7 @@
 
     body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
       padding-right: 0
-  
+
   #concept-goals-list
     margin-left: 20px
 

--- a/app/views/play/level/LevelGoalsView.coffee
+++ b/app/views/play/level/LevelGoalsView.coffee
@@ -40,6 +40,8 @@ module.exports = class LevelGoalsView extends SubVueComponentView
     super options
     @level = options.level
 
+    @setState({ showStatus: true })
+
   getMountPoint: ->
     return @$('.goals-component')[0]
 

--- a/app/views/play/level/LevelGoalsView.coffee
+++ b/app/views/play/level/LevelGoalsView.coffee
@@ -1,5 +1,5 @@
 require('app/styles/play/level/goals.sass')
-CocoView = require 'views/core/CocoView'
+SubVueComponentView = require('views/core/SubVueComponentView').default
 template = require 'templates/play/level/goals'
 {me} = require 'core/auth'
 utils = require 'core/utils'
@@ -10,7 +10,9 @@ LevelGoals = require('./LevelGoals').default
 store = require 'core/store'
 
 
-module.exports = class LevelGoalsView extends CocoView
+module.exports = class LevelGoalsView extends SubVueComponentView
+  VueComponent: LevelGoals
+
   id: 'goals-view'
   template: template
   className: 'secret expanded'
@@ -37,17 +39,22 @@ module.exports = class LevelGoalsView extends CocoView
   constructor: (options) ->
     super options
     @level = options.level
-    
-  afterRender: ->
-    @levelGoalsComponent = new LevelGoals({
-      el: @$('.goals-component')[0],
-      store
-      propsData: { showStatus: true }
-    })
+
+  getMountPoint: ->
+    return @$('.goals-component')[0]
+
+#  afterRender: ->
+#    @levelGoalsComponent = new LevelGoals({
+#      el: @$('.goals-component')[0],
+#      store
+#      propsData: { showStatus: true }
+#    })
 
   onNewGoalStates: (e) ->
-    _.assign(@levelGoalsComponent, _.pick(e, 'overallStatus', 'timedOut', 'goals', 'goalStates'))
-    @levelGoalsComponent.casting = false
+    @setState(_.pick(e, 'overallStatus', 'timedOut', 'goals', 'goalStates'))
+    @setState({ casting: false })
+#    _.assign(@levelGoalsComponent, _.pick(e, 'overallStatus', 'timedOut', 'goals', 'goalStates'))
+#    @levelGoalsComponent.casting = false
 
     firstRun = not @previousGoalStatus?
     @previousGoalStatus ?= {}
@@ -68,7 +75,7 @@ module.exports = class LevelGoalsView extends CocoView
 
   onTomeCast: (e) ->
     return if e.preload
-    @levelGoalsComponent.casting = true
+    @setState({ casting: true })
 
   onSetPlaying: (e) ->
     return unless e.playing

--- a/app/views/play/level/LevelGoalsView.coffee
+++ b/app/views/play/level/LevelGoalsView.coffee
@@ -45,18 +45,9 @@ module.exports = class LevelGoalsView extends SubVueComponentView
   getMountPoint: ->
     return @$('.goals-component')[0]
 
-#  afterRender: ->
-#    @levelGoalsComponent = new LevelGoals({
-#      el: @$('.goals-component')[0],
-#      store
-#      propsData: { showStatus: true }
-#    })
-
   onNewGoalStates: (e) ->
     @setState(_.pick(e, 'overallStatus', 'timedOut', 'goals', 'goalStates'))
     @setState({ casting: false })
-#    _.assign(@levelGoalsComponent, _.pick(e, 'overallStatus', 'timedOut', 'goals', 'goalStates'))
-#    @levelGoalsComponent.casting = false
 
     firstRun = not @previousGoalStatus?
     @previousGoalStatus ?= {}


### PR DESCRIPTION
This idea came out of a discussion with @AndrewJakubowicz on how we can being reskinning the level UX.  During the reskinning we do not want to reimplement existing Backbone views (we want to leverage the existing logic) but we do want to be able to write the new skins in Vue.  Ideally we could use Vue as a replacement for the template engine for these existing Backbone views until we have time to the rest of the view.

This fits well with our smart / dumb component model.  If we treat the existing Backbone view as a "smart" component (it has the business logic already implemented) then our Vue work for this project can exist entirely as "dumb" views.  If we implment the reskin as a set of Vue components that only take props (as presentational components should) then we can simply use those components again when we later migrate the smart Backbone view to Vue. 

It turns our we're already using this model in places within our code base.  `LevelGoalsView.coffee` is a great example, it uses Backbone to orchestrate the view and then passes the data to a rendered Vue component.  It's implementation doesn't quite fit with the presentational component structure we'd like (it does not use props, making the component incompatible with smart components).

This PR adds a prototype `SubVueComponentView` that is based off of `VueComponentView`.  It standardizes the rendering of a set of presentational Vue components within a Backbone view and allows data to be shared from Backbone to Vue via a simple `setState` method.

An example integration was shown with `LevelGoalsView.coffee`.  To integrate:

1. Extend `SubVueComponentView` instead of CocoView
1. Set `VueComponent` as an instance variable pointing to the Vue component you want to render.
1. Call setState whenever you have new data you want to pass to the Vue component.

The rest is handled for you.

We can also apply this to root views.  Using the same model we can use `VueComponentView` to render a presentational Vue component in place of a Jade template.  The steps are the same as above except we subclass `VueComponentView` instead of `SubVueComponentView`.

This can also be modified to support events and backbone mediator if necessary.  With minimal work we can proxy events between the two.