### PR TITLE
Set intuitive origin points for Cinematic dialog bubbles

### DIFF
--- a/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
+++ b/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
@@ -112,17 +112,24 @@ class SpeechBubble {
     const textDiv = html.body.firstChild
     textDiv.style.display = 'inline-block'
     textDiv.style.position = 'absolute'
-    textDiv.style.left = `${x}`
-    textDiv.style.top = `${y}`
     textDiv.id = this.id
 
     div.appendChild(textDiv)
 
-    // We've created and attached the dialog text.
-    // Now we can calculate the bounding box and draw the svg shape.
+    // Calculate bounding box for svg shape
     const bbox = textDiv.getBoundingClientRect()
     const width = (bbox.right - bbox.left) + 2 * padding
     const height = (bbox.bottom - bbox.top) + 2 * padding
+
+    // Set the origin for the left character speech bubble on the bottom left.
+    // Set the origin for the right character speech bubble on the bottom right.
+    y -= (height - padding)
+    if (side === 'right') {
+      x -= width
+    }
+
+    textDiv.style.left = `${x}px`
+    textDiv.style.top = `${y}px`
 
     const svgGroup = createSvgShape({
       x,


### PR DESCRIPTION
## Quality of life improvement for Cinematic Content Creation

Change the origin points for the speech bubbles.
Prior to this change the text location was calculated from the top left of the text bubble.

![speech bubble](https://user-images.githubusercontent.com/15080861/58055849-f7976500-7b13-11e9-9bbd-d42caba8b5f7.png)

The diagram shows where the origin point is set based on the text given. The text location point is the red circle.

This new origin allows cinematic designers to set the text location point near the characters mouth and have the dialogue bubble expand up and away from the character.