### PR TITLE
:bug: Background object delay not connected

### DIFF
--- a/app/schemas/models/selectors/cinematic.js
+++ b/app/schemas/models/selectors/cinematic.js
@@ -300,11 +300,23 @@ export const triggers = dialogNode => (dialogNode || {}).triggers
 
 const backgroundObject = triggers => {
   const bgObject = (triggers || {}).backgroundObject
-  if (!bgObject) {
+  if (!(bgObject || {}).thangType) {
     return
   }
 
   return _.merge(DEFAULT_THANGTYPE(), bgObject.thangType)
+}
+
+/**
+ * @param {Object} triggers
+ * @returns {number|undefined} number of ms before background object appears
+ */
+const backgroundObjectDelay = triggers => {
+  const bgObject = (triggers || {}).backgroundObject
+  if (!bgObject) {
+    return
+  }
+  return bgObject.triggerStart || 0
 }
 
 /**
@@ -394,6 +406,12 @@ export const getBackgroundSlug = compose(shotSetup, backgroundArt, background, s
  * @returns {Object|undefined} backgroundObject
  */
 export const getBackgroundObject = compose(triggers, backgroundObject)
+
+/**
+ * @param {DialogNode} dialogNode
+ * @returns {number|undefined} delay
+ */
+export const getBackgroundObjectDelay = compose(triggers, backgroundObjectDelay)
 
 /**
  * @param {DialogNode} dialogNode

--- a/ozaria/engine/cinematic/CinematicLankBoss.js
+++ b/ozaria/engine/cinematic/CinematicLankBoss.js
@@ -9,6 +9,7 @@ import {
   getBackground,
   getExitCharacter,
   getBackgroundObject,
+  getBackgroundObjectDelay,
   getClearBackgroundObject,
   getText,
   getTextAnimationLength,
@@ -143,14 +144,17 @@ export default class CinematicLankBoss {
         pos: { x, y },
         stateChanged: true
       }
-      commands.push(
+      const delay = getBackgroundObjectDelay(dialogNode)
+
+      commands.push(new SequentialCommands([
+        new Sleep(delay),
         this.moveLankCommand({
           key: BACKGROUND_OBJECT,
           resource: slug,
           thang: thangOptions,
           ms: 0
         })
-      )
+      ]))
     }
 
     const removeBgDelay = getClearBackgroundObject(dialogNode)

--- a/test/app/models/Cinematic.spec.js
+++ b/test/app/models/Cinematic.spec.js
@@ -6,6 +6,7 @@ import {
   getRightHero,
   getClearBackgroundObject,
   getBackgroundObject,
+  getBackgroundObjectDelay,
   getBackground,
   getClearText,
   getSpeaker,
@@ -87,6 +88,14 @@ describe('Cinematic', () => {
       expect(result).toEqual({ scaleX: 1, scaleY: 1, pos: { x: 0, y: 0 }, type: { slug: 'background-obj-fixture' } })
 
       const result2 = getBackgroundObject(shotFixture2.dialogNodes[0])
+      expect(result2).toBeUndefined()
+    })
+
+    it('getBackgroundObjectDelay', () => {
+      const result = getBackgroundObjectDelay(shotFixture1.dialogNodes[0])
+      expect(result).toEqual(1337)
+
+      const result2 = getBackgroundObjectDelay(shotFixture2.dialogNodes[0])
       expect(result2).toBeUndefined()
     })
 


### PR DESCRIPTION
## Issue

In the cinematic editor is was found that this property wasn't correctly attached. There was no delay happening for background objects added to the cinematic shot.

## Fix

Connect the data of the delay to a delay command when creating a background object.