### PR TITLE
Cinematic Canvas View Wrapper

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -212,6 +212,12 @@ module.exports = class CocoRouter extends Backbone.Router
       }
       @routeDirectly('interactive', [], {vueRoute: true, baseTemplate: 'base-empty', propsData: props})
 
+    'cinematic/:cinematicIdOrSlug': (cinematicIdOrSlug) ->
+      props = {
+        cinematicIdOrSlug: cinematicIdOrSlug,
+      }
+      @routeDirectly('cinematic', [], {vueRoute: true, baseTemplate: 'base-empty', propsData: props})
+
     'premium': go('PremiumFeaturesView', { redirectStudents: true, redirectTeachers: true })
     'Premium': go('PremiumFeaturesView', { redirectStudents: true, redirectTeachers: true })
 

--- a/app/lib/dynamicRequire.js
+++ b/app/lib/dynamicRequire.js
@@ -134,6 +134,7 @@ module.exports = {
 
   // TODO: Why does chunk name `ozariaPlay` not work sporadically?
   'views/ozaria/site/play/level/PlayLevelView': function () { return import(/* webpackChunkName: "ozariaPlay" */ 'ozaria/site/views/play/level/PlayLevelView') },
+  'views/cinematic': function() { return import(/* webpackChunkName: "ozariaPlay" */ 'ozaria/site/components/cinematic/PageCinematic') },
   'views/interactive': function() { return import(/* webpackChunkName: "ozariaPlay" */ 'ozaria/site/components/interactive/PageInteractive') },
 
   // Temporary

--- a/ozaria/site/components/cinematic/PageCinematic/index.vue
+++ b/ozaria/site/components/cinematic/PageCinematic/index.vue
@@ -34,10 +34,18 @@ module.exports = Vue.extend({
         }
       })
     }
-  }
+  },
+  methods: {
+    completedHandler () {
+      this.$emit('completed')
+    }
+  },
 })
 </script>
 
 <template>
-  <cinematic-canvas v-if="cinematicData" :cinematicData="cinematicData" />
+  <cinematic-canvas
+    v-if="cinematicData"
+    v-on:completed="completedHandler"
+    :cinematicData="cinematicData" />
 </template>

--- a/ozaria/site/components/cinematic/PageCinematic/index.vue
+++ b/ozaria/site/components/cinematic/PageCinematic/index.vue
@@ -1,0 +1,43 @@
+<script>
+import { getCinematic } from '../../../api/cinematic'
+import CinematicCanvas from '../common/CinematicCanvas'
+
+module.exports = Vue.extend({
+  props: {
+    cinematicIdOrSlug: {
+      type: String,
+      required: true
+    }
+  },
+  data: () => ({
+    cinematicData: null
+  }),
+  components: {
+    'cinematic-canvas': CinematicCanvas
+  },
+  async created () {
+    if (!me.hasCinematicAccess())  {
+      alert('You must be logged in as an admin to use this page.')
+      return application.router.navigate('/', { trigger: true })
+    }
+    try {
+      this.cinematicData = await getCinematic(this.cinematicIdOrSlug)
+    } catch (e) {
+      return noty({
+        text: `Error finding slug '${cinematicIdOrSlug}'.`,
+        type:'error',
+        timeout: 3000,
+        callback: {
+          onClose: () => {
+            application.router.navigate('/editor/cinematic', { trigger: true })
+          }
+        }
+      })
+    }
+  }
+})
+</script>
+
+<template>
+  <cinematic-canvas v-if="cinematicData" :cinematicData="cinematicData" />
+</template>

--- a/ozaria/site/components/cinematic/PageCinematic/index.vue
+++ b/ozaria/site/components/cinematic/PageCinematic/index.vue
@@ -24,14 +24,9 @@ module.exports = Vue.extend({
       this.cinematicData = await getCinematic(this.cinematicIdOrSlug)
     } catch (e) {
       return noty({
-        text: `Error finding slug '${cinematicIdOrSlug}'.`,
+        text: `Error finding cinematic '${cinematicIdOrSlug}'.`,
         type:'error',
-        timeout: 3000,
-        callback: {
-          onClose: () => {
-            application.router.navigate('/editor/cinematic', { trigger: true })
-          }
-        }
+        timeout: 3000
       })
     }
   },

--- a/ozaria/site/components/cinematic/common/CinematicCanvas.vue
+++ b/ozaria/site/components/cinematic/common/CinematicCanvas.vue
@@ -48,6 +48,7 @@ export default {
       handlers: {
         onPlay: this.handlePlay,
         onPause: this.handleWait,
+        onCompletion: () => this.$emit('completed')
       }})
     window.addEventListener('keypress', this.handleKeyboardCancellation)
   },


### PR DESCRIPTION
Create a wrapper and test page for the Cinematic Canvas.

This wrapper accepts a slug and emits a completion event at the end of the cinematic.

It has been temporarily attached using the interactives page as a guide. This route is admin gated.