### PR TITLE
Disable and hide save new major version checkbox

### DIFF
--- a/app/templates/editor/level/save-level-modal.jade
+++ b/app/templates/editor/level/save-level-modal.jade
@@ -15,9 +15,10 @@ block modal-body-content
       .form-group.commit-message
         input.form-control#level-commit-message(name="commit-message", type="text", value=commitMessage)
       if level.isPublished()
-        .checkbox
+        // We don't use the major version feature, and it might be buggy, so hide for now.
+        .checkbox.hide
           label
-            input#level-version-is-major(name="version-is-major", type="checkbox")
+            input#level-version-is-major(name="version-is-major", type="checkbox", disabled=true)
             span(data-i18n="versions.new_major_version") New Major Version
       if !level.isPublished()
         .checkbox
@@ -40,9 +41,10 @@ block modal-body-content
       .form-group.commit-message
         input.form-control(id=id + "-commit-message", name="commit-message", type="text")
       if component.isPublished()
-        .checkbox
+        // We don't use the major version feature, and it might be buggy, so hide for now.
+        .checkbox.hide
           label
-            input(id=id + "-version-is-major", name="version-is-major", type="checkbox")
+            input(id=id + "-version-is-major", name="version-is-major", type="checkbox", disabled=true)
             span(data-i18n="versions.new_major_version") New Major Version
 
   if modifiedSystems.length
@@ -60,9 +62,10 @@ block modal-body-content
       .form-group.commit-message
         input.form-control(id=id + "-commit-message", name="commit-message", type="text", placeholder="Commit Message")
       if system.isPublished()
-        .checkbox
+        // We don't use the major version feature, and it might be buggy, so hide for now.
+        .checkbox.hide
           label
-            input(id=id + "-version-is-major", name="version-is-major", type="checkbox")
+            input(id=id + "-version-is-major", name="version-is-major", type="checkbox", disabled=true)
             span(data-i18n="versions.new_major_version") New Major Version
 
   if me.isAdmin()

--- a/app/templates/editor/modal/save-version-modal.jade
+++ b/app/templates/editor/modal/save-version-modal.jade
@@ -13,9 +13,10 @@ block modal-body-content
       .form-group.commit-message
         input.form-control#commit-message(name="commitMessage", type="text")
       if !view.isPatch && !view.options.noNewMajorVersions
-        .checkbox
+        // We don't use the major version feature, and it might be buggy, so hide for now.
+        .checkbox.hide
           label
-            input#major-version(name="version-is-major", type="checkbox")
+            input#major-version(name="version-is-major", type="checkbox", disabled=true)
             span(data-i18n="versions.new_major_version") New Major Version
   else
     .alert.alert-danger(data-i18n="delta.no_changes") No changes


### PR DESCRIPTION
We don't know if this feature fully works and have been mostly relying on not using it, but that's fragile. Rather than find out or use it, a quick fix to disable.