### PR TITLE
Tint editor extension

### DIFF
--- a/app/styles/editor/thang/colors_tab.sass
+++ b/app/styles/editor/thang/colors_tab.sass
@@ -6,7 +6,7 @@ $height: 550px
     box-sizing: border-box
     float: right
 
-  #color-groups-treema
+  #color-groups-treema, #color-tint-treema
     float: left
     width: 25%
     height: $height
@@ -24,7 +24,7 @@ $height: 550px
     padding: 5px
     box-sizing: border-box
     
-    button
+    button:not(.save-btn)
       width: 36px
       height: 36px
       margin: 7px

--- a/app/templates/editor/thang/colors_tab.jade
+++ b/app/templates/editor/thang/colors_tab.jade
@@ -1,11 +1,16 @@
-div#color-groups-treema
+div#tabs
+  button#color-group-btn(disabled=view.tab == "COLORGROUPTAB") Color Group Assignment
+  button#tint-assignment-btnTint(disabled=view.tab == "TINTTAB") Tint Assignment
+
+div#color-tabs
+  div#color-groups-treema
+  div#color-tint-treema
 
 div#color-group-settings.secret
   div#shape-buttons
-    
-  canvas#tinting-display(width=400, height=400)
-
   div#saved-color-tabs
+
+  canvas#tinting-display(width=400, height=400)
 
   div#controls
     div.slider-cell

--- a/app/views/editor/thang/ThangTypeColorsTabView.coffee
+++ b/app/views/editor/thang/ThangTypeColorsTabView.coffee
@@ -105,21 +105,19 @@ module.exports = class ThangTypeColorsTabView extends CocoView
       .then((res) -> res.json())
       .then((tintData)=>
         tintData = tintData.filter((o) => o.slug)
-        # Create a custom schema for the colorGroups.
+
         treemaOptions =
           data: tintData
-          schema: {
-            type: 'array',
+          schema:
+            type: 'array'
             items: tintSchema
-          }
           readOnly: true unless me.isAdmin()
           callbacks:
-            change: @createColorGroupTintButtons()
+            change: () => @createColorGroupTintButtons()
 
         @tintAssignments = @$el.find('#color-tint-treema').treema treemaOptions
         @tintAssignments.build()
         @tintAssignments.open()
-
         @createColorGroupTintButtons()
       )
 
@@ -193,6 +191,7 @@ module.exports = class ThangTypeColorsTabView extends CocoView
 
   # Attaches hard coded color tabs for manipulating defined color groups on the ThangType
   createColorGroupTintButtons: ->
+    return if @destroyed
     return unless @tintAssignments
     buttons = $('<div></div>').prop('id', 'saved-color-tabs')
     buttons.append($("<h1>Saved Color Presets</h1>"))

--- a/app/views/editor/thang/ThangTypeColorsTabView.coffee
+++ b/app/views/editor/thang/ThangTypeColorsTabView.coffee
@@ -9,8 +9,8 @@ initSlider = require 'lib/initSlider'
 tintApi = require('../../../../ozaria/site/api/tint')
 tintSchema = require 'app/schemas/models/tint.schema.js'
 
-COLORGROUPTAB = 'COLORGROUPTAB'
-TINTTAB = 'TINTTAB'
+COLOR_GROUP_TAB = 'COLORGROUPTAB'
+TINT_TAB = 'TINTTAB'
 
 module.exports = class ThangTypeColorsTabView extends CocoView
   id: 'editor-thang-colors-tab-view'
@@ -25,7 +25,7 @@ module.exports = class ThangTypeColorsTabView extends CocoView
 
   constructor: (@thangType, options) ->
     super options
-    @tab = COLORGROUPTAB
+    @tab = COLOR_GROUP_TAB
     @supermodel.loadModel @thangType
     @currentColorConfig = { hue: 0, saturation: 0.5, lightness: 0.5 }
     # tint slug and index pairs.
@@ -51,12 +51,12 @@ module.exports = class ThangTypeColorsTabView extends CocoView
     @initSliders()
     @tryToBuild()
 
-    if @tab == COLORGROUPTAB
+    if @tab == COLOR_GROUP_TAB
       $("#color-tint-treema").hide()
       $("#color-groups-treema").show()
       $("#shape-buttons").show()
       $("#saved-color-tabs").hide()
-    else if @tab == TINTTAB
+    else if @tab == TINT_TAB
       $("#color-tint-treema").show()
       $("#color-groups-treema").hide()
       $("#shape-buttons").hide()
@@ -77,7 +77,7 @@ module.exports = class ThangTypeColorsTabView extends CocoView
 
   getColorConfig: ->
     colorConfig = {}
-    if @tab == COLORGROUPTAB
+    if @tab == COLOR_GROUP_TAB
       colorConfig[@currentColorGroupTreema.keyForParent] = @currentColorConfig
       return colorConfig
 
@@ -94,15 +94,14 @@ module.exports = class ThangTypeColorsTabView extends CocoView
 
   onColorGroupTab: ->
     @tintAssignments?.destroy()
-    @tab = COLORGROUPTAB
+    @tab = COLOR_GROUP_TAB
     @render()
 
   onTintAssignmentTab: ->
-    @tab = TINTTAB
+    @tab = TINT_TAB
     @render()
 
-    fetch("/db/tint/all")
-      .then((res) -> res.json())
+    tintApi.getAllTints()
       .then((tintData)=>
         tintData = tintData.filter((o) => o.slug)
 
@@ -209,6 +208,7 @@ module.exports = class ThangTypeColorsTabView extends CocoView
     buttons.append($('<button />', {
       text: "Save '#{tintName}' Tints",
       class: 'save-btn',
+      # Bind the variable `index` to the function in coffeescript.
       click: ((index) => () =>
         tintApi.putTint({data: @tintAssignments.data[index]})
           .catch((e) ->

--- a/ozaria/site/api/tint.js
+++ b/ozaria/site/api/tint.js
@@ -1,0 +1,20 @@
+import fetchJson from 'app/core/api/fetch-json'
+
+/**
+ * Updates a Tint in the database.
+ * @async
+ * @returns {Object} Tint object
+ */
+export const putTint = ({ data }, options = {}) => {
+  if (!data) {
+    throw new Error('Please pass in a data property.')
+  }
+  const slugOrId = data.id || data.slug
+  if (!slugOrId) {
+    throw new Error('You must pass either a slug or ObjectId')
+  }
+  return fetchJson(`/db/tint/${slugOrId}`, _.assign({}, options, {
+    method: 'PUT',
+    json: data
+  }))
+}

--- a/ozaria/site/api/tint.js
+++ b/ozaria/site/api/tint.js
@@ -18,3 +18,10 @@ export const putTint = ({ data }, options = {}) => {
     json: data
   }))
 }
+
+/**
+ * Returns a list of all tint objects.
+ * @async
+ * @returns {Object[]} tints
+ */
+export const getAllTints = () => fetchJson('/db/tint/all')


### PR DESCRIPTION
# Features

Add tint editor to the thang editor color tab. Can be accessed via `/editor/thang` and then clicking on the Color tab.
This tab now has two modes. The default mode is the original purpose which is to define color groups. But there is now a button that switches the page to a tint playground tab and mode.

The tint assignment tab allows testing out various color tint combinations, and saving them to the database.

This tab includes a second treema for editing the tints.
It also replaces the grid of colors with dynamically created tints from the treema. This allows designers to combine the various tints together on the thang instead of one at a time as per prior behavior.

Once tints have been defined in the treema, they can now also be saved to the database if the user is an admin.

<img width="1792" alt="Screen Shot 2019-05-23 at 11 05 14 PM" src="https://user-images.githubusercontent.com/15080861/58306118-4ad91400-7daf-11e9-8f99-ec1adf8bc9dd.png">

Features in the image:
 - two hair tints defined by treema
 - generated tint color presets
 - ugly save button
 - preview of selected tints (only one per group)
 - buttons for switching between modes or tabs along top.
