### PR TITLE
Update cinematic dimensions to 1280x850

### DIFF
--- a/app/schemas/models/cinematic.schema.js
+++ b/app/schemas/models/cinematic.schema.js
@@ -65,7 +65,11 @@ const ShotSetup = c.object({
       title: 'Position',
       description: 'The position of the camera in meters.'
     }),
-    zoom: { title: 'Zoom', description: 'The zoom level of the camera. A good default is 6. Recommended you change between 0 and 10.', type: 'number' }
+    zoom: {
+      title: 'Zoom',
+      description: 'The zoom level of the camera. A good default is \'2.1\'. There is a bug with the value 2. Recommended you change between 0 and 10.',
+      type: 'number'
+    }
   }),
   music: c.sound()
 })

--- a/app/schemas/models/cinematic.schema.js
+++ b/app/schemas/models/cinematic.schema.js
@@ -67,7 +67,7 @@ const ShotSetup = c.object({
     }),
     zoom: {
       title: 'Zoom',
-      description: 'The zoom level of the camera. A good default is \'2.1\'. There is a bug with the value 2. Recommended you change between 0 and 10.',
+      description: 'The zoom level of the camera. A good default is \'2.01\'. There is a bug with the value 2. Recommended you change between 0 and 10.',
       type: 'number'
     }
   }),

--- a/app/schemas/models/selectors/cinematic.js
+++ b/app/schemas/models/selectors/cinematic.js
@@ -239,7 +239,8 @@ export const CAMERA_DEFAULT = {
     x: 0,
     y: 0
   },
-  zoom: 6
+  // There appears to be a bug in our camera and it can't support exactly 2.
+  zoom: 2.01
 }
 
 /**

--- a/ozaria/site/components/cinematic/common/CinematicCanvas.vue
+++ b/ozaria/site/components/cinematic/common/CinematicCanvas.vue
@@ -22,7 +22,6 @@
  */
 import { CinematicController } from '../../../../engine/cinematic/cinematicController'
 
-
 export default {
   props: {
     cinematicData: {

--- a/ozaria/site/components/cinematic/common/CinematicCanvas.vue
+++ b/ozaria/site/components/cinematic/common/CinematicCanvas.vue
@@ -1,9 +1,15 @@
 <template>
   <!-- TODO: Canvas needs to be responsive to scaling up and down. -->
   <!-- Currently fixed size to the aspect ratio of our play view. -->
-  <div>
-    <div height="514px" id="cinematic-div" ref="cinematic-div" v-on:click="skipShot">
-      <canvas width="800" height="514" id="cinematic-canvas" ref="cinematic-canvas"></canvas>
+  <div id="cinematic-canvas-div">
+    <div height="850px" id="cinematic-div" ref="cinematic-div" v-on:click="skipShot">
+      <canvas
+        id="cinematic-canvas"
+        ref="cinematic-canvas"
+        :width="width"
+        :height="height"
+        :style="{ width: width+'px', height: height+'px' }">
+      </canvas>
     </div>
     <button :disabled="enterDisabled" v-on:click="nextShot">Enter</button>
   </div>
@@ -16,6 +22,7 @@
  */
 import { CinematicController } from '../../../../engine/cinematic/cinematicController'
 
+
 export default {
   props: {
     cinematicData: {
@@ -25,7 +32,9 @@ export default {
   },
   data: () => ({
     controller: null,
-    enterDisabled: false
+    enterDisabled: false,
+    width: 1280,
+    height: 850
   }),
   mounted: function() {
     if (!me.hasCinematicAccess()) {
@@ -76,8 +85,8 @@ export default {
 #cinematic-div {
   position: relative;
   font-size: 1.5em;
-  height: 514px;
-  width: 800px;
+  height: 850px;
+  width: 1280px;
 }
 
 #cinematic-div canvas {

--- a/ozaria/site/components/cinematic/common/CinematicCanvas.vue
+++ b/ozaria/site/components/cinematic/common/CinematicCanvas.vue
@@ -2,7 +2,7 @@
   <!-- TODO: Canvas needs to be responsive to scaling up and down. -->
   <!-- Currently fixed size to the aspect ratio of our play view. -->
   <div id="cinematic-canvas-div">
-    <div height="850px" id="cinematic-div" ref="cinematic-div" v-on:click="skipShot">
+    <div id="cinematic-div" ref="cinematic-div" v-on:click="skipShot">
       <canvas
         id="cinematic-canvas"
         ref="cinematic-canvas"


### PR DESCRIPTION
Increased resolution to 1280x850.

Did a time boxed investigation updating the resolution based on the `window.devicePixelRatio`. (This would make our game support retina displays).
This is a very hard problem as it requires modifying our Camera system in a major way in order to preserve the transformations. Without camera modifications the game will appear at different scales on different pixel densities. I.e. on a retina display the game will look zoomed out.

Thus this change just scales up the screen size as per requested.
The default camera zoom is also updated to prefer zoomed out shots, which will default a higher quality, and allow more screen space for our larger assets.