### PR TITLE
Improve the player customization schema

### DIFF
--- a/app/schemas/models/tint.schema.js
+++ b/app/schemas/models/tint.schema.js
@@ -2,16 +2,16 @@ const schema = require('./../schemas')
 
 const Tint = schema.object({
   title: 'Group Tint',
-  description: 'A list of allowed colors for tinting a particular group'
+  description: 'A list of tint options'
 }, {
-  colorGroupName: schema.shortString({
-    title: 'Color Group Name',
-    description: 'Name of the group we are tinting on a ThangType.'
-  }),
-  allowedTints: schema.array({
-    title: 'Tints',
-    description: 'Legal tints for the color group'
-  }, schema.colorConfig())
+  allowedTints: schema.array(
+    {
+      title: 'Tints',
+      description: 'Legal tints for the color group'
+    },
+    // Property is the colorGroup name, and value is a colorConfig object.
+    schema.object({ additionalProperties: schema.colorConfig() })
+  )
 })
 
 schema.extendBasicProperties(Tint, 'tint')

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -148,10 +148,27 @@ _.extend UserSchema.properties,
   wizard: c.object {},
     colorConfig: c.object {additionalProperties: c.colorConfig()}
 
-  customization: c.object {
-    title: 'Player Customization',
-    descipription: 'Individual player customization options'
-  }, { colorConfig: c.object { additionalProperties: c.colorConfig() } }
+  customization: c.object(
+    {
+      title: 'Player Customization',
+      descipription: 'Individual player customization options'
+    }, {
+      tints: c.array(
+        {
+          title: 'Tints',
+          description: 'Array of possible tints'
+        },
+        c.object({
+          title: 'tintGroup',
+          description: 'Duplicate data that would be found in a tint',
+          required: ['slug', 'colorGroups']
+        }, {
+          slug: c.shortString({
+            title: 'Tint Slug',
+          }),
+          colorGroups: c.object({ additionalProperties: c.colorConfig() })
+        }))
+    })
 
   aceConfig: c.object { default: { language: 'python', keyBindings: 'default', invisibles: false, indentGuides: false, behaviors: false, liveCompletion: true }},
     language: {type: 'string', 'enum': ['python', 'javascript', 'coffeescript', 'clojure', 'lua', 'java', 'io']}


### PR DESCRIPTION
## Issue

When saving tints it's not precise enough to store a list of colors.

## Fix

Improve the schema to force tint objects to contain a slug, referencing the origin of the tint color. And then store color configs related to that tint.

A valid customization schema on the user now looks like so (taken from server tests):
```
    tints: [
      {
        slug: 'hair',
        colorGroups: {
          hairHighlight: { hue: 0.1, saturation: 0.2, lightness: 0.3 },
          hairBase: { hue: 0.3, saturation: 0.1, lightness: 0.01 }
        }
      }]
```