### PR TITLE
Remove G+ social links (G+ is dead)

### DIFF
--- a/app/locale/ar.coffee
+++ b/app/locale/ar.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "العربية", englishDescription: "Arabi
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/az.coffee
+++ b/app/locale/az.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "azərbaycan dili", englishDescription: "Aze
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/bg.coffee
+++ b/app/locale/bg.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "български език", englishDescri
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/ca.coffee
+++ b/app/locale/ca.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Català", englishDescription: "Catalan", tr
     social_discource: "Uneix-te a les discussions al nostre fòrum de comentaris"
     social_facebook: "Fes Like a CodeCombat en Facebook"
     social_twitter: "Segueix CodeCombat al Twitter"
-    social_gplus: "Uneix-te a CodeCombat en Google+"
     social_slack: "Xateja amb nosaltres al canal públic CodeCombat Slack"
     contribute_to_the_project: "Contribueix al projecte"
 

--- a/app/locale/cs.coffee
+++ b/app/locale/cs.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "čeština", englishDescription: "Czech", tr
     social_discource: "Vstupte do diskuze na našem Discourse fóru"
     social_facebook: "Dejte Like CodeCombat na Facebooku"
     social_twitter: "Sledujte CodeCombat na Twitteru"
-    social_gplus: "Připojte se k CodeCombat na Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
     contribute_to_the_project: "Přispějte tomuto projektu"
 

--- a/app/locale/da.coffee
+++ b/app/locale/da.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "dansk", englishDescription: "Danish", trans
     social_discource: "Deltag i diskussionen på vores Discourse-forum"
     social_facebook: "Like CodeCombat på Facebook"
     social_twitter: "Følg CodeCombat på Twitter"
-    social_gplus: "Følg CodeCombat på Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
     contribute_to_the_project: "Bidrag til projektet"
 

--- a/app/locale/de-AT.coffee
+++ b/app/locale/de-AT.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Deutsch (Österreich)", englishDescription:
     social_discource: "Schließe dich den Diskussionen in unserem Discourse Forum an"
     social_facebook: "Like CodeCombat auf Facebook"
     social_twitter: "Folge CodeCombat auf Twitter"
-    social_gplus: "Schließe dich CodeCombat bei Google+ an"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
     contribute_to_the_project: "Trage zu diesem Projekt bei"
 

--- a/app/locale/de-CH.coffee
+++ b/app/locale/de-CH.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Dütsch (Schwiiz)", englishDescription: "Ge
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/de-DE.coffee
+++ b/app/locale/de-DE.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Deutsch (Deutschland)", englishDescription:
     social_discource: "Schließe dich den Diskussionen in unserem Discourse Forum an"
     social_facebook: "Like CodeCombat auf Facebook"
     social_twitter: "Folge CodeCombat auf Twitter"
-    social_gplus: "Schließe dich CodeCombat bei Google+ an"
     social_slack: "Im öffentlichen Slack-Channel von CodeCombat kannst du mit uns chatten"
     contribute_to_the_project: "Trage zu diesem Projekt bei"
 

--- a/app/locale/el.coffee
+++ b/app/locale/el.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Ελληνικά", englishDescription: "Gre
     social_discource: "Μπείτε στη συζήτηση στο φόρουμ μας που είναι βασισμένο στο Discourse"
     social_facebook: "Κάντε Like στο CodeCombat στο Facebook"
     social_twitter: "Ακολουθείστε το CodeCombat στο Twitter"
-    social_gplus: "Συνδεθείτε με το CodeCombat στο Google+"
     social_slack: "Συζητήστε μαζί μας στο δημόσιο κανάλι του CodeCombat στο Slack"
     contribute_to_the_project: "Συμβάλλετε στο έργο"
 

--- a/app/locale/en-GB.coffee
+++ b/app/locale/en-GB.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "English (UK)", englishDescription: "English
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/en-US.coffee
+++ b/app/locale/en-US.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "English (US)", englishDescription: "English
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     social_discource: "Join the discussion on our Discourse forum"
     social_facebook: "Like CodeCombat on Facebook"
     social_twitter: "Follow CodeCombat on Twitter"
-    social_gplus: "Join CodeCombat on Google+"
     social_slack: "Chat with us in the public CodeCombat Slack channel"
     contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/eo.coffee
+++ b/app/locale/eo.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Esperanto", englishDescription: "Esperanto"
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/es-419.coffee
+++ b/app/locale/es-419.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Español (América Latina)", englishDescrip
     social_discource: "Únete a la discusión en nuestro foro"
     social_facebook: "Me Gusta CodeCombat en Facebook"
     social_twitter: "Sigue a CodeCombat en Twitter"
-    social_gplus: "Únete a CodeCombat con Google+"
     social_slack: "Conversa con nosotros en nuestro canal de Slack"
     contribute_to_the_project: "Contribuir al proyecto"
 

--- a/app/locale/es-ES.coffee
+++ b/app/locale/es-ES.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "español (ES)", englishDescription: "Spanis
     social_discource: "Unete a la discusion en nuestro foro"
     social_facebook: "Dale a Me Gusta a CodeCombat en Facebook"
     social_twitter: "Sigue a CodeCombat en Twitter"
-    social_gplus: "Unete a CodeCombat en Google+"
     social_slack: "Chatea con nosotros en el canal público de CodeCombat"
     contribute_to_the_project: "Contribuye al proyecto"
 

--- a/app/locale/et.coffee
+++ b/app/locale/et.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Eesti", englishDescription: "Estonian", tra
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/fa.coffee
+++ b/app/locale/fa.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "فارسی", englishDescription: "Persian",
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/fi.coffee
+++ b/app/locale/fi.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "suomi", englishDescription: "Finnish", tran
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/fil.coffee
+++ b/app/locale/fil.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Tagalog", englishDescription: "Filipino (Ph
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/fr.coffee
+++ b/app/locale/fr.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "français", englishDescription: "French", t
     social_discource: "Participez à la discussion sur notre forum Discourse"
     social_facebook: "Aimer CodeCombat sur Facebook"
     social_twitter: "Suivre CodeCombat sur Twitter"
-    social_gplus: "Rejoindre CodeCombat sur Google+"
     social_slack: "Bavardez avec nous sur la chaîne publique Slack de CodeCombat."
     contribute_to_the_project: "Contribuer au projet"
 

--- a/app/locale/gl.coffee
+++ b/app/locale/gl.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Galego", englishDescription: "Galician", tr
     social_discource: "Únete á discusion no noso foro"
     social_facebook: "Dalle a Gústame a CodeCombat en Facebook"
     social_twitter: "Segue a CodeCombat en Twitter"
-    social_gplus: "Únete a CodeCombat en Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
     contribute_to_the_project: "Contribúe ao proxecto"
 

--- a/app/locale/haw.coffee
+++ b/app/locale/haw.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "ʻŌlelo Hawaiʻi", englishDescription: "Ha
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/he.coffee
+++ b/app/locale/he.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "עברית", englishDescription: "Hebrew", 
     social_discource: "הצטרפו לדיון בפורום ה-Discourse שלנו"
     social_facebook: "תנו ל-CodeCombat \"לייק\" ב-Facebook"
     social_twitter: "עקבו אחרי CodeCombat ב-Twitter"
-    social_gplus: "הצטרפו ל-CodeCombat ב-Google+‎"
     social_slack: "שוחחו עמנו בצ'אט בערוץ ה-Slack הציבורי של CodeCombat"
     contribute_to_the_project: "תרמו לפרויקט"
 

--- a/app/locale/hi.coffee
+++ b/app/locale/hi.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "मानक हिन्दी", englishDe
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/hr.coffee
+++ b/app/locale/hr.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "hrvatski jezik", englishDescription: "Croat
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/hu.coffee
+++ b/app/locale/hu.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "magyar", englishDescription: "Hungarian", t
     social_discource: "Csatlakozz a beszélgetéshez a Discourse forumon"
     social_facebook: "Like-old a CodeCombat-et a Facebookon"
     social_twitter: "Kövesd a CodeCombat-et a Twitteren"
-    social_gplus: "Csatlakozz a CodeCombat-hez a Google+ -on"
     social_slack: "Csatlakozz a nyilvános CodeCombat Slack csatornához"
     contribute_to_the_project: "Vegyél részt a projektben"
 

--- a/app/locale/id.coffee
+++ b/app/locale/id.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Bahasa Indonesia", englishDescription: "Ind
     social_discource: "Bergabung dalam diskusi di forum Discourse kami"
     social_facebook: "Like CodeCombat di Facebook"
     social_twitter: "Follow CodeCombat di Twitter"
-    social_gplus: "Bergabung CodeCombat di Google+"
     social_slack: "Mengobrol bersama kami di channel publik Slack CodeCombat"
     contribute_to_the_project: "Berkontribusi pada proyek"
 

--- a/app/locale/it.coffee
+++ b/app/locale/it.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Italiano", englishDescription: "Italian", t
     social_discource: "Partecipa alle discussioni nel nostro forum Discourse"
     social_facebook: "Metti 'mi piace' a CodeCombat su Facebook"
     social_twitter: "Segui CodeCombat su Twitter"
-    social_gplus: "Unisciti a CodeCombat su Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
     contribute_to_the_project: "Contribuisci al progetto"
 

--- a/app/locale/ja.coffee
+++ b/app/locale/ja.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "日本語", englishDescription: "Japanese",
     social_discource: "Discourse のフォーラムで議論しよう"
     social_facebook: "Facebook で CodeCombat にいいね！する"
     social_twitter: "Twitter の CodeCombat をフォローする"
-    social_gplus: "Google+ の CodeCombat に参加する"
     social_slack: "公開CodeCombat Slackチャンネルで私たちと話す"
     contribute_to_the_project: "プロジェクトに貢献する"
 

--- a/app/locale/kk.coffee
+++ b/app/locale/kk.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "қазақ тілі", englishDescription: "
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/ko.coffee
+++ b/app/locale/ko.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "한국어", englishDescription: "Korean", t
     social_discource: "토론 포럼에서 토론에 참여하기"
     social_facebook: "Facebook에서 코드컴뱃 좋아요하기"
     social_twitter: "Twitter에서 코드컴뱃 팔로우하기"
-    social_gplus: "Google+로 코드컴뱃 참여하기"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
     contribute_to_the_project: "프로젝트에 기여하기"
 

--- a/app/locale/lt.coffee
+++ b/app/locale/lt.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "lietuvių kalba", englishDescription: "Lith
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/mi.coffee
+++ b/app/locale/mi.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "te reo Māori", englishDescription: "Māori
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/mk-MK.coffee
+++ b/app/locale/mk-MK.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Македонски", englishDescription: 
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/mn.coffee
+++ b/app/locale/mn.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Монгол хэл", englishDescription: "
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/ms.coffee
+++ b/app/locale/ms.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Bahasa Melayu", englishDescription: "Bahasa
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/my.coffee
+++ b/app/locale/my.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "မြန်မာစကား", englishDes
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/nb.coffee
+++ b/app/locale/nb.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Norsk Bokmål", englishDescription: "Norweg
     social_discource: "Diskuter CodeCombat i forumet vårt på Discourse"
     social_facebook: "Lik CodeCombat på Facebook"
     social_twitter: "Følg CodeCombat på Twitter"
-    social_gplus: "Følg CodeCombat på Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
     contribute_to_the_project: "Bidra på prosjektet"
 

--- a/app/locale/nl-BE.coffee
+++ b/app/locale/nl-BE.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Nederlands (België)", englishDescription: 
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-    social_gplus: "Join CodeCombat op Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/nl-BE.coffee
+++ b/app/locale/nl-BE.coffee
@@ -1346,7 +1346,7 @@ module.exports = nativeDescription: "Nederlands (België)", englishDescription: 
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
-#    contribute_to_the_project: "Contribute to the project"
+    contribute_to_the_project: "Help mee met het project"
 
   clans:
 #    title: "Join CodeCombat Clans - Learn to Code in Python, JavaScript, and HTML"

--- a/app/locale/nl-NL.coffee
+++ b/app/locale/nl-NL.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Nederlands (Nederland)", englishDescription
     social_discource: "Doe mee aan discussies op ons Discourse forum"
     social_facebook: "Like CodeCombat op Facebook"
     social_twitter: "Volg CodeCombat op Twitter"
-    social_gplus: "Volg CodeCombat op Google+"
     social_slack: "Chat met ons in het openbare CodeCombat Slack kanaal"
     contribute_to_the_project: "Help mee met het project"
 

--- a/app/locale/nl.coffee
+++ b/app/locale/nl.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Nederlands", englishDescription: "Dutch", t
     social_discource: "Doe mee aan discussies op ons Discourse forum"
     social_facebook: "Like CodeCombat op Facebook"
     social_twitter: "Volg CodeCombat op Twitter"
-    social_gplus: "Volg CodeCombat op Google+"
     social_slack: "Chat met ons in het openbare CodeCombat Slack kanaal"
     contribute_to_the_project: "Help mee met het project"
 

--- a/app/locale/nn.coffee
+++ b/app/locale/nn.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Norsk Nynorsk", englishDescription: "Norweg
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/pl.coffee
+++ b/app/locale/pl.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "polski", englishDescription: "Polish", tran
     social_discource: "Dołącz do dyskusji na naszym forum"
     social_facebook: "Polub CodeCombat na Facebooku"
     social_twitter: "Obserwuj CodeCombat na Twitterze"
-    social_gplus: "Dołącz do CodeCombat na Google+"
     social_slack: "Porozmawiaj z nami na publicznym kanale CodeCombat na Slacku"
     contribute_to_the_project: "Zostań współtwórcą CodeCombat"
 

--- a/app/locale/pt-BR.coffee
+++ b/app/locale/pt-BR.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Português (Brasil)", englishDescription: "
     social_discource: "Entre na discussão no nosso Fórum"
     social_facebook: "Curta o CodeCombat no Facebook"
     social_twitter: "Siga o CodeCombat no Twitter"
-    social_gplus: "Ingresse no CodeCombat no Google+"
     social_slack: "Converse conosco usando o canal público Slack do CodeCombat"
     contribute_to_the_project: "Contribuir para o projeto"
 

--- a/app/locale/pt-PT.coffee
+++ b/app/locale/pt-PT.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Português (Portugal)", englishDescription:
     social_discource: "Junta-te à discussão no nosso fórum Discourse"
     social_facebook: "Gosta do CodeCombat no Facebook"
     social_twitter: "Segue o CodeCombat no Twitter"
-    social_gplus: "Junta-te ao CodeCombat no Google+"
     social_slack: "Fala connosco no canal público do CodeCombat no Slack"
     contribute_to_the_project: "Contribui para o projeto"
 

--- a/app/locale/ro.coffee
+++ b/app/locale/ro.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "limba română", englishDescription: "Roman
     social_discource: "Alăturăte discuțiilor pe forumul Discourse"
     social_facebook: "Lasă un Like pentru CodeCombat pe facebook"
     social_twitter: "Urmărește CodeCombat pe Twitter"
-    social_gplus: "Alăturăte pe Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
     contribute_to_the_project: "Contribuie la proiect"
 

--- a/app/locale/rot13.coffee
+++ b/app/locale/rot13.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "rot13", englishDescription: "English with t
     social_discource: "Wbva gur qvfphffvba ba bhe Qvfpbhefr sbehz"
     social_facebook: "Yvxr PbqrPbzong ba Snprobbx"
     social_twitter: "Sbyybj PbqrPbzong ba Gjvggre"
-    social_gplus: "Wbva PbqrPbzong ba Tbbtyr+"
     social_slack: "Pung jvgu hf va gur choyvp PbqrPbzong Fynpx punaary"
     contribute_to_the_project: "Pbagevohgr gb gur cebwrpg"
 

--- a/app/locale/ru.coffee
+++ b/app/locale/ru.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "русский", englishDescription: "Russi
     social_discource: "Присоединяйтесь к обсуждению на нашем форуме"
     social_facebook: "Оцените CodeCombat на Facebook"
     social_twitter: "Следуйте за CodeCombat на Twitter"
-    social_gplus: "Присоединяйтесь к CodeCombat на Google+"
     social_slack: "Общайтесь с нами в общем чате - CodeCombat Slack channel"
     contribute_to_the_project: "Сотрудничайте с проектом"
 

--- a/app/locale/sk.coffee
+++ b/app/locale/sk.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "slovenčina", englishDescription: "Slovak",
     social_discource: "Pridaj sa k diskusii na fóre Discourse"
     social_facebook: "Daj Like CodeCombatu na Facebooku"
     social_twitter: "Sleduj CodeCombat na Twitteri"
-    social_gplus: "Pripoj sa ku CodeCombatu na Google+"
     social_slack: "Chatuj s nami na verejnom kanáli Slack."
     contribute_to_the_project: "Prispej svojou prácou"
 

--- a/app/locale/sl.coffee
+++ b/app/locale/sl.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "slovenščina", englishDescription: "Sloven
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/sr.coffee
+++ b/app/locale/sr.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "српски", englishDescription: "Serbian
     social_discource: "Придружи се дискусији на нашем Discourse форуму"
     social_facebook: "Лајкуј CodeCombat на Фејсбуку"
     social_twitter: "Запрати CodeCombat на Твитеру"
-    social_gplus: "Придружи се CodeCombat-у на Гугл+"
     social_slack: "Ћаскај са нама на јавном CodeCombat Slack каналу"
     contribute_to_the_project: "Допринеси пројекту"
 

--- a/app/locale/sv.coffee
+++ b/app/locale/sv.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Svenska", englishDescription: "Swedish", tr
     social_discource: "Gå med i diskussionerna i vårt forum"
     social_facebook: "Gilla CodeCombat på Facebook"
     social_twitter: "Följ CodeCombat på Twitter"
-    social_gplus: "Följ CodeCombat på Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
     contribute_to_the_project: "Bidra till projektet"
 

--- a/app/locale/th.coffee
+++ b/app/locale/th.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "ไทย", englishDescription: "Thai", tra
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/tr.coffee
+++ b/app/locale/tr.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Türkçe", englishDescription: "Turkish", t
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/uk.coffee
+++ b/app/locale/uk.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Українська", englishDescription: 
     social_discource: "Приєднайтеся до обговорення на форумі"
     social_facebook: "Вподобайте CodeCombat на Facebook"
     social_twitter: "Слідкуйте за CodeCombat у Twitter"
-    social_gplus: "Приєднайтесь до CodeCombat у Google+"
     social_slack: "Переписуйтесь з нами в публічному каналі CodeCombat Slack"
     contribute_to_the_project: "Взяти участь у розробці"
 

--- a/app/locale/ur.coffee
+++ b/app/locale/ur.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "اُردُو", englishDescription: "Urdu", 
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/uz.coffee
+++ b/app/locale/uz.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "O'zbekcha", englishDescription: "Uzbek", tr
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/vi.coffee
+++ b/app/locale/vi.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "Tiếng Việt", englishDescription: "Vietn
     social_discource: "Tham gia giao lưu trên diễn đàn Discourse"
     social_facebook: "Thích trang Facebook của CodeCombat"
     social_twitter: "Theo dõi CodeCombat trên Twitter"
-    social_gplus: "Gia nhập CodeCombat trên Google+"
     social_slack: "Chat với chúng tôi trên kênh Slack của CodeCombat"
     contribute_to_the_project: "Đóng góp vào dự án"
 

--- a/app/locale/zh-HANS.coffee
+++ b/app/locale/zh-HANS.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "简体中文", englishDescription: "Chinese
     social_discource: "在我们的论坛参与讨论"
     social_facebook: "关注CodeCombat的Facebook主页"
     social_twitter: "关注CodeCombat的Twitter"
-    social_gplus: "关注CodeCombat的Google+主页"
     social_slack: "在公共 CodeCombat Slack 聊天频道与我们交谈"
     contribute_to_the_project: "为项目做贡献"
 

--- a/app/locale/zh-HANT.coffee
+++ b/app/locale/zh-HANT.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "繁體中文", englishDescription: "Chinese
     social_discource: "加入我們在Discourse論壇上的討論"
     social_facebook: "關注CodeCombat的Facebook"
     social_twitter: "關注CodeCombat的Twitter"
-    social_gplus: "關注CodeCombat的Google+"
     social_slack: "與我們在CodeCombat公共休閒頻道中聊天"
     contribute_to_the_project: "貢獻這專案"
 

--- a/app/locale/zh-WUU-HANS.coffee
+++ b/app/locale/zh-WUU-HANS.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "吴语", englishDescription: "Wuu (Simplifi
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/locale/zh-WUU-HANT.coffee
+++ b/app/locale/zh-WUU-HANT.coffee
@@ -1345,7 +1345,6 @@ module.exports = nativeDescription: "吳語", englishDescription: "Wuu (Traditio
 #    social_discource: "Join the discussion on our Discourse forum"
 #    social_facebook: "Like CodeCombat on Facebook"
 #    social_twitter: "Follow CodeCombat on Twitter"
-#    social_gplus: "Join CodeCombat on Google+"
 #    social_slack: "Chat with us in the public CodeCombat Slack channel"
 #    contribute_to_the_project: "Contribute to the project"
 

--- a/app/templates/community-view.jade
+++ b/app/templates/community-view.jade
@@ -53,7 +53,7 @@ block content
           img(src="/images/pages/community/logo_github.png", data-i18n="[data-content]community.social_github" data-content="Check out all our code on GitHub")
 
         a(href="http://blog.codecombat.com")
-          img(src="/images/pages/community/logo_sett.png", data-i18n="[data-content]community.social_blog" data-content="Read the CodeCombat blog on Sett")
+          img(src="/images/pages/community/logo_sett.png", data-i18n="[data-content]community.social_blog" data-content="Read the CodeCombat blog")
 
         a(href="http://discourse.codecombat.com")
           img(src="/images/pages/community/logo_discourse.png", data-i18n="[data-content]community.social_discource" data-content="Join the discussion on our Discourse forum")
@@ -63,9 +63,6 @@ block content
 
         a(href="https://twitter.com/CodeCombat")
           img(src="/images/pages/community/logo_twitter.png", data-i18n="[data-content]community.social_twitter" data-content="Follow CodeCombat on Twitter")
-
-        a(href="https://plus.google.com/115285980638641924488/posts")
-          img(src="/images/pages/community/logo_g+.png", data-i18n="[data-content]community.social_gplus" data-content="Join CodeCombat on Google+")
 
         a(href="https://coco-slack-invite.herokuapp.com/")
           img(src="/images/pages/community/logo_slack.png", data-i18n="[data-content]community.social_slack" data-content="Chat with us in the public CodeCombat Slack channel")

--- a/app/templates/contribute/adventurer.jade
+++ b/app/templates/contribute/adventurer.jade
@@ -42,12 +42,9 @@ block content
         span , 
         a(href="https://www.facebook.com/codecombat")
           | Facebook
-        span , 
+        span , and
         a(href="https://twitter.com/CodeCombat")
           | Twitter
-        span , and 
-        a(href="https://plus.google.com/115285980638641924488/posts")
-          | Google+
         span , 
         span(data-i18n="contribute.adventurer_join_suf")
           | so if you prefer to be notified those ways, sign up there!

--- a/app/templates/contribute/adventurer.jade
+++ b/app/templates/contribute/adventurer.jade
@@ -42,7 +42,7 @@ block content
         span , 
         a(href="https://www.facebook.com/codecombat")
           | Facebook
-        span , and
+        span , and 
         a(href="https://twitter.com/CodeCombat")
           | Twitter
         span , 


### PR DESCRIPTION
The G+ logo image file in CodeCombat style was used in a couple other places, so I left that there.