### PR TITLE
:Bug: Cinematic Lank Scaling Issues

### DIFF
--- a/app/lib/surface/Lank.coffee
+++ b/app/lib/surface/Lank.coffee
@@ -350,6 +350,7 @@ module.exports = Lank = class Lank extends CocoClass
 #    console.error 'No thang for', @ unless @thang
     @sprite.scaleX = @sprite.baseScaleX * @scaleFactorX * scaleX
     @sprite.scaleY = @sprite.baseScaleY * @scaleFactorY * scaleY
+
     newScaleFactorX = @thang?.scaleFactorX ? @thang?.scaleFactor ? 1
     newScaleFactorY = @thang?.scaleFactorY ? @thang?.scaleFactor ? 1
     if @layer?.name is 'Land' or @thang?.isLand or @thang?.spriteName is 'Beam' or @isCinematicLank

--- a/app/lib/surface/Lank.coffee
+++ b/app/lib/surface/Lank.coffee
@@ -68,7 +68,7 @@ module.exports = Lank = class Lank extends CocoClass
     @options = _.extend($.extend(true, {}, @options), options)
     @gameUIState = @options.gameUIState
     @handleEvents = @options.handleEvents
-    @isCinematicLank = options.isCinematic or false
+    @isCinematicLank = @options.isCinematic or false
     @setThang @options.thang
     @setColorConfig()
 

--- a/app/lib/surface/Lank.coffee
+++ b/app/lib/surface/Lank.coffee
@@ -68,6 +68,7 @@ module.exports = Lank = class Lank extends CocoClass
     @options = _.extend($.extend(true, {}, @options), options)
     @gameUIState = @options.gameUIState
     @handleEvents = @options.handleEvents
+    @isCinematicLank = options.isCinematic or false
     @setThang @options.thang
     @setColorConfig()
 
@@ -349,10 +350,9 @@ module.exports = Lank = class Lank extends CocoClass
 #    console.error 'No thang for', @ unless @thang
     @sprite.scaleX = @sprite.baseScaleX * @scaleFactorX * scaleX
     @sprite.scaleY = @sprite.baseScaleY * @scaleFactorY * scaleY
-
     newScaleFactorX = @thang?.scaleFactorX ? @thang?.scaleFactor ? 1
     newScaleFactorY = @thang?.scaleFactorY ? @thang?.scaleFactor ? 1
-    if @layer?.name is 'Land' or @thang?.isLand or @thang?.spriteName is 'Beam'
+    if @layer?.name is 'Land' or @thang?.isLand or @thang?.spriteName is 'Beam' or @isCinematicLank
       @scaleFactorX = newScaleFactorX
       @scaleFactorY = newScaleFactorY
     else if @thang and (newScaleFactorX isnt @targetScaleFactorX or newScaleFactorY isnt @targetScaleFactorY)

--- a/ozaria/engine/cinematic/CinematicLankBoss.js
+++ b/ozaria/engine/cinematic/CinematicLankBoss.js
@@ -51,12 +51,15 @@ export default class CinematicLankBoss {
       'Background': backgroundAdapter
     }
     this.camera = camera
-    this.stageBounds = {
+    this.loader = loader
+    this.lanks = {}
+  }
+
+  get stageBounds () {
+    return {
       topLeft: this.camera.canvasToWorld({ x: 0, y: 0 }),
       bottomRight: this.camera.canvasToWorld({ x: this.camera.canvasWidth, y: this.camera.canvasHeight })
     }
-    this.loader = loader
-    this.lanks = {}
   }
 
   /**
@@ -234,13 +237,13 @@ export default class CinematicLankBoss {
         if (resource) {
           this.addLank(key, this.loader.getThangType(resource), thang)
         }
-
         _.merge(this.lanks[key].thang, {
           pos: thang.pos,
           scaleFactorX: thang.scaleX,
           scaleFactorY: thang.scaleY,
           stateChanged: true
         })
+        this.lanks[key].updateScale()
       })
     }
 
@@ -372,13 +375,13 @@ export default class CinematicLankBoss {
         scaleFactorY: thang.scaleY || 1
       })
     }
-
     const lank = new Lank(thangType, {
       resolutionFactor: 60,
       preloadSounds: false,
       thang,
       camera: this.camera,
-      groundLayer: this.groundLayer
+      groundLayer: this.groundLayer,
+      isCinematic: true
     })
     if (key === BACKGROUND) {
       this.layerAdapters['Background'].addLank(lank)
@@ -414,7 +417,7 @@ const createThang = thang => {
     //  Looking left
     rotation: 0
   }
-  return _.merge(defaults, thang)
+  return _.cloneDeep(_.merge(defaults, thang))
 }
 
 /**

--- a/ozaria/engine/cinematic/CinematicLankBoss.js
+++ b/ozaria/engine/cinematic/CinematicLankBoss.js
@@ -237,6 +237,7 @@ export default class CinematicLankBoss {
         if (resource) {
           this.addLank(key, this.loader.getThangType(resource), thang)
         }
+
         _.merge(this.lanks[key].thang, {
           pos: thang.pos,
           scaleFactorX: thang.scaleX,
@@ -375,6 +376,7 @@ export default class CinematicLankBoss {
         scaleFactorY: thang.scaleY || 1
       })
     }
+
     const lank = new Lank(thangType, {
       resolutionFactor: 60,
       preloadSounds: false,

--- a/ozaria/engine/cinematic/cinematicController.js
+++ b/ozaria/engine/cinematic/cinematicController.js
@@ -24,12 +24,14 @@ export class CinematicController {
     handlers: {
       onPlay,
       onPause,
-      onCompletion
+      onCompletion,
+      onLoaded
     }
   }) {
     this.onPlay = onPlay || (() => {})
     this.onPause = onPause || (() => {})
     this.onCompletion = onCompletion || (() => {})
+    this.onLoaded = onLoaded || (() => {})
 
     this.systems = {}
 
@@ -86,6 +88,7 @@ export class CinematicController {
     attachListener({ cinematicLankBoss: this.systems.cinematicLankBoss, stage: this.stage })
 
     this.commands = commands
+    this.onLoaded()
   }
 
   /**
@@ -146,8 +149,11 @@ export class CinematicController {
   }
 
   destroy () {
-    this.systems.sound.stopAllSounds()
+    this.systems.cameraSystem.destroy()
+    createjs.Ticker.removeAllEventListeners()
     this.systems.cinematicLankBoss.cleanup()
+    this.stage.removeAllEventListeners()
+    this.systems.sound.stopAllSounds()
   }
 }
 

--- a/ozaria/site/components/cinematic/PageCinematicEditor/index.vue
+++ b/ozaria/site/components/cinematic/PageCinematicEditor/index.vue
@@ -95,7 +95,7 @@ module.exports = Vue.extend({
      * Pushes changes from treema to the cinematic model.
      */
     pushChanges() {
-      const shots = this.treema.data.shots
+      const shots = _.cloneDeep(this.treema.data.shots)
       this.cinematic.set('shots', shots)
     },
 
@@ -120,7 +120,7 @@ module.exports = Vue.extend({
     runCinematic() {
       this.rerenderKey += 1;
       this.rawData = this.rawData || {}
-      this.rawData.shots = this.treema.data.shots
+      this.rawData.shots = JSON.parse(JSON.stringify(this.treema.data.shots))
     },
 
     async createCinematic() {

--- a/ozaria/site/components/cinematic/common/CinematicCanvas.vue
+++ b/ozaria/site/components/cinematic/common/CinematicCanvas.vue
@@ -47,7 +47,8 @@ export default {
       handlers: {
         onPlay: this.handlePlay,
         onPause: this.handleWait,
-        onCompletion: () => this.$emit('completed')
+        onCompletion: () => this.$emit('completed'),
+        onLoaded: this.userInterruptionEvent
       }})
     window.addEventListener('keypress', this.handleKeyboardCancellation)
   },


### PR DESCRIPTION
## Issues

This bug manifests in many ways. Currently you can see it best when you navigate to this [cinematic](https://www.codecombat.com/cinematic/1fhl1c2).

The mushroom should be the same scale throughout the entire cinematic. (Which you can manually test locally using the proxy).

To test with proxy. Have two terminals open and run `npm run dev` and `npm run proxy` simultaneously.

## Fix

The issue seemed to be the way the engine handles scaling.
I first decoupled the treema editor data to make replaying the same cinematic deterministic.
The stage bounds were made into a dynamic getter to ensure the characters always have the latest camera bounds.

Finally we've added an `isCinematic` option to the Lank which prevents the implicit tweening and stretching of the scaling.

I also added an isLoaded callback that can be used to start the cinematic once it is loaded. Another improvement for smoother cinematic editing.