### PR TITLE
Changes for 1fh capstone flow on unit map

### DIFF
--- a/app/models/Classroom.coffee
+++ b/app/models/Classroom.coffee
@@ -172,8 +172,7 @@ module.exports = class Classroom extends CocoModel
       unless utils.ozariaCourseIDs.includes(courseID)
         nextIndex = utils.findNextLevel(levels, currentIndex, needsPractice)
     if utils.ozariaCourseIDs.includes(courseID)
-      # assuming that there will be only one next level in ozaria v1 for now
-      nextLevelOriginal = findNextLevelsBySession(sessions, courseLevels.models)[0]
+      nextLevelOriginal = findNextLevelsBySession(sessions, courseLevels.models)
       nextLevel = new Level(getLevelsDataByOriginals(courseLevels.models, [nextLevelOriginal])[0])
     else
       nextLevel = courseLevels.models[nextIndex]

--- a/app/schemas/models/campaign.schema.coffee
+++ b/app/schemas/models/campaign.schema.coffee
@@ -80,13 +80,17 @@ _.extend CampaignSchema.properties, {
 
       # properties relevant for ozaria campaigns
       nextLevels: {
-        type: 'array'
-        description: 'array of next levels original id'
-        items: {
+        type: 'object'
+        description: 'object containing next levels original id and their details'
+        format: 'levels' # key is level original id
+        additionalProperties: {
           type: 'object'
-          additionalProperties: false
+          format: 'nextLevel'
           properties: {
-            levelOriginal: c.stringID()
+            nextLevelStage: {type: 'number', title: 'Next Level Stage', description: 'Which capstone stage is unlocked'}
+            conditions: c.object({}, {
+              afterCapstoneStage: {type: 'number', title: 'After Capstone Stage', description: 'What capstone stage needs to be completed to unlock this next level'}
+            })
           }
         }
       }
@@ -141,6 +145,7 @@ CampaignSchema.denormalizedLevelProperties = [
   'campaign'
   'campaignIndex'
   'scoreTypes'
+  'isPlayedInStages'
 ]
 hiddenLevelProperties = ['name', 'description', 'i18n', 'replayable', 'slug', 'original', 'primerLanguage', 'shareable', 'concepts', 'scoreTypes']
 for prop in CampaignSchema.denormalizedLevelProperties

--- a/app/schemas/models/classroom.schema.coffee
+++ b/app/schemas/models/classroom.schema.coffee
@@ -42,13 +42,19 @@ _.extend ClassroomSchema.properties,
 
       # properties relevant for ozaria campaigns 
       nextLevels: {
-        type: 'array'
-        description: 'array of next levels original id'
-        items: {
+        type: 'object'
+        description: 'object containing next levels original id and their details'
+        additionalProperties: { # key is the level original id
           type: 'object'
-          additionalProperties: false
           properties: {
-            levelOriginal: c.stringID()
+            type: c.shortString()
+            original: c.objectId()
+            name: {type: 'string'}
+            slug: {type: 'string'}
+            nextLevelStage: {type: 'number', title: 'Next Level Stage', description: 'Which capstone stage is unlocked'}
+            conditions: c.object({}, {
+              afterCapstoneStage: {type: 'number', title: 'After Capstone Stage', description: 'What capstone stage needs to be completed to unlock this next level'}
+            })
           }
         }
       }

--- a/app/views/editor/campaign/CampaignEditorView.coffee
+++ b/app/views/editor/campaign/CampaignEditorView.coffee
@@ -245,6 +245,7 @@ module.exports = class CampaignEditorView extends RootView
       nodeClasses:
         levels: LevelsNode
         level: LevelNode
+        nextLevel: NextLevelNode 
         campaigns: CampaignsNode
         campaign: CampaignNode
         achievement: AchievementNode
@@ -398,6 +399,12 @@ class LevelNode extends TreemaObjectNode
   populateData: ->
     return if @data.name?
     data = _.pick LevelsNode.levels[@keyForParent].attributes, Campaign.denormalizedLevelProperties
+    _.extend @data, data
+
+class NextLevelNode extends LevelNode
+  populateData: ->
+    return if @data.name?
+    data = _.pick LevelsNode.levels[@keyForParent].attributes, ['original', 'name', 'slug', 'type']
     _.extend @data, data
 
 class CampaignsNode extends TreemaObjectNode

--- a/app/views/play/level/modal/CourseVictoryModal.coffee
+++ b/app/views/play/level/modal/CourseVictoryModal.coffee
@@ -8,7 +8,7 @@ LevelSessions = require 'collections/LevelSessions'
 ProgressView = require './ProgressView'
 Classroom = require 'models/Classroom'
 utils = require 'core/utils'
-{ findNextLevelsBySession, getNextLevelOriginalForLevel } = require 'ozaria/site/common/ozariaUtils'
+{ findNextLevelsBySession, getNextLevelForLevel } = require 'ozaria/site/common/ozariaUtils'
 api = require('core/api')
 urls = require 'core/urls'
 store = require 'core/store'
@@ -163,10 +163,13 @@ module.exports = class CourseVictoryModal extends ModalView
   getNextLevelOzaria: ->
     if @classroom and @levelSessions # fetch next level based on sessions and classroom levels
       classroomLevels = @classroom.get('courses')?.find((c) => c._id == @courseID)?.levels
-      nextLevelOriginal = findNextLevelsBySession(@levelSessions.models, classroomLevels)[0] # assuming there will be only 1 next level for ozaria v1
+      nextLevelOriginal = findNextLevelsBySession(@levelSessions.models, classroomLevels)
     else if @campaign # fetch next based on course's campaign levels (for teachers)
       currentLevel = @campaign.levels[@level.get('original')]
-      nextLevelOriginal = getNextLevelOriginalForLevel(currentLevel)[0]
+      # TODO how to get current level stage for capstone and load capstone from the next stage, if there is no level session
+      # if (currentLevel.isPlayedInStages)
+      #   currentLevelStage = ?
+      nextLevelOriginal = (getNextLevelForLevel(currentLevel) || {}).original
     if nextLevelOriginal
       return api.levels.getByOriginal(nextLevelOriginal)
     else

--- a/ozaria/site/components/play/PageIntroLevel/index.vue
+++ b/ozaria/site/components/play/PageIntroLevel/index.vue
@@ -2,7 +2,7 @@
   import api from 'core/api'
   import interactivesComponent from '../../interactive/PageInteractive'
   import cinematicsComponent from '../../cinematic/PageCinematic'
-  import { defaultCodeLanguage, getNextLevelLink, getNextLevelOriginalForLevel } from 'ozaria/site/common/ozariaUtils'
+  import { defaultCodeLanguage, getNextLevelLink, getNextLevelForLevel } from 'ozaria/site/common/ozariaUtils'
   import { mapActions, mapGetters } from 'vuex'
 
   export default Vue.extend({
@@ -152,9 +152,10 @@
         fetchNextLevel: async function () {
           try {
             const currentLevel = this.campaignData.levels[this.introLevelData.original]
-            const nextLevelOriginal = getNextLevelOriginalForLevel(currentLevel)[0]
+            const nextLevelOriginal = (getNextLevelForLevel(currentLevel) || {}).original
             if (nextLevelOriginal) {
               this.nextLevel = await api.levels.getByOriginal(nextLevelOriginal)
+              // TODO If next level is played in stages, how to load it from a certain stage if there is no level session, i.e. for teachers?
             }
           } catch (err) {
             console.error('Error in fetching next level', err)
@@ -167,7 +168,8 @@
             const nextLevelOptions = {
               courseId: this.courseId,
               courseInstanceId: this.courseInstanceId,
-              campaignId: this.campaignId
+              campaignId: this.campaignId,
+              codeLanguage: this.codeLanguage
             }
             return getNextLevelLink(this.nextLevel, nextLevelOptions)
           } else {


### PR DESCRIPTION
- Schema changed for campaign.levels.nextLevels and similarly for classroom - nextLevels is now an object
- Changes in the next level logic
- Changes in building the level status map

Design doc with description of the new next level logic:
https://docs.google.com/document/d/1XTVtPjG_9gGic3FBPC7PYClTrf82fhxyzMnXzCK529Q/edit#heading=h.z287uqh1z7hk (specially section "How to handle non-linear flow(1FH Capstone)")