### PR TITLE
Change contentSlug to contentId in intro levels

### DIFF
--- a/app/schemas/models/level.coffee
+++ b/app/schemas/models/level.coffee
@@ -211,7 +211,7 @@ IntroContentObject = {
   additionalProperties: false,
   properties: {
     type: { title: 'Content type', enum: ['cinematic', 'interactive', 'cutscene-video', 'avatarSelectionScreen'] }
-    contentSlug: { type: 'string', title: 'Content Slug' }
+    contentId: c.stringID(title: 'Content ID')
   }
 }
 

--- a/ozaria/site/components/play/PageIntroLevel/index.vue
+++ b/ozaria/site/components/play/PageIntroLevel/index.vue
@@ -185,14 +185,14 @@
   <div v-if="dataLoaded">
     <interactives-component
       v-if="currentContent.type == 'interactive'"
-      :interactive-id-or-slug="currentContent.contentSlug"
+      :interactive-id-or-slug="currentContent.contentId"
       :intro-level-id="introLevelData.original"
       :course-instance-id="courseInstanceId"
       @completed="onContentCompleted"
     />
     <cinematics-component
       v-else-if="currentContent.type == 'cinematic'"
-      :cinematic-id-or-slug="currentContent.contentSlug"
+      :cinematic-id-or-slug="currentContent.contentId"
       :userOptions="{ programmingLanguage: language }"
       @completed="onContentCompleted"
     />

--- a/test/ozaria/site/components/play/PageIntroLevel.spec.js
+++ b/test/ozaria/site/components/play/PageIntroLevel.spec.js
@@ -14,11 +14,11 @@ const introLevel = {
   introContent: [
     {
       type: 'cinematic',
-      contentSlug: 'cinematic-slug-1'
+      contentId: 'cinematic-slug-1'
     },
     {
       type: 'interactive',
-      contentSlug: 'interactive-slug-1'
+      contentId: 'interactive-slug-1'
     }
   ]
 }


### PR DESCRIPTION
Changed intro level's `introContent` to take content ids instead of content slugs so that it does not break when slugs are updated