### PR TITLE
Remove broken font links

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -102,8 +102,6 @@
     }
   },
   "devDependencies": {
-    "modernizr-mixin": "~3.0.0",
-    "openSansCondensed": "https://google-fonts.azurewebsites.net/googleFonts/openSansCondensed?family=Open+Sans+Condensed:700&subset=latin,latin-ext,cyrillic-ext,greek-ext,greek,vietnamese,cyrillic",
-    "openSans": "https://google-fonts.azurewebsites.net/googleFonts/openSans?family=Open+Sans:600,700&subset=latin,latin-ext,cyrillic-ext,greek-ext,greek,vietnamese,cyrillic"
+    "modernizr-mixin": "~3.0.0"
   }
 }


### PR DESCRIPTION
Remove font links that are now broken preventing deploy.

These fonts appear to be stored locally within `assets/fonts`.


Manually tested and appears to work. Will want to test in staging. Test by changing homepage language to Russian and ensure it looks the same as the CodeCombat.com russian page in production now.