### PR TITLE
Add _off support on movieclip

### DIFF
--- a/app/lib/sprites/SpriteBuilder.coffee
+++ b/app/lib/sprites/SpriteBuilder.coffee
@@ -86,6 +86,7 @@ module.exports = class SpriteBuilder
     for localAnimation in localAnimations
       animation = @buildMovieClip(localAnimation.gn, localAnimation.a...)
       animation.setTransform(localAnimation.t...)
+      animation._off = true if localAnimation.off
       map[localAnimation.bn] = animation
     map
 

--- a/app/schemas/models/thang_type.coffee
+++ b/app/schemas/models/thang_type.coffee
@@ -45,6 +45,7 @@ RawAnimationObjectSchema = c.object {},
     gn: {type: 'string', title: 'Global Name'}
     t: c.array {}, {type: 'number', title: 'Transform'}
     a: c.array {title: 'Arguments'}
+    off: {type: 'bolean', title: 'Starts Hidden (_off)'}
   tweens: c.array {},
     c.array {title: 'Function Chain'},
       c.object {title: 'Function Call'},


### PR DESCRIPTION
## Issue

New Adobe Animate art turns movieclips off instead of containers.

## Fix

Extend support for off onto movieclips.

Manually checked with the Isometric walk down Hero A.

Should be merged with https://github.com/codecombat/adobe-animate-parser/pull/3.