### PR TITLE
Color customization schema

### DIFF
--- a/app/schemas/models/tint.schema.js
+++ b/app/schemas/models/tint.schema.js
@@ -1,0 +1,20 @@
+const schema = require('./../schemas')
+
+const Tint = schema.object({
+  title: 'Group Tint',
+  description: 'A list of allowed colors for tinting a particular group'
+}, {
+  colorGroupName: schema.shortString({
+    title: 'Color Group Name',
+    description: 'Name of the group we are tinting on a ThangType.'
+  }),
+  allowedTints: schema.array({
+    title: 'Tints',
+    description: 'Legal tints for the color group'
+  }, schema.colorConfig())
+})
+
+schema.extendBasicProperties(Tint, 'tint')
+schema.extendNamedProperties(Tint)
+
+module.exports = Tint

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -143,8 +143,15 @@ _.extend UserSchema.properties,
   preferredLanguage: {'enum': [null].concat(c.getLanguageCodeArray())}
 
   signedCLA: c.date({title: 'Date Signed the CLA'})
+
+  # Legacy customizable wizard from a very early version of the game.
   wizard: c.object {},
     colorConfig: c.object {additionalProperties: c.colorConfig()}
+
+  customization: c.object {
+    title: 'Player Customization',
+    descipription: 'Individual player customization options'
+  }, { colorConfig: c.object { additionalProperties: c.colorConfig() } }
 
   aceConfig: c.object { default: { language: 'python', keyBindings: 'default', invisibles: false, indentGuides: false, behaviors: false, liveCompletion: true }},
     language: {type: 'string', 'enum': ['python', 'javascript', 'coffeescript', 'clojure', 'lua', 'java', 'io']}


### PR DESCRIPTION
This is a stepping stone for the server work which will present end points for these schema additions.

We are adding a new collection that will store valid color tints for the ThangType color groupings that we define in the editor.

Then the player will be able to choose a valid tint. The server will use the `tints` collection to validate the user's decision.