### PR TITLE
Add ozariaType in levels schema

### DIFF
--- a/app/schemas/models/campaign.schema.coffee
+++ b/app/schemas/models/campaign.schema.coffee
@@ -146,6 +146,7 @@ CampaignSchema.denormalizedLevelProperties = [
   'campaignIndex'
   'scoreTypes'
   'isPlayedInStages'
+  'ozariaType'
 ]
 hiddenLevelProperties = ['name', 'description', 'i18n', 'replayable', 'slug', 'original', 'primerLanguage', 'shareable', 'concepts', 'scoreTypes']
 for prop in CampaignSchema.denormalizedLevelProperties

--- a/app/schemas/models/level.coffee
+++ b/app/schemas/models/level.coffee
@@ -275,6 +275,7 @@ _.extend LevelSchema.properties,
   goals: c.array {title: 'Goals', description: 'An array of goals which are visible to the player and can trigger scripts.'}, GoalSchema
   type: c.shortString(title: 'Type', description: 'What type of level this is.', 'enum': ['campaign', 'ladder', 'ladder-tutorial', 'hero', 'hero-ladder', 'hero-coop', 'course', 'course-ladder', 'game-dev', 'web-dev', 'intro'])
   kind: c.shortString(title: 'Kind', description: 'Similar to type, but just for our organization.', enum: ['demo', 'usage', 'mastery', 'advanced', 'practice', 'challenge'])
+  ozariaType: c.shortString(title: 'Ozaria Level Type', description: 'Similar to type, specific to ozaria.', enum: ['practice', 'challenge', 'capstone'])
   terrain: c.terrainString
   requiresSubscription: {title: 'Requires Subscription', description: 'Whether this level is available to subscribers only.', type: 'boolean'}
   tasks: c.array {title: 'Tasks', description: 'Tasks to be completed for this level.'}, c.task

--- a/app/views/editor/level/settings/SettingsTabView.coffee
+++ b/app/views/editor/level/settings/SettingsTabView.coffee
@@ -22,7 +22,7 @@ module.exports = class SettingsTabView extends CocoView
     'practiceThresholdMinutes', 'primerLanguage', 'shareable', 'studentPlayInstructions', 'requiredCode', 'suspectCode',
     'requiredGear', 'restrictedGear', 'requiredProperties', 'restrictedProperties', 'recommendedHealth', 'allowedHeroes',
     'maximumHealth', 'assessmentPlacement', 'password', 'mirrorMatch', 'autocompleteReplacement', 'introContent',
-    'additionalGoals', 'isPlayedInStages'
+    'additionalGoals', 'isPlayedInStages', 'ozariaType'
   ]
 
   subscriptions:


### PR DESCRIPTION
Adding a new property `ozariaType` in the levels to identify the type for ozaria levels as practice/challenge/capstone.
The existing properties `type`/`kind` could not be used since they have different meanings (Eg: type is for the type of campaigns like game-dev, hero, web-dev), and its unclear if using a different value in type could interfere with the existing functionality.

However, for ozaria level type `intro` we can continue to use the existing `type` since it is completely different than other types and will not interfere with the existing types and their functionality.