### PR TITLE
Fix cinematic character swooping in bug

### DIFF
--- a/ozaria/engine/cinematic/CinematicLankBoss.js
+++ b/ozaria/engine/cinematic/CinematicLankBoss.js
@@ -18,6 +18,7 @@ import {
 } from '../../../app/schemas/models/selectors/cinematic'
 
 export const HERO_THANG_ID = '55527eb0b8abf4ba1fe9a107'
+const OFF_CAMERA_OFFSET = 20
 
 // Throws an error if `import ... from ..` syntax.
 const Promise = require('bluebird')
@@ -121,7 +122,7 @@ export default class CinematicLankBoss {
         key: 'left',
         thang: {
           pos: {
-            x: this.stageBounds.topLeft.x - 20
+            x: this.stageBounds.topLeft.x - OFF_CAMERA_OFFSET
           }
         },
         ms: 800 }))
@@ -132,7 +133,7 @@ export default class CinematicLankBoss {
         key: 'right',
         thang: {
           pos: {
-            x: this.stageBounds.bottomRight.x + 20
+            x: this.stageBounds.bottomRight.x + OFF_CAMERA_OFFSET
           }
         },
         ms: 800 }))
@@ -359,7 +360,7 @@ export default class CinematicLankBoss {
     if (key === 'right') {
       thang = createThang({
         pos: {
-          x: this.stageBounds.bottomRight.x + 20,
+          x: this.stageBounds.bottomRight.x + OFF_CAMERA_OFFSET,
           y: (thang.pos || {}).y || this.stageBounds.bottomRight.y
         },
         rotation: RIGHT,
@@ -369,7 +370,7 @@ export default class CinematicLankBoss {
     } else if (key === 'left') {
       thang = createThang({
         pos: {
-          x: this.stageBounds.topLeft.x - 20,
+          x: this.stageBounds.topLeft.x - OFF_CAMERA_OFFSET,
           y: (thang.pos || {}).y || this.stageBounds.bottomRight.y
         },
         scaleFactorX: thang.scaleX || 1,

--- a/ozaria/engine/cinematic/CinematicLankBoss.js
+++ b/ozaria/engine/cinematic/CinematicLankBoss.js
@@ -121,7 +121,7 @@ export default class CinematicLankBoss {
         key: 'left',
         thang: {
           pos: {
-            x: this.stageBounds.topLeft.x - 8
+            x: this.stageBounds.topLeft.x - 20
           }
         },
         ms: 800 }))
@@ -132,7 +132,7 @@ export default class CinematicLankBoss {
         key: 'right',
         thang: {
           pos: {
-            x: this.stageBounds.bottomRight.x + 8
+            x: this.stageBounds.bottomRight.x + 20
           }
         },
         ms: 800 }))
@@ -359,8 +359,8 @@ export default class CinematicLankBoss {
     if (key === 'right') {
       thang = createThang({
         pos: {
-          x: this.stageBounds.bottomRight.x + 4,
-          y: this.stageBounds.bottomRight.y
+          x: this.stageBounds.bottomRight.x + 20,
+          y: (thang.pos || {}).y || this.stageBounds.bottomRight.y
         },
         rotation: RIGHT,
         scaleFactorX: thang.scaleX || 1,
@@ -369,8 +369,8 @@ export default class CinematicLankBoss {
     } else if (key === 'left') {
       thang = createThang({
         pos: {
-          x: this.stageBounds.topLeft.x - 4,
-          y: this.stageBounds.bottomRight.y
+          x: this.stageBounds.topLeft.x - 20,
+          y: (thang.pos || {}).y || this.stageBounds.bottomRight.y
         },
         scaleFactorX: thang.scaleX || 1,
         scaleFactorY: thang.scaleY || 1


### PR DESCRIPTION
## Issue

Before this fix the cinematic character is created at an arbitrary y axis and then slid into position. This y position was a silly programmer default that looks horrible.

## Fix

We want characters to start and end at the same y position. Thus this fix assigns the end position y coordinate to the start position if it is provided.

Also made characters slide in and out further so that they completely leave the frame when entering and leaving.