### PR TITLE
Add cinematic hero tint customization support

### DIFF
--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -151,10 +151,10 @@ _.extend UserSchema.properties,
   ozariaHeroConfig: c.object(
     {
       title: 'Player Ozaria Customization',
-      descipription: 'Player customization options, including hero name, objectId and applied color tints.'
+      description: 'Player customization options, including hero name, objectId and applied color tints.'
     }, {
       thangType: c.objectId(links: [{rel: 'db', href: '/db/thang.type/{($)}/version'}], title: 'Thang Type', description: 'The ThangType of the hero.', format: 'thang-type'),
-      playerHeroName: c.shortString({ title: 'Ozaria Hero Name', description: 'The user set name for the ozaria hero. Used in cinematics.' })
+      playerHeroName: c.shortString({ title: 'Ozaria Hero Name', description: 'The user set name for the ozaria hero. Used in cinematics.' }),
       tints: c.array(
         {
           title: 'Tints',

--- a/ozaria/engine/cinematic/CinematicLankBoss.js
+++ b/ozaria/engine/cinematic/CinematicLankBoss.js
@@ -480,7 +480,21 @@ const createThang = thang => {
     scaleFactorX: 1,
     scaleFactorY: 1,
     action: 'idle',
-    rotation: LEFT
+    rotation: LEFT,
+    // This method is required by the Lank to support customization
+    getLankOptions: function () {
+      // TODO: Make this only applied to hero character instead of anything customizable.
+      let options = { colorConfig: {} }
+      const playerTints = (me.get('customization') || {}).tints || []
+      playerTints.forEach((tint) => {
+        const colorGroups = (tint.colorGroups || {})
+        for (const key in colorGroups) {
+          const value = colorGroups[key]
+          options.colorConfig[key] = value
+        }
+      })
+      return options
+    }
   }
   return _.cloneDeep(_.merge(defaults, thang))
 }

--- a/ozaria/engine/cinematic/CinematicLankBoss.js
+++ b/ozaria/engine/cinematic/CinematicLankBoss.js
@@ -485,7 +485,7 @@ const createThang = thang => {
     getLankOptions: function () {
       // TODO: Make this only applied to hero character instead of anything customizable.
       let options = { colorConfig: {} }
-      const playerTints = (me.get('customization') || {}).tints || []
+      const playerTints = (me.get('ozariaHeroConfig') || {}).tints || []
       playerTints.forEach((tint) => {
         const colorGroups = (tint.colorGroups || {})
         for (const key in colorGroups) {

--- a/ozaria/engine/cinematic/CinematicLankBoss.js
+++ b/ozaria/engine/cinematic/CinematicLankBoss.js
@@ -484,14 +484,11 @@ const createThang = thang => {
     // This method is required by the Lank to support customization
     getLankOptions: function () {
       // TODO: Make this only applied to hero character instead of anything customizable.
-      let options = { colorConfig: {} }
+      const options = { colorConfig: {} }
       const playerTints = (me.get('ozariaHeroConfig') || {}).tints || []
-      playerTints.forEach((tint) => {
+      playerTints.forEach(tint => {
         const colorGroups = (tint.colorGroups || {})
-        for (const key in colorGroups) {
-          const value = colorGroups[key]
-          options.colorConfig[key] = value
-        }
+        options.colorConfig = _.merge(options.colorConfig, colorGroups)
       })
       return options
     }


### PR DESCRIPTION
Adds a missing method to the cinematic thang that is used to customize singular and segmented sprites.

Also fixes a typo in the schema.

Change is isolated to Cinematics, and was tested manually.