### PR TITLE
Set reasonable Cinematic default values

### DIFF
--- a/app/schemas/models/selectors/cinematic.js
+++ b/app/schemas/models/selectors/cinematic.js
@@ -87,6 +87,46 @@ const DEFAULT_THANGTYPE = () => ({
 })
 
 /**
+ * @param {Object} thangDefaults
+ * @returns {Function} sets thangDefaults on the thang property for a character.
+ */
+const setCharacterDefaults = ({ pos, scaleX, scaleY }) =>
+  character => {
+    if (!character) {
+      return
+    }
+
+    const thang = character.thang || {}
+    thang.pos = _.merge(pos, (thang.pos || {}))
+    thang.scaleX = thang.scaleX || scaleX
+    thang.scaleY = thang.scaleY || scaleY
+    character.thang = thang
+    return character
+  }
+
+/**
+ * @param {Object|undefined} leftCharacter The left character object
+ * @param {Object} leftCharacter.thang The thang options for the left character.
+ * @returns {Object|undefined} leftCharacter with default values set on thang.
+ */
+const setLeftCharacterDefaults = setCharacterDefaults({
+  pos: { x: -30, y: -73 },
+  scaleX: 0.7,
+  scaleY: 0.7
+})
+
+/**
+ * @param {Object|undefined} rightCharacter The left character object
+ * @param {Object} rightCharacter.thang The thang options for the left character.
+ * @returns {Object|undefined} rightCharacter with default values set on thang.
+ */
+const setRightCharacterDefaults = setCharacterDefaults({
+  pos: { x: 35, y: -65 },
+  scaleX: 0.7,
+  scaleY: 0.7
+})
+
+/**
  * Takes the cinematic data that adheres to cinematic schema and returns
  * just the array of shots.
  * @param {Cinematic} cinematicData
@@ -158,7 +198,7 @@ const characterFromThangTypeSchema = thangType => {
   const { scaleX, scaleY, pos } = thangType
   return {
     slug,
-    thang: _.merge(DEFAULT_THANGTYPE(), { scaleX, scaleY, pos })
+    thang: { scaleX, scaleY, pos }
   }
 }
 
@@ -180,7 +220,7 @@ const getHeroFromThangTypeSchema = thangType => {
 
   const { scaleX, scaleY, pos } = thangType
   return {
-    thang: _.merge(DEFAULT_THANGTYPE(), { scaleX, scaleY, pos })
+    thang: { scaleX, scaleY, pos }
   }
 }
 
@@ -259,14 +299,14 @@ const camera = shotSetup => {
  * @param {Shot} shot
  * @returns {Object|undefined} thangType slug, position data and whether to animate in the thang.
  */
-export const getLeftCharacterThangTypeSlug = compose(shotSetup, leftCharacter, characterThangTypeSlug)
+export const getLeftCharacterThangTypeSlug = compose(shotSetup, leftCharacter, characterThangTypeSlug, setLeftCharacterDefaults)
 
 /**
  * Returns the right character if it's a thangType slug.
  * @param {Shot} shot
  * @returns {Object|undefined} thangType slug, position data and whether to animate in the thang.
  */
-export const getRightCharacterThangTypeSlug = compose(shotSetup, rightCharacter, characterThangTypeSlug)
+export const getRightCharacterThangTypeSlug = compose(shotSetup, rightCharacter, characterThangTypeSlug, setRightCharacterDefaults)
 
 /**
  * @param {DialogNode} dialogNode
@@ -378,14 +418,14 @@ const soundEffects = triggers => {
  * @param {Shot} shot
  * @returns {bool}
  */
-export const getLeftHero = compose(shotSetup, leftCharacter, heroThangTypeOriginal)
+export const getLeftHero = compose(shotSetup, leftCharacter, heroThangTypeOriginal, setLeftCharacterDefaults)
 
 /**
  * Returns the right hero character
  * @param {Shot} shot
  * @returns {bool}
  */
-export const getRightHero = compose(shotSetup, rightCharacter, heroThangTypeOriginal)
+export const getRightHero = compose(shotSetup, rightCharacter, heroThangTypeOriginal, setRightCharacterDefaults)
 
 /**
  * Returns the background

--- a/app/schemas/models/selectors/cinematic.js
+++ b/app/schemas/models/selectors/cinematic.js
@@ -279,8 +279,7 @@ export const CAMERA_DEFAULT = {
     x: 0,
     y: 0
   },
-  // There appears to be a bug in our camera and it can't support exactly 2.
-  zoom: 2.01
+  zoom: 1
 }
 
 /**
@@ -461,7 +460,7 @@ export const getClearBackgroundObject = compose(triggers, clearBackgroundObject)
 
 /**
  * @param {Shot} shot
- * @returns {Object|undefined}
+ * @returns {Object} Always returns a camera
  */
 export const getCamera = compose(shotSetup, camera)
 

--- a/ozaria/engine/cinematic/CameraSystem.js
+++ b/ozaria/engine/cinematic/CameraSystem.js
@@ -25,4 +25,8 @@ export class CameraSystem {
     }
     return commands
   }
+
+  destroy () {
+    this.camera.destroy()
+  }
 }

--- a/ozaria/engine/cinematic/cinematicController.js
+++ b/ozaria/engine/cinematic/cinematicController.js
@@ -149,8 +149,8 @@ export class CinematicController {
   }
 
   destroy () {
-    this.systems.cameraSystem.destroy()
     createjs.Ticker.removeAllEventListeners()
+    this.systems.cameraSystem.destroy()
     this.systems.cinematicLankBoss.cleanup()
     this.stage.removeAllEventListeners()
     this.systems.sound.stopAllSounds()

--- a/ozaria/engine/cinematic/commands/CinematicParser.js
+++ b/ozaria/engine/cinematic/commands/CinematicParser.js
@@ -62,15 +62,17 @@ const parseSetup = (shot, systems) =>
 /**
  * Returns an array of commands.
  * This is required as we update this list to add commands to the start and end.
- * @param {DialogNode} dialogNode
- * @param {Object} systems
+ * @param {Object} arg
+ * @param {DialogNode} arg.dialogNode
+ * @param {Object} arg.systems
+ * @param {Object} arg.shot the current shot
  * @returns {AbstractCommand[]}
  */
-const parseDialogNode = (dialogNode, systems) => {
+const parseDialogNode = ({ dialogNode, systems, shot }) => {
   const dialogCommands = Object.values(systems)
     .filter(sys => sys !== undefined && typeof sys.parseDialogNode === 'function')
     .reduce((commands, sys) => {
-      const dialogCommands = sys.parseDialogNode(dialogNode)
+      const dialogCommands = sys.parseDialogNode(dialogNode, shot)
       if (!Array.isArray(dialogCommands)) {
         throw new Error('Your system should always return an array of commands for a dialogNode')
       }
@@ -93,7 +95,7 @@ const parseDialogNode = (dialogNode, systems) => {
 export const parseShot = (shot, systems = {}) => {
   const setupCommands = parseSetup(shot, systems) || []
   const dialogNodes = (shot.dialogNodes || [])
-    .map(node => parseDialogNode(node, systems))
+    .map(node => parseDialogNode({ dialogNode: node, systems, shot }))
     .filter(dialogCommands => dialogCommands.length > 0)
 
   // If we have both dialogNodes and some setupCommands we want to

--- a/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
+++ b/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
@@ -11,7 +11,7 @@ import { processText, getDefaultTextPosition } from './helper'
 
 const SVGNS = 'http://www.w3.org/2000/svg'
 const padding = 10
-const SPEECH_BUBBLE_MAX_WIDTH = `400px`
+const SPEECH_BUBBLE_MAX_WIDTH = `443px` // Removed 20 px to account for padding.
 
 /**
  * This system coordinates drawing HTML and SVG to the screen.

--- a/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
+++ b/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
@@ -121,7 +121,7 @@ class SpeechBubble {
     const textDiv = html.body.firstChild
     textDiv.style.display = 'inline-block'
     textDiv.style.position = 'absolute'
-    textDiv.style.maxWidth = `350px`
+    textDiv.style.maxWidth = `400px`
     textDiv.id = this.id
 
     div.appendChild(textDiv)

--- a/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
+++ b/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
@@ -121,6 +121,7 @@ class SpeechBubble {
     const textDiv = html.body.firstChild
     textDiv.style.display = 'inline-block'
     textDiv.style.position = 'absolute'
+    textDiv.style.maxWidth = `350px`
     textDiv.id = this.id
 
     div.appendChild(textDiv)

--- a/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
+++ b/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
@@ -7,10 +7,11 @@ import {
   getTextAnimationLength,
   getCamera
 } from '../../../../app/schemas/models/selectors/cinematic'
-import { processText } from './helper'
+import { processText, getDefaultTextPosition } from './helper'
 
 const SVGNS = 'http://www.w3.org/2000/svg'
 const padding = 10
+const SPEECH_BUBBLE_MAX_WIDTH = `400px`
 
 /**
  * This system coordinates drawing HTML and SVG to the screen.
@@ -121,7 +122,7 @@ class SpeechBubble {
     const textDiv = html.body.firstChild
     textDiv.style.display = 'inline-block'
     textDiv.style.position = 'absolute'
-    textDiv.style.maxWidth = `400px`
+    textDiv.style.maxWidth = SPEECH_BUBBLE_MAX_WIDTH
     textDiv.id = this.id
 
     div.appendChild(textDiv)
@@ -228,38 +229,4 @@ function createSvgShape ({ x, y, width, height, side, className }) {
   g.appendChild(rect)
   g.appendChild(path)
   return g
-}
-
-/**
- * Try to guess the frame of the camera and provide sensible defaults for the
- * text bubbles. Uses values sourced from Brian.
- *
- * If value can't be guessed, sets the text bubble in the center of the canvas.
- *
- * @param {'left'|'right'} speaker
- * @param {number} cameraZoom
- * @param {Object} cameraPosition
- * @param {number} cameraPosition.x
- */
-function getDefaultTextPosition (speaker, cameraZoom, { x }) {
-  const cameraX = x
-  // Handling special cases of zoom, checking if speaker is in frame.
-  if (speaker === 'left') {
-    if (cameraZoom === 1) {
-      return { x: 550, y: 330 }
-    }
-    // Then zoom must be 2.
-    if (cameraX < -145) {
-      return { x: 800, y: 250 }
-    }
-  } else if (speaker === 'right') {
-    if (cameraZoom === 1) {
-      return { x: 850, y: 300 }
-    }
-    if (cameraX > 145) {
-      return { x: 550, y: 250 }
-    }
-  }
-  // Default to center
-  return { x: 1366 / 2, y: 768 / 2 }
 }

--- a/ozaria/engine/cinematic/dialogsystem/helper.js
+++ b/ozaria/engine/cinematic/dialogsystem/helper.js
@@ -82,3 +82,37 @@ export function wrapText (htmlString, wrapLetterString, wrapWordString) {
 
   return wrapWord(htmlString, / ?([^ ])+ ?/)
 }
+
+/**
+ * Try to guess the frame of the camera and provide sensible defaults for the
+ * text bubbles. Uses values sourced from Brian.
+ *
+ * If value can't be guessed, sets the text bubble in the center of the canvas.
+ *
+ * @param {'left'|'right'} speaker
+ * @param {number} cameraZoom
+ * @param {Object} cameraPosition
+ * @param {number} cameraPosition.x
+ */
+export function getDefaultTextPosition (speaker, cameraZoom, { x }) {
+  const cameraX = x
+  // Handling special cases of zoom, checking if speaker is in frame.
+  if (speaker === 'left') {
+    if (cameraZoom === 1) {
+      return { x: 550, y: 330 }
+    }
+    // Then zoom must be 2.
+    if (cameraX < -145) {
+      return { x: 800, y: 250 }
+    }
+  } else if (speaker === 'right') {
+    if (cameraZoom === 1) {
+      return { x: 850, y: 300 }
+    }
+    if (cameraX > 145) {
+      return { x: 550, y: 250 }
+    }
+  }
+  // Default to center
+  return { x: 1366 / 2, y: 768 / 2 }
+}

--- a/test/app/lib/cinematic/cinematicParser.spec.js
+++ b/test/app/lib/cinematic/cinematicParser.spec.js
@@ -33,7 +33,7 @@ describe('parseShot', () => {
     expect(results).toEqual([['setup command1', 'setup command2']])
   })
 
-  it('dialogNode array data passed into parseDialogNode system', () => {
+  it('dialogNode array data passed into parseDialogNode system with shot information', () => {
     const systems = [{
       parseDialogNode: jasmine.createSpy().and.returnValue(['dialog commands'])
     }]
@@ -41,7 +41,8 @@ describe('parseShot', () => {
       dialogNodes: ['DialogNode1', 'DialogNode2']
     }
     const results = parseShot(shot, systems)
-    expect(systems[0].parseDialogNode.calls.all().map(o => o.args)).toEqual([['DialogNode1'], ['DialogNode2']])
+    expect(systems[0].parseDialogNode.calls.all().map(o => o.args))
+      .toEqual([ [ 'DialogNode1', { dialogNodes: [ 'DialogNode1', 'DialogNode2' ] } ], [ 'DialogNode2', { dialogNodes: [ 'DialogNode1', 'DialogNode2' ] } ] ])
     // I don't like this test but I couldn't figure out another way.
     expect(JSON.stringify(results)).toEqual('[[{"commands":["dialog commands"]}],[{"commands":["dialog commands"]}]]')
   })
@@ -57,7 +58,8 @@ describe('parseShot', () => {
     }
 
     const results = parseShot(shot, systems)
-    expect(systems[0].parseDialogNode.calls.all().map(o => o.args)).toEqual([['DialogNode1'], ['DialogNode2']])
+    expect(systems[0].parseDialogNode.calls.all().map(o => o.args))
+      .toEqual([ [ 'DialogNode1', { setupShot: 'Example setup shot', dialogNodes: [ 'DialogNode1', 'DialogNode2' ] } ], [ 'DialogNode2', { setupShot: 'Example setup shot', dialogNodes: [ 'DialogNode1', 'DialogNode2' ] } ] ])
     expect(systems[0].parseSetupShot).toHaveBeenCalledWith(shot)
     expect(JSON.stringify(results)).toEqual('[["setup commands",{"commands":["dialog commands"]}],[{"commands":["dialog commands"]}]]')
   })

--- a/test/app/models/Cinematic.spec.js
+++ b/test/app/models/Cinematic.spec.js
@@ -48,7 +48,7 @@ describe('Cinematic', () => {
       expect(result).toBeUndefined()
 
       const result2 = getLeftCharacterThangTypeSlug(shotFixture2)
-      expect(result2).toEqual({ slug: 'fake-slug-thangtype', enterOnStart: false, thang: { scaleX: 1, scaleY: 1, pos: { x: 0, y: 0 } } })
+      expect(result2).toEqual({ slug: 'fake-slug-thangtype', enterOnStart: false, thang: { scaleX: 0.7, scaleY: 0.7, pos: { x: -30, y: -73 } } })
     })
 
     it('getRightCharacterThangTypeSlug', () => {
@@ -56,7 +56,7 @@ describe('Cinematic', () => {
       expect(result).toBeUndefined()
 
       const result2 = getRightCharacterThangTypeSlug(shotFixture1)
-      expect(result2).toEqual({ slug: 'fake-slug-thangtype', enterOnStart: false, thang: { scaleX: 1, scaleY: 1, pos: { x: 0, y: 0 } } })
+      expect(result2).toEqual({ slug: 'fake-slug-thangtype', enterOnStart: false, thang: { scaleX: 0.7, scaleY: 0.7, pos: { x: 35, y: -65 } } })
     })
 
     it('getLeftHero', () => {


### PR DESCRIPTION
## Issue

Currently, Cinematic defaults are nonsense, and it puts a lot of work on content production to type out the same numbers repeatedly.

By setting defaults based on [this doc](https://codecombat.slab.com/posts/cinematic-default-values-x0j7dmw8), we'll be able to increase content production velocity.

This change gives the Cinematic System some context around how it is used. We predominantly use zoom level 1 and zoom level 2 for the dual shot and close up shots.

For both of these shots there is a standard text position that can be used by default.

Similarly characters are always placed in the same position and also have specific values that can be set.

It is important that if a value is ever set in the cinematic editor it overrides the default.
We should also expect these defaults to change as art is added.

## Defaults set

 - Camera defaults to zoom 1, which fits both characters.
 - Left and Right character positions and scales are defaulted.
 - Text bubble location defaults based on slab.
    - Required minor extension for DialogSystem to become aware of camera zoom and position.
 - Max width added to speech bubbles.