### PR TITLE
Add Hero Dog to Cinematic 

### DIFF
--- a/app/schemas/models/cinematic.schema.js
+++ b/app/schemas/models/cinematic.schema.js
@@ -56,6 +56,7 @@ const ShotSetup = c.object({
 }, {
   rightThangType: CharacterSchema('Right Character'),
   leftThangType: CharacterSchema('Left Character'),
+  heroDogThangType: ThangTypeSchema('Hero Dog', 'The position property will be used to place the dog at an offset on the right lank.'),
   backgroundArt: ThangTypeSchema('Background Art', 'The rasterized image to place on the background'),
   camera: c.object({
     title: 'Camera placement',

--- a/app/schemas/models/cinematic.schema.js
+++ b/app/schemas/models/cinematic.schema.js
@@ -56,7 +56,7 @@ const ShotSetup = c.object({
 }, {
   rightThangType: CharacterSchema('Right Character'),
   leftThangType: CharacterSchema('Left Character'),
-  heroDogThangType: ThangTypeSchema('Hero Dog', 'The position property will be used to place the dog at an offset on the right lank.'),
+  heroPetThangType: ThangTypeSchema('Hero Pet', 'The position property will be used to place the dog at an offset on the right lank.'),
   backgroundArt: ThangTypeSchema('Background Art', 'The rasterized image to place on the background'),
   camera: c.object({
     title: 'Camera placement',

--- a/app/schemas/models/selectors/cinematic.js
+++ b/app/schemas/models/selectors/cinematic.js
@@ -158,10 +158,34 @@ const rightCharacter = shotSetup => (shotSetup || {}).rightThangType
 const backgroundArt = shotSetup => (shotSetup || {}).backgroundArt
 
 /**
+ * @param {ShotSetup} shotSetup
+ * @returns {Object|undefined} heroDogThangType
+ */
+const heroDogThangType = shotSetup => (shotSetup || {}).heroDogThangType
+
+/**
  * @param {Object} o Object that may have slug property
  * @returns {string|undefined}
  */
 const slug = o => (o || {}).slug
+
+/**
+ * Returns a thang from a thangType if properties exist.
+ * @param {Object} thangType that matches the ThangTypeSchema with a Character Slug
+ * @returns {Object|undefined} returns thang if required properties exist.
+ */
+const extractThangTypeSchemaSlug = thangType => {
+  if (!(thangType || {}).type) {
+    return
+  }
+  if (!(thangType.type || {}).slug) {
+    return
+  }
+  const { pos, scaleX, scaleY } = thangType
+  const thang = { pos, scaleX, scaleY }
+  const slug = thangType.type.slug
+  return { thang, slug }
+}
 
 /**
  * Returns properties required to place a background Lank.
@@ -169,17 +193,33 @@ const slug = o => (o || {}).slug
  * @returns {Object|undefined} a background object
  */
 const background = backgroundArt => {
-  if (!(backgroundArt || {}).type) {
+  const thangData = extractThangTypeSchemaSlug(backgroundArt)
+  if (!thangData) {
     return
   }
-  if (!(backgroundArt.type || {}).slug) {
-    return
-  }
-  const { pos, scaleX, scaleY } = backgroundArt
+  const { slug, thang } = thangData
 
   return {
-    slug: backgroundArt.type.slug,
-    thang: _.merge(DEFAULT_THANGTYPE(), { pos, scaleX, scaleY })
+    slug,
+    thang: _.merge(DEFAULT_THANGTYPE(), thang)
+  }
+}
+
+/**
+ * Returns properties required to place a hero dog Lank.
+ * @param {Object} heroDogSchema
+ * @returns {Object|undefined} a dog object with slug and thang
+ */
+const heroDog = heroDog => {
+  const thangData = extractThangTypeSchemaSlug(heroDog)
+  if (!thangData) {
+    return
+  }
+  const { slug, thang } = thangData
+
+  return {
+    slug,
+    thang: _.merge(DEFAULT_THANGTYPE(), thang)
   }
 }
 
@@ -439,6 +479,13 @@ export const getBackground = compose(shotSetup, backgroundArt, background)
  * @returns {string|undefined}
  */
 export const getBackgroundSlug = compose(shotSetup, backgroundArt, background, slug)
+
+/**
+ * Get hero dog thang
+ * @param {Shot} shot
+ * @returns {Object|undefined}
+ */
+export const getHeroDog = compose(shotSetup, heroDogThangType, heroDog)
 
 /**
  * @param {DialogNode} dialogNode

--- a/app/schemas/models/selectors/cinematic.js
+++ b/app/schemas/models/selectors/cinematic.js
@@ -159,9 +159,9 @@ const backgroundArt = shotSetup => (shotSetup || {}).backgroundArt
 
 /**
  * @param {ShotSetup} shotSetup
- * @returns {Object|undefined} heroDogThangType
+ * @returns {Object|undefined} heroPetThangType
  */
-const heroDogThangType = shotSetup => (shotSetup || {}).heroDogThangType
+const heroPetThangType = shotSetup => (shotSetup || {}).heroPetThangType
 
 /**
  * @param {Object} o Object that may have slug property
@@ -206,12 +206,12 @@ const background = backgroundArt => {
 }
 
 /**
- * Returns properties required to place a hero dog Lank.
- * @param {Object} heroDogSchema
- * @returns {Object|undefined} a dog object with slug and thang
+ * Returns properties required to place a hero pet Lank.
+ * @param {Object} heroPetSchema
+ * @returns {Object|undefined} a pet object with slug and thang
  */
-const heroDog = heroDog => {
-  const thangData = extractThangTypeSchemaSlug(heroDog)
+const heroPet = heroPet => {
+  const thangData = extractThangTypeSchemaSlug(heroPet)
   if (!thangData) {
     return
   }
@@ -481,11 +481,11 @@ export const getBackground = compose(shotSetup, backgroundArt, background)
 export const getBackgroundSlug = compose(shotSetup, backgroundArt, background, slug)
 
 /**
- * Get hero dog thang
+ * Get hero pet thang
  * @param {Shot} shot
  * @returns {Object|undefined}
  */
-export const getHeroDog = compose(shotSetup, heroDogThangType, heroDog)
+export const getHeroPet = compose(shotSetup, heroPetThangType, heroPet)
 
 /**
  * @param {DialogNode} dialogNode

--- a/ozaria/engine/cinematic/CinematicLankBoss.js
+++ b/ozaria/engine/cinematic/CinematicLankBoss.js
@@ -15,7 +15,7 @@ import {
   getTextAnimationLength,
   getSpeakingAnimationAction,
   getSpeaker,
-  getHeroDog
+  getHeroPet
 } from '../../../app/schemas/models/selectors/cinematic'
 import { LETTER_ANIMATE_TIME, getHeroSlug } from './constants'
 
@@ -33,7 +33,7 @@ Promise.config({
 // Key constants for special lank types
 const LEFT_LANK_KEY = 'left'
 const RIGHT_LANK_KEY = 'right'
-const HERO_DOG = 'HERO_DOG'
+const HERO_PET = 'HERO_PET'
 const BACKGROUND_OBJECT = 'BACKGROUND_OBJECT'
 const BACKGROUND = 'BACKGROUND'
 
@@ -44,7 +44,7 @@ const BACKGROUND_LAYER = 'Background'
 // Lank to Background mapping. If not set, will default to 'Default' layer.
 const lankLayer = new Map([
   [ BACKGROUND, BACKGROUND_LAYER ],
-  [ HERO_DOG, BACKGROUND_LAYER ]
+  [ HERO_PET, BACKGROUND_LAYER ]
 ])
 
 // Thang rotation constants
@@ -102,18 +102,18 @@ export default class CinematicLankBoss {
       commands.push(this.setBackgroundCommand(background))
     }
 
-    const heroDog = getHeroDog(shot)
-    if (heroDog) {
-      const { slug, thang } = heroDog
+    const heroPet = getHeroPet(shot)
+    if (heroPet) {
+      const { slug, thang } = heroPet
       thang.rotation = RIGHT
-      this.heroDogOffset = thang.pos
-      const moveDog = this.moveLankCommand({
-        key: HERO_DOG,
+      this.heroPetOffset = thang.pos
+      const placePet = this.moveLankCommand({
+        key: HERO_PET,
         resource: slug,
         thang,
         ms: 0
       })
-      commands.push(moveDog)
+      commands.push(placePet)
     }
 
     const lHero = getLeftHero(shot)
@@ -138,8 +138,8 @@ export default class CinematicLankBoss {
 
     const rightCharSlug = getRightCharacterThangTypeSlug(shot)
     if (rightCharSlug) {
-      // Remove the hero dog if not a hero being added to the right.
-      commands.push(new SyncFunction(() => this.removeLank(HERO_DOG)))
+      // Remove the hero pet if not a hero being added to the right.
+      commands.push(new SyncFunction(() => this.removeLank(HERO_PET)))
 
       const { slug, enterOnStart, thang } = rightCharSlug
       addMoveCharacterCommand(RIGHT_LANK_KEY, slug, enterOnStart, thang)
@@ -344,30 +344,30 @@ export default class CinematicLankBoss {
    * @param {bool} frameChanged - Needs to be true for Lank updates to occur.
    */
   update (frameChanged) {
-    this.updateHeroDogPosition()
+    this.updateHeroPetPosition()
     Object.values(this.lanks)
       .forEach(lank => lank.update(frameChanged))
   }
 
   /**
-   * Custom update method that pins the hero dog to the right
-   * character if it exists, by updating the hero dog thang.
+   * Custom update method that pins the hero pet to the right
+   * character if it exists, by updating the hero pet thang.
    */
-  updateHeroDogPosition () {
-    if (!(this.lanks[HERO_DOG] && this.lanks[RIGHT_LANK_KEY])) {
+  updateHeroPetPosition () {
+    if (!(this.lanks[HERO_PET] && this.lanks[RIGHT_LANK_KEY])) {
       return
     }
 
-    const dogThang = this.lanks[HERO_DOG].thang
+    const petThang = this.lanks[HERO_PET].thang
     const rightThang = this.lanks[RIGHT_LANK_KEY].thang
     if (!rightThang.stateChanged) {
       return
     }
 
-    dogThang.stateChanged = true
-    dogThang.pos = _.clone(rightThang.pos)
-    dogThang.pos.x += this.heroDogOffset.x
-    dogThang.pos.y += this.heroDogOffset.y
+    petThang.stateChanged = true
+    petThang.pos = _.clone(rightThang.pos)
+    petThang.pos.x += this.heroPetOffset.x
+    petThang.pos.y += this.heroPetOffset.y
   }
 
   /**
@@ -434,8 +434,8 @@ export default class CinematicLankBoss {
         scaleFactorX: thang.scaleX || 1,
         scaleFactorY: thang.scaleY || 1
       })
-    } else if (key === HERO_DOG) {
-      // Hack to ensure dog renders off screen
+    } else if (key === HERO_PET) {
+      // Hack to ensure pet renders off screen
       // TODO: Remove when we have a way to make lanks invisible.
       thang.pos = {
         x: this.stageBounds.bottomRight.x * 10,

--- a/ozaria/engine/cinematic/CinematicLankBoss.js
+++ b/ozaria/engine/cinematic/CinematicLankBoss.js
@@ -138,6 +138,9 @@ export default class CinematicLankBoss {
 
     const rightCharSlug = getRightCharacterThangTypeSlug(shot)
     if (rightCharSlug) {
+      // Remove the hero dog if not a hero being added to the right.
+      commands.push(new SyncFunction(() => this.removeLank(HERO_DOG)))
+
       const { slug, enterOnStart, thang } = rightCharSlug
       addMoveCharacterCommand(RIGHT_LANK_KEY, slug, enterOnStart, thang)
     }

--- a/ozaria/engine/cinematic/Loader.js
+++ b/ozaria/engine/cinematic/Loader.js
@@ -4,7 +4,7 @@ import {
   getBackgroundObject,
   getRightCharacterThangTypeSlug,
   getLeftCharacterThangTypeSlug,
-  getHeroDog
+  getHeroPet
 } from '../../../app/schemas/models/selectors/cinematic'
 import { HERO_THANG_ID } from './CinematicLankBoss'
 import { getHeroSlug } from './constants'
@@ -100,9 +100,9 @@ export default class Loader {
         if (backgroundSlug) {
           slugs.push(backgroundSlug)
         }
-        const heroDogSlug = (getHeroDog(shot) || {}).slug
-        if (heroDogSlug) {
-          slugs.push(heroDogSlug)
+        const heroPetSlug = (getHeroPet(shot) || {}).slug
+        if (heroPetSlug) {
+          slugs.push(heroPetSlug)
         }
       })
     // Now we have a list of only slugs, we can fetch the data,

--- a/ozaria/engine/cinematic/Loader.js
+++ b/ozaria/engine/cinematic/Loader.js
@@ -1,5 +1,11 @@
 import { getThang, getThangTypeOriginal } from '../../../app/core/api/thang-types'
-import { getBackgroundSlug, getBackgroundObject, getRightCharacterThangTypeSlug, getLeftCharacterThangTypeSlug } from '../../../app/schemas/models/selectors/cinematic'
+import {
+  getBackgroundSlug,
+  getBackgroundObject,
+  getRightCharacterThangTypeSlug,
+  getLeftCharacterThangTypeSlug,
+  getHeroDog
+} from '../../../app/schemas/models/selectors/cinematic'
 import { HERO_THANG_ID } from './CinematicLankBoss'
 import { getHeroSlug } from './constants'
 
@@ -90,10 +96,13 @@ export default class Loader {
         if (slug2) {
           slugs.push(slug2)
         }
-
         const backgroundSlug = getBackgroundSlug(shot) || {}
         if (backgroundSlug) {
           slugs.push(backgroundSlug)
+        }
+        const heroDogSlug = (getHeroDog(shot) || {}).slug
+        if (heroDogSlug) {
+          slugs.push(heroDogSlug)
         }
       })
     // Now we have a list of only slugs, we can fetch the data,

--- a/test/app/models/Cinematic.spec.js
+++ b/test/app/models/Cinematic.spec.js
@@ -21,7 +21,7 @@ import {
   getSoundEffects,
   getWaitUserInput,
   getLanguageFilter,
-  getHeroDog
+  getHeroPet
 } from '../../../app/schemas/models/selectors/cinematic'
 
 /**
@@ -217,11 +217,11 @@ describe('Cinematic', () => {
       expect(getLanguageFilter({ programmingLanguageFilter: 'javascript' })).toEqual('javascript')
     })
 
-    it('getHeroDog', () => {
-      const result = getHeroDog(shotFixture1)
+    it('getHeroPet', () => {
+      const result = getHeroPet(shotFixture1)
       expect(result).toEqual({ slug: 'hero-dog-slug', thang: { scaleX: 1, scaleY: 2, pos: { x: 2, y: 0 } } })
 
-      const result2 = getHeroDog(shotFixture2)
+      const result2 = getHeroPet(shotFixture2)
       expect(result2).toBeUndefined()
     })
   })
@@ -264,7 +264,7 @@ var shotFixture1 = {
         }
       }
     },
-    heroDogThangType: {
+    heroPetThangType: {
       type: {
         slug: 'hero-dog-slug'
       },

--- a/test/app/models/Cinematic.spec.js
+++ b/test/app/models/Cinematic.spec.js
@@ -20,7 +20,8 @@ import {
   getSetupMusic,
   getSoundEffects,
   getWaitUserInput,
-  getLanguageFilter
+  getLanguageFilter,
+  getHeroDog
 } from '../../../app/schemas/models/selectors/cinematic'
 
 /**
@@ -215,6 +216,14 @@ describe('Cinematic', () => {
       expect(getLanguageFilter({ programmingLanguageFilter: 'python' })).toEqual('python')
       expect(getLanguageFilter({ programmingLanguageFilter: 'javascript' })).toEqual('javascript')
     })
+
+    it('getHeroDog', () => {
+      const result = getHeroDog(shotFixture1)
+      expect(result).toEqual({ slug: 'hero-dog-slug', thang: { scaleX: 1, scaleY: 2, pos: { x: 2, y: 0 } } })
+
+      const result2 = getHeroDog(shotFixture2)
+      expect(result2).toBeUndefined()
+    })
   })
 })
 
@@ -254,6 +263,15 @@ var shotFixture1 = {
           slug: 'fake-slug-thangtype'
         }
       }
+    },
+    heroDogThangType: {
+      type: {
+        slug: 'hero-dog-slug'
+      },
+      pos: {
+        x: 2
+      },
+      scaleY: 2
     },
     backgroundArt: {
       type: {


### PR DESCRIPTION
Features:

 - Can add hero dog thangType that attaches itself to the right character if and only if this character is a hero.
 - Add heroDog schema, selector, and test.
 - CinematicLankBoss handles heroDog as an edge case to stick the dog to the right hero character with an offset.
 - If the right character isn't a hero the pet is removed.
 - Refactor out constants to the top of the file.

# How to manually test

Open a test cinematic, via `localhost:3000/editor/cinematics`.
In the cinematic editor click through Shots -> Shot Setup and click the Plus. Add a `Hero Pet` property and fill it in like so:

```
{
  "type": {
    "slug": "duck-pet"
  },
  "pos": {
    "x": -8,
    "y": 10
  },
  "scaleX": 4,
  "scaleY": 4
}
```

You may be able to copy that JSON and paste it in by selecting the `Hero Pet` block and using `Ctrl + Shift + V`.

Then test the cinematic.