### PR TITLE
Fix Catherine's "cut-off" avatar image in README.md. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Note: the levels on codecombat.com are [not open source](LICENSE-LEVELS.md).
 ![George Saines](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/George%20Saines/george_small.png "George Saines")
 ![Scott Erickson](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Scott%20Erickson/scott-avatar.png "Scott Erickson")
 ![Matt Lott](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Matt%20Lott/matt-avatar.png "Matt Lott")
-![Catherine Weresow](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Cat%20Weresow/cat-avatar.png "Catherine Weresow")
+![Catherine Weresow](https://sjc1.discourse-cdn.com/business6/user_avatar/discourse.codecombat.com/catsync/240/6431_2.png "Catherine Weresow")
 ![Maka Gradin](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Maka%20Gradin/maka_gradin_100.png "Maka Gradin")
 ![Rob Blanckaert](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Rob%20Blanckaert/rob_blanckaert_100.png "Rob Blanckaert")
 ![Josh Callebaut](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Josh%20Callebaut/josh_callebaut_100.png "Josh Callebaut")

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Note: the levels on codecombat.com are [not open source](LICENSE-LEVELS.md).
 ![George Saines](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/George%20Saines/george_small.png "George Saines")
 ![Scott Erickson](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Scott%20Erickson/scott-avatar.png "Scott Erickson")
 ![Matt Lott](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Matt%20Lott/matt-avatar.png "Matt Lott")
-![Catherine Weresow](https://sjc1.discourse-cdn.com/business6/user_avatar/discourse.codecombat.com/catsync/240/6431_2.png "Catherine Weresow")
+![Catherine Weresow](https://sjc1.discourse-cdn.com/business6/user_avatar/discourse.codecombat.com/catsync/100/6431_2.png "Catherine Weresow")
 ![Maka Gradin](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Maka%20Gradin/maka_gradin_100.png "Maka Gradin")
 ![Rob Blanckaert](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Rob%20Blanckaert/rob_blanckaert_100.png "Rob Blanckaert")
 ![Josh Callebaut](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Josh%20Callebaut/josh_callebaut_100.png "Josh Callebaut")

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Note: the levels on codecombat.com are [not open source](LICENSE-LEVELS.md).
 ![George Saines](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/George%20Saines/george_small.png "George Saines")
 ![Scott Erickson](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Scott%20Erickson/scott-avatar.png "Scott Erickson")
 ![Matt Lott](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Matt%20Lott/matt-avatar.png "Matt Lott")
-![Catherine Weresow](https://sjc1.discourse-cdn.com/business6/user_avatar/discourse.codecombat.com/catsync/100/6431_2.png "Catherine Weresow")
+![Catherine Weresow](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Cat+Weresow/cat_sync.png "Catherine Weresow")
 ![Maka Gradin](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Maka%20Gradin/maka_gradin_100.png "Maka Gradin")
 ![Rob Blanckaert](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Rob%20Blanckaert/rob_blanckaert_100.png "Rob Blanckaert")
 ![Josh Callebaut](https://s3.amazonaws.com/files.codecombat.com/wiki-images/avatars/Josh%20Callebaut/josh_callebaut_100.png "Josh Callebaut")


### PR DESCRIPTION
The current README has top of Catherine's avatar cut-off, as shown below:
<img width="185" alt="Screen Shot 2019-06-03 at 7 03 05 PM" src="https://user-images.githubusercontent.com/29741391/58794384-006b5900-8633-11e9-88f3-1bf05b14cfab.png">
This PR will fix that issue by using a non-cut-off image. (I've resized it so it matches the sizes of others). After fix:
<img width="165" alt="Screen Shot 2019-06-03 at 7 06 35 PM" src="https://user-images.githubusercontent.com/29741391/58794428-1c6efa80-8633-11e9-80ff-e3c6a120b4eb.png">
