### PR TITLE
Add support for head tag management to Backbone / Vue

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -61,7 +61,6 @@ app/views/special_event/HoC2018VictoryModal.vue
 app/views/LicensorViewComponent.vue
 app/views/core/LoadingProgress.vue
 app/views/core/ParentReferTeacherModalComponent.vue
-app/views/core/Root.vue
 app/views/minigames/ConditionalMinigameComponent.vue
 app/views/school-administrator/SchoolAdministratorComponent.vue
 app/views/school-administrator/teachers/SchoolAdminTeacherListRow.vue

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,10 @@ module.exports = {
         'plugin:vue/recommended'
     ],
 
+    'globals': {
+        "Vue": "readonly"
+    },
+
     'env': {
         'browser': true,
         'es6': true

--- a/app/components/Root.vue
+++ b/app/components/Root.vue
@@ -4,13 +4,19 @@
   export default {
     components: {
       'meta-manager': MetaManger
+    },
+
+    computed: {
+      currentQueryParams: function () {
+        return this.$router.currentRoute.query
+      }
     }
   }
 </script>
 
 <template>
   <router-view>
-    <meta-manager>
+    <meta-manager :current-query-params="currentQueryParams">
       <slot />
     </meta-manager>
   </router-view>

--- a/app/components/Root.vue
+++ b/app/components/Root.vue
@@ -1,0 +1,17 @@
+<script>
+  import MetaManger from './common/MetaManager'
+
+  export default {
+    components: {
+      'meta-manager': MetaManger
+    }
+  }
+</script>
+
+<template>
+  <router-view>
+    <meta-manager>
+      <slot />
+    </meta-manager>
+  </router-view>
+</template>

--- a/app/components/common/MetaManager.vue
+++ b/app/components/common/MetaManager.vue
@@ -3,14 +3,38 @@
    * Renderless component that manages default head tag configuration for vue-meta.
    */
   export default {
+    props: {
+      currentQueryParams: {
+        type: Object,
+        default: () => ({})
+      }
+    },
+
     metaInfo: function () {
+      const links = []
+      const utmKeys = Object
+        .keys(this.currentQueryParams || {})
+        .filter(k => k.startsWith('utm_'))
+
+      if (utmKeys.length > 0) {
+        const urlWithoutUtm = new URL(window.location.href)
+
+        const urlSearchParams = new URLSearchParams(urlWithoutUtm.search)
+        utmKeys.forEach(k => urlSearchParams.delete(k))
+
+        urlWithoutUtm.search = urlSearchParams.toString()
+        links.push({ vmid: 'rel-canonical', rel: 'canonical', href: urlWithoutUtm.toString() })
+      }
+
       return {
         title: this.$t('common.default_title'),
         titleTemplate: '%s | CodeCombat',
 
         meta: [
           { vmid: 'meta-description', name: 'description', content: this.$t('common.default_meta_description') }
-        ]
+        ],
+
+        link: links
       }
     },
 

--- a/app/components/common/MetaManager.vue
+++ b/app/components/common/MetaManager.vue
@@ -1,0 +1,21 @@
+<script>
+  /**
+   * Renderless component that manages default head tag configuration for vue-meta.
+   */
+  export default {
+    metaInfo: function () {
+      return {
+        title: this.$t('common.default_title'),
+        titleTemplate: '%s | CodeCombat',
+
+        meta: [
+          { vmid: 'meta-description', name: 'description', content: this.$t('common.default_meta_description') }
+        ]
+      }
+    },
+
+    render () {
+      return this.$slots.default
+    }
+  }
+</script>

--- a/app/core/BackboneVueMetaBinding/MetaInfoInjector.vue
+++ b/app/core/BackboneVueMetaBinding/MetaInfoInjector.vue
@@ -1,0 +1,25 @@
+<script>
+  /**
+   * Simple component that injects metaInfo from its props.  Used to override metaInfo in MetaManager
+   * component.
+   *
+   * {@see BackboneVueMetaBinding}
+   */
+  export default Vue.extend({
+
+    props: {
+      meta: {
+        type: Object,
+        default: () => ({})
+      }
+    },
+
+    metaInfo () {
+      return this.meta
+    }
+  })
+</script>
+
+<template>
+  <span />
+</template>

--- a/app/core/BackboneVueMetaBinding/index.vue
+++ b/app/core/BackboneVueMetaBinding/index.vue
@@ -1,0 +1,65 @@
+<script>
+  import { merge } from 'lodash'
+
+  import MetaManager from 'app/components/common/MetaManager'
+  import MetaInfoInjector from './MetaInfoInjector'
+
+  /**
+   * Allows Backbone based views to update head tags using the same API as our Vue components.  Also sets default
+   * head tag configuration for Backbone Views.  Exposes a single method setMeta that can be used by Backbone
+   * Views to update head tag configuration.
+   *
+   * Note this component acts as a binding between Backbone and vue-meta, it should not be used directly in
+   * Backbone Views.  It's functionality is exposed via methods in {@link RootView}
+   */
+  export default Vue.extend({
+    components: {
+      'meta-manager': MetaManager,
+      'meta-info-injector': MetaInfoInjector
+    },
+
+    props: {
+      baseMeta: {
+        type: Object,
+        default: () => ({})
+      },
+
+      legacyTitle: {
+        type: String,
+        default: () => ''
+      }
+    },
+
+    data: function () {
+      const currentUrl = new URL(window.location.href)
+      const currentQueryParams = {}
+
+      new URLSearchParams(currentUrl.search).forEach((v, k) => {
+        currentQueryParams[k] = v
+      })
+
+      const meta = merge({}, this.baseMeta)
+
+      if (this.legacyTitle.trim().length > 0) {
+        meta.title = this.legacyTitle.trim()
+      }
+
+      return {
+        meta,
+        currentQueryParams
+      }
+    },
+
+    methods: {
+      setMeta: function (meta) {
+        this.meta = merge({}, this.meta, meta)
+      }
+    }
+  })
+</script>
+
+<template>
+  <meta-manager :current-query-params="currentQueryParams">
+    <meta-info-injector :meta="meta" />
+  </meta-manager>
+</template>

--- a/app/core/initialize.coffee
+++ b/app/core/initialize.coffee
@@ -7,12 +7,14 @@ VueRouter = require 'vue-router'
 Vuex = require 'vuex'
 VTooltip = require 'v-tooltip'
 VueMoment = require 'vue-moment'
+VueMeta = require 'vue-meta'
 
 Vue.use(VueRouter.default)
 Vue.use(Vuex.default)
 Vue.use(VueMoment.default)
 
 Vue.use(VTooltip.default)
+Vue.use(VueMeta)
 
 channelSchemas =
   'auth': require 'schemas/subscriptions/auth'

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1,7 +1,7 @@
 ﻿module.exports = nativeDescription: "English", englishDescription: "English", translation:
   new_home:
-    title: "CodeCombat - Learn Python and JavaScript through a coding game"
-    meta_description: "Learn typed code through a programming game. Learn Python, JavaScript, and HTML as you solve puzzles and learn to make your own games and websites."
+    title: "CodeCombat - Coding games to learn Python and JavaScript"
+    meta_description: "Learn typed code through a programming game. Learn Python, JavaScript, and HTML as you solve puzzles and learn to make your own coding games and websites."
     built_for_teachers_title: "A Coding Game Built with Teachers in Mind"
     built_for_teachers_blurb: "Teaching kids to code can often feel overwhelming. CodeCombat helps all educators teach students how to code in either JavaScript or Python, two of the most popular programming languages. With a comprehensive curriculum that includes six computer science units and reinforces learning through project-based game development and web development units, kids will progress on a journey from basic syntax to recursion!"
     built_for_teachers_subtitle1: "Computer Science"
@@ -210,7 +210,12 @@
     subscribe_as_diplomat: "Subscribe as a Diplomat"
 
   play:
+    title: 'Play CodeCombat Levels - Learn Python, JavaScript, and HTML'
+    meta_description: 'Learn programming with a coding game for beginners. Learn Python or JavaScript as you solve mazes, make your own games, and level up. Challenge your friends in multiplayer arena levels!'
     level_title: '__level__ - Learn to Code in Python, JavaScript, HTML'
+    video_title: '__video__ | Video Level'
+    game_development_title: '__level__ | Game Development'
+    web_development_title: '__level__ | Web Development'
     anon_signup_title_1: "CodeCombat has a"
     anon_signup_title_2: "Classroom Version!"
     anon_signup_enter_code: "Enter Class Code:"
@@ -425,8 +430,8 @@
     books: "Books"
 
   common:
-    default_title: "CodeCombat - Learn Python and JavaScript through a coding game"
-    default_meta_description: "Learn programming with a multiplayer live coding strategy game for beginners. Learn Python or JavaScript as you defeat ogres, solve mazes, and level up. Open source HTML5 game!"
+    default_title: "CodeCombat - Coding games to learn Python and JavaScript"
+    default_meta_description: "Learn typed code through a programming game. Learn Python, JavaScript, and HTML as you solve puzzles and learn to make your own coding games and websites."
     back: "Back" # When used as an action verb, like "Navigate backward"
     coming_soon: "Coming soon!"
     continue: "Continue"  # When used as an action verb, like "Continue forward"
@@ -1033,6 +1038,8 @@
     editor_config_behaviors_description: "Autocompletes brackets, braces, and quotes."
 
   about:
+    title: "About CodeCombat - Engaging Students, Empowering Teachers, Inspiring Creation"
+    meta_description: "Our mission is to level computer science through game-based learning and make coding accessible to every learner. We believe programming is magic and want learners to be empowered to to create things from pure imagination."
     learn_more: "Learn More"
     main_title:"If you want to learn to program, you need to write (a lot of) code."
     main_description: "At CodeCombat, our job is to make sure you're doing that with a smile on your face."
@@ -1321,6 +1328,9 @@
     contribute_to_the_project: "Contribute to the project"
 
   clans:
+    title: 'Join CodeCombat Clans - Learn to Code in Python, JavaScript, and HTML'
+    clan_title: '__clan__ - Join CodeCombat Clans and Learn to Code'
+    meta_description: 'Join a Clan or build your own community of coders. Play multiplayer arena levels and level up your hero and your coding skills.'
     clan: "Clan"
     clans: "Clans"
     new_name: "New clan name"
@@ -1831,6 +1841,8 @@
     starter_license: "Starter License"
     trial: "Trial"
     hoc_welcome: "Happy Computer Science Education Week"
+    hoc_title: "Hour of Code Games - Free Activities to Learn Real Coding Languages"
+    hoc_meta_description: "Make your own game or code your way out of a dungeon! CodeCombat has four different Hour of Code activities and over 60 levels to learn code, play, and create."
     hoc_intro: "There are three ways for your class to participate in Hour of Code with CodeCombat"
     hoc_self_led: "Self-Led Gameplay"
     hoc_self_led_desc: "Students can play through two Hour of Code CodeCombat tutorials on their own"
@@ -2148,6 +2160,8 @@
     helpful_ambassadors: "Our Helpful Ambassadors:"
 
   ladder:
+    title: 'Multiplayer Arenas'
+    arena_title: '__arena__ | Multiplayer Arenas'
     my_matches: "My Matches"
     simulate: "Simulate"
     simulation_explanation: "By simulating games you can get your game ranked faster!"
@@ -2212,6 +2226,7 @@
     ogres: "Blue"
 
   user:
+    user_title: '__name__ - Learn to Code with CodeCombat'
     stats: "Stats"
     singleplayer_title: "Singleplayer Levels"
     multiplayer_title: "Multiplayer Levels"
@@ -2250,6 +2265,13 @@
     left_xp_postfix: ""
 
   account:
+    title: 'Account'
+    settings_title: 'Account Settings'
+    unsubscribe_title: 'Unsubscribe'
+    payments_title: 'Payments'
+    subscription_title: 'Subscription'
+    invoices_title: 'Invoices'
+    prepaids_title: 'Prepaids'
     payments: "Payments"
     prepaid_codes: "Prepaid Codes"
     purchased: "Purchased"
@@ -2683,6 +2705,8 @@
     your_parentheses_must_match: "Your parentheses must match."
 
   apcsp:
+    title: 'AP Computer Science Principals | College Board Endorsed'
+    meta_description: 'CodeCombat’s comprehensive curriculum and professional development program are all you need to offer College Board’s newest computer science course to your students.'
     syllabus: "AP CS Principles Syllabus"
     syllabus_description: "Use this resource to plan CodeCombat curriculum for your AP Computer Science Principles class."
     computational_thinking_practices: "Computational Thinking Practices"

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1,5 +1,7 @@
 ﻿module.exports = nativeDescription: "English", englishDescription: "English", translation:
   new_home:
+    title: "CodeCombat - Learn Python and JavaScript through a coding game"
+    meta_description: "Learn typed code through a programming game. Learn Python, JavaScript, and HTML as you solve puzzles and learn to make your own games and websites."
     built_for_teachers_title: "A Coding Game Built with Teachers in Mind"
     built_for_teachers_blurb: "Teaching kids to code can often feel overwhelming. CodeCombat helps all educators teach students how to code in either JavaScript or Python, two of the most popular programming languages. With a comprehensive curriculum that includes six computer science units and reinforces learning through project-based game development and web development units, kids will progress on a journey from basic syntax to recursion!"
     built_for_teachers_subtitle1: "Computer Science"
@@ -208,6 +210,7 @@
     subscribe_as_diplomat: "Subscribe as a Diplomat"
 
   play:
+    level_title: '__level__ - Learn to Code in Python, JavaScript, HTML'
     anon_signup_title_1: "CodeCombat has a"
     anon_signup_title_2: "Classroom Version!"
     anon_signup_enter_code: "Enter Class Code:"
@@ -422,6 +425,8 @@
     books: "Books"
 
   common:
+    default_title: "CodeCombat - Learn Python and JavaScript through a coding game"
+    default_meta_description: "Learn programming with a multiplayer live coding strategy game for beginners. Learn Python or JavaScript as you defeat ogres, solve mazes, and level up. Open source HTML5 game!"
     back: "Back" # When used as an action verb, like "Navigate backward"
     coming_soon: "Coming soon!"
     continue: "Continue"  # When used as an action verb, like "Continue forward"
@@ -2819,6 +2824,7 @@
     teacher_email: "Teacher's email address"
 
   school_administrator:
+    title: 'School Administrator Dashboard',
     my_teachers: 'My Teachers'
     last_login: 'Last Login'
     licenses_used: 'licenses used'

--- a/app/templates/static/layout.static.pug
+++ b/app/templates/static/layout.static.pug
@@ -6,7 +6,6 @@ html(lang='en')
     meta(name='viewport', content='width=1024')
     meta(http-equiv='Accept-CH', content='Viewport-Width')
     title CodeCombat - Learn how to code by playing a game
-    meta(name='description', content='Learn programming with a multiplayer live coding strategy game for beginners. Learn Python or JavaScript as you defeat ogres, solve mazes, and level up. Open source HTML5 game!')
     meta(property='og:title', content='CodeCombat: Learn to Code by Playing a Game')
     meta(property='og:url', content='http://codecombat.com')
     meta(property='og:type', content='game')
@@ -67,7 +66,7 @@ html(lang='en')
 
     script(src='https://checkout.stripe.com/checkout.js')
     // CodePlay Tags Header
-    
+
     // Webpack-inserted CSS:
     //- (will be inserted at runtime)
 

--- a/app/views/AboutView.coffee
+++ b/app/views/AboutView.coffee
@@ -19,7 +19,11 @@ module.exports = class AboutView extends RootView
     'left': 'onLeftPressed'
     'esc': 'onEscapePressed'
 
-  getTitle: -> return $.i18n.t('nav.about')
+  getMeta: ->
+    title: $.i18n.t 'about.title'
+    meta: [
+      { vmid: 'meta-description', name: 'description', content: $.i18n.t 'about.meta_description' }
+    ]
 
   afterRender: ->
     super(arguments...)

--- a/app/views/HomeView.coffee
+++ b/app/views/HomeView.coffee
@@ -31,6 +31,8 @@ module.exports = class HomeView extends RootView
     'click a': 'onClickAnchor'
 
   initialize: (options) ->
+    super(options)
+
     @courses = new Courses()
     @supermodel.trackRequest @courses.fetchReleased()
 
@@ -43,6 +45,10 @@ module.exports = class HomeView extends RootView
     title: $.i18n.t 'new_home.title'
     meta: [
         { vmid: 'meta-description', name: 'description', content: $.i18n.t 'new_home.meta_description' }
+    ],
+    link: [
+      { vmid: 'rel-canonical', rel: 'canonical', href: 'https://' + window.location.hostname  }
+
     ]
 
   onLoaded: ->

--- a/app/views/HomeView.coffee
+++ b/app/views/HomeView.coffee
@@ -39,6 +39,12 @@ module.exports = class HomeView extends RootView
       @trialRequests.fetchOwn()
       @supermodel.loadCollection(@trialRequests)
 
+  getMeta: ->
+    title: $.i18n.t 'new_home.title'
+    meta: [
+        { vmid: 'meta-description', name: 'description', content: $.i18n.t 'new_home.meta_description' }
+    ]
+
   onLoaded: ->
     @trialRequest = @trialRequests.first() if @trialRequests?.size()
     @isTeacherWithDemo = @trialRequest and @trialRequest.get('status') in ['approved', 'submitted']

--- a/app/views/account/AccountSettingsRootView.coffee
+++ b/app/views/account/AccountSettingsRootView.coffee
@@ -7,9 +7,12 @@ CreateAccountModal = require 'views/core/CreateAccountModal'
 module.exports = class AccountSettingsRootView extends RootView
   id: "account-settings-root-view"
   template: template
-  
+
   events:
     'click #save-button': -> @accountSettingsView.save()
+
+  getMeta: ->
+    title: $.i18n.t 'account.settings_title'
 
   shortcuts:
     'enter': -> @

--- a/app/views/account/InvoicesView.coffee
+++ b/app/views/account/InvoicesView.coffee
@@ -21,6 +21,9 @@ module.exports = class InvoicesView extends RootView
     @amount = utils.getQueryVariable('a', 0)
     @description = utils.getQueryVariable('d', '')
 
+  getMeta: ->
+    title: $.i18n.t 'account.invoices_title'
+
   onPayButton: ->
     @description = $('#description').val()
 

--- a/app/views/account/MainAccountView.coffee
+++ b/app/views/account/MainAccountView.coffee
@@ -8,3 +8,6 @@ module.exports = class MainAccountView extends RootView
 
   events:
     'click .logout-btn': 'logoutAccount'
+
+  getMeta: ->
+    title: $.i18n.t 'account.title'

--- a/app/views/account/PaymentsView.coffee
+++ b/app/views/account/PaymentsView.coffee
@@ -9,25 +9,30 @@ module.exports = class PaymentsView extends RootView
   template: template
 
   initialize: ->
+    super()
+
     @payments = new Payments()
     @supermodel.trackRequest @payments.fetchByRecipient(me.id)
     @prepaids = new Prepaids()
     @supermodel.trackRequest @prepaids.fetchByCreator(me.id, {data: {allTypes: true}})
 
+  getMeta: ->
+    title: $.i18n.t 'account.payments_title'
+
   onLoaded: ->
     @prepaidMap = _.zipObject(_.map(@prepaids.models, (m) => m.id), @prepaids.models)
     @reload?()
-    
+
     # for administration
     for payment in @payments.models
       payPal = payment.get('payPal')
       transactionId = payPal?.transactions?[0]?.related_resources?[0]?.sale?.id
       if transactionId
         console.log('PayPal Payment', transactionId, payment.get('amount'))
-      
+
       payPalSale = payment.get('payPalSale')
       transactionId = payPalSale?.id
       if transactionId
         console.log('PayPal Subscription Payment', transactionId)
-    
+
     super()

--- a/app/views/account/PrepaidView.coffee
+++ b/app/views/account/PrepaidView.coffee
@@ -18,6 +18,8 @@ module.exports = class PrepaidView extends RootView
     'click #redeem-code-btn': 'onClickRedeemCodeButton'
 
   initialize: ->
+    super()
+
     # HACK: Make this one specific page responsive on mobile.
     $('head').append('<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">');
 
@@ -30,13 +32,16 @@ module.exports = class PrepaidView extends RootView
       @ppcQuery = true
       @loadPrepaid(@ppc)
 
+  getMeta: ->
+    title: $.i18n.t 'account.prepaids_title'
+
   afterRender: ->
     super()
     @$el.find("span[title]").tooltip()
 
   statusMessage: (message, type='alert') ->
     noty text: message, layout: 'topCenter', type: type, killer: false, timeout: 5000, dismissQueue: true, maxVisible: 3
-    
+
   confirmRedeem: =>
 
     options =

--- a/app/views/account/SubscriptionView.coffee
+++ b/app/views/account/SubscriptionView.coffee
@@ -63,6 +63,9 @@ module.exports = class SubscriptionView extends RootView
     @products = new Products()
     @supermodel.loadCollection @products
 
+  getMeta: ->
+    title: $.i18n.t 'account.subscription_title'
+
   # Personal Subscriptions
 
   onClickStartSubscription: (e) ->

--- a/app/views/account/UnsubscribeView.coffee
+++ b/app/views/account/UnsubscribeView.coffee
@@ -14,6 +14,9 @@ module.exports = class UnsubscribeView extends RootView
   events:
     'click #unsubscribe-button': 'onUnsubscribeButtonClicked'
 
+  getMeta: ->
+    title: $.i18n.t 'account.unsubscribe_title'
+
   onUnsubscribeButtonClicked: ->
     @$el.find('#unsubscribe-button').hide()
     @$el.find('.progress').show()

--- a/app/views/clans/ClanDetailsView.coffee
+++ b/app/views/clans/ClanDetailsView.coffee
@@ -21,6 +21,12 @@ module.exports = class ClanDetailsView extends RootView
   id: 'clan-details-view'
   template: template
 
+  getMeta: ->
+    title: $.i18n.t 'clans.title'
+    meta: [
+      { vmid: 'meta-description', name: 'description', content: $.i18n.t 'clans.meta_description' }
+    ]
+
   events:
     'change .expand-progress-checkbox': 'onExpandedProgressCheckbox'
     'click .delete-clan-btn': 'onDeleteClan'
@@ -201,6 +207,10 @@ module.exports = class ClanDetailsView extends RootView
     @render?()
 
   onClanSync: ->
+    @setMeta({
+      title: $.i18n.t('clans.clan_title', { clan: @clan.get('name') })
+    })
+
     unless @owner?
       @owner = new User _id: @clan.get('ownerID')
       @listenTo @owner, 'sync', => @render?()

--- a/app/views/clans/ClansView.coffee
+++ b/app/views/clans/ClansView.coffee
@@ -14,6 +14,11 @@ module.exports = class ClansView extends RootView
   id: 'clans-view'
   template: template
 
+  getMeta: ->
+    title: $.i18n.t 'clans.title'
+    meta: [
+      { vmid: 'meta-description', name: 'description', content: $.i18n.t 'clans.meta_description' }
+    ]
 
   events:
     'click .create-clan-btn': 'onClickCreateClan'
@@ -22,6 +27,8 @@ module.exports = class ClansView extends RootView
     'click .private-clan-checkbox': 'onClickPrivateCheckbox'
 
   initialize: ->
+    super()
+
     @publicClansArray = []
     @myClansArray = []
     @idNameMap = {}

--- a/app/views/core/Root.vue
+++ b/app/views/core/Root.vue
@@ -1,7 +1,0 @@
-<template>
-    <router-view></router-view>
-</template>
-
-<script>
-  export default {}
-</script>

--- a/app/views/core/RootView.coffee
+++ b/app/views/core/RootView.coffee
@@ -1,6 +1,8 @@
 # A root view is one that replaces everything else on the screen when it
 # comes into being, as opposed to sub-views which get inserted into other views.
 
+merge = require('lodash').merge
+
 CocoView = require './CocoView'
 
 {logoutUser, me} = require('core/auth')
@@ -10,6 +12,8 @@ Achievement = require 'models/Achievement'
 AchievementPopup = require 'views/core/AchievementPopup'
 errors = require 'core/errors'
 utils = require 'core/utils'
+
+BackboneVueMetaBinding = require('app/core/BackboneVueMetaBinding').default
 
 # TODO remove
 
@@ -38,6 +42,14 @@ module.exports = class RootView extends CocoView
 
   shortcuts:
     'ctrl+shift+a': 'navigateToAdmin'
+
+  initialize: (options) ->
+    super(options)
+
+    try
+      @initializeMetaBinding()
+    catch e
+      console.error 'Failed to initialize meta binding', e
 
   showNewAchievement: (achievement, earnedAchievement) ->
     earnedAchievement.set('notified', true)
@@ -95,8 +107,8 @@ module.exports = class RootView extends CocoView
     AuthModal = require 'views/core/AuthModal'
     if @id is 'home-view'
       properties = { category: 'Homepage' }
-      window.tracker?.trackEvent 'Login', properties, ['Google Analytics'] 
-      
+      window.tracker?.trackEvent 'Login', properties, ['Google Analytics']
+
       eventAction = $(e.target)?.data('event-action')
       if $(e.target)?.hasClass('track-ab-result')
         _.extend(properties, { trackABResult: true })
@@ -126,16 +138,6 @@ module.exports = class RootView extends CocoView
     @chooseTab(location.hash.replace('#', '')) if location.hash
     @buildLanguages()
     $('body').removeClass('is-playing')
-
-    if title = @getTitle() then title += ' | CodeCombat'
-    else title = 'CodeCombat - Learn how to code by playing a game'
-
-    if localStorage?.showViewNames
-      title = @constructor.name
-
-    $('title').text(title)
-
-  getTitle: -> ''
 
   chooseTab: (category) ->
     $("a[href='##{category}']", @$el).tab('show')
@@ -216,3 +218,55 @@ module.exports = class RootView extends CocoView
 
   onTreemaError: (e) ->
     noty text: e.message, layout: 'topCenter', type: 'error', killer: false, timeout: 5000, dismissQueue: true
+
+  # Initialize the binding to vue-meta by initializing a Vue component that sets the head tags
+  # on render.  This binding will be destroyed via the Vue component's $destory method when
+  # this view is destroyed.  Views can specify @skipMetaBinding = true when they want to manage
+  # head tags in their own way.  This is useful for legacy Vue components that eventually inherit
+  # from RootView (ie RootComponent and VueComponentView).  These views can use vue-meta directly
+  # within their Vue components.
+  initializeMetaBinding: ->
+    if @metaBinding
+      return @metaBinding
+
+    # Set a noop meta binding object when the view opts to skip meta binding
+    if @skipMetaBinding
+      return @metaBinding = {
+        $destroy: ->
+        setMeta: ->
+      }
+
+    legacyTitle = @getTitle()
+    if localStorage?.showViewNames
+      legacyTitle = @constructor.name
+
+    # Create an empty, mounted element so that the vue component actually renders and runs vue-meta
+    @metaBinding = new BackboneVueMetaBinding({
+      el: document.createElement('div'),
+      propsData: {
+        baseMeta: @getMeta(),
+        legacyTitle: legacyTitle
+      }
+    })
+
+  # Set the page title when the view is loaded.  This value is merged into the
+  # result of getMeta.  It will override any title specified in getMeta.  Kept
+  # for backwards compatibility
+  getTitle: -> ''
+
+  # Head tag configuration used to configure vue-meta when the View is loaded.
+  # See https://vue-meta.nuxtjs.org/ for available configuration options.  This
+  # can be later modified by calling setMeta
+  getMeta: -> {}
+
+  # Allow async updates of the view's meta configuration.  This can be used in addition to getMeta
+  # to update meta configuration when the meta configuration is computed asynchronously
+  setMeta: (meta) ->
+    @metaBinding.setMeta(meta)
+
+  destroy: ->
+    super()
+
+    if @metaBinding
+      @metaBinding.$destroy()
+      delete @metaBinding

--- a/app/views/core/SingletonAppVueComponentView.js
+++ b/app/views/core/SingletonAppVueComponentView.js
@@ -3,13 +3,16 @@ import VueComponentView from './VueComponentView'
 import store from 'core/store'
 import cocoVueRouter from 'app/core/vueRouter'
 
-import Root from './Root'
+import Root from '../../components/Root'
 
 export default class SingletonAppVueComponentView extends VueComponentView {
 
   constructor () {
     // For now we only support the default the default base-flat template
     super(null, {})
+
+    // Head tag management will be performed inside of Vue app
+    this.skipMetaBinding = true
   }
 
   buildVueComponent () {

--- a/app/views/courses/CoursesView.coffee
+++ b/app/views/courses/CoursesView.coffee
@@ -41,9 +41,17 @@ module.exports = class CoursesView extends RootView
     'click .view-challenges-link': 'onClickViewChallengesLink'
     'click .view-videos-link': 'onClickViewVideosLink'
 
-  getTitle: -> return $.i18n.t('courses.students')
+  getMeta: ->
+    return {
+      title: $.i18n.t('courses.students')
+      links: [
+        { vmid: 'rel-canonical', rel: 'canonical', href: 'https://' + window.location.hostname + '/students'}
+      ]
+    }
 
   initialize: ->
+    super()
+
     @classCodeQueryVar = utils.getQueryVariable('_cc', false)
     @courseInstances = new CocoCollection([], { url: "/db/user/#{me.id}/course_instances", model: CourseInstance})
     @courseInstances.comparator = (ci) -> return parseInt(ci.get('classroomID'), 16) + utils.orderedCourseIDs.indexOf ci.get('courseID')
@@ -245,7 +253,7 @@ module.exports = class CoursesView extends RootView
     courseID = $(e.target).data('course-id')
     window.tracker?.trackEvent 'Students View To Student Assessments View', category: 'Students', classroomID: classroomID, ['Mixpanel']
     application.router.navigate("/students/assessments/#{classroomID}##{courseID}", { trigger: true })
-  
+
   onClickViewVideosLink: (e) ->
     classroomID = $(e.target).data('classroom-id')
     courseID = $(e.target).data('course-id')

--- a/app/views/courses/TeacherClassesView.coffee
+++ b/app/views/courses/TeacherClassesView.coffee
@@ -100,7 +100,10 @@ module.exports = class TeacherClassesView extends RootView
     'click .see-less-office-hours': 'onClickSeeLessOfficeHours'
     'click .see-no-office-hours': 'onClickSeeNoOfficeHours'
 
-  getTitle: -> $.i18n.t 'teacher.my_classes'
+  getMeta: ->
+    {
+      title: $.i18n.t 'teacher.my_classes'
+    }
 
   initialize: (options) ->
     super(options)

--- a/app/views/editor/level/LevelEditView.coffee
+++ b/app/views/editor/level/LevelEditView.coffee
@@ -95,6 +95,9 @@ module.exports = class LevelEditView extends RootView
     @courses = new CocoCollection([], { url: "/db/course", model: Course})
     @supermodel.loadCollection(@courses, 'courses')
 
+  getMeta: ->
+    title: 'Level Editor'
+
   destroy: ->
     clearInterval @timerIntervalID
     super()
@@ -102,8 +105,6 @@ module.exports = class LevelEditView extends RootView
   showLoading: ($el) ->
     $el ?= @$el.find('.outer-content')
     super($el)
-
-  getTitle: -> "LevelEditor - " + (@level.get('name') or '...')
 
   onLoaded: ->
     _.defer =>
@@ -160,7 +161,7 @@ module.exports = class LevelEditView extends RootView
   openRevertModal: (e) ->
     e.stopPropagation()
     @openModalView new RevertModal()
-  
+
   openGenerateTerrainModal: (e) ->
     e.stopPropagation()
     @openModalView new GenerateTerrainModal()

--- a/app/views/ladder/LadderView.coffee
+++ b/app/views/ladder/LadderView.coffee
@@ -70,6 +70,9 @@ module.exports = class LadderView extends RootView
 
   getMeta: ->
     title: $.i18n.t 'ladder.title'
+    link: [
+      { vmid: 'rel-canonical', rel: 'canonical', content: 'http://' + window.location.href + '/play' }
+    ]
 
   loadLeague: ->
     @leagueID = @leagueType = null unless @leagueType in ['clan', 'course']

--- a/app/views/ladder/LadderView.coffee
+++ b/app/views/ladder/LadderView.coffee
@@ -42,9 +42,15 @@ module.exports = class LadderView extends RootView
     'click .spectate-button': 'onClickSpectateButton'
 
   initialize: (options, @levelID, @leagueType, @leagueID) ->
+    super(options)
+
     if features.china and @leagueType == 'course' and @leagueID == "5cb8403a60778e004634ee6e"   #just for china tarena hackthon 2019 classroom RestPoolLeaf
       @leagueID = @leagueType = null
+
     @level = @supermodel.loadModel(new Level(_id: @levelID)).model
+    @level.once 'sync', (level) =>
+      @setMeta({ title: $.i18n.t 'ladder.arena_title', { arena: level.get('name') } })
+
     onLoaded = =>
       return if @destroyed
       @levelDescription = marked(@level.get('description')) if @level.get('description')
@@ -61,6 +67,9 @@ module.exports = class LadderView extends RootView
 
     @loadLeague()
     @urls = require('core/urls')
+
+  getMeta: ->
+    title: $.i18n.t 'ladder.title'
 
   loadLeague: ->
     @leagueID = @leagueType = null unless @leagueType in ['clan', 'course']

--- a/app/views/ladder/MainLadderView.coffee
+++ b/app/views/ladder/MainLadderView.coffee
@@ -17,6 +17,8 @@ module.exports = class MainLadderView extends RootView
   template: template
 
   initialize: ->
+    super()
+
     @levelStatusMap = []
     @levelPlayCountMap = []
     @campaigns = campaigns
@@ -27,6 +29,9 @@ module.exports = class MainLadderView extends RootView
     # TODO: Make sure this is also enabled server side.
     # Disabled due to high load on database.
     # @getLevelPlayCounts()
+
+  getMeta: ->
+    title: $.i18n.t 'ladder.title'
 
   onSessionsLoaded: (e) ->
     for session in @sessions.models

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -71,6 +71,9 @@ module.exports = class CampaignView extends RootView
     meta: [
       { vmid: 'meta-description', name: 'description', content: $.i18n.t 'play.meta_description' }
     ]
+    link: [
+      { vmid: 'rel-canonical', rel: 'canonical', content: 'http://' + window.location.href + '/play' }
+    ]
 
   subscriptions:
     'subscribe-modal:subscribed': 'onSubscribed'

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -66,6 +66,12 @@ module.exports = class CampaignView extends RootView
   id: 'campaign-view'
   template: template
 
+  getMeta: ->
+    title: $.i18n.t 'play.title'
+    meta: [
+      { vmid: 'meta-description', name: 'description', content: $.i18n.t 'play.meta_description' }
+    ]
+
   subscriptions:
     'subscribe-modal:subscribed': 'onSubscribed'
 
@@ -440,7 +446,7 @@ module.exports = class CampaignView extends RootView
           unless @levelStatusMap[session.get('levelID')] is 'complete'  # Don't overwrite a complete session with an incomplete one
             @levelStatusMap[session.get('levelID')] = if session.get('state')?.complete then 'complete' else 'started'
           @levelDifficultyMap[session.get('levelID')] = session.get('state').difficulty if session.get('state')?.difficulty
-       
+
   buildLevelScoreMap: ->
     for session in @sessions.models
       levels = @getLevels()
@@ -1006,9 +1012,9 @@ module.exports = class CampaignView extends RootView
     courseInstanceID = $(e.target).parents('.course-version').data 'course-instance-id'
 
     classroomLevel = @classroomLevelMap?[levelOriginal]
-    
+
     # If classroomItems is on, don't go to PlayLevelView directly.
-    # Go through LevelSetupManager which will load required modals before going to PlayLevelView. 
+    # Go through LevelSetupManager which will load required modals before going to PlayLevelView.
     if(me.showHeroAndInventoryModalsToStudents() and not classroomLevel?.isAssessment())
       @startLevel levelElement, courseID, courseInstanceID
       window.tracker?.trackEvent 'Clicked Start Level', category: 'World Map', levelID: levelSlug
@@ -1427,7 +1433,7 @@ module.exports = class CampaignView extends RootView
 
     if what in ['back-to-classroom']
       return isStudentOrTeacher and not application.getHocCampaign()
-    
+
     if what in ['videos']
       return me.isStudent() and @course?.get('_id') == utils.courseIDs.INTRODUCTION_TO_COMPUTER_SCIENCE
 

--- a/app/views/play/level/PlayGameDevLevelView.coffee
+++ b/app/views/play/level/PlayGameDevLevelView.coffee
@@ -157,6 +157,13 @@ module.exports = class PlayGameDevLevelView extends RootView
       throw e if e.stack
       @state.set('errorMessage', e.message)
 
+  getMeta: ->
+    return {
+      links: [
+        { vmid: 'rel-canonical', rel: 'canonical', href: 'https://' + window.location.hostname + '/play'}
+      ]
+    }
+
   onEditLevelButton: ->
     viewClass = 'views/play/level/PlayLevelView'
     route = "/play/level/#{@level.get('slug')}"

--- a/app/views/play/level/PlayGameDevLevelView.coffee
+++ b/app/views/play/level/PlayGameDevLevelView.coffee
@@ -39,6 +39,8 @@ module.exports = class PlayGameDevLevelView extends RootView
     'click #play-more-codecombat-btn': 'onClickPlayMoreCodeCombatButton'
 
   initialize: (@options, @sessionID) ->
+    super(@options)
+
     @state = new State({
       loading: true
       progress: 0
@@ -77,6 +79,11 @@ module.exports = class PlayGameDevLevelView extends RootView
 
     .then (levelLoader) =>
       { @level, @session, @world } = levelLoader
+
+      @setMeta({
+        title: $.i18n.t 'play.game_development_title', { level: @level.get('name') }
+      })
+
       @god.setLevel(@level.serialize {@supermodel, @session})
       @god.setWorldClassMap(@world.classMap)
       @goalManager = new GoalManager(@world, @level.get('goals'), @team)
@@ -223,7 +230,7 @@ module.exports = class PlayGameDevLevelView extends RootView
     if @world.uiText?.levelName
       @levelName = @world.uiText.levelName
       @renderSelectors '#directions'
-  
+
   updateVictoryMessage: ->
     if @world.uiText?.victoryMessage
       @victoryMessage = @world.uiText?.victoryMessage

--- a/app/views/play/level/PlayLevelVideoComponent.vue
+++ b/app/views/play/level/PlayLevelVideoComponent.vue
@@ -59,7 +59,10 @@ export default Vue.extend({
 
   metaInfo () {
     return {
-      title: this.$t('play.video_title', { video: this.videoData.title })
+      title: this.$t('play.video_title', { video: this.videoData.title }),
+      link: [
+        { vmid: 'rel-canonical', rel: 'canonical', content: 'http://' + window.location.href + '/play' }
+      ]
     }
   },
 

--- a/app/views/play/level/PlayLevelVideoComponent.vue
+++ b/app/views/play/level/PlayLevelVideoComponent.vue
@@ -17,7 +17,7 @@ flat-layout
           a#skip-btn(
             @click="onSkip",
             :href="nextLevelLink"
-          ) 
+          )
             u {{ $t('play_level.skip') }}
         .col-sm-6.text-uppercase
           a#next-level-btn.btn-illustrated.btn-success.btn-block.btn-lg.btn(
@@ -56,18 +56,21 @@ export default Vue.extend({
       required: true
     }
   },
+
+  metaInfo () {
+    return {
+      title: this.$t('play.video_title', { video: this.videoData.title })
+    }
+  },
+
   data: () => ({
-    videoData: {},
-    videoUrl: "",
     originalDisplaySettings: {}
   }),
+
   components: {
     'flat-layout': FlatLayout
   },
-  created() {
-    this.videoData = utils.videoLevels[this.levelOriginalID]
-    this.videoUrl = me.showChinaVideo() ? this.videoData.cn_url : this.videoData.url
-  },
+
   mounted() {
     this.$nextTick(function () {
       if(!me.showChinaVideo()){
@@ -77,7 +80,7 @@ export default Vue.extend({
         })
       }
       // hack to remove base template's header and footer
-      // store existing display settings to revert to these before leaving 
+      // store existing display settings to revert to these before leaving
       this.originalDisplaySettings = {
         'main-nav': $('#main-nav')[0]? $('#main-nav')[0].style.display : "",
         'footer': $('#footer')[0]? $('#footer')[0].style.display : "",
@@ -88,13 +91,23 @@ export default Vue.extend({
       if ($('#final-footer')[0])  $('#final-footer')[0].style.display = "none"
     })
   },
+
   beforeDestroy () {
     // make header and footer visible again before leaving
     if ($('#main-nav')[0])  $('#main-nav')[0].style.display = this.originalDisplaySettings['main-nav']
     if ($('#footer')[0])  $('#footer')[0].style.display = this.originalDisplaySettings['footer']
     if ($('#final-footer')[0])  $('#final-footer')[0].style.display = this.originalDisplaySettings['final-footer']
   },
+
   computed: {
+    videoData: function () {
+      return utils.videoLevels[this.levelOriginalID] || {}
+    },
+
+    videoUrl: function () {
+      return me.showChinaVideo() ? this.videoData.cn_url : this.videoData.url
+    },
+
     nextLevelLink: function () {
       let link = ''
       if (me.isSessionless()){
@@ -110,6 +123,7 @@ export default Vue.extend({
       return link
     }
   },
+
   methods: {
     onNextLevel: function() {
       if (window.tracker){
@@ -124,8 +138,9 @@ export default Vue.extend({
         )
       }
     },
+
     onSkip: function() {
-      if (window.tracker){  
+      if (window.tracker){
         window.tracker.trackEvent(
         'Play Video Skip',
           {
@@ -162,7 +177,7 @@ export default Vue.extend({
     width: 100%
     height: 100%
     position: absolute
-    background: transparent url('/images/level/videos/videos_background_dungeon.png') no-repeat 
+    background: transparent url('/images/level/videos/videos_background_dungeon.png') no-repeat
     background-position: 0px 0px
     background-size: 100% 100%
 
@@ -170,7 +185,7 @@ export default Vue.extend({
       position: absolute
       left: 10%
       top: 5%
-      background: transparent url('/images/level/popover_background.png') no-repeat 
+      background: transparent url('/images/level/popover_background.png') no-repeat
       background-position: 0px 0px
       background-size: 100% 100%
       width: 80%
@@ -196,7 +211,7 @@ export default Vue.extend({
         .video-col
           width: 100%
           height: 100%
-      
+
           .video
             margin: auto
             width: 100%
@@ -217,7 +232,7 @@ export default Vue.extend({
           border-radius: 0
           font-weight: bold
           font-family: "Open Sans Condensed", "Helvetica Neue", Helvetica, Arial, sans-serif
-      
+
       .img-unlocked
         position: absolute
         left: -35px

--- a/app/views/play/level/PlayLevelVideoView.coffee
+++ b/app/views/play/level/PlayLevelVideoView.coffee
@@ -6,8 +6,9 @@ module.exports = class PlayLevelVideoView extends RootComponent
   id: 'play-level-video-view'
   template: require 'templates/base-flat'
   VueComponent: PlayLevelVideoComponent
+  skipMetaBinding: true
 
-  constructor: (options, @levelID) ->
+  initialize: (options, @levelID) ->
     @propsData ?= {}
     @propsData.levelSlug = @levelID
     @propsData.courseID = utils.getQueryVariable 'course'

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -109,7 +109,7 @@ module.exports = class PlayLevelView extends RootView
     # workaround to get users out of permanent idle status
     if application.userIsIdle
       application.idleTracker.onVisible()
-    
+
     #hide context menu if visible
     if @$('#surface-context-menu-view').is(":visible")
       Backbone.Mediator.publish 'level:surface-context-menu-hide', {}
@@ -237,6 +237,11 @@ module.exports = class PlayLevelView extends RootView
     console.debug('PlayLevelView: world necessities loaded')
     # Called when we have enough to build the world, but not everything is loaded
     @grabLevelLoaderData()
+
+    @setMeta({
+      title: $.i18n.t('play.level_title', { level: @level.get('name') })
+    })
+
     randomTeam = @world?.teamForPlayer()  # If no team is set, then we will want to equally distribute players to teams
     team = utils.getQueryVariable('team') ?  @session.get('team') ? randomTeam ? 'humans'
     @loadOpponentTeam(team)
@@ -358,7 +363,7 @@ module.exports = class PlayLevelView extends RootView
     @insertSubView new LevelDialogueView {level: @level, sessionID: @session.id}
     @insertSubView new ChatView levelID: @levelID, sessionID: @session.id, session: @session
     @insertSubView new ProblemAlertView session: @session, level: @level, supermodel: @supermodel
-    @insertSubView new SurfaceContextMenuView session: @session, level: @level 
+    @insertSubView new SurfaceContextMenuView session: @session, level: @level
     @insertSubView new DuelStatsView level: @level, session: @session, otherSession: @otherSession, supermodel: @supermodel, thangs: @world.thangs, showsGold: goldInDuelStatsView if @level.isType('hero-ladder', 'course-ladder')
     @insertSubView @controlBar = new ControlBarView {worldName: utils.i18n(@level.attributes, 'name'), session: @session, level: @level, supermodel: @supermodel, courseID: @courseID, courseInstanceID: @courseInstanceID}
     @insertSubView @hintsView = new HintsView({ @session, @level, @hintsState }), @$('.hints-view')
@@ -716,7 +721,7 @@ module.exports = class PlayLevelView extends RootView
     pos = x: e.clientX, y: e.clientY
     wop = @surface.coordinateDisplay.lastPos
     Backbone.Mediator.publish 'level:surface-context-menu-pressed', posX: pos.x, posY: pos.y, wopX: wop.x, wopY: wop.y
-    
+
 
   # Dynamic sound loading
 

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -147,6 +147,11 @@ module.exports = class PlayLevelView extends RootView
       @load()
       application.tracker?.trackEvent 'Started Level Load', category: 'Play Level', level: @levelID, label: @levelID unless @observing
 
+  getMeta: ->
+    link: [
+      { vmid: 'rel-canonical', rel: 'canonical', content: 'http://' + window.location.href + '/play' }
+    ]
+
   setLevel: (@level, givenSupermodel) ->
     @supermodel.models = givenSupermodel.models
     @supermodel.collections = givenSupermodel.collections

--- a/app/views/play/level/PlayWebDevLevelView.coffee
+++ b/app/views/play/level/PlayWebDevLevelView.coffee
@@ -14,6 +14,8 @@ module.exports = class PlayWebDevLevelView extends RootView
   template: require 'templates/play/level/play-web-dev-level-view'
 
   initialize: (@options, @sessionID) ->
+    super(@options)
+
     @courseID = utils.getQueryVariable 'course'
     @session = @supermodel.loadModel(new LevelSession _id: @sessionID).model
     @level = new Level()
@@ -29,6 +31,13 @@ module.exports = class PlayWebDevLevelView extends RootView
           @setMeta({
             title: $.i18n.t 'play.web_development_title', { level: @level.get('name') }
           })
+
+  getMeta: ->
+    return {
+      links: [
+        { vmid: 'rel-canonical', rel: 'canonical', href: 'https://' + window.location.hostname + '/play'}
+      ]
+    }
 
   onLoaded: ->
     super()

--- a/app/views/play/level/PlayWebDevLevelView.coffee
+++ b/app/views/play/level/PlayWebDevLevelView.coffee
@@ -26,6 +26,10 @@ module.exports = class PlayWebDevLevelView extends RootView
         @level.once 'sync', =>
           levelResource.markLoaded()
 
+          @setMeta({
+            title: $.i18n.t 'play.web_development_title', { level: @level.get('name') }
+          })
+
   onLoaded: ->
     super()
     @insertSubView @webSurface = new WebSurfaceView {level: @level}

--- a/app/views/school-administrator/SchoolAdministratorComponent.vue
+++ b/app/views/school-administrator/SchoolAdministratorComponent.vue
@@ -17,6 +17,12 @@
     import teacherDashboardNavTemplate from 'templates/courses/teacher-dashboard-nav.jade'
 
     export default {
+      metaInfo: function () {
+        return {
+          title: this.$t('school_administrator.title')
+        }
+      },
+
       data: () => ({ teacherDashboardNavTemplate }),
 
       components: {

--- a/app/views/special_event/HoC2018Component.vue
+++ b/app/views/special_event/HoC2018Component.vue
@@ -92,6 +92,15 @@
 
 <script>
 module.exports = Vue.extend({
+  metaInfo: function () {
+    return {
+      title: this.$t('teacher.hoc_title'),
+      meta: [
+        { vmid: 'meta-description', name: 'description', content: this.$t('teacher.hoc_meta_description') }
+      ]
+    }
+  },
+
   data: function() {
     return {
       teacherEmail: ''

--- a/app/views/special_event/HoC2018View.coffee
+++ b/app/views/special_event/HoC2018View.coffee
@@ -7,6 +7,7 @@ module.exports = class HoC2018View extends RootComponent
   id: 'hoc-2018'
   template: template
   VueComponent: HoC2018
+  skipMetaBinding: true
 
   constructor: (options) ->
     super(options)

--- a/app/views/teachers/DynamicAPCSPView.coffee
+++ b/app/views/teachers/DynamicAPCSPView.coffee
@@ -9,7 +9,11 @@ module.exports = class DynamicAPCSPView extends RootView
   id: 'dynamic-apcsp-view'
   template: require 'templates/teachers/dynamic-apcsp-view'
 
-  getTitle: -> 'AP CS Principles'
+  getMeta: ->
+    title: $.i18n.t 'apcsp.title'
+    meta: [
+      { vmid: 'meta-description', name: 'description', content: $.i18n.t 'apcsp.meta_description' }
+    ]
 
   initialize: (options, @name) ->
     super(options)
@@ -24,7 +28,7 @@ module.exports = class DynamicAPCSPView extends RootView
         promise = api.markdown.getMarkdownFile(@name.replace('markdown/', ''))
       else
         promise = api.apcsp.getAPCSPFile(@name)
-      
+
       promise.then((data) =>
         @content = marked(data, sanitize: false)
         @loadingData = false

--- a/app/views/user/MainUserView.coffee
+++ b/app/views/user/MainUserView.coffee
@@ -29,8 +29,12 @@ module.exports = class MainUserView extends UserView
 
   onLoaded: ->
     if @user.loaded
+      @setMeta({
+        title: $.i18n.t('user.user_title', { name: @user.broadName() })
+      })
+
       if !@levelSessions
-        @levelSessions = new LevelSessionsCollection @user.getSlugOrID()      
+        @levelSessions = new LevelSessionsCollection @user.getSlugOrID()
         @listenTo @levelSessions, 'sync', =>
           @onSyncLevelSessions @levelSessions?.models
           @render()

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "underscore.string": "~2.3.3",
     "v-tooltip": "^2.0.0-rc.33",
     "vue": "^2.6.10",
+    "vue-meta": "^1.6.0",
     "vue-moment": "^4.0.0",
     "vue-router": "^3.0.2",
     "vuex": "^2.4.0",

--- a/test/app/views/play/level/PlayLevelVideoView.spec.js
+++ b/test/app/views/play/level/PlayLevelVideoView.spec.js
@@ -1,10 +1,17 @@
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, createLocalVue } from '@vue/test-utils'
+import VueMeta from 'vue-meta'
+
 import playLevelVideoComponent from 'views/play/level/PlayLevelVideoComponent'
 import locale from 'locale/locale'
 import utils from 'core/utils'
 
 const createComponent = (values = {}) => {
+  const vue = createLocalVue()
+  vue.use(VueMeta)
+
   return shallowMount(playLevelVideoComponent, {
+    localVue: vue,
+
     propsData: values,
     mocks: {
       $t: (text) => {
@@ -13,7 +20,7 @@ const createComponent = (values = {}) => {
           return locale.en.translation[res[0]][res[1]];
         }
         else {
-          return locale.en.translation[text]; 
+          return locale.en.translation[text];
         }
       }
     }


### PR DESCRIPTION
This PR adds the foundational support for SEO header tag management to Backbone and Vue.  It does so by adding a popular Vue library ([vue-meta](https://github.com/nuxt/vue-meta)) to our Vue tooling and then adding a small binding to vue-meta in `RootView` (which extends `CocoView`).

This PR also updates the site wide default title and adds a site wide default meta description tag.  It also includes various examples of how to use the head tag management in Backbone and Vue.

**Rationale for this structure:**

We need the ability to create / cleanup header tags (`title`, `meta`, `link`) to improve our SEO.  Thus, we need the ability for `CocoView` to add tags when it renders and remove those tags (or fall back to the default) when it destroys.  We'll eventually need this in Vue as well and will soon need only to do this in Vue.  Backbone does not have a standard head management library and instead of implementing a rudimentary version of what vue-meta allows us to do we instead integrate CocoView with the vue-meta API.  This allows us to use the same tag management API across all parts of the code base which will allow us to seamlessly transition head tag management from Backbone to Vue.  We also get a more robust set of head tag management features, all of which are tested.


