### PR TITLE
Fix timing of text and speaking animation in Cinematics

### DIFF
--- a/app/schemas/models/cinematic.schema.js
+++ b/app/schemas/models/cinematic.schema.js
@@ -80,7 +80,7 @@ const DialogNode = c.object({
 }, {
   speaker: c.shortString({ enum: ['left', 'right'], title: 'Speaker', description: 'Which character is speaking. Used to select speech bubble.' }),
   text: { type: 'string', title: 'Text', description: 'html text', maxLength: 500 },
-  textAnimationLength: c.int({ title: 'Text Animation Length(ms)', description: 'The number of milliseconds it takes for the text to animate out. Defaults to 1000ms.' }),
+  textAnimationLength: c.int({ title: 'Text Animation Length(ms)', description: 'The number of milliseconds it takes for the text to animate in.' }),
   speakingAnimationAction: c.shortString({ title: 'Speaking Animation', description: 'The animation to play on the lank while the text is being animated.' }),
   i18n: { type: 'object', format: 'i18n', props: ['text'], description: 'Help translate this cinematic dialogNode.' },
   textLocation: c.object({ title: 'Text Location', description: 'An {x, y} coordinate point.', format: 'point2d', required: ['x', 'y'] }, {

--- a/app/schemas/models/selectors/cinematic.js
+++ b/app/schemas/models/selectors/cinematic.js
@@ -360,9 +360,9 @@ const backgroundObjectDelay = triggers => {
 
 /**
  * @param {DialogNode} dialogNode
- * @returns {number}
+ * @returns {number|undefined}
  */
-const textAnimationLength = dialogNode => (dialogNode || {}).textAnimationLength || 1000
+const textAnimationLength = dialogNode => (dialogNode || {}).textAnimationLength
 
 /**
  * @param {ShotSetup} shotSetup

--- a/ozaria/engine/cinematic/CinematicLankBoss.js
+++ b/ozaria/engine/cinematic/CinematicLankBoss.js
@@ -16,6 +16,7 @@ import {
   getSpeakingAnimationAction,
   getSpeaker
 } from '../../../app/schemas/models/selectors/cinematic'
+import { LETTER_ANIMATE_TIME } from './constants'
 
 export const HERO_THANG_ID = '55527eb0b8abf4ba1fe9a107'
 
@@ -173,7 +174,10 @@ export default class CinematicLankBoss {
     const text = getText(dialogNode)
     const animation = getSpeakingAnimationAction(dialogNode)
     if (text && animation) {
-      const textLength = getTextAnimationLength(dialogNode)
+      let textLength = getTextAnimationLength(dialogNode)
+      if (textLength === undefined) {
+        textLength = text.length * LETTER_ANIMATE_TIME
+      }
       const speaker = getSpeaker(dialogNode)
       commands.push(new SequentialCommands([
         // TODO: Is a minimum time of 100 required to ensure animation always plays?

--- a/ozaria/engine/cinematic/constants.js
+++ b/ozaria/engine/cinematic/constants.js
@@ -8,3 +8,5 @@
 export const WIDTH = 1366
 export const HEIGHT = 768
 export const CINEMATIC_ASPECT_RATIO = HEIGHT / WIDTH
+
+export const LETTER_ANIMATE_TIME = 90

--- a/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
+++ b/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
@@ -8,7 +8,7 @@ import {
   getCamera
 } from '../../../../app/schemas/models/selectors/cinematic'
 import { processText, getDefaultTextPosition } from './helper'
-import { WIDTH, HEIGHT } from '../constants'
+import { WIDTH, HEIGHT, LETTER_ANIMATE_TIME } from '../constants'
 
 const BUBBLE_PADDING = 10
 const SPEECH_BUBBLE_MAX_WIDTH = `300px` // Removed 20 px to account for padding.
@@ -129,6 +129,10 @@ class SpeechBubble {
     textDiv.style.left = `${ x / WIDTH * 100}%`
     textDiv.style.top = `${ y / HEIGHT * 100}%`
 
+    const letters = (document.querySelectorAll(`#${this.id} .letter`) || []).length || 1
+    if (textDuration === undefined) {
+      textDuration = letters * LETTER_ANIMATE_TIME
+    }
     // We set up the animation but don't play it yet.
     // On completion we attach html node to the `shownDialogBubbles`
     // array for future cleanup.
@@ -145,8 +149,8 @@ class SpeechBubble {
       .add({
         targets: `#${this.id} .letter`,
         opacity: 1,
-        duration: textDuration,
-        delay: anime.stagger(50, { easing: 'linear' }),
+        duration: 20,
+        delay: anime.stagger(textDuration / letters, { easing: 'linear' }),
         easing: 'easeOutQuad',
         complete: () => {
           shownDialogBubbles.push(textDiv)

--- a/test/app/models/Cinematic.spec.js
+++ b/test/app/models/Cinematic.spec.js
@@ -173,7 +173,7 @@ describe('Cinematic', () => {
       expect(result).toEqual(42)
 
       const result2 = getTextAnimationLength(shotFixture2.dialogNodes[0])
-      expect(result2).toEqual(1000)
+      expect(result2).toBeUndefined()
     })
 
     it('getSpeakingAnimationAction', () => {


### PR DESCRIPTION
## Issue

The text animation length did not change how long it took letters to animate on the screen.

This made it impossible to synchronize the talking animation with text appearing on the screen.

## Fix

 - Fix timing logic by considering time per letter.
 - Extend default logic to be based on the length of the text. A 1000ms default isn't useful with long and short text. Instead use a constant for how long each letter takes to appear on screen.