### PR TITLE
Add initial Color Tinting Panel to Thang editor

### DIFF
--- a/app/styles/editor/thang/colors_tab.sass
+++ b/app/styles/editor/thang/colors_tab.sass
@@ -13,7 +13,7 @@ $height: 550px
     box-sizing: border-box
     margin-bottom: 20px
       
-  #shape-buttons
+  #shape-buttons, #saved-color-tabs
     border: 1px solid saddlebrown
     margin: 0 20px 0 10px
     width: 30%

--- a/app/templates/editor/thang/colors_tab.jade
+++ b/app/templates/editor/thang/colors_tab.jade
@@ -4,7 +4,9 @@ div#color-group-settings.secret
   div#shape-buttons
     
   canvas#tinting-display(width=400, height=400)
-    
+
+  div#saved-color-tabs
+
   div#controls
     div.slider-cell
       | Hue:


### PR DESCRIPTION
## Feature

This is a small step in the direction and design of Character Customization, via color tinting.

This small change introduces a way to define and test colors on predefined Thang groups within our Thang color editor.
This modification is entirely cosmetic, and kept minimal in order to create a stepping stone for more character customization features.

The panel presents some hard coded hair and skin colors that can be applied once hair and skin color groups have been defined on a given ThangType.

## Saved Color Presets Panel
<img width="380" alt="Screen Shot 2019-05-14 at 9 17 22 PM" src="https://user-images.githubusercontent.com/15080861/57748189-b7f0f900-768d-11e9-95dd-4cf88503c2cc.png">

This panel is at the  bottom of the  Colors tab within `/editor/thang`. I've hard coded some colors which will eventually be fetched and saved from the database.

If you have defined a color group for `skin` or `hair`, clicking these colors will apply them to the thang.


[Demo](https://i.gyazo.com/c89267c9a5b4419bb2f8a3a9584b7583.mp4)