### PR TITLE
Changes for Interactive editor

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -132,6 +132,7 @@ module.exports = class CocoRouter extends Backbone.Router
     'editor/article/preview': go('editor/article/ArticlePreviewView')
     'editor/article/:articleID': go('editor/article/ArticleEditView')
     'editor/cinematic(/*subpath)': go('core/SingletonAppVueComponentView')
+    'editor/interactive(/*subpath)': go('core/SingletonAppVueComponentView')
     'editor/level': go('editor/level/LevelSearchView')
     'editor/level/:levelID': go('editor/level/LevelEditView')
     'editor/thang': go('editor/thang/ThangTypeSearchView')

--- a/app/core/ozariaUtils.js
+++ b/app/core/ozariaUtils.js
@@ -108,5 +108,15 @@ module.exports = {
       levelDataMap = levels
     }
     return levelOriginals.map((original) => levelDataMap[original])
+  },
+
+  /**
+   * Returns the options to be used with ajv for json schema validation (used for draft-07 as of now)
+   */
+  getAjvOptions: function () {
+    const options = {
+      unknownFormats: ['ace', 'hidden', 'i18n'] // list of formats unknown to ajv but need to be supported
+    }
+    return options // If we want to support both draft-04 and draft-06/07 schemas then add { schemaId: 'auto' } to options
   }
 }

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -8,6 +8,7 @@ import TeacherClassView from 'app/views/courses/TeacherClassView.vue'
 import TeacherStudentView from 'app/views/teachers/classes/TeacherStudentView.vue'
 
 import PageCinematicEditor from '../../ozaria/site/components/cinematic/PageCinematicEditor'
+import PageInteractiveEditor from '../../ozaria/site/components/interactive/PageInteractiveEditor'
 
 let vueRouter
 
@@ -23,6 +24,11 @@ export default function getVueRouter () {
           // TODO: Once we have a base editor component, use the nested route structure.
           path: '/editor/cinematic/:slug?',
           component: PageCinematicEditor,
+          props: true
+        },
+        {
+          path: '/editor/interactive/:slug?',
+          component: PageInteractiveEditor,
           props: true
         },
         {

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -575,13 +575,15 @@ module.exports = class User extends CocoModel
   useGoogleAnalytics: -> not (features?.chinaInfra ? false)
   # features.china is set globally for our China server
   showChinaVideo: -> (features?.china ? false) or (features?.chinaInfra ? false)
-  # Ozaria flags
-  showOzariaCampaign: -> @isAdmin()
   canAccessCampaignFreelyFromChina: (campaignID) -> campaignID == "55b29efd1cd6abe8ce07db0d" or campaignID == "5789236960deed1f00ec2ab8" or campaignID == "578913f2c8871ac2326fa3e4"
   isCreatedByTarena: -> @get('clientCreator') == "5c80a2a0d78b69002448f545"   #ClientID of Tarena2 on koudashijie.com
-  hasCinematicAccess: -> @isAdmin()
   # Special flag to detect whether we're temporarily showing static html while loading full site
   showingStaticPagesWhileLoading: -> false
+
+  # Ozaria flags
+  showOzariaCampaign: -> @isAdmin()
+  hasCinematicAccess: -> @isAdmin()
+  hasInteractiveAccess: -> @isAdmin()
 
 
 tiersByLevel = [-1, 0, 0.05, 0.14, 0.18, 0.32, 0.41, 0.5, 0.64, 0.82, 0.91, 1.04, 1.22, 1.35, 1.48, 1.65, 1.78, 1.96, 2.1, 2.24, 2.38, 2.55, 2.69, 2.86, 3.03, 3.16, 3.29, 3.42, 3.58, 3.74, 3.89, 4.04, 4.19, 4.32, 4.47, 4.64, 4.79, 4.96,

--- a/app/schemas/models/interactives/common/interactive_types.schema.js
+++ b/app/schemas/models/interactives/common/interactive_types.schema.js
@@ -6,6 +6,7 @@ const schema = require('../../../schemas')
 const interactiveDraggableOrderingSchema = {
   type: 'object',
   additionalProperties: false,
+  title: 'Draggable Ordering interactive data',
   properties: {
     labels: { type: 'array', items: { type: 'string' } },
     elements: {
@@ -15,19 +16,21 @@ const interactiveDraggableOrderingSchema = {
         additionalProperties: false,
         properties: {
           text: { type: 'string' },
-          elementId: schema.objectId({ hidden: true })
+          elementId: schema.stringID({ readOnly: true })
         }
       }
     },
-    solution: solutionSchema.elementOrderingSolutionSchema
+    solution: solutionSchema.elementOrderingSolutionSchema,
+    i18n: { type: 'object', format: 'i18n', props: ['labels', 'elements'], description: 'Help translate this interactive.' }
   }
 }
 
 const interactiveInsertCodeSchema = {
   type: 'object',
   additionalProperties: false,
+  title: 'Insert Code interactive data',
   properties: {
-    starterCode: { type: 'string' }, // codeLanguage will be determined by unitCodeLanguage in interactives schema
+    starterCode: { type: 'string', format: 'ace' }, // codeLanguage will be determined by unitCodeLanguage in interactives schema
     choices: {
       type: 'array',
       items: {
@@ -35,7 +38,7 @@ const interactiveInsertCodeSchema = {
         additionalProperties: false,
         properties: {
           text: { type: 'string' },
-          choiceId: schema.objectId({ hidden: true }),
+          choiceId: schema.stringID({ readOnly: true }),
           triggerArt: { type: 'string' }
         }
       }
@@ -47,6 +50,7 @@ const interactiveInsertCodeSchema = {
 const interactiveDraggableClassificationSchema = {
   type: 'object',
   additionalProperties: false,
+  title: 'Draggable Classification interactive data',
   properties: {
     categories: {
       type: 'array',
@@ -54,7 +58,7 @@ const interactiveDraggableClassificationSchema = {
         type: 'object',
         additionalProperties: false,
         properties: {
-          categoryId: schema.objectId({ hidden: true }),
+          categoryId: schema.stringID({ readOnly: true }),
           text: { type: 'string' }
         }
       }
@@ -66,17 +70,19 @@ const interactiveDraggableClassificationSchema = {
         additionalProperties: false,
         properties: {
           text: { type: 'string' },
-          elementId: schema.objectId({ hidden: true })
+          elementId: schema.stringID({ readOnly: true })
         }
       }
     },
-    solution: solutionSchema.classificationSolutionSchema
+    solution: solutionSchema.classificationSolutionSchema,
+    i18n: { type: 'object', format: 'i18n', props: ['categories', 'elements'], description: 'Help translate this interactive.' }
   }
 }
 
 const interactiveMultipleChoiceSchema = {
   type: 'object',
   additionalProperties: false,
+  title: 'Multiple Choice interactive data',
   properties: {
     choices: {
       type: 'array',
@@ -85,19 +91,21 @@ const interactiveMultipleChoiceSchema = {
         additionalProperties: false,
         properties: {
           text: { type: 'string' },
-          choiceId: schema.objectId({ hidden: true })
+          choiceId: schema.stringID({ readOnly: true })
         }
       }
     },
-    solution: solutionSchema.singleSolutionSchema
+    solution: solutionSchema.singleSolutionSchema,
+    i18n: { type: 'object', format: 'i18n', props: ['choices'], description: 'Help translate this interactive.' }
   }
 }
 
 const interactiveFillInCodeSchema = {
   type: 'object',
   additionalProperties: false,
+  title: 'Fill-in Code interactive data',
   properties: {
-    starterCode: { type: 'string' }, // codeLanguage will be determined by unitCodeLanguage in interactives schema
+    starterCode: { type: 'string', format: 'ace' }, // codeLanguage will be determined by unitCodeLanguage in interactives schema
     commonResponses: {
       type: 'array',
       items: {
@@ -105,7 +113,7 @@ const interactiveFillInCodeSchema = {
         additionalProperties: false,
         properties: {
           text: { type: 'string' },
-          responseId: schema.objectId({ hidden: true }),
+          responseId: schema.stringID({ readOnly: true }),
           triggerArt: { type: 'string' }
         }
       }
@@ -117,6 +125,7 @@ const interactiveFillInCodeSchema = {
 const interactiveDraggableStatementCompletionSchema = {
   type: 'object',
   additionalProperties: false,
+  title: 'Draggable Statement Completion interactive data',
   properties: _.extend({}, interactiveDraggableOrderingSchema.properties)
 }
 

--- a/app/schemas/models/interactives/interactive.schema.js
+++ b/app/schemas/models/interactives/interactive.schema.js
@@ -7,7 +7,6 @@ const schema = require('../../schemas')
 
 const interactiveSchema = {
   type: 'object',
-  required: ['interactiveType', 'promptText', 'interactiveData', 'unitCodeLanguage'],
   properties: {
     interactiveType: {
       'enum': ['draggable-ordering', 'insert-code', 'draggable-classification', 'multiple-choice', 'fill-in-code', 'draggable-statement-completion']

--- a/app/schemas/models/interactives/interactive.schema.js
+++ b/app/schemas/models/interactives/interactive.schema.js
@@ -9,9 +9,18 @@ const interactiveSchema = {
   type: 'object',
   properties: {
     interactiveType: {
-      'enum': ['draggable-ordering', 'insert-code', 'draggable-classification', 'multiple-choice', 'fill-in-code', 'draggable-statement-completion']
+      'enum': ['draggable-ordering', 'insert-code', 'draggable-classification', 'multiple-choice', 'fill-in-code', 'draggable-statement-completion'],
+      title: 'Type of interactive'
     },
-    promptText: { type: 'string' }
+    promptText: { type: 'string', title: 'Prompt text' },
+    draggableOrderingData: interactiveTypeSchema.interactiveDraggableOrderingSchema,
+    insertCodeData: interactiveTypeSchema.interactiveInsertCodeSchema,
+    draggableClassificationData: interactiveTypeSchema.interactiveDraggableClassificationSchema,
+    multipleChoiceData: interactiveTypeSchema.interactiveMultipleChoiceSchema,
+    fillInCodeData: interactiveTypeSchema.interactiveFillInCodeSchema,
+    draggableStatementCompletionData: interactiveTypeSchema.interactiveDraggableStatementCompletionSchema,
+    unitCodeLanguage: { 'enum': ['python', 'javascript', 'both'], title: 'Code Language' },
+    i18n: { type: 'object', format: 'i18n', props: ['promptText'], description: 'Help translate this interactive.' }
   },
   allOf: [
     {
@@ -20,7 +29,11 @@ const interactiveSchema = {
       },
       then: {
         'properties': {
-          'interactiveData': interactiveTypeSchema.interactiveDraggableOrderingSchema,
+          'insertCodeData': { type: 'null' },
+          'draggableClassificationData': { type: 'null' },
+          'multipleChoiceData': { type: 'null' },
+          'fillInCodeData': { type: 'null' },
+          'draggableStatementCompletionData': { type: 'null' },
           'unitCodeLanguage': { 'enum': ['python', 'javascript', 'both'] }
         }
       }
@@ -31,7 +44,11 @@ const interactiveSchema = {
       },
       then: {
         'properties': {
-          'interactiveData': interactiveTypeSchema.interactiveInsertCodeSchema,
+          'draggableOrderingData': { type: 'null' },
+          'draggableClassificationData': { type: 'null' },
+          'multipleChoiceData': { type: 'null' },
+          'fillInCodeData': { type: 'null' },
+          'draggableStatementCompletionData': { type: 'null' },
           'unitCodeLanguage': { 'enum': ['python', 'javascript'] }
         }
       }
@@ -42,7 +59,11 @@ const interactiveSchema = {
       },
       then: {
         'properties': {
-          'interactiveData': interactiveTypeSchema.interactiveDraggableClassificationSchema,
+          'draggableOrderingData': { type: 'null' },
+          'insertCodeData': { type: 'null' },
+          'multipleChoiceData': { type: 'null' },
+          'fillInCodeData': { type: 'null' },
+          'draggableStatementCompletionData': { type: 'null' },
           'unitCodeLanguage': { 'enum': ['python', 'javascript', 'both'] }
         }
       }
@@ -53,7 +74,11 @@ const interactiveSchema = {
       },
       then: {
         'properties': {
-          'interactiveData': interactiveTypeSchema.interactiveMultipleChoiceSchema,
+          'draggableOrderingData': { type: 'null' },
+          'insertCodeData': { type: 'null' },
+          'draggableClassificationData': { type: 'null' },
+          'fillInCodeData': { type: 'null' },
+          'draggableStatementCompletionData': { type: 'null' },
           'unitCodeLanguage': { 'enum': ['python', 'javascript', 'both'] }
         }
       }
@@ -64,7 +89,11 @@ const interactiveSchema = {
       },
       then: {
         'properties': {
-          'interactiveData': interactiveTypeSchema.interactiveFillInCodeSchema,
+          'draggableOrderingData': { type: 'null' },
+          'insertCodeData': { type: 'null' },
+          'draggableClassificationData': { type: 'null' },
+          'multipleChoiceData': { type: 'null' },
+          'draggableStatementCompletionData': { type: 'null' },
           'unitCodeLanguage': { 'enum': ['python', 'javascript'] }
         }
       }
@@ -75,7 +104,11 @@ const interactiveSchema = {
       },
       then: {
         'properties': {
-          'interactiveData': interactiveTypeSchema.interactiveDraggableStatementCompletionSchema,
+          'draggableOrderingData': { type: 'null' },
+          'insertCodeData': { type: 'null' },
+          'draggableClassificationData': { type: 'null' },
+          'multipleChoiceData': { type: 'null' },
+          'fillInCodeData': { type: 'null' },
           'unitCodeLanguage': { 'enum': ['python', 'javascript', 'both'] }
         }
       }
@@ -83,7 +116,7 @@ const interactiveSchema = {
   ]
 }
 
-schema.extendBasicPropertiesNew(interactiveSchema, 'interactive')
-schema.extendNamedPropertiesNew(interactiveSchema)
+schema.extendBasicProperties(interactiveSchema, 'interactive')
+schema.extendNamedProperties(interactiveSchema)
 
 module.exports = interactiveSchema

--- a/app/schemas/models/interactives/interactive_session.schema.js
+++ b/app/schemas/models/interactives/interactive_session.schema.js
@@ -14,7 +14,7 @@ const interactiveSessionSchema = {
       'enum': ['draggable-ordering', 'insert-code', 'draggable-classification', 'multiple-choice', 'fill-in-code', 'draggable-statement-completion']
     },
     userId: schema.objectId(),
-    sessionCodeLanguage: { 'enum': ['python', 'javascript'] }, // this will come from the course instance / intro level language
+    sessionCodeLanguage: { 'enum': ['python', 'javascript'] }, // this will come from the course instance(for classroom) / me.aceConfig (for home users)
     submissionCount: { type: 'number' },
     complete: { type: 'boolean' },
     created: schema.stringDate(),

--- a/app/schemas/models/interactives/interactive_session.schema.js
+++ b/app/schemas/models/interactives/interactive_session.schema.js
@@ -73,6 +73,6 @@ const interactiveSessionSchema = {
   ]
 }
 
-schema.extendBasicPropertiesNew(interactiveSessionSchema, 'interactive.session')
+schema.extendBasicProperties(interactiveSessionSchema, 'interactive.session')
 
 module.exports = interactiveSessionSchema

--- a/app/schemas/schemas.coffee
+++ b/app/schemas/schemas.coffee
@@ -65,15 +65,6 @@ me.extendBasicProperties = (schema, linkFragment) ->
   schema.properties = {} unless schema.properties?
   _.extend(schema.properties, basicProps(linkFragment))
 
-# Basic props for new schemas using json draft 07 
-basicPropsNew = (linkFragment) ->
-  _id: me.objectId(links: [{rel: 'self', href: "/db/#{linkFragment}/{($)}"}], hidden: true)
-  __v: {title: 'Mongoose Version', hidden: true}
-
-me.extendBasicPropertiesNew = (schema, linkFragment) ->
-  schema.properties = {} unless schema.properties?
-  _.extend(schema.properties, basicPropsNew(linkFragment))
-
 # PATCHABLE
 
 patchableProps = ->
@@ -98,16 +89,6 @@ namedProps = ->
 me.extendNamedProperties = (schema) ->
   schema.properties = {} unless schema.properties?
   _.extend(schema.properties, namedProps())
-
-
-# Named props for new schemas using json draft 07 
-namedPropsNew = ->
-  name: me.shortString({title: 'Name'})
-  slug: me.shortString({title: 'Slug', hidden: true})
-
-me.extendNamedPropertiesNew = (schema) ->
-  schema.properties = {} unless schema.properties?
-  _.extend(schema.properties, namedPropsNew())
 
 # VERSIONED
 

--- a/ozaria/site/api/interactive.js
+++ b/ozaria/site/api/interactive.js
@@ -1,0 +1,54 @@
+import fetchJson from 'app/core/api/fetch-json'
+
+/**
+ * Retrieves the json representation of a interactive.
+ * @param {string} slug - Slug of the interactive.
+ * @return {Promise<Object>} - Raw Interactive object
+ */
+export const getInteractive = slug => {
+  if (!slug) {
+    throw new Error(`No slug supplied`)
+  }
+  return fetchJson(`/db/interactive/${slug}`)
+}
+
+/**
+ * @typedef {Object} InteractiveList
+ * @param {string} name - The name of the Interactive
+ * @param {string} slug - The Interactive's slug
+ * @param {string} interactiveType - The interactive type
+ */
+
+/**
+ * Returns a list of all interactives in the database.
+ * @returns {Promise<InteractiveList[]>} - List of interactives sorted by slug
+ */
+export const getAllInteractives = () => fetchJson('/db/interactives')
+
+/**
+ * Updates a interactive in the database.
+ * @returns {Promise<Object>} - Raw Interactive object
+ */
+export const putInteractive = ({ data }, options = {}) => {
+  if (!data) {
+    throw new Error('Please pass in a data property.')
+  }
+  const slugOrId = data.id || data.slug
+  if (!slugOrId) {
+    throw new Error('You must pass either a slug or ObjectId')
+  }
+  return fetchJson(`/db/interactive/${slugOrId}`, _.assign({}, options, {
+    method: 'PUT',
+    json: data
+  }))
+}
+
+/**
+ * Creates a new interactive in the database.
+ * @returns {Promise<Object>} - Raw Interactive object
+ */
+export const postInteractive = ({ name }, options = {}) =>
+  fetchJson('/db/interactive', _.assign({}, options, {
+    method: 'POST',
+    json: { name }
+  }))

--- a/ozaria/site/components/cinematic/PageCinematicEditor/index.vue
+++ b/ozaria/site/components/cinematic/PageCinematicEditor/index.vue
@@ -1,7 +1,7 @@
 <script>
 import { getCinematic, putCinematic, createCinematic, getAllCinematics } from '../../../api/cinematic'
 import Cinematic from '../../../models/Cinematic'
-import ListItem from '../common/BaseListItem'
+import ListItem from '../../common/BaseListItem'
 import CinematicCanvas from '../common/CinematicCanvas'
 import CocoCollection from 'app/collections/CocoCollection'
 const api = require('core/api')

--- a/ozaria/site/components/common/BaseListItem.vue
+++ b/ozaria/site/components/common/BaseListItem.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-// Simple list component used in the Cinematic editor.
+// Simple list component used in the Cinematic/Interactive editor.
 export default {
   props: {
     text: {

--- a/ozaria/site/components/interactive/PageInteractiveEditor/index.vue
+++ b/ozaria/site/components/interactive/PageInteractiveEditor/index.vue
@@ -1,0 +1,208 @@
+<script>
+import { getInteractive, putInteractive, postInteractive, getAllInteractives } from '../../../api/interactive'
+import Interactive from '../../../models/Interactive'
+import ListItem from '../../common/BaseListItem'
+import Ajv from 'ajv'
+import ozariaUtils from 'app/core/ozariaUtils'
+
+require('lib/setupTreema')
+
+module.exports = Vue.extend({
+  props: {
+    slug: String
+  },
+  data: () => ({
+    interactive: null,
+    treema: null,
+    interactiveList: null,
+    valid: true,
+    state: {
+      saving: false
+    },
+    interactiveSlug: ""
+  }),
+  components: {
+    'list-item': ListItem
+  },
+  async created () {
+    if (!me.hasInteractiveAccess()) {
+      alert('You must be logged in as an admin to use this page.')
+      return application.router.navigate('/editor', { trigger: true })
+    }
+    console.log(`Got the slug: ${this.slug}`)
+    this.interactiveSlug = this.slug
+    if (this.interactiveSlug)  {
+      await this.fetchInteractive(this.interactiveSlug)
+    }
+    else {
+      await this.fetchList()
+    }
+  },
+  methods: {
+    /**
+     * Fetch and populate treema with interactive slug.
+     * Clears the list
+     */
+    async fetchInteractive(slug) {
+      this.interactiveList = null
+      this.interactiveSlug = slug
+      try {
+        this.interactive = new Interactive(await getInteractive(slug))
+      } catch (e) {
+        noty({ text: `Error finding slug '${slug}'.`, type: 'error', timeout: '1000' })
+        return this.fetchList()
+      }
+      const data = $.extend(true, {}, this.interactive.attributes)
+      const el = $(`<div></div>`);
+      const treemaOptions = {
+        data: data,
+        schema: Interactive.schema,
+        callbacks: {
+          change: this.onTreemaChanged
+        }
+      }
+      const treema = this.treema = TreemaNode.make(el, treemaOptions)
+      treema.build()
+      $(this.$refs.treemaEditor).append(el)
+    },
+
+    /**
+     * Fetch all names and slugs of interactives from the database.
+     * Clears the slug and treema.
+     */
+    async fetchList () {
+      this.interactive = null
+      this.interactiveSlug = ''
+      this.treema = null
+      $(this.$refs.treemaEditor).children().remove()
+      try {
+        this.interactiveList = await getAllInteractives();
+      } catch (e) {
+        console.error("Error while fetching the interactive list:", e)
+        noty({ text: 'Error occured while fetching the interactive list', type: 'error', timeout: 1000 })
+      }
+    },
+
+    /**
+     * Performs schema validation and pushes changes from treema to the interactive model.
+     */
+    onTreemaChanged() {
+      const ajv = new Ajv(ozariaUtils.getAjvOptions())
+      const data = this.treema.data
+      this.valid = ajv.validate(Interactive.schema, data)
+      if (this.valid) {
+        this.interactive.set(data)
+      } 
+      else {
+        console.error('Schema validation error', ajv.errors)
+        noty({
+          text: 'Schema validation error.',
+          type:'error',
+          timeout: 1000
+        })
+      }
+    },
+
+    /**
+     * Saves the properties of the interactive to the database.
+     */
+    async saveInteractive() {
+      if (this.valid) {
+        this.state.saving = true
+        try {
+          this.interactive = new Interactive(await putInteractive({ data: this.interactive.toJSON() }))
+          this.treema.set('/', $.extend(true, {}, this.interactive.attributes))
+          noty({ text: 'Saved', type: 'success', timeout: 1000 })
+        } catch (e) {
+          console.error("Error while saving the interactive", e)
+          noty({ text: 'Error occured while saving the interactive', type: 'error', timeout: 1000 })
+        }
+        this.state.saving = false
+      } else {
+        noty({
+          text: `Cant save since the schema is not valid.`,
+          type:'error',
+          timeout: 1000
+        })
+      }
+    },
+
+    /**
+     * Creates a new interactive in the database.
+     */
+    async createInteractive() {
+      const name = window.prompt("Name of new interactive?")
+      if (!name) { return }
+      try {
+        const result = await postInteractive({ name })
+        return this.fetchList()
+      } catch(e) {
+        console.error("Error:", e)
+        noty({ text: 'An error occurred', type: 'error', timeout: 1000 })
+      }
+    }
+
+  },
+  computed: {
+    heading: function() {
+      if (this.interactiveSlug && this.interactive) {
+        return `Interactive Editor: '${this.interactive.get('name')}'`
+      }
+      return "Interactive Editor"
+    }
+  }
+})
+</script>
+
+<template>
+  <div class="container">
+
+    <div v-if='!interactiveSlug'>
+      <div class="row">
+        <div class="col-md-12"><h1>{{ heading }}</h1></div>
+      </div>
+      <div class="row">
+        <ul>
+          <list-item
+            v-for="int in interactiveList"
+            :key="int.slug"
+            :text="int.name"
+            :slug="int.slug"
+            :clickHandler="() => fetchInteractive(int.slug)"
+            ></list-item>
+            <li><button @click="createInteractive">+</button></li>
+        </ul>
+      </div>
+    </div>
+
+    <div v-else>
+      <div class="row">
+        <div class="col-md-8"><h1>{{ heading }}</h1></div>
+        <div class="col-md-4">
+          <span>There is no autosave. Please click this button often.</span>
+          <button @click="saveInteractive" :disabled="state.saving || !interactive">save</button>
+          <button><a @click="fetchList()">Back to list view</a></button>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-12">
+          <p style="padding-top:20px">NOTE: Please save the data for interactives before adding the solution.</p>
+          <div id="treema-editor" ref="treemaEditor"></div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</template>
+
+<style scoped>
+  .container {
+    margin-top: 30px;
+    background-color: white;
+    padding: 20px;
+  }
+  button {
+    margin: 5px;
+    padding: 5px;
+  }
+</style>

--- a/ozaria/site/components/interactive/PageInteractiveEditor/index.vue
+++ b/ozaria/site/components/interactive/PageInteractiveEditor/index.vue
@@ -96,7 +96,7 @@ module.exports = Vue.extend({
       else {
         console.error('Schema validation error', ajv.errors)
         noty({
-          text: 'Schema validation error.',
+          text: 'Schema validation error. Please check the console for errors.',
           type:'error',
           timeout: 1000
         })
@@ -107,24 +107,24 @@ module.exports = Vue.extend({
      * Saves the properties of the interactive to the database.
      */
     async saveInteractive() {
-      if (this.valid) {
-        this.state.saving = true
-        try {
-          this.interactive = new Interactive(await putInteractive({ data: this.interactive.toJSON() }))
-          this.treema.set('/', $.extend(true, {}, this.interactive.attributes))
-          noty({ text: 'Saved', type: 'success', timeout: 1000 })
-        } catch (e) {
-          console.error("Error while saving the interactive", e)
-          noty({ text: 'Error occured while saving the interactive', type: 'error', timeout: 1000 })
-        }
-        this.state.saving = false
-      } else {
+      if (!this.valid) {
         noty({
           text: `Cant save since the schema is not valid.`,
           type:'error',
           timeout: 1000
         })
+        return
       }
+      this.state.saving = true
+      try {
+        this.interactive = new Interactive(await putInteractive({ data: this.interactive.toJSON() }))
+        this.treema.set('/', $.extend(true, {}, this.interactive.attributes))
+        noty({ text: 'Saved', type: 'success', timeout: 1000 })
+      } catch (e) {
+        console.error("Error while saving the interactive", e)
+        noty({ text: 'Error occured while saving the interactive', type: 'error', timeout: 1000 })
+      }
+      this.state.saving = false
     },
 
     /**

--- a/ozaria/site/models/Interactive.js
+++ b/ozaria/site/models/Interactive.js
@@ -1,0 +1,10 @@
+import CocoModel from 'app/models/CocoModel'
+import schema from 'schemas/models/interactives/interactive.schema'
+
+class Interactive extends CocoModel { }
+
+Interactive.className = 'Interactive'
+Interactive.schema = schema
+Interactive.urlRoot = '/db/interactive'
+
+module.exports = Interactive

--- a/test/app/models/Interactive.spec.js
+++ b/test/app/models/Interactive.spec.js
@@ -15,10 +15,11 @@ import {
 import interactiveSchema from '../../../app/schemas/models/interactives/interactive.schema'
 
 import Ajv from 'ajv'
+import ozariaUtils from 'core/ozariaUtils'
 
 function schemaCompileTest (schemaObject) {
   it('compiles successfully', () => {
-    const ajv = new Ajv() // If we want to use both draft-04 and draft-06/07 schemas then use { schemaId: 'auto' }
+    const ajv = new Ajv(ozariaUtils.getAjvOptions())
     const validate = ajv.compile(schemaObject)
     expect(typeof validate).toBe('function')
     expect(ajv.errors).toBe(null)
@@ -27,7 +28,7 @@ function schemaCompileTest (schemaObject) {
 
 function schemaValidateObjectTest (schemaObject, testObject) {
   it('validates a correct object', () => {
-    const ajv = new Ajv()
+    const ajv = new Ajv(ozariaUtils.getAjvOptions())
     const valid = ajv.validate(schemaObject, testObject)
     expect(valid).toBe(true)
     expect(ajv.errors).toBe(null)
@@ -36,7 +37,7 @@ function schemaValidateObjectTest (schemaObject, testObject) {
 
 function schemaValidateBadObjectTest (schemaObject, testObject) {
   it('fails to validate an incorrect object', () => {
-    const ajv = new Ajv()
+    const ajv = new Ajv(ozariaUtils.getAjvOptions())
     const valid = ajv.validate(schemaObject, testObject)
     expect(valid).toBe(false)
     expect(ajv.errors).toBeDefined()
@@ -45,7 +46,7 @@ function schemaValidateBadObjectTest (schemaObject, testObject) {
 
 function schemaValidateBadPropertyTest (schemaObject, testObject) {
   it('fails to validate incorrect properties on object', () => {
-    const ajv = new Ajv()
+    const ajv = new Ajv(ozariaUtils.getAjvOptions())
     const valid = ajv.validate(schemaObject, testObject)
     expect(valid).toBe(false)
     expect(ajv.errors).toBeDefined()
@@ -119,142 +120,151 @@ const interactiveDraggableStatementCompletionObject = {
   solution: ['1123456789abcdefghijklmn', '0123456789abcdefghijklmn']
 }
 
-describe('interactive solutions schema tests', () => {
-  describe('elementOrderingSolutionSchema', () => {
-    const elementOrderingObject = ['0123456789abcdefghijklmn', '1123456789abcdefghijklmn']
-    const badElementOrderingObject = { 'string in object': 'hello' }
-    schemaCompileTest(elementOrderingSolutionSchema)
-    schemaValidateObjectTest(elementOrderingSolutionSchema, elementOrderingObject)
-    schemaValidateBadObjectTest(elementOrderingSolutionSchema, badElementOrderingObject)
+describe('Interactive', () => {
+  describe('interactive solutions schema tests', () => {
+    describe('elementOrderingSolutionSchema', () => {
+      const elementOrderingObject = ['0123456789abcdefghijklmn', '1123456789abcdefghijklmn']
+      const badElementOrderingObject = { 'string in object': 'hello' }
+      schemaCompileTest(elementOrderingSolutionSchema)
+      schemaValidateObjectTest(elementOrderingSolutionSchema, elementOrderingObject)
+      schemaValidateBadObjectTest(elementOrderingSolutionSchema, badElementOrderingObject)
+    })
+
+    describe('singleSolutionSchema', () => {
+      const singleSolutionObject = '0123456789abcdefghijklmn'
+      const badSingleSolutionObject = 42
+      schemaCompileTest(singleSolutionSchema)
+      schemaValidateObjectTest(singleSolutionSchema, singleSolutionObject)
+      schemaValidateBadObjectTest(singleSolutionSchema, badSingleSolutionObject)
+    })
+
+    describe('classificationSolutionSchema', () => {
+      const classificationSolutionObject = [{ categoryId: 'c123456789abcdefghijklmn', elements: ['0123456789abcdefghijklmn', '1123456789abcdefghijklmn'] }]
+      const badClassificationSolutionObject = { answer: 'wrong' }
+      const badClassificationSolutionPropertiesObject = [{ categoryId: 42, elements: 'element1' }]
+      schemaCompileTest(classificationSolutionSchema)
+      schemaValidateObjectTest(classificationSolutionSchema, classificationSolutionObject)
+      schemaValidateBadObjectTest(classificationSolutionSchema, badClassificationSolutionObject)
+      schemaValidateBadPropertyTest(classificationSolutionSchema, badClassificationSolutionPropertiesObject)
+    })
   })
 
-  describe('singleSolutionSchema', () => {
-    const singleSolutionObject = '0123456789abcdefghijklmn'
-    const badSingleSolutionObject = 42
-    schemaCompileTest(singleSolutionSchema)
-    schemaValidateObjectTest(singleSolutionSchema, singleSolutionObject)
-    schemaValidateBadObjectTest(singleSolutionSchema, badSingleSolutionObject)
+  describe('interactive-type schema tests', () => {
+    describe('interactiveDraggableOrderingSchema', () => {
+      const badInteractiveDraggableObject = 'wrong'
+      const badInteractiveDraggablePropertiesObject = {
+        labels: { not: 'an array' },
+        elements: [{ text: { not: 'just a string' }, elementId: ['not just a string'] }]
+      }
+      schemaCompileTest(interactiveDraggableOrderingSchema)
+      schemaValidateObjectTest(interactiveDraggableOrderingSchema, interactiveDraggableObject)
+      schemaValidateBadObjectTest(interactiveDraggableOrderingSchema, badInteractiveDraggableObject)
+      schemaValidateBadPropertyTest(interactiveDraggableOrderingSchema, badInteractiveDraggablePropertiesObject)
+    })
+
+    describe('interactiveInsertCodeSchema', () => {
+      const badInteractiveInsertCodeObject = 'it is only a rabbit'
+      const badInteractiveInsertCodePropertiesObject = {
+        starterCode: 'monty python',
+        choices: [{
+          text: 42,
+          choiceId: [42],
+          triggerArt: { 'fail?': 'yep' }
+        }]
+      }
+      schemaCompileTest(interactiveInsertCodeSchema)
+      schemaValidateObjectTest(interactiveInsertCodeSchema, interactiveInsertCodeObject)
+      schemaValidateBadObjectTest(interactiveInsertCodeSchema, badInteractiveInsertCodeObject)
+      schemaValidateBadPropertyTest(interactiveInsertCodeSchema, badInteractiveInsertCodePropertiesObject)
+    })
+
+    describe('interactiveDraggableClassificationSchema', () => {
+      const badInteractiveDraggableClassificationObject = ['something', 'draggable']
+      const badInteractiveDraggableClassificationPropertiesObject = {
+        categories: {
+          categoryId: 'draggable-id',
+          text: 'Something draggable'
+        },
+        elements: 'only one element'
+      }
+      schemaCompileTest(interactiveDraggableClassificationSchema)
+      schemaValidateObjectTest(interactiveDraggableClassificationSchema, interactiveDraggableClassificationObject)
+      schemaValidateBadObjectTest(interactiveDraggableClassificationSchema, badInteractiveDraggableClassificationObject)
+      schemaValidateBadPropertyTest(interactiveDraggableClassificationSchema, badInteractiveDraggableClassificationPropertiesObject)
+    })
+
+    describe('interactiveMultipleChoiceSchema', () => {
+      const badInteractiveMultipleChoiceObject = 'not an object'
+      const badInteractiveMultipleChoicePropertiesObject = {
+        choices: [{
+          text: ['not just text'],
+          choiceId: { not: 'a choiceId' }
+        }]
+      }
+      schemaCompileTest(interactiveMultipleChoiceSchema)
+      schemaValidateObjectTest(interactiveMultipleChoiceSchema, interactiveMultipleChoiceObject)
+      schemaValidateBadObjectTest(interactiveMultipleChoiceSchema, badInteractiveMultipleChoiceObject)
+      schemaValidateBadPropertyTest(interactiveMultipleChoiceSchema, badInteractiveMultipleChoicePropertiesObject)
+    })
+
+    describe('interactiveFillInCodeSchema', () => {
+      const badInteractiveFillInCodeObject = ['not', 'an', 'object']
+      const badInteractiveFillInCodePropertiesObject = {
+        starterCode: {
+          language: ['javascript'],
+          code: 42
+        },
+        commonResponses: { hello: 'world!' }
+      }
+      schemaCompileTest(interactiveFillInCodeSchema)
+      schemaValidateObjectTest(interactiveFillInCodeSchema, interactiveFillInCodeObject)
+      schemaValidateBadObjectTest(interactiveFillInCodeSchema, badInteractiveFillInCodeObject)
+      schemaValidateBadPropertyTest(interactiveFillInCodeSchema, badInteractiveFillInCodePropertiesObject)
+    })
+
+    describe('interactiveDraggableStatementCompletionSchema', () => {
+      const badInteractiveDraggableStatementCompletionObject = ['not', 'correct']
+      const badInteractiveDraggableStatementCompletionPropertiesObject = {
+        labels: 'not an array',
+        elements: [{ text: { not: 'a string' }, elementId: 42 }]
+      }
+      schemaCompileTest(interactiveDraggableStatementCompletionSchema)
+      schemaValidateObjectTest(interactiveDraggableStatementCompletionSchema, interactiveDraggableStatementCompletionObject)
+      schemaValidateBadObjectTest(interactiveDraggableStatementCompletionSchema, badInteractiveDraggableStatementCompletionObject)
+      schemaValidateBadPropertyTest(interactiveDraggableStatementCompletionSchema, badInteractiveDraggableStatementCompletionPropertiesObject)
+    })
   })
 
-  describe('classificationSolutionSchema', () => {
-    const classificationSolutionObject = [{ categoryId: 'c123456789abcdefghijklmn', elements: ['0123456789abcdefghijklmn', '1123456789abcdefghijklmn'] }]
-    const badClassificationSolutionObject = { answer: 'wrong' }
-    const badClassificationSolutionPropertiesObject = [{ categoryId: 42, elements: 'element1' }]
-    schemaCompileTest(classificationSolutionSchema)
-    schemaValidateObjectTest(classificationSolutionSchema, classificationSolutionObject)
-    schemaValidateBadObjectTest(classificationSolutionSchema, badClassificationSolutionObject)
-    schemaValidateBadPropertyTest(classificationSolutionSchema, badClassificationSolutionPropertiesObject)
-  })
-})
-
-describe('interactive-type schema tests', () => {
-  describe('interactiveDraggableOrderingSchema', () => {
-    const badInteractiveDraggableObject = 'wrong'
-    const badInteractiveDraggablePropertiesObject = {
-      labels: { not: 'an array' },
-      elements: [{ text: { not: 'just a string' }, elementId: ['not just a string'] }]
+  describe('interactive overall schema', () => {
+    const interactivesObject = {
+      interactiveType: 'draggable-ordering',
+      promptText: 'prompt text for interactive',
+      draggableOrderingData: interactiveDraggableObject,
+      unitCodeLanguage: 'python'
     }
-    schemaCompileTest(interactiveDraggableOrderingSchema)
-    schemaValidateObjectTest(interactiveDraggableOrderingSchema, interactiveDraggableObject)
-    schemaValidateBadObjectTest(interactiveDraggableOrderingSchema, badInteractiveDraggableObject)
-    schemaValidateBadPropertyTest(interactiveDraggableOrderingSchema, badInteractiveDraggablePropertiesObject)
-  })
-
-  describe('interactiveInsertCodeSchema', () => {
-    const badInteractiveInsertCodeObject = 'it is only a rabbit'
-    const badInteractiveInsertCodePropertiesObject = {
-      starterCode: 'monty python',
-      choices: [{
-        text: 42,
-        choiceId: [42],
-        triggerArt: { 'fail?': 'yep' }
-      }]
+    const badInteractivesObjectProperties = {
+      interactiveType: 'draggable-ordering',
+      promptText: 'prompt text for interactive',
+      insertCodeData: interactiveInsertCodeObject, // incorrect data schema
+      unitCodeLanguage: 'python'
     }
-    schemaCompileTest(interactiveInsertCodeSchema)
-    schemaValidateObjectTest(interactiveInsertCodeSchema, interactiveInsertCodeObject)
-    schemaValidateBadObjectTest(interactiveInsertCodeSchema, badInteractiveInsertCodeObject)
-    schemaValidateBadPropertyTest(interactiveInsertCodeSchema, badInteractiveInsertCodePropertiesObject)
-  })
-
-  describe('interactiveDraggableClassificationSchema', () => {
-    const badInteractiveDraggableClassificationObject = ['something', 'draggable']
-    const badInteractiveDraggableClassificationPropertiesObject = {
-      categories: {
-        categoryId: 'draggable-id',
-        text: 'Something draggable'
-      },
-      elements: 'only one element'
+    const badInteractivesObjectData = {
+      interactiveType: 'draggable-ordering',
+      promptText: 'prompt text for interactive',
+      draggableOrderingData: interactiveInsertCodeObject, // incorrect data schema
+      unitCodeLanguage: 'python'
     }
-    schemaCompileTest(interactiveDraggableClassificationSchema)
-    schemaValidateObjectTest(interactiveDraggableClassificationSchema, interactiveDraggableClassificationObject)
-    schemaValidateBadObjectTest(interactiveDraggableClassificationSchema, badInteractiveDraggableClassificationObject)
-    schemaValidateBadPropertyTest(interactiveDraggableClassificationSchema, badInteractiveDraggableClassificationPropertiesObject)
-  })
-
-  describe('interactiveMultipleChoiceSchema', () => {
-    const badInteractiveMultipleChoiceObject = 'not an object'
-    const badInteractiveMultipleChoicePropertiesObject = {
-      choices: [{
-        text: ['not just text'],
-        choiceId: { not: 'a choiceId' }
-      }]
+    const badInsertCodeInteractivesObject = {
+      interactiveType: 'insert-code',
+      promptText: 'prompt text for interactive',
+      insertCodeData: interactiveInsertCodeObject,
+      unitCodeLanguage: 'both' // only python/javascript valid for insert code
     }
-    schemaCompileTest(interactiveMultipleChoiceSchema)
-    schemaValidateObjectTest(interactiveMultipleChoiceSchema, interactiveMultipleChoiceObject)
-    schemaValidateBadObjectTest(interactiveMultipleChoiceSchema, badInteractiveMultipleChoiceObject)
-    schemaValidateBadPropertyTest(interactiveMultipleChoiceSchema, badInteractiveMultipleChoicePropertiesObject)
+
+    schemaCompileTest(interactiveSchema)
+    schemaValidateObjectTest(interactiveSchema, interactivesObject)
+    schemaValidateBadObjectTest(interactiveSchema, badInsertCodeInteractivesObject)
+    schemaValidateBadPropertyTest(interactiveSchema, badInteractivesObjectProperties)
+    schemaValidateBadPropertyTest(interactiveSchema, badInteractivesObjectData)
   })
-
-  describe('interactiveFillInCodeSchema', () => {
-    const badInteractiveFillInCodeObject = ['not', 'an', 'object']
-    const badInteractiveFillInCodePropertiesObject = {
-      starterCode: {
-        language: ['javascript'],
-        code: 42
-      },
-      commonResponses: { hello: 'world!' }
-    }
-    schemaCompileTest(interactiveFillInCodeSchema)
-    schemaValidateObjectTest(interactiveFillInCodeSchema, interactiveFillInCodeObject)
-    schemaValidateBadObjectTest(interactiveFillInCodeSchema, badInteractiveFillInCodeObject)
-    schemaValidateBadPropertyTest(interactiveFillInCodeSchema, badInteractiveFillInCodePropertiesObject)
-  })
-
-  describe('interactiveDraggableStatementCompletionSchema', () => {
-    const badInteractiveDraggableStatementCompletionObject = ['not', 'correct']
-    const badInteractiveDraggableStatementCompletionPropertiesObject = {
-      labels: 'not an array',
-      elements: [{ text: { not: 'a string' }, elementId: 42 }]
-    }
-    schemaCompileTest(interactiveDraggableStatementCompletionSchema)
-    schemaValidateObjectTest(interactiveDraggableStatementCompletionSchema, interactiveDraggableStatementCompletionObject)
-    schemaValidateBadObjectTest(interactiveDraggableStatementCompletionSchema, badInteractiveDraggableStatementCompletionObject)
-    schemaValidateBadPropertyTest(interactiveDraggableStatementCompletionSchema, badInteractiveDraggableStatementCompletionPropertiesObject)
-  })
-})
-
-describe('interactive overall schema', () => {
-  const interactivesObject = {
-    interactiveType: 'draggable-ordering',
-    promptText: 'prompt text for interactive',
-    interactiveData: interactiveDraggableObject,
-    unitCodeLanguage: 'python'
-  }
-  const badInteractivesObjectProperties = {
-    interactiveType: 'draggable-ordering',
-    promptText: 'prompt text for interactive',
-    interactiveData: interactiveInsertCodeObject, // incorrect data schema
-    unitCodeLanguage: 'python'
-  }
-  const badInsertCodeInteractivesObject = {
-    interactiveType: 'insert-code',
-    promptText: 'prompt text for interactive',
-    interactiveData: interactiveInsertCodeObject,
-    unitCodeLanguage: 'both' // only python/javascript valid for insert code
-  }
-
-  schemaCompileTest(interactiveSchema)
-  schemaValidateObjectTest(interactiveSchema, interactivesObject)
-  schemaValidateBadObjectTest(interactiveSchema, badInsertCodeInteractivesObject)
-  schemaValidateBadPropertyTest(interactiveSchema, badInteractivesObjectProperties)
 })

--- a/test/app/models/InteractiveSession.spec.js
+++ b/test/app/models/InteractiveSession.spec.js
@@ -2,10 +2,11 @@
 import submissionSchema from '../../../app/schemas/models/interactives/common/submissions.schema'
 import interactiveSessionSchema from '../../../app/schemas/models/interactives/interactive_session.schema'
 import Ajv from 'ajv'
+import ozariaUtils from 'core/ozariaUtils'
 
 function schemaCompileTest (schemaObject) {
   it('compiles successfully', () => {
-    const ajv = new Ajv() // If we want to use both draft-04 and draft-06/07 schemas then use { schemaId: 'auto' }
+    const ajv = new Ajv(ozariaUtils.getAjvOptions())
     const validate = ajv.compile(schemaObject)
     expect(typeof validate).toBe('function')
     expect(ajv.errors).toBe(null)
@@ -14,7 +15,7 @@ function schemaCompileTest (schemaObject) {
 
 function schemaValidateObjectTest (schemaObject, testObject) {
   it('validates a correct object', () => {
-    const ajv = new Ajv()
+    const ajv = new Ajv(ozariaUtils.getAjvOptions())
     const valid = ajv.validate(schemaObject, testObject)
     expect(valid).toBe(true)
     expect(ajv.errors).toBe(null)
@@ -23,7 +24,7 @@ function schemaValidateObjectTest (schemaObject, testObject) {
 
 function schemaValidateBadObjectTest (schemaObject, testObject) {
   it('fails to validate an incorrect object', () => {
-    const ajv = new Ajv()
+    const ajv = new Ajv(ozariaUtils.getAjvOptions())
     const valid = ajv.validate(schemaObject, testObject)
     expect(valid).toBe(false)
     expect(ajv.errors).toBeDefined()
@@ -32,7 +33,7 @@ function schemaValidateBadObjectTest (schemaObject, testObject) {
 
 function schemaValidateBadPropertyTest (schemaObject, testObject) {
   it('fails to validate incorrect properties on object', () => {
-    const ajv = new Ajv()
+    const ajv = new Ajv(ozariaUtils.getAjvOptions())
     const valid = ajv.validate(schemaObject, testObject)
     expect(valid).toBe(false)
     expect(ajv.errors).toBeDefined()
@@ -80,99 +81,101 @@ const draggableStatementCompletionSubmissionObject = {
   submittedSolution: ['0123456789abcdefghijklmn', '1123456789abcdefghijklmn']
 }
 
-describe('interactive submission schema for each type', () => {
-  describe('draggableOrderingSubmissionSchema', () => {
-    const badDraggableOrderingSubmissionObject = 'not an array'
-    const badDraggableOrderingSubmissionPropertiesObject = {
-      submittedSolution: 'not an array'
-    }
-    schemaCompileTest(submissionSchema.draggableOrderingSubmissionSchema)
-    schemaValidateObjectTest(submissionSchema.draggableOrderingSubmissionSchema, draggableOrderingSubmissionObject)
-    schemaValidateBadObjectTest(submissionSchema.draggableOrderingSubmissionSchema, badDraggableOrderingSubmissionObject)
-    schemaValidateBadPropertyTest(submissionSchema.draggableOrderingSubmissionSchema, badDraggableOrderingSubmissionPropertiesObject)
-  })
-
-  describe('insertCodeSubmissionSchema', () => {
-    const badInsertCodeSubmissionObject = 42
-    const badInsertCodeSubmissionPropertiesObject = {
-      submittedSolution: {
-        not: 'a string'
+describe('InteractiveSession', () => {
+  describe('interactive submission schema for each type', () => {
+    describe('draggableOrderingSubmissionSchema', () => {
+      const badDraggableOrderingSubmissionObject = 'not an array'
+      const badDraggableOrderingSubmissionPropertiesObject = {
+        submittedSolution: 'not an array'
       }
-    }
-    schemaCompileTest(submissionSchema.insertCodeSubmissionSchema)
-    schemaValidateObjectTest(submissionSchema.insertCodeSubmissionSchema, insertCodeSubmissionObject)
-    schemaValidateBadObjectTest(submissionSchema.insertCodeSubmissionSchema, badInsertCodeSubmissionObject)
-    schemaValidateBadPropertyTest(submissionSchema.insertCodeSubmissionSchema, badInsertCodeSubmissionPropertiesObject)
-  })
+      schemaCompileTest(submissionSchema.draggableOrderingSubmissionSchema)
+      schemaValidateObjectTest(submissionSchema.draggableOrderingSubmissionSchema, draggableOrderingSubmissionObject)
+      schemaValidateBadObjectTest(submissionSchema.draggableOrderingSubmissionSchema, badDraggableOrderingSubmissionObject)
+      schemaValidateBadPropertyTest(submissionSchema.draggableOrderingSubmissionSchema, badDraggableOrderingSubmissionPropertiesObject)
+    })
 
-  describe('draggableClassificationSubmissionSchema', () => {
-    const badDraggableClassificationSubmissionObject = 42
-    const badDraggableClassificationSubmissionPropertiesObject = {
-      submittedSolution: [{
-        categoryId: 42,
-        elements: { not: 'an array' }
-      }]
-    }
-    schemaCompileTest(submissionSchema.draggableClassificationSubmissionSchema)
-    schemaValidateObjectTest(submissionSchema.draggableClassificationSubmissionSchema, draggableClassificationSubmissionObject)
-    schemaValidateBadObjectTest(submissionSchema.draggableClassificationSubmissionSchema, badDraggableClassificationSubmissionObject)
-    schemaValidateBadPropertyTest(submissionSchema.draggableClassificationSubmissionSchema, badDraggableClassificationSubmissionPropertiesObject)
-  })
-
-  describe('multipleChoiceSubmissionSchema', () => {
-    const badMultipleChoiceSubmissionObject = 42
-    const badMultipleChoiceSubmissionPropertiesObject = {
-      submittedSolution: {
-        not: 'a string'
+    describe('insertCodeSubmissionSchema', () => {
+      const badInsertCodeSubmissionObject = 42
+      const badInsertCodeSubmissionPropertiesObject = {
+        submittedSolution: {
+          not: 'a string'
+        }
       }
-    }
-    schemaCompileTest(submissionSchema.multipleChoiceSubmissionSchema)
-    schemaValidateObjectTest(submissionSchema.multipleChoiceSubmissionSchema, multipleChoiceSubmissionObject)
-    schemaValidateBadObjectTest(submissionSchema.multipleChoiceSubmissionSchema, badMultipleChoiceSubmissionObject)
-    schemaValidateBadPropertyTest(submissionSchema.multipleChoiceSubmissionSchema, badMultipleChoiceSubmissionPropertiesObject)
-  })
+      schemaCompileTest(submissionSchema.insertCodeSubmissionSchema)
+      schemaValidateObjectTest(submissionSchema.insertCodeSubmissionSchema, insertCodeSubmissionObject)
+      schemaValidateBadObjectTest(submissionSchema.insertCodeSubmissionSchema, badInsertCodeSubmissionObject)
+      schemaValidateBadPropertyTest(submissionSchema.insertCodeSubmissionSchema, badInsertCodeSubmissionPropertiesObject)
+    })
 
-  describe('fillInCodeSubmissionSchema', () => {
-    const badFillInCodeSubmissionObject = 42
-    const badFillInCodeSubmissionPropertiesObject = {
-      submittedSolution: {
-        not: 'a string'
+    describe('draggableClassificationSubmissionSchema', () => {
+      const badDraggableClassificationSubmissionObject = 42
+      const badDraggableClassificationSubmissionPropertiesObject = {
+        submittedSolution: [{
+          categoryId: 42,
+          elements: { not: 'an array' }
+        }]
       }
-    }
-    schemaCompileTest(submissionSchema.fillInCodeSubmissionSchema)
-    schemaValidateObjectTest(submissionSchema.fillInCodeSubmissionSchema, fillInCodeSubmissionObject)
-    schemaValidateBadObjectTest(submissionSchema.fillInCodeSubmissionSchema, badFillInCodeSubmissionObject)
-    schemaValidateBadPropertyTest(submissionSchema.fillInCodeSubmissionSchema, badFillInCodeSubmissionPropertiesObject)
+      schemaCompileTest(submissionSchema.draggableClassificationSubmissionSchema)
+      schemaValidateObjectTest(submissionSchema.draggableClassificationSubmissionSchema, draggableClassificationSubmissionObject)
+      schemaValidateBadObjectTest(submissionSchema.draggableClassificationSubmissionSchema, badDraggableClassificationSubmissionObject)
+      schemaValidateBadPropertyTest(submissionSchema.draggableClassificationSubmissionSchema, badDraggableClassificationSubmissionPropertiesObject)
+    })
+
+    describe('multipleChoiceSubmissionSchema', () => {
+      const badMultipleChoiceSubmissionObject = 42
+      const badMultipleChoiceSubmissionPropertiesObject = {
+        submittedSolution: {
+          not: 'a string'
+        }
+      }
+      schemaCompileTest(submissionSchema.multipleChoiceSubmissionSchema)
+      schemaValidateObjectTest(submissionSchema.multipleChoiceSubmissionSchema, multipleChoiceSubmissionObject)
+      schemaValidateBadObjectTest(submissionSchema.multipleChoiceSubmissionSchema, badMultipleChoiceSubmissionObject)
+      schemaValidateBadPropertyTest(submissionSchema.multipleChoiceSubmissionSchema, badMultipleChoiceSubmissionPropertiesObject)
+    })
+
+    describe('fillInCodeSubmissionSchema', () => {
+      const badFillInCodeSubmissionObject = 42
+      const badFillInCodeSubmissionPropertiesObject = {
+        submittedSolution: {
+          not: 'a string'
+        }
+      }
+      schemaCompileTest(submissionSchema.fillInCodeSubmissionSchema)
+      schemaValidateObjectTest(submissionSchema.fillInCodeSubmissionSchema, fillInCodeSubmissionObject)
+      schemaValidateBadObjectTest(submissionSchema.fillInCodeSubmissionSchema, badFillInCodeSubmissionObject)
+      schemaValidateBadPropertyTest(submissionSchema.fillInCodeSubmissionSchema, badFillInCodeSubmissionPropertiesObject)
+    })
+
+    describe('draggableStatementCompletionSubmissionSchema', () => {
+      const badDraggableStatementCompletionSubmissionObject = 'not an array'
+      const badDraggableStatementCompletionSubmissionPropertiesObject = {
+        submittedSolution: 'not an array'
+      }
+      schemaCompileTest(submissionSchema.draggableStatementCompletionSubmissionSchema)
+      schemaValidateObjectTest(submissionSchema.draggableStatementCompletionSubmissionSchema, draggableStatementCompletionSubmissionObject)
+      schemaValidateBadObjectTest(submissionSchema.draggableStatementCompletionSubmissionSchema, badDraggableStatementCompletionSubmissionObject)
+      schemaValidateBadPropertyTest(submissionSchema.draggableStatementCompletionSubmissionSchema, badDraggableStatementCompletionSubmissionPropertiesObject)
+    })
   })
 
-  describe('draggableStatementCompletionSubmissionSchema', () => {
-    const badDraggableStatementCompletionSubmissionObject = 'not an array'
-    const badDraggableStatementCompletionSubmissionPropertiesObject = {
-      submittedSolution: 'not an array'
+  describe('overall interactive session schema', () => {
+    const interactiveSessionObject = {
+      interactiveId: 'i123456789abcdefghijklmn',
+      userId: 'u123456789abcdefghijklmn',
+      interactiveType: 'draggable-ordering',
+      sessionCodeLanguage: 'python',
+      submissions: [ draggableOrderingSubmissionObject ]
     }
-    schemaCompileTest(submissionSchema.draggableStatementCompletionSubmissionSchema)
-    schemaValidateObjectTest(submissionSchema.draggableStatementCompletionSubmissionSchema, draggableStatementCompletionSubmissionObject)
-    schemaValidateBadObjectTest(submissionSchema.draggableStatementCompletionSubmissionSchema, badDraggableStatementCompletionSubmissionObject)
-    schemaValidateBadPropertyTest(submissionSchema.draggableStatementCompletionSubmissionSchema, badDraggableStatementCompletionSubmissionPropertiesObject)
+    const badInteractiveSessionObjectProperties = {
+      interactiveId: 'i123456789abcdefghijklmn',
+      userId: 'u123456789abcdefghijklmn',
+      interactiveType: 'draggable-ordering',
+      sessionCodeLanguage: 'python',
+      submissions: [ insertCodeSubmissionObject ] // incorrect submission schema
+    }
+    schemaCompileTest(interactiveSessionSchema)
+    schemaValidateObjectTest(interactiveSessionSchema, interactiveSessionObject)
+    schemaValidateBadPropertyTest(interactiveSessionSchema, badInteractiveSessionObjectProperties)
   })
-})
-
-describe('overall interactive session schema', () => {
-  const interactiveSessionObject = {
-    interactiveId: 'i123456789abcdefghijklmn',
-    userId: 'u123456789abcdefghijklmn',
-    interactiveType: 'draggable-ordering',
-    sessionCodeLanguage: 'python',
-    submissions: [ draggableOrderingSubmissionObject ]
-  }
-  const badInteractiveSessionObjectProperties = {
-    interactiveId: 'i123456789abcdefghijklmn',
-    userId: 'u123456789abcdefghijklmn',
-    interactiveType: 'draggable-ordering',
-    sessionCodeLanguage: 'python',
-    submissions: [ insertCodeSubmissionObject ] // incorrect submission schema
-  }
-  schemaCompileTest(interactiveSessionSchema)
-  schemaValidateObjectTest(interactiveSessionSchema, interactiveSessionObject)
-  schemaValidateBadPropertyTest(interactiveSessionSchema, badInteractiveSessionObjectProperties)
 })


### PR DESCRIPTION
- Added a new route for interactive editor
- Split `interactiveData` property into 6 properties for each type of interactive in the schema.
- Changed the type of element ids to stringID
- Added i18n
- Added ajv support for format ace(for code editor field in the editor), and hidden(for hidden fields)

Related changes on server: https://github.com/codecombat/codecombat-server/pull/84