### PR TITLE
ClearDialog cinematic property default should be true

### DIFF
--- a/app/schemas/selectors/cinematic.js
+++ b/app/schemas/selectors/cinematic.js
@@ -265,11 +265,11 @@ export const getRightCharacterThangTypeSlug = compose(shotSetup, rightCharacter,
  * @returns {bool} whether we should clear all existing dialogs. Defaults to true.
  */
 export const getClearText = dialogNode => {
-  const shouldClear = (dialogNode || {}).dialogClear
-  if (typeof shouldClear === 'undefined') {
+  const shouldClearDialogue = (dialogNode || {}).dialogClear
+  if (typeof shouldClearDialogue === 'undefined') {
     return true
   }
-  return shouldClear
+  return shouldClearDialogue
 }
 
 export const getTextPosition = dialogNode => (dialogNode || {}).textLocation

--- a/app/schemas/selectors/cinematic.js
+++ b/app/schemas/selectors/cinematic.js
@@ -265,9 +265,11 @@ export const getRightCharacterThangTypeSlug = compose(shotSetup, rightCharacter,
  * @returns {bool} whether we should clear all existing dialogs. Defaults to true.
  */
 export const getClearText = dialogNode => {
-  const dialogueNode = dialogNode || {}
-  const dialogClear = dialogueNode.dialogClear || true
-  return dialogClear
+  const shouldClearDialogue = (dialogNode || {}).dialogClear
+  if (typeof shouldClearDialogue === 'undefined') {
+    return true
+  }
+  return shouldClearDialogue
 }
 
 export const getTextPosition = dialogNode => (dialogNode || {}).textLocation

--- a/app/schemas/selectors/cinematic.js
+++ b/app/schemas/selectors/cinematic.js
@@ -265,11 +265,9 @@ export const getRightCharacterThangTypeSlug = compose(shotSetup, rightCharacter,
  * @returns {bool} whether we should clear all existing dialogs. Defaults to true.
  */
 export const getClearText = dialogNode => {
-  const shouldClearDialogue = (dialogNode || {}).dialogClear
-  if (typeof shouldClearDialogue === 'undefined') {
-    return true
-  }
-  return shouldClearDialogue
+  const dialogueNode = dialogNode || {}
+  const dialogClear = dialogueNode.dialogClear || true
+  return dialogClear
 }
 
 export const getTextPosition = dialogNode => (dialogNode || {}).textLocation

--- a/app/schemas/selectors/cinematic.js
+++ b/app/schemas/selectors/cinematic.js
@@ -262,9 +262,15 @@ export const getRightCharacterThangTypeSlug = compose(shotSetup, rightCharacter,
 
 /**
  * @param {DialogNode} dialogNode
- * @returns {bool} whether we should clear all existing dialogs.
+ * @returns {bool} whether we should clear all existing dialogs. Defaults to true.
  */
-export const getClearText = dialogNode => (dialogNode || {}).dialogClear || false
+export const getClearText = dialogNode => {
+  const shouldClear = (dialogNode || {}).dialogClear
+  if (typeof shouldClear === 'undefined') {
+    return true
+  }
+  return shouldClear
+}
 
 export const getTextPosition = dialogNode => (dialogNode || {}).textLocation
 

--- a/test/app/models/Cinematic.spec.js
+++ b/test/app/models/Cinematic.spec.js
@@ -100,10 +100,10 @@ describe('Cinematic', () => {
 
     it('getClearText', () => {
       const result = getClearText(shotFixture1.dialogNodes[0])
-      expect(result).toEqual(true)
+      expect(result).toEqual(false)
 
       const result2 = getClearText(shotFixture2.dialogNodes[0])
-      expect(result2).toEqual(false)
+      expect(result2).toEqual(true)
     })
 
     it('getSpeaker', () => {
@@ -254,7 +254,7 @@ var shotFixture1 = {
   },
   dialogNodes: [
     {
-      dialogClear: true,
+      dialogClear: false,
       exitCharacter: 'both',
       text: 'hello, world',
       triggers: {


### PR DESCRIPTION
## Issue

The clearDialog attribute has the wrong default value. It is far more common to clear the dialog than leave it.

## Fix
Update the selector to return `true` by default. Tests are also updated to reflect the change.