### PR TITLE
Add Cinematic support for filtering by programming language

### DIFF
--- a/app/schemas/models/cinematic.schema.js
+++ b/app/schemas/models/cinematic.schema.js
@@ -87,6 +87,7 @@ const DialogNode = c.object({
   textLocation: c.object({ title: 'Text Location', description: 'An {x, y} coordinate point.', format: 'point2d', required: ['x', 'y'] }, {
     x: { title: 'x', description: 'The x coordinate.', type: 'number', 'default': 0 },
     y: { title: 'y', description: 'The y coordinate.', type: 'number', 'default': 0 } }),
+  programmingLanguageFilter: c.shortString({ enum: ['python', 'javascript'], title: 'Programming Language Filter', description: 'If set, this node is only shown if the user is using the programming language selected.' }),
   triggers: c.object({
     title: 'Triggers',
     description: 'Events that can occur during the dialogue.'

--- a/app/schemas/models/selectors/cinematic.js
+++ b/app/schemas/models/selectors/cinematic.js
@@ -498,3 +498,9 @@ export const getWaitUserInput = dialogNode => {
   }
   return true
 }
+
+/**
+ * @param {DialogNode} dialogNode
+ * @returns {string|undefined}
+ */
+export const getLanguageFilter = dialogNode => (dialogNode || {}).programmingLanguageFilter

--- a/ozaria/engine/cinematic/cinematicController.js
+++ b/ozaria/engine/cinematic/cinematicController.js
@@ -5,7 +5,7 @@ import CommandRunner from './commands/CommandRunner'
 import DialogSystem from './dialogsystem/DialogSystem'
 import { CameraSystem } from './CameraSystem'
 import { SoundSystem } from './SoundSystem'
-import Autoplay from './systems/autoplay';
+import Autoplay from './systems/autoplay'
 
 const createjs = require('lib/createjs-parts')
 const LayerAdapter = require('lib/surface/LayerAdapter')
@@ -27,12 +27,19 @@ export class CinematicController {
       onPause,
       onCompletion,
       onLoaded
-    }
+    },
+    userOptions: {
+      programmingLanguage
+    } = {}
   }) {
     this.onPlay = onPlay || (() => {})
     this.onPause = onPause || (() => {})
     this.onCompletion = onCompletion || (() => {})
     this.onLoaded = onLoaded || (() => {})
+
+    this.userOptions = {
+      programmingLanguage: programmingLanguage || 'python'
+    }
 
     this.systems = {}
 
@@ -83,7 +90,7 @@ export class CinematicController {
     const data = await this.systems.loader.loadAssets()
 
     const commands = data.shots
-      .map(shot => parseShot(shot, this.systems))
+      .map(shot => parseShot(shot, this.systems, this.userOptions))
       .filter(commands => commands.length > 0)
       .reduce((acc, commands) => [...acc, ...commands], [])
 

--- a/ozaria/engine/cinematic/commands/CinematicParser.js
+++ b/ozaria/engine/cinematic/commands/CinematicParser.js
@@ -1,4 +1,5 @@
 import { ConcurrentCommands } from './commands'
+import { getLanguageFilter } from '../../../../app/schemas/models/selectors/cinematic'
 
 /**
  * @typedef {import('../../../../app/schemas/models/selectors/cinematic').Cinematic} Cinematic
@@ -92,9 +93,10 @@ const parseDialogNode = ({ dialogNode, systems, shot }) => {
  * @param {Object} systems The systems.
  * @returns {AbstractCommand[][]} A 2d array of commands.
  */
-export const parseShot = (shot, systems = {}) => {
+export const parseShot = (shot, systems, { programmingLanguage }) => {
   const setupCommands = parseSetup(shot, systems) || []
   const dialogNodes = (shot.dialogNodes || [])
+    .filter(node => getLanguageFilter(node) === undefined || getLanguageFilter(node) === programmingLanguage)
     .map(node => parseDialogNode({ dialogNode: node, systems, shot }))
     .filter(dialogCommands => dialogCommands.length > 0)
 

--- a/ozaria/site/components/cinematic/PageCinematic/index.vue
+++ b/ozaria/site/components/cinematic/PageCinematic/index.vue
@@ -9,6 +9,10 @@ module.exports = Vue.extend({
     cinematicIdOrSlug: {
       type: String,
       required: true
+    },
+    userOptions: {
+      type: Object,
+      required: false
     }
   },
   data: () => ({
@@ -57,7 +61,9 @@ module.exports = Vue.extend({
       <cinematic-canvas
         v-if="cinematicData"
         v-on:completed="completedHandler"
-        :cinematicData="cinematicData" />
+        :cinematicData="cinematicData"
+        :userOptions="userOptions"
+        />
     </layout-center-content>
   </layout-chrome>
 </template>

--- a/ozaria/site/components/cinematic/PageCinematicEditor/index.vue
+++ b/ozaria/site/components/cinematic/PageCinematicEditor/index.vue
@@ -21,7 +21,8 @@ module.exports = Vue.extend({
       saving: false
     },
     rerenderKey: 0,
-    cinematicSlug: ""
+    cinematicSlug: '',
+    programmingLanguage: 'python'
   }),
   components: {
     'editor-list': ListItem,
@@ -190,10 +191,14 @@ module.exports = Vue.extend({
 
       <div class="row">
         <div class="col-md-6">
+          <label>User Language:</label><select v-model="programmingLanguage">
+            <option>python</option>
+            <option>javascript</option>
+          </select>
           <div id="treema-editor" ref="treemaEditor" v-once></div>
         </div>
         <div class="col-md-6" v-if="rawData">
-          <cinematic-canvas :cinematicData="rawData" :key="rerenderKey" />
+          <cinematic-canvas :cinematicData="rawData" :key="rerenderKey" :userOptions="{ programmingLanguage }" />
         </div>
       </div>
 

--- a/ozaria/site/components/cinematic/common/CinematicCanvas.vue
+++ b/ozaria/site/components/cinematic/common/CinematicCanvas.vue
@@ -32,6 +32,10 @@ export default {
     cinematicData: {
       type: Object,
       required: true
+    },
+    userOptions: {
+      type: Object,
+      required: false
     }
   },
   data: () => ({
@@ -50,6 +54,7 @@ export default {
       canvas,
       canvasDiv,
       cinematicData: this.cinematicData,
+      userOptions: this.userOptions,
       handlers: {
         onPlay: this.handlePlay,
         onPause: this.handleWait,

--- a/ozaria/site/components/play/PageIntroLevel/index.vue
+++ b/ozaria/site/components/play/PageIntroLevel/index.vue
@@ -193,6 +193,7 @@
     <cinematics-component
       v-else-if="currentContent.type == 'cinematic'"
       :cinematic-id-or-slug="currentContent.contentSlug"
+      :userOptions="{ programmingLanguage: language }"
       @completed="onContentCompleted"
     />
     <!-- TODO add when ready -->

--- a/test/app/lib/cinematic/cinematicParser.spec.js
+++ b/test/app/lib/cinematic/cinematicParser.spec.js
@@ -83,4 +83,28 @@ describe('parseShot', () => {
     }
     expect(() => parseShot(shot, systems, { programmingLanguage: 'python' })).toThrow()
   })
+
+  it('dialogNode language filtering works correctly for python', () => {
+    const systems = [{
+      parseDialogNode: jasmine.createSpy().and.returnValue(['dialog commands'])
+    }]
+    const shot = {
+      dialogNodes: [{ programmingLanguageFilter: 'python' }, { programmingLanguageFilter: 'javascript' }]
+    }
+    parseShot(shot, systems, { programmingLanguage: 'python' })
+    expect(systems[0].parseDialogNode.calls.all().map(o => o.args))
+      .toEqual([ [ { programmingLanguageFilter: 'python' }, { dialogNodes: [ { programmingLanguageFilter: 'python' }, { programmingLanguageFilter: 'javascript' } ] } ] ])
+  })
+
+  it('dialogNode language filtering works correctly for javascript', () => {
+    const systems = [{
+      parseDialogNode: jasmine.createSpy().and.returnValue(['dialog commands'])
+    }]
+    const shot = {
+      dialogNodes: [{ programmingLanguageFilter: 'python' }, { programmingLanguageFilter: 'javascript' }]
+    }
+    parseShot(shot, systems, { programmingLanguage: 'javascript' })
+    expect(systems[0].parseDialogNode.calls.all().map(o => o.args))
+      .toEqual([ [ { programmingLanguageFilter: 'javascript' }, { dialogNodes: [ { programmingLanguageFilter: 'python' }, { programmingLanguageFilter: 'javascript' } ] } ] ])
+  })
 })

--- a/test/app/lib/cinematic/cinematicParser.spec.js
+++ b/test/app/lib/cinematic/cinematicParser.spec.js
@@ -3,7 +3,7 @@ import { parseShot } from '../../../../ozaria/engine/cinematic/commands/Cinemati
 
 describe('parseShot', () => {
   it('handles an empty shot', () => {
-    expect(parseShot({})).toEqual([[]])
+    expect(parseShot({}, {}, {})).toEqual([[]])
   })
 
   it('parses setup correctly', () => {
@@ -13,7 +13,7 @@ describe('parseShot', () => {
     const shot = {
       setupShot: 'Example setup shot'
     }
-    const results = parseShot(shot, systems)
+    const results = parseShot(shot, systems, { programmingLanguage: 'python' })
     expect(systems[0].parseSetupShot).toHaveBeenCalledWith({ setupShot: 'Example setup shot' })
     expect(results).toEqual([['setup commands']])
   })
@@ -27,7 +27,7 @@ describe('parseShot', () => {
     const shot = {
       setupShot: 'Example setup shot'
     }
-    const results = parseShot(shot, systems)
+    const results = parseShot(shot, systems, { programmingLanguage: 'python' })
     expect(systems[0].parseSetupShot).toHaveBeenCalledWith({ setupShot: 'Example setup shot' })
     expect(systems[1].parseSetupShot).toHaveBeenCalledWith({ setupShot: 'Example setup shot' })
     expect(results).toEqual([['setup command1', 'setup command2']])
@@ -40,7 +40,7 @@ describe('parseShot', () => {
     const shot = {
       dialogNodes: ['DialogNode1', 'DialogNode2']
     }
-    const results = parseShot(shot, systems)
+    const results = parseShot(shot, systems, { programmingLanguage: 'python' })
     expect(systems[0].parseDialogNode.calls.all().map(o => o.args))
       .toEqual([ [ 'DialogNode1', { dialogNodes: [ 'DialogNode1', 'DialogNode2' ] } ], [ 'DialogNode2', { dialogNodes: [ 'DialogNode1', 'DialogNode2' ] } ] ])
     // I don't like this test but I couldn't figure out another way.
@@ -57,7 +57,7 @@ describe('parseShot', () => {
       dialogNodes: ['DialogNode1', 'DialogNode2']
     }
 
-    const results = parseShot(shot, systems)
+    const results = parseShot(shot, systems, { programmingLanguage: 'python' })
     expect(systems[0].parseDialogNode.calls.all().map(o => o.args))
       .toEqual([ [ 'DialogNode1', { setupShot: 'Example setup shot', dialogNodes: [ 'DialogNode1', 'DialogNode2' ] } ], [ 'DialogNode2', { setupShot: 'Example setup shot', dialogNodes: [ 'DialogNode1', 'DialogNode2' ] } ] ])
     expect(systems[0].parseSetupShot).toHaveBeenCalledWith(shot)
@@ -71,7 +71,7 @@ describe('parseShot', () => {
     const shot = {
       setupShot: 'example setup shot'
     }
-    expect(() => parseShot(shot, systems)).toThrow()
+    expect(() => parseShot(shot, systems, { programmingLanguage: 'python' })).toThrow()
   })
 
   it('parseDialogNode must return array or error is thrown', () => {
@@ -81,6 +81,6 @@ describe('parseShot', () => {
     const shot = {
       dialogNodes: ['example setup shot']
     }
-    expect(() => parseShot(shot, systems)).toThrow()
+    expect(() => parseShot(shot, systems, { programmingLanguage: 'python' })).toThrow()
   })
 })

--- a/test/app/lib/cinematic/cinematicParser.spec.js
+++ b/test/app/lib/cinematic/cinematicParser.spec.js
@@ -84,27 +84,33 @@ describe('parseShot', () => {
     expect(() => parseShot(shot, systems, { programmingLanguage: 'python' })).toThrow()
   })
 
-  it('dialogNode language filtering works correctly for python', () => {
-    const systems = [{
-      parseDialogNode: jasmine.createSpy().and.returnValue(['dialog commands'])
-    }]
-    const shot = {
-      dialogNodes: [{ programmingLanguageFilter: 'python' }, { programmingLanguageFilter: 'javascript' }]
-    }
-    parseShot(shot, systems, { programmingLanguage: 'python' })
-    expect(systems[0].parseDialogNode.calls.all().map(o => o.args))
-      .toEqual([ [ { programmingLanguageFilter: 'python' }, { dialogNodes: [ { programmingLanguageFilter: 'python' }, { programmingLanguageFilter: 'javascript' } ] } ] ])
-  })
+  describe('dialogNode language filtering', () => {
+    // A dialog node is called with two arguments. A node and the entire cinematic.
+    // In these tests we expect nodes that aren't tagged with the correct programming
+    // language to be filtered out.
+    // These dialogNodes are still visibile in the complete cinematic data.
+    it('works correctly for python', () => {
+      const systems = [{
+        parseDialogNode: jasmine.createSpy().and.returnValue(['dialog commands'])
+      }]
+      const shot = {
+        dialogNodes: [{ programmingLanguageFilter: 'python' }, { programmingLanguageFilter: 'javascript' }]
+      }
+      parseShot(shot, systems, { programmingLanguage: 'python' })
+      expect(systems[0].parseDialogNode.calls.all().map(o => o.args))
+        .toEqual([ [ { programmingLanguageFilter: 'python' }, shot ] ])
+    })
 
-  it('dialogNode language filtering works correctly for javascript', () => {
-    const systems = [{
-      parseDialogNode: jasmine.createSpy().and.returnValue(['dialog commands'])
-    }]
-    const shot = {
-      dialogNodes: [{ programmingLanguageFilter: 'python' }, { programmingLanguageFilter: 'javascript' }]
-    }
-    parseShot(shot, systems, { programmingLanguage: 'javascript' })
-    expect(systems[0].parseDialogNode.calls.all().map(o => o.args))
-      .toEqual([ [ { programmingLanguageFilter: 'javascript' }, { dialogNodes: [ { programmingLanguageFilter: 'python' }, { programmingLanguageFilter: 'javascript' } ] } ] ])
+    it('works correctly for javascript', () => {
+      const systems = [{
+        parseDialogNode: jasmine.createSpy().and.returnValue(['dialog commands'])
+      }]
+      const shot = {
+        dialogNodes: [{ programmingLanguageFilter: 'python' }, { programmingLanguageFilter: 'javascript' }]
+      }
+      parseShot(shot, systems, { programmingLanguage: 'javascript' })
+      expect(systems[0].parseDialogNode.calls.all().map(o => o.args))
+        .toEqual([ [ { programmingLanguageFilter: 'javascript' }, shot ] ])
+    })
   })
 })

--- a/test/app/models/Cinematic.spec.js
+++ b/test/app/models/Cinematic.spec.js
@@ -19,7 +19,8 @@ import {
   getSpeakingAnimationAction,
   getSetupMusic,
   getSoundEffects,
-  getWaitUserInput
+  getWaitUserInput,
+  getLanguageFilter
 } from '../../../app/schemas/models/selectors/cinematic'
 
 /**
@@ -206,6 +207,13 @@ describe('Cinematic', () => {
       expect(getWaitUserInput({})).toEqual(true)
       expect(getWaitUserInput()).toEqual(true)
       expect(getWaitUserInput({ waitUserInput: true })).toEqual(true)
+    })
+
+    it('getLanguageFilter', () => {
+      expect(getLanguageFilter({})).toBeUndefined()
+      expect(getLanguageFilter()).toBeUndefined()
+      expect(getLanguageFilter({ programmingLanguageFilter: 'python' })).toEqual('python')
+      expect(getLanguageFilter({ programmingLanguageFilter: 'javascript' })).toEqual('javascript')
     })
   })
 })


### PR DESCRIPTION
## Why?

Some dialog in the cinematic is language specific. Currently there is no way to skip nodes that may not be relevant.

## Improvement

This provides a way to tag a dialog node with a specific programming language. If you tag a dialog node with python it will not display for javascript watchers.

Also includes a selector in the editor environment allowing a designer to toggle between the supported languages.

## Known limitation

Defaults to python on the `/cinematic` view. This will need to be integrated when cinematics is integrated into the intro flow.