### PR TITLE
Add shape rendering to segmented sprite

### DIFF
--- a/app/lib/surface/SegmentedSprite.coffee
+++ b/app/lib/surface/SegmentedSprite.coffee
@@ -134,6 +134,7 @@ module.exports = class SegmentedSprite extends createjs.Container
     @lastAnimData = animData
 
     locals = {}
+    _.extend locals, @buildMovieClipShapes(animData.shapes)
     _.extend locals, @buildMovieClipContainers(animData.containers)
     _.extend locals, @buildMovieClipAnimations(animData.animations)
 
@@ -171,6 +172,39 @@ module.exports = class SegmentedSprite extends createjs.Container
 
     @spriteSheet.mcPool[key].push(anim)
     return anim
+
+  buildMovieClipShapes: (localShapes) ->
+    map = {}
+    for localShape in localShapes
+      if localShape.im
+        shape = new createjs.Shape(@spriteSheet)
+        shape._off = true
+      else
+        shape = @buildShapeFromStore(localShape.gn)
+        if localShape.m
+          shape.mask = map[localShape.m]
+      map[localShape.bn] = shape
+    map
+
+  buildShapeFromStore: (shapeKey, debug=false) ->
+    shapeData = @thangType.get('raw').shapes[shapeKey]
+    shape = new createjs.Shape()
+    if shapeData.lf?
+      shape.graphics.lf shapeData.lf...
+    else if shapeData.fc?
+      # TODO: Add reference to colorMap to allow character customization
+      shape.graphics.f shapeData.fc # @colorMap[shapeKey] or shapeData.fc
+    else if shapeData.rf?
+      shape.graphics.rf shapeData.rf...
+    if shapeData.ls?
+      shape.graphics.ls shapeData.ls...
+    else if shapeData.sc?
+      shape.graphics.s shapeData.sc
+    shape.graphics.ss shapeData.ss... if shapeData.ss?
+    shape.graphics.de shapeData.de... if shapeData.de?
+    shape.graphics.p shapeData.p if shapeData.p?
+    shape.setTransform shapeData.t...
+    shape
 
   buildMovieClipContainers: (localContainers) ->
     map = {}

--- a/app/lib/surface/SegmentedSprite.coffee
+++ b/app/lib/surface/SegmentedSprite.coffee
@@ -134,7 +134,15 @@ module.exports = class SegmentedSprite extends createjs.Container
     @lastAnimData = animData
 
     locals = {}
-    _.extend locals, @buildMovieClipShapes(animData.shapes)
+
+    try
+      # Protects us from legacy art regressions.
+      localShapes = @buildMovieClipShapes(animData.shapes)
+      _.extend locals, localShapes
+    catch e
+      console.error("Couldn't create shapes for '#{@thangType.get('name')}':", e.message)
+      console.error(e.stack)
+
     _.extend locals, @buildMovieClipContainers(animData.containers)
     _.extend locals, @buildMovieClipAnimations(animData.animations)
 


### PR DESCRIPTION
## Features

Adds shape rendering code path to the Segmented Sprite builder.

This allows shapes to be rendered in our segmented sprites.

Code is heavily inspired (copied) from [an existing code path that renders shapes](https://github.com/codecombat/codecombat/blob/983b6ac2f33c07b6619f8b1d3fc5a4aaa0386bce/app/lib/sprites/SpriteBuilder.coffee#L21) correctly.

**This unblocks us from importing art into Adobe Animate**. Which doesn't have containers, and thus fails to render in our segmented sprite. It does render in the editor using the SpriteBuilder.


## Side effects

This will improve all artwork in our game that has relied on shapes for some kind of effect.

For example, this is what is currently being rendered in the game:
![5b50165db2b61406bfd6e71fa269f47e](https://user-images.githubusercontent.com/15080861/59074012-816a6080-887e-11e9-8034-c14acd3c5f56.gif)


This is the art that we were given, and what the animation looks like after this fix:
![16a2d9ed617a8929cc7a25a1eea2f3e4](https://user-images.githubusercontent.com/15080861/59074001-76173500-887e-11e9-8659-c974905e31dc.gif)

## Testing

I've been running this code change through spectator arenas where many characters and effects are used. They seem to be unchanged from production due to this change.


## TODO in following PRs

 - Check/Update character customization to work with this new shape format.
 - Likely need to use the raster portraits and thumbnails for new art.