### PR TITLE
:Bug: Revert shapes in segmented sprites

### DIFF
--- a/app/lib/surface/SegmentedSprite.coffee
+++ b/app/lib/surface/SegmentedSprite.coffee
@@ -214,7 +214,6 @@ module.exports = class SegmentedSprite extends createjs.Container
     shape.graphics.de shapeData.de... if shapeData.de?
     shape.graphics.p shapeData.p if shapeData.p?
     shape.setTransform shapeData.t...
-    # shape.cache(0, 0, 300, 300)
     shape
 
   buildMovieClipContainers: (localContainers) ->

--- a/app/lib/surface/SegmentedSprite.coffee
+++ b/app/lib/surface/SegmentedSprite.coffee
@@ -135,13 +135,15 @@ module.exports = class SegmentedSprite extends createjs.Container
 
     locals = {}
 
-    try
-      # Protects us from legacy art regressions.
-      localShapes = @buildMovieClipShapes(animData.shapes)
-      _.extend locals, localShapes
-    catch e
-      console.error("Couldn't create shapes for '#{@thangType.get('name')}':", e.message)
-      console.error(e.stack)
+    # TODO Add support for shapes to segmented sprites.
+    # TODO Ensure this change works on http://direct.codecombat.com/play/level/coinucopia
+    # try
+    #   # Protects us from legacy art regressions.
+    #   localShapes = @buildMovieClipShapes(animData.shapes)
+    #   _.extend locals, localShapes
+    # catch e
+    #   console.error("Couldn't create shapes for '#{@thangType.get('name')}':", e.message)
+    #   console.error(e.stack)
 
     _.extend locals, @buildMovieClipContainers(animData.containers)
     _.extend locals, @buildMovieClipAnimations(animData.animations)
@@ -212,6 +214,7 @@ module.exports = class SegmentedSprite extends createjs.Container
     shape.graphics.de shapeData.de... if shapeData.de?
     shape.graphics.p shapeData.p if shapeData.p?
     shape.setTransform shapeData.t...
+    # shape.cache(0, 0, 300, 300)
     shape
 
   buildMovieClipContainers: (localContainers) ->


### PR DESCRIPTION
After the shapes were introduced to segmented sprites in #5393, a bug has appeared on the level [Coinucopia](https://direct.codecombat.com/play/level/coinucopia).

This reverts the change temporarily until we've resolved this issue.