### PR TITLE
Refactor CinematicLankBoss to consolidate move commands

### DIFF
--- a/ozaria/engine/cinematic/CinematicLankBoss.js
+++ b/ozaria/engine/cinematic/CinematicLankBoss.js
@@ -309,9 +309,6 @@ export default class CinematicLankBoss {
    * @param {Object|undefined} thang?
    */
   addLank (key, thangType, thang) {
-    if (!thangType) {
-      return
-    }
     thang = thang || {}
     // Handle a duplicate thangType with the same key.
     if (this.lanks[key] && this.lanks[key].thangType) {

--- a/ozaria/engine/cinematic/Loader.js
+++ b/ozaria/engine/cinematic/Loader.js
@@ -36,15 +36,11 @@ export default class Loader {
   /**
    * Loads the player thangType from the global `me` object if accessible.
    * Has a side effect of storing the players thangType by original as a resource.
+   *
+   * If an admin or player doesn't have a hero, falls back to a default.
    */
   loadPlayerThangType () {
-    if ((me || {}) && !me.get('heroConfig')) {
-      return
-    }
-    const original = me.get('heroConfig').thangType
-    if (!original) {
-      return
-    }
+    const original = (me.get('heroConfig') || {}).thangType || '55527eb0b8abf4ba1fe9a107'
 
     this.loadingThangTypes.set(
       original,

--- a/ozaria/engine/cinematic/Loader.js
+++ b/ozaria/engine/cinematic/Loader.js
@@ -1,5 +1,6 @@
 import { getThang, getThangTypeOriginal } from '../../../app/core/api/thang-types'
 import { getBackgroundSlug, getBackgroundObject, getRightCharacterThangTypeSlug, getLeftCharacterThangTypeSlug } from '../../../app/schemas/models/selectors/cinematic'
+import { HERO_THANG_ID } from './CinematicLankBoss'
 
 /**
  * @typedef {import('../../../app/schemas/models/selectors/cinematic')} Cinematic
@@ -40,7 +41,7 @@ export default class Loader {
    * If an admin or player doesn't have a hero, falls back to a default.
    */
   loadPlayerThangType () {
-    const original = (me.get('heroConfig') || {}).thangType || '55527eb0b8abf4ba1fe9a107'
+    const original = (me.get('heroConfig') || {}).thangType || HERO_THANG_ID
 
     this.loadingThangTypes.set(
       original,

--- a/ozaria/engine/cinematic/cinematicController.js
+++ b/ozaria/engine/cinematic/cinematicController.js
@@ -147,6 +147,7 @@ export class CinematicController {
 
   destroy () {
     this.systems.sound.stopAllSounds()
+    this.systems.cinematicLankBoss.cleanup()
   }
 }
 


### PR DESCRIPTION
## Issue

We need to be able to scale Lanks. Like the background object, and characters.

We had 3 different ways of moving lanks.

 - An animated movement, that was called `moveLankCommand`.
 - An instant move, `moveLank`.
 - Move background called `setBackground`, which could position the background between scenes. And supported scaling.

As the schema defines the same thang object between the 3 lanks, it is possible to consolidate this functionality into a single method.

## Fix

Simplify the logic into a single method `moveLankCommand` that handles an instantaneous move as an edge case (when milliseconds is 0).

Also fixed the bug  where a user could have never selected a hero and thus crashed the cinematic. Instead a default hero is chosen.