### PR TITLE
Capstone stages

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -267,6 +267,7 @@ module.exports = class CocoRouter extends Backbone.Router
       @routeDirectly('teachers/ConvertToTeacherAccountView', [])
 
     'school-administrator(/*subpath)': go('core/SingletonAppVueComponentView')
+    'cinematicplaceholder/:levelSlug': go('core/SingletonAppVueComponentView')
 
     'test(/*subpath)': go('TestView')
 

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -11,6 +11,8 @@ import PageCinematicEditor from '../../ozaria/site/components/cinematic/PageCine
 import PageInteractiveEditor from '../../ozaria/site/components/interactive/PageInteractiveEditor'
 import PageIntroLevel from '../../ozaria/site/components/play/PageIntroLevel'
 
+import CinematicPlaceholder from '../../ozaria/site/components/cinematic/CinematicPlaceholder'
+
 let vueRouter
 
 export default function getVueRouter () {
@@ -54,7 +56,16 @@ export default function getVueRouter () {
             { path: 'teacher/:teacherId/classroom/:classroomId', component: TeacherClassView },
             { path: 'teacher/:teacherId/classroom/:classroomId/:studentId', component: TeacherStudentView }
           ]
-        }
+        },
+        {
+          path: '/cinematicplaceholder/:levelSlug?',
+          component: CinematicPlaceholder,
+          props: (route) => {
+            return {
+              levelSlug: route.params.levelSlug
+            }
+          }
+        },
       ]
     })
   }

--- a/app/lib/LevelBus.coffee
+++ b/app/lib/LevelBus.coffee
@@ -198,8 +198,9 @@ module.exports = class LevelBus extends Bus
     @changedSessionProperties.state = true
     @saveSession()
 
-  onVictory: ->
+  onVictory: (e) ->
     return unless @onPoint()
+    return if e and e.capstoneInProgress
     state = @session.get('state')
     state.complete = true
     @session.set('state', state)

--- a/app/lib/simulator/Simulator.coffee
+++ b/app/lib/simulator/Simulator.coffee
@@ -238,7 +238,11 @@ module.exports = class Simulator extends CocoClass
     @god.setLevel @level.serialize {@supermodel, @session, @otherSession, headless: true, sessionless: false}
     @god.setLevelSessionIDs (session.sessionID for session in @task.getSessions())
     @god.setWorldClassMap @world.classMap
-    @god.setGoalManager new GoalManager @world, @level.get('goals'), null, {headless: true}
+    @god.setGoalManager new GoalManager @world, @level.get('goals'), null, {
+      headless: true
+      additionalGoals: @level.additionalGoals
+      session: @session
+    }
     humanFlagHistory = _.filter @session.get('state')?.flagHistory ? [], (event) => event.source isnt 'code' and event.team is (@session.get('team') ? 'humans')
     ogreFlagHistory = _.filter @otherSession.get('state')?.flagHistory ? [], (event) => event.source isnt 'code' and event.team is (@otherSession.get('team') ? 'ogres')
     @god.lastFlagHistory = humanFlagHistory.concat ogreFlagHistory

--- a/app/lib/world/GoalManager.coffee
+++ b/app/lib/world/GoalManager.coffee
@@ -28,6 +28,13 @@ module.exports = class GoalManager extends CocoClass
     @thangTeams = {}
     @initThangTeams()
     @addGoal goal for goal in @initialGoals if @initialGoals
+    if @options?.session and @options?.additionalGoals
+      state = @options.session.get('state')
+      capstoneStage = state.capstoneStage
+      stages = _.filter(@options.additionalGoals, (ag) -> ag.stage <= capstoneStage)
+      goals = _.map(stages, (stage) -> stage.goals)
+      unwrappedGoals = _.flatten(goals)
+      @addGoal goal for goal in unwrappedGoals
 
   initThangTeams: ->
     return unless @world
@@ -60,6 +67,8 @@ module.exports = class GoalManager extends CocoClass
 
   # world generator gets current goals from the main instance
   getGoals: -> @goals
+
+  getRemainingGoals: -> _.filter(@goalStates, (state) -> state.status != 'success')
 
   # background instance created by world generator,
   # gets these goals and code, and is told to be all ears during world gen
@@ -95,6 +104,44 @@ module.exports = class GoalManager extends CocoClass
       continue unless @goalStates[goalID]?
       @goalStates[goalID] = goalState
     @notifyGoalChanges()
+
+  # Adds any goals for the current capstoneStage
+  # Returns the current capstoneStage
+  addAdditionalGoals: (session, additionalGoals) ->
+    capstoneStage = (session.get('state') or {}).capstoneStage
+    if not capstoneStage
+      # In daily speak, we think of initial goals as stage 1 and additional goals
+      # as stage 2 and above. That is why we are starting from 2.
+      capstoneStage = 2
+    else
+      # The capstoneStage will eventually end up being 1 above the final
+      # additionalStage, when the entire level has been completed.
+      capstoneStage += 1
+    goalsAdded = false
+    _.forEach(additionalGoals, (stageGoals) =>
+      if stageGoals.stage == capstoneStage
+        _.forEach(stageGoals.goals, (goal) =>
+          if not _.find(@goals, (existingGoal) -> goal.id == existingGoal.id)
+            @addGoal(goal)
+            goalsAdded = true
+        )
+    )
+    if goalsAdded
+      state = session.get('state') ? {}
+      state.capstoneStage = capstoneStage
+      session.set('state', state)
+      session.save(null, { success: -> }) # Save and move on, we don't have time to wait here
+
+    return capstoneStage
+
+  # Checks if the overall goal status is 'success', then progresses
+  # capstone goals to the next stage if there are more goals
+  finishLevel: ->
+    stageFinished = @checkOverallStatus() is 'success'
+    if @options.additionalGoals and stageFinished
+      @addAdditionalGoals(@options.session, @options.additionalGoals)
+
+    return stageFinished
 
   # IMPLEMENTATION DETAILS
 
@@ -269,6 +316,10 @@ module.exports = class GoalManager extends CocoClass
 
   setGoalState: (goalID, status) ->
     state = @goalStates[goalID]
+    if not state
+      console.log('Could not set state for goalID ', goalID)
+      return
+
     state.status = status
     if overallStatus = @checkOverallStatus true
       matchedGoals = (_.find(@goals, {id: goalID}) for goalID, goalState of @goalStates when goalState.status is overallStatus)

--- a/app/schemas/models/level.coffee
+++ b/app/schemas/models/level.coffee
@@ -393,7 +393,7 @@ _.extend LevelSchema.properties,
     minItems: 1,
     uniqueItems: true,
     properties: {
-      stage: { type: 'integer', title: 'Goal Stage', description: 'Which stage these additional goals are for (2 and onwards)' },
+      stage: { type: 'integer', minimum: 2, title: 'Goal Stage', description: 'Which stage these additional goals are for (2 and onwards)' },
       goals: c.array { title: 'Goals', description: 'An array of goals which are visible to the player and can trigger scripts.' }, GoalSchema
     }
   }

--- a/app/schemas/models/level_session.coffee
+++ b/app/schemas/models/level_session.coffee
@@ -143,7 +143,7 @@ _.extend LevelSessionSchema.properties,
     capstoneStage:
       type: 'number'
       title: 'Capstone Stage'
-      description: 'Current capstone stage of the level. A capstone level is not complete until all stages are complete.'
+      description: 'Current capstone stage of the level. If, say, stage 7 is yet incomplete, capstoneStage will be 7. If stage 7 is complete, capstoneStage will be 8. When a capstone level is complete, capstoneStage will be 1 higher than the final stage number.'
 
   code:
     type: 'object'

--- a/app/schemas/subscriptions/play.coffee
+++ b/app/schemas/subscriptions/play.coffee
@@ -124,7 +124,7 @@ module.exports =
   'level:show-victory': c.object {required: ['showModal']},
     showModal: {type: 'boolean'}
     manual: { type: 'boolean' }
-    capstoneVictory: { type: 'boolean' }
+    capstoneInProgress: { type: 'boolean' }
 
   'level:highlight-dom': c.object {required: ['selector']},
     selector: {type: 'string'}

--- a/app/views/play/level/LevelGoalsView.coffee
+++ b/app/views/play/level/LevelGoalsView.coffee
@@ -53,7 +53,7 @@ module.exports = class LevelGoalsView extends CocoView
     @previousGoalStatus ?= {}
     @succeeded = e.overallStatus is 'success'
     for goal in e.goals
-      state = e.goalStates[goal.id]
+      state = e.goalStates[goal.id] or { status: 'incomplete' }
       if not firstRun and state.status is 'success' and @previousGoalStatus[goal.id] isnt 'success'
         @soundToPlayWhenPlaybackEnded = 'goal-success'
       else if not firstRun and state.status isnt 'success' and @previousGoalStatus[goal.id] is 'success'

--- a/ozaria/site/components/cinematic/CinematicPlaceholder/index.vue
+++ b/ozaria/site/components/cinematic/CinematicPlaceholder/index.vue
@@ -1,0 +1,33 @@
+<script>
+  module.exports = Vue.extend({
+    props: {
+      levelSlug: {
+        type: String,
+        required: true,
+        default: ''
+      }
+    },
+    computed: {
+      playLink: function () {
+        return `/ozaria/play/level/${this.levelSlug}`
+      }
+    },
+    async created () {
+      if (!me.hasCinematicAccess()) {
+        alert('You must be logged in as an admin to use this page.')
+        return application.router.navigate('/', { trigger: true })
+      }
+    }
+  })
+</script>
+
+<template>
+  <div>
+    <p>Hello! This is where a cinematic would play, but all you got was this placeholder... :)</p>
+    <a :href="playLink">Go back to play more</a>
+  </div>
+</template>
+
+<style scoped>
+
+</style>

--- a/ozaria/site/views/play/level/modal/CapstoneProgressComponent.vue
+++ b/ozaria/site/views/play/level/modal/CapstoneProgressComponent.vue
@@ -1,0 +1,44 @@
+<template>
+  <div>
+    <h1>Nice work!</h1>
+    <p>For level: {{ levelSlug }}</p>
+    <p>Stage: {{ capstoneStage }}</p>
+    <p>Known goals left: {{ remainingGoals }}</p>
+    <a :href="cinematicLink">Onwards!</a>
+  </div>
+</template>
+
+<script>
+  export default Vue.extend({
+    name: 'CapstoneProgressModal',
+    props: {
+      levelSlug: {
+        type: String,
+        required: true
+      },
+      capstoneStage: {
+        type: Number,
+        required: true
+      },
+      remainingGoals: {
+        type: Array,
+        required: true
+      }
+    },
+    computed: {
+      cinematicLink: function () {
+        if (this.levelSlug) {
+          return `/cinematicplaceholder/${this.levelSlug}`
+        } else {
+          return ''
+        }
+      }
+    }
+  })
+</script>
+
+<style scoped>
+  div {
+    background-color: white;
+  }
+</style>

--- a/ozaria/site/views/play/level/modal/CapstoneProgressModal.js
+++ b/ozaria/site/views/play/level/modal/CapstoneProgressModal.js
@@ -1,0 +1,43 @@
+import ModalComponent from 'app/views/core/ModalComponent'
+import CapstoneProgressComponent from './CapstoneProgressComponent.vue'
+
+class CapstoneProgressModal extends ModalComponent {
+  // Runs before the constructor is called.
+  initialize () {
+    this.propsData = {
+      levelSlug: null,
+      capstoneStage: null,
+      remainingGoals: null
+    }
+  }
+
+  constructor (options) {
+    super(options)
+    if (options) {
+      this.propsData = {
+        levelSlug: options.levelSlug,
+        capstoneStage: options.capstoneStage,
+        remainingGoals: options.remainingGoals
+      }
+    }
+  }
+
+  destroy () {
+    if (this.onDestroy) {
+      this.onDestroy()
+    }
+
+    this.goToCinematic()
+  }
+
+  goToCinematic () {
+    application.router.navigate(`/cinematicplaceholder/${this.propsData.levelSlug}`, { trigger: true })
+  }
+}
+
+CapstoneProgressModal.prototype.id = 'capstone-progress-modal'
+CapstoneProgressModal.prototype.template = require('app/templates/core/modal-base-flat')
+CapstoneProgressModal.prototype.VueComponent = CapstoneProgressComponent
+CapstoneProgressModal.prototype.propsData = null
+
+export default CapstoneProgressModal

--- a/ozaria/site/views/play/level/modal/CapstoneVictoryComponent.vue
+++ b/ozaria/site/views/play/level/modal/CapstoneVictoryComponent.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <h1>All done! Much victory, very celebration!</h1>
+    <p>For level: {{ levelSlug }}</p>
+    <p>Stage: {{ capstoneStage }}</p>
+    <a :href="cinematicLink">Celebrate!</a>
+  </div>
+</template>
+
+<script>
+  export default Vue.extend({
+    name: 'CapstoneVictoryModal',
+    props: {
+      levelSlug: {
+        type: String,
+        required: true
+      },
+      capstoneStage: {
+        type: Number,
+        required: true
+      }
+    },
+    computed: {
+      cinematicLink: function () {
+        if (this.levelSlug) {
+          return `/cinematicplaceholder/${this.levelSlug}`
+        } else {
+          return ''
+        }
+      }
+    }
+  })
+</script>
+
+<style scoped>
+  div {
+    background-color: white;
+  }
+</style>

--- a/ozaria/site/views/play/level/modal/CapstoneVictoryModal.js
+++ b/ozaria/site/views/play/level/modal/CapstoneVictoryModal.js
@@ -1,0 +1,43 @@
+import ModalComponent from 'app/views/core/ModalComponent'
+import CapstoneVictoryComponent from './CapstoneVictoryComponent.vue'
+
+class CapstoneVictoryModal extends ModalComponent {
+  // Runs before the constructor is called.
+  initialize () {
+    this.propsData = {
+      levelSlug: null,
+      capstoneStage: null,
+      remainingGoals: null
+    }
+  }
+
+  constructor (options) {
+    super(options)
+    if (options) {
+      this.propsData = {
+        levelSlug: options.levelSlug,
+        capstoneStage: options.capstoneStage,
+        remainingGoals: options.remainingGoals
+      }
+    }
+  }
+
+  destroy () {
+    if (this.onDestroy) {
+      this.onDestroy()
+    }
+
+    this.goToCinematic()
+  }
+
+  goToCinematic () {
+    application.router.navigate(`/cinematicplaceholder/${this.propsData.levelSlug}`, { trigger: true })
+  }
+}
+
+CapstoneVictoryModal.prototype.id = 'capstone-victory-modal'
+CapstoneVictoryModal.prototype.template = require('app/templates/core/modal-base-flat')
+CapstoneVictoryModal.prototype.VueComponent = CapstoneVictoryComponent
+CapstoneVictoryModal.prototype.propsData = null
+
+export default CapstoneVictoryModal

--- a/test/app/lib/world/GoalManager.spec.coffee
+++ b/test/app/lib/world/GoalManager.spec.coffee
@@ -1,5 +1,8 @@
+factories = require 'test/app/factories'
+
 describe('GoalManager', ->
   GoalManager = require 'lib/world/GoalManager'
+
   killGoal = {name: 'Kill Guy', killThangs: ['Guy1', 'Guy2'], id: 'killguy'}
   saveGoal = {name: 'Save Guy', saveThangs: ['Guy1', 'Guy2'], id: 'saveguy'}
   getToLocGoal = {name: 'Go there', getToLocation: {target: 'Frying Pan', who: 'Potato'}, id: 'id'}
@@ -8,6 +11,25 @@ describe('GoalManager', ->
   stayMapGoal =  {name: 'Stay here', keepFromLeavingOffSide: {who: 'Yall'}, id: 'id'}
   getItemGoal = {name: 'Mine', getItem: {who: 'Grabby', itemID: 'Sandwich'}, id: 'id'}
   keepItemGoal = {name: 'Not Yours', keepFromGettingItem: {who: 'Grabby', itemID: 'Sandwich'}, id: 'id'}
+  additionalGoals = [{
+    stage: 2,
+    goals: [
+      {name: 'Additional Kill Guy', killThangs: ['AdditionalKillGuy1', 'AdditionalKillGuy2'], id: 'additionalkillguy'},
+      {name: 'Additional Save Guy', saveThangs: ['AdditionalSaveGuy1', 'AdditionalSaveGuy2'], id: 'additionalsaveguy'}
+    ]
+  }, {
+    stage: 3,
+    goals: [
+      {name: 'Additional Kill Guy 2', killThangs: ['AdditionalKillGuy3', 'AdditionalKillGuy4'], id: 'additionalkillguy2'},
+    ]
+  }, {
+    stage: -1,
+    goals: [killGoal]
+  }]
+  session = null
+
+  beforeEach ->
+    session = factories.makeLevelSession({ state: { complete: false }})
 
   it('handles kill goal', ->
     gm = new GoalManager()
@@ -51,6 +73,244 @@ describe('GoalManager', ->
     expect(goalStates.saveguy.killed.Guy2).toBe(false)
     expect(goalStates.saveguy.keyFrame).toBe('end')
   )
+
+  it 'adds new additional goals without affecting old goals', ->
+    gm = new GoalManager()
+    # Add and complete a regular goal
+    gm.setGoals([killGoal])
+    gm.worldGenerationWillBegin()
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'Guy1'}}, 10)
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'Guy2'}}, 20)
+    gm.worldGenerationEnded()
+
+    expect(gm.getRemainingGoals().length).toBe(0)
+
+    # Add additional goals, expecting them to be incomplete while original goals are still complete
+    gm.addAdditionalGoals(session, additionalGoals)
+    goalStates = gm.getGoalStates()
+
+    expect(goalStates.killguy.status).toBe('success')
+    expect(goalStates.killguy.killed.Guy1).toBe(true)
+    expect(goalStates.killguy.killed.Guy2).toBe(true)
+    expect(goalStates.killguy.keyFrame).toBe(20)
+    expect(goalStates.additionalkillguy.status).toBe('incomplete')
+    expect(goalStates.additionalkillguy.killed).toBeUndefined()
+    expect(goalStates.additionalkillguy.keyFrame).toBe(0)
+    expect(gm.getRemainingGoals().length).toBe(2)
+
+  it 'adds all additionalGoals for the next stage', ->
+    gm = new GoalManager()
+    gm.setGoals([killGoal])
+    gm.worldGenerationWillBegin()
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'Guy1'}}, 10)
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'Guy2'}}, 20)
+    gm.worldGenerationEnded()
+
+    goalStates = gm.getGoalStates()
+    expect(goalStates.killguy.status).toBe('success')
+    expect(goalStates.killguy.killed.Guy1).toBe(true)
+    expect(goalStates.killguy.killed.Guy2).toBe(true)
+    expect(goalStates.killguy.keyFrame).toBe(20)
+    expect(gm.getRemainingGoals().length).toBe(0)
+
+    gm.addAdditionalGoals(session, additionalGoals)
+    goalStates = gm.getGoalStates()
+
+    expect(goalStates.additionalkillguy.status).toBe('incomplete')
+    expect(goalStates.additionalkillguy.killed).toBeUndefined()
+    expect(goalStates.additionalkillguy.keyFrame).toBe(0)
+
+    # Complete all goals for the world, as world generation resets goals
+    gm.worldGenerationWillBegin()
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'Guy1'}}, 10)
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'Guy2'}}, 20)
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'AdditionalKillGuy1'}}, 30)
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'AdditionalKillGuy2'}}, 40)
+    gm.worldGenerationEnded()
+    goalStates = gm.getGoalStates()
+
+    # Expect all additional goals to be completed
+    expect(goalStates.additionalkillguy.status).toBe('success')
+    expect(goalStates.additionalkillguy.killed.AdditionalKillGuy1).toBe(true)
+    expect(goalStates.additionalkillguy.killed.AdditionalKillGuy2).toBe(true)
+    expect(goalStates.additionalkillguy.keyFrame).toBe(40)
+    expect(goalStates.additionalsaveguy.status).toBe('success')
+    expect(goalStates.additionalsaveguy.killed.AdditionalSaveGuy1).toBe(false)
+    expect(goalStates.additionalsaveguy.killed.AdditionalSaveGuy2).toBe(false)
+    expect(goalStates.additionalsaveguy.keyFrame).toBe('end')
+    expect(gm.getRemainingGoals().length).toBe(0)
+
+  it 'does not add additionalGoals when they don\'t match the stage', ->
+    gm = new GoalManager()
+    gm.setGoals([killGoal])
+    gm.worldGenerationWillBegin()
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'Guy1'}}, 10)
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'Guy2'}}, 20)
+    gm.worldGenerationEnded()
+
+    # Add additional goals and expect them to be incomplete
+    gm.addAdditionalGoals(session, additionalGoals)
+    goalStates = gm.getGoalStates()
+    expect(goalStates.additionalkillguy.status).toBe('incomplete')
+    expect(goalStates.additionalkillguy.killed).toBeUndefined()
+    expect(goalStates.additionalkillguy.keyFrame).toBe(0)
+    expect(goalStates.additionalsaveguy.status).toBe('incomplete')
+    expect(goalStates.additionalsaveguy.keyFrame).toBe(0)
+
+    gm.worldGenerationWillBegin()
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'Guy1'}}, 10)
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'Guy2'}}, 20)
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'AdditionalKillGuy1'}}, 30)
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'AdditionalKillGuy2'}}, 40)
+    gm.worldGenerationEnded()
+
+    goalStates = gm.getGoalStates()
+    expect(goalStates.additionalkillguy2).toBeUndefined() # The goals for the next stage should not be defined yet
+    expect(goalStates.additionalkillguy.killed.AdditionalKillGuy1).toBe(true)
+    expect(goalStates.additionalkillguy.killed.AdditionalKillGuy2).toBe(true)
+    expect(goalStates.additionalkillguy.keyFrame).toBe(40)
+    expect(goalStates.additionalsaveguy.status).toBe('success')
+    expect(goalStates.additionalsaveguy.killed.AdditionalSaveGuy1).toBe(false)
+    expect(goalStates.additionalsaveguy.killed.AdditionalSaveGuy2).toBe(false)
+    expect(goalStates.additionalsaveguy.keyFrame).toBe('end')
+    expect(gm.getRemainingGoals().length).toBe(0)
+
+  it 'reports that all goals are complete when additionalGoals have been completed', ->
+    gm = new GoalManager()
+    gm.setGoals([saveGoal])
+    gm.worldGenerationWillBegin()
+    gm.worldGenerationEnded()
+
+    goalStates = gm.getGoalStates()
+    expect(goalStates.saveguy.status).toBe('success')
+    expect(goalStates.saveguy.killed.Guy1).toBe(false)
+    expect(goalStates.saveguy.killed.Guy2).toBe(false)
+    expect(goalStates.saveguy.keyFrame).toBe('end')
+
+    gm.addAdditionalGoals(session, additionalGoals)
+
+    gm.worldGenerationWillBegin()
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'AdditionalKillGuy1'}}, 30)
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'AdditionalKillGuy2'}}, 40)
+    gm.worldGenerationEnded()
+
+    # Both original goals (saving saveguy) and additional goals are complete, so the whole world is complete
+    goalStates = gm.getGoalStates()
+    expect(goalStates.saveguy.status).toBe('success')
+    expect(goalStates.saveguy.killed.Guy1).toBe(false)
+    expect(goalStates.saveguy.killed.Guy2).toBe(false)
+    expect(goalStates.saveguy.keyFrame).toBe('end')
+    expect(goalStates.additionalkillguy.status).toBe('success')
+    expect(goalStates.additionalkillguy.killed.AdditionalKillGuy1).toBe(true)
+    expect(goalStates.additionalkillguy.killed.AdditionalKillGuy2).toBe(true)
+    expect(goalStates.additionalkillguy.keyFrame).toBe(40)
+    expect(goalStates.additionalsaveguy.status).toBe('success')
+    expect(goalStates.additionalsaveguy.killed.AdditionalSaveGuy1).toBe(false)
+    expect(goalStates.additionalsaveguy.killed.AdditionalSaveGuy2).toBe(false)
+    expect(goalStates.additionalsaveguy.keyFrame).toBe('end')
+    expect(gm.getRemainingGoals().length).toBe(0)
+    expect(gm.checkOverallStatus()).toBe('success')
+
+
+  it 'reports that not all goals are complete when not all additionalGoals have been completed', ->
+    gm = new GoalManager()
+    gm.setGoals([saveGoal])
+    gm.worldGenerationWillBegin()
+    gm.worldGenerationEnded()
+
+    goalStates = gm.getGoalStates()
+    expect(goalStates.saveguy.status).toBe('success')
+    expect(goalStates.saveguy.killed.Guy1).toBe(false)
+    expect(goalStates.saveguy.killed.Guy2).toBe(false)
+    expect(goalStates.saveguy.keyFrame).toBe('end')
+    expect(gm.getRemainingGoals().length).toBe(0)
+
+    gm.addAdditionalGoals(session, additionalGoals)
+
+    # No events mean that the save goal is completed
+    gm.worldGenerationWillBegin()
+    gm.worldGenerationEnded()
+
+    # Only the save goal should be complete
+    goalStates = gm.getGoalStates()
+    expect(goalStates.saveguy.status).toBe('success')
+    expect(goalStates.saveguy.killed.Guy1).toBe(false)
+    expect(goalStates.saveguy.killed.Guy2).toBe(false)
+    expect(goalStates.saveguy.keyFrame).toBe('end')
+    expect(goalStates.additionalkillguy.status).toBe('incomplete')
+    expect(goalStates.additionalsaveguy.status).toBe('success')
+    expect(goalStates.additionalsaveguy.killed.AdditionalSaveGuy1).toBe(false)
+    expect(goalStates.additionalsaveguy.killed.AdditionalSaveGuy2).toBe(false)
+    expect(goalStates.additionalsaveguy.keyFrame).toBe('end')
+    expect(gm.getRemainingGoals().length).toBe(1)
+
+    expect(gm.checkOverallStatus()).not.toBe('success')
+
+  it 'progresses to the next additional goal when completing them all', ->
+    # Create the goal manager in the more traditional way with a mocked session
+    gm = new GoalManager(null, [saveGoal], {}, {
+      session
+      additionalGoals
+    })
+    gm.worldGenerationWillBegin()
+    gm.worldGenerationEnded()
+
+    # Use goalManager.finishLevel() to automatically progress through additionalGoals
+    stageFinished = gm.finishLevel()
+    expect(stageFinished).toBe(true)
+
+    # The new goal should not be done yet
+    goalStates = gm.getGoalStates()
+    expect(goalStates.additionalkillguy.status).toBe('incomplete')
+
+    gm.worldGenerationWillBegin()
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'AdditionalKillGuy1'}}, 30)
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'AdditionalKillGuy2'}}, 40)
+    gm.worldGenerationEnded()
+
+    stageFinished = gm.finishLevel()
+    expect(stageFinished).toBe(true)
+
+    # The new goal should not be done yet
+    goalStates = gm.getGoalStates()
+    expect(goalStates.additionalkillguy2.status).toBe('incomplete')
+
+    # We have to complete all goals as the world resets when worldGenerationWillBegin() runs
+    gm.worldGenerationWillBegin()
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'AdditionalKillGuy1'}}, 30)
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'AdditionalKillGuy2'}}, 40)
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'AdditionalKillGuy3'}}, 30)
+    gm.submitWorldGenerationEvent('world:thang-died', {thang: {id: 'AdditionalKillGuy4'}}, 40)
+    gm.worldGenerationEnded()
+
+    goalStates = gm.getGoalStates()
+
+    expect(goalStates.additionalkillguy2.status).toBe('success')
+    expect(goalStates.additionalkillguy2.killed.AdditionalKillGuy3).toBe(true)
+    expect(goalStates.additionalkillguy2.killed.AdditionalKillGuy4).toBe(true)
+    expect(goalStates.additionalkillguy2.keyFrame).toBe(40)
+
+    # The level should now stay complete, with no new goals being added
+    stageFinished = gm.finishLevel()
+    expect(stageFinished).toBe(true)
+    expect(gm.getRemainingGoals().length).toBe(0)
+    expect(gm.checkOverallStatus()).toBe('success')
+
+  it 'does not add goals twice for the same stage', ->
+    gm = new GoalManager(null, [saveGoal], {}, {
+      session
+      additionalGoals
+    })
+    gm.worldGenerationWillBegin()
+    gm.worldGenerationEnded()
+
+    stageFinished = gm.finishLevel()
+    expect(stageFinished).toBe(true)
+    expect(session.get('state').capstoneStage).toBe(2)
+
+    stageFinished = gm.finishLevel()
+    expect(stageFinished).toBe(false)
+    expect(session.get('state').capstoneStage).toBe(2)
 
   xit 'handles getToLocation', ->
     gm = new GoalManager()


### PR DESCRIPTION
# Feature: Capstone levels with multiple stages

We need a type of capstone level that can have multiple completions. This means that as the student is playing, they are effectively on a stage of the capstone level. 

For each stage that is completed, a cinematic will be shown. Once the cinematic has been watched, the level can be continued - now at the next stage. 

# How to test/review this PR

Due to the questions around deploying this safely to Next for testing, this needs to be reviewed locally. That means creating a new level to serve as the capstone level, in order to test the functionality. This is fairly involved, so it is explained in [this Slab doc](https://codecombat.slab.com/posts/capstone-levels-guide-rcosczss) as a general guide for Capstone Levels.

# Implementation

- `Level` now has a new property called `additionalGoals`, deciding how many stages are possible to complete in the level.
- `LevelSession` now has a new state property called `capstoneStage`, keeping track of what stage the student has reached.

When a student reaches victory for their level session, we check if it is a capstone level. If it is, we add the capstone stage to the level session - marking that they have completed stage 1.

The victory flow is retained, but actually marking the level as completed is stopped at the `LevelBus` step for `onVictory` - preventing the `complete` state to be set for the level session.

A new progression modal is shown when progressing through the stages, a new victory modal is shown when the capstone level has been fully completed. The contents here is TBD - two new models have been created, but right now a simple game dev modal is being used.

# Deploy

This needs to be deployed only after https://github.com/codecombat/codecombat/pull/5383 merges, so schemas are in order.

This feature is effectively "gated" as it is only in effect once a level has `additionalGoals`. Without this new property, the `capstoneStage` on the level session will not progress. 

As such, this can be deployed without affecting anything in production as preparation for the upcoming interactives work. 

# Questions

- The tests cover the `GoalManager` well, but not the flow through the system. I could not find code that would test this - is this something we would test with smoke tests, because of the multiple steps? 
- Are the tests readable? World generation will reset goal states and so many events typically need to be sent each step of the test. Would it be more clear with less `expect()` calls? 