### PR TITLE
Designer can set cinematic shot to continue without user input

### DIFF
--- a/app/schemas/models/cinematic.schema.js
+++ b/app/schemas/models/cinematic.schema.js
@@ -83,6 +83,7 @@ const DialogNode = c.object({
   textAnimationLength: c.int({ title: 'Text Animation Length(ms)', description: 'The number of milliseconds it takes for the text to animate out. Defaults to 1000ms.' }),
   speakingAnimationAction: c.shortString({ title: 'Speaking Animation', description: 'The animation to play on the lank while the text is being animated.' }),
   i18n: { type: 'object', format: 'i18n', props: ['text'], description: 'Help translate this cinematic dialogNode.' },
+  waitUserInput: { type: 'boolean', title: 'User Input?', description: 'Whether or not user input is required to continue to the next dialog node or shot setup. Defaults to true.' },
   textLocation: c.object({ title: 'Text Location', description: 'An {x, y} coordinate point.', format: 'point2d', required: ['x', 'y'] }, {
     x: { title: 'x', description: 'The x coordinate.', type: 'number', 'default': 0 },
     y: { title: 'y', description: 'The y coordinate.', type: 'number', 'default': 0 } }),

--- a/app/schemas/models/selectors/cinematic.js
+++ b/app/schemas/models/selectors/cinematic.js
@@ -486,3 +486,15 @@ export const getSetupMusic = compose(shotSetup, setupMusic)
  * @returns {SoundEffect[] | undefined}
  */
 export const getSoundEffects = compose(triggers, soundEffects)
+
+/**
+ * @param {DialogNode} dialogNode
+ * @returns {bool}
+ */
+export const getWaitUserInput = dialogNode => {
+  const waitUserInput = (dialogNode || {}).waitUserInput
+  if (typeof waitUserInput === 'boolean') {
+    return waitUserInput
+  }
+  return true
+}

--- a/ozaria/engine/cinematic/cinematicController.js
+++ b/ozaria/engine/cinematic/cinematicController.js
@@ -5,6 +5,7 @@ import CommandRunner from './commands/CommandRunner'
 import DialogSystem from './dialogsystem/DialogSystem'
 import { CameraSystem } from './CameraSystem'
 import { SoundSystem } from './SoundSystem'
+import Autoplay from './systems/autoplay';
 
 const createjs = require('lib/createjs-parts')
 const LayerAdapter = require('lib/surface/LayerAdapter')
@@ -48,6 +49,7 @@ export class CinematicController {
     this.systems.cameraSystem = new CameraSystem(camera)
     this.systems.loader = new Loader({ data: cinematicData })
     this.systems.sound = new SoundSystem()
+    this.systems.autoplay = new Autoplay()
 
     this.systems.dialogSystem = new DialogSystem({
       canvasDiv,
@@ -142,10 +144,17 @@ export class CinematicController {
   cleanupRunShot () {
     if (!this.runner) return
     this.runner = null
-    this.onPause()
+
     if (Array.isArray(this.commands) && this.commands.length === 0) {
       this.onCompletion()
     }
+
+    if (this.systems.autoplay.autoplay) {
+      this.systems.autoplay.autoplay = false
+      return this.runShot()
+    }
+
+    this.onPause()
   }
 
   onResize ({ width, height }) {

--- a/ozaria/engine/cinematic/systems/autoplay.js
+++ b/ozaria/engine/cinematic/systems/autoplay.js
@@ -1,0 +1,17 @@
+import { getWaitUserInput } from '../../../../app/schemas/models/selectors/cinematic'
+import { SyncFunction } from '../commands/commands'
+
+export default class Autoplay {
+  constructor () {
+    this.autoplay = false
+  }
+
+  parseDialogNode (dialogNode) {
+    if (!getWaitUserInput(dialogNode)) {
+      return [new SyncFunction(() => {
+        this.autoplay = true
+      })]
+    }
+    return []
+  }
+}

--- a/test/app/models/Cinematic.spec.js
+++ b/test/app/models/Cinematic.spec.js
@@ -18,7 +18,8 @@ import {
   getTextAnimationLength,
   getSpeakingAnimationAction,
   getSetupMusic,
-  getSoundEffects
+  getSoundEffects,
+  getWaitUserInput
 } from '../../../app/schemas/models/selectors/cinematic'
 
 /**
@@ -198,6 +199,13 @@ describe('Cinematic', () => {
 
       const result2 = getSetupMusic(shotFixture2)
       expect(result2).toBeUndefined()
+    })
+
+    it('getWaitUserInput', () => {
+      expect(getWaitUserInput({ waitUserInput: false })).toEqual(false)
+      expect(getWaitUserInput({})).toEqual(true)
+      expect(getWaitUserInput()).toEqual(true)
+      expect(getWaitUserInput({ waitUserInput: true })).toEqual(true)
     })
   })
 })


### PR DESCRIPTION
- Add additional property to cinematic schema, which by default requires user input to start next cinematic shot.
- Designer can set this to false and have next shot autoplay. This is useful for better coordination of shots.

Likely still need to discuss how much of a shot needs to be skipped if it is autoplaying dialog nodes.