### PR TITLE
Player Customization ColorConfig Middleware

### DIFF
--- a/app/lib/world/thang.coffee
+++ b/app/lib/world/thang.coffee
@@ -175,7 +175,15 @@ module.exports = class Thang
     colorConfigs = @teamColors or @world?.getTeamColors() or {}
     options = {colorConfig: {}}
     if @id is 'Hero Placeholder' and not @world.getThangByID 'Hero Placeholder 1'
-      return options  # No team colors for heroes on single-player levels
+
+      # Single player color customization options
+      player_tints = me.get('customization')?.tints or []
+      player_tints.forEach((tint) =>
+        for key,value of (tint.colorGroups or {})
+          options.colorConfig[key] = _.clone(value)
+      )
+
+      return options
     if @team and teamColor = colorConfigs[@team]
       options.colorConfig.team = teamColor
     if @color and color = @grabColorConfig @color


### PR DESCRIPTION
## Implement Player Customization

This commit brings player color customization into production for single player levels.

In order for the ThangType to be customized we first check if the player has `tints` in their `customizations` data.
These tints are applied to the colorConfig options.

In order for the tint to be displayed the ThangType must also have a matching colorGroup.

## Manually Test

(You can use proxy server for test)

1. Choose the Anya hero.
2. Run the following code to set customization. (We're going to set team colors.)

```
me.set('customization', {
  tints: [
    {
      "slug": "teamExample",
      "colorGroups": {
        "team": { hue: 0.8, saturation: 0.9, lightness: 0.7 }
      }
    }
  ]
});

me.save()
```

3. Play a single player level with Anya and notice she is customized.

You will end up [with something like this](https://i.gyazo.com/dfef3ae9458f3b7b1beaefe567fff759.mp4)

## Manual testing for bugs

We already have very robust checks for colorConfigs that don't exist. A color config is applied if and only if the thangType has the colorGroup defined.
Therefore we can ship this production and know that it could only be abused to color in your own hero's team color.