### PR TITLE
Use capstone stage in query params to get next level for teachers

### DIFF
--- a/app/views/play/level/modal/CourseVictoryComponent.vue
+++ b/app/views/play/level/modal/CourseVictoryComponent.vue
@@ -116,7 +116,7 @@
   
   module.exports = Vue.extend({
     # TODO: Move these props to vuex
-    props: ['nextLevel', 'nextAssessment', 'session', 'course', 'courseInstanceID', 'stats', 'supermodel', 'parent', 'codeLanguage'],
+    props: ['nextLevel', 'nextLevelStage', 'nextAssessment', 'session', 'course', 'courseInstanceID', 'stats', 'supermodel', 'parent', 'codeLanguage'],
     components: {
       PieChart
     }
@@ -144,7 +144,8 @@
             linkOptions = {
               courseId: @course._id,
               courseInstanceId: @courseInstanceID,
-              codeLanguage: utils.getQueryVariable('codeLanguage', 'python')
+              codeLanguage: utils.getQueryVariable('codeLanguage', 'python'),
+              nextLevelStage: @nextLevelStage
             }
             link = getNextLevelLink(@nextLevel, linkOptions)
           else if me.isSessionless()

--- a/app/views/play/level/modal/CourseVictoryModal.coffee
+++ b/app/views/play/level/modal/CourseVictoryModal.coffee
@@ -32,7 +32,7 @@ module.exports = class CourseVictoryModal extends ModalView
 
     @session = options.session
     @level = options.level
-    @capstoneStage = Number(options.capstoneStage)
+    @capstoneStage = options.capstoneStage
 
     if @courseInstanceID
       @classroom = new Classroom()

--- a/app/views/play/level/modal/CourseVictoryModal.coffee
+++ b/app/views/play/level/modal/CourseVictoryModal.coffee
@@ -32,6 +32,7 @@ module.exports = class CourseVictoryModal extends ModalView
 
     @session = options.session
     @level = options.level
+    @capstoneStage = Number(options.capstoneStage)
 
     if @courseInstanceID
       @classroom = new Classroom()
@@ -166,10 +167,11 @@ module.exports = class CourseVictoryModal extends ModalView
       nextLevelOriginal = findNextLevelsBySession(@levelSessions.models, classroomLevels)
     else if @campaign # fetch next based on course's campaign levels (for teachers)
       currentLevel = @campaign.levels[@level.get('original')]
-      # TODO how to get current level stage for capstone and load capstone from the next stage, if there is no level session
-      # if (currentLevel.isPlayedInStages)
-      #   currentLevelStage = ?
-      nextLevelOriginal = (getNextLevelForLevel(currentLevel) || {}).original
+      if (currentLevel.isPlayedInStages && @capstoneStage) # @capstoneStage comes from PlayLevelView's query params
+        currentLevelStage = @capstoneStage
+      nextLevelData = getNextLevelForLevel(currentLevel, currentLevelStage) || {}
+      nextLevelOriginal = nextLevelData.original
+      @nextLevelStage = nextLevelData.nextLevelStage
     if nextLevelOriginal
       return api.levels.getByOriginal(nextLevelOriginal)
     else
@@ -197,6 +199,7 @@ module.exports = class CourseVictoryModal extends ModalView
   showVictoryComponent: ->
     propsData = {
       nextLevel: @nextLevel.toJSON(),
+      nextLevelStage: @nextLevelStage
       nextAssessment: @nextAssessment.toJSON()
       level: @level.toJSON(),
       session: @session.toJSON(),

--- a/ozaria/site/common/ozariaUtils.js
+++ b/ozaria/site/common/ozariaUtils.js
@@ -131,7 +131,7 @@ export const getLevelStatusMap = (sessions) => {
  * @param {number} capstoneStage - Stage of 1FH capstone level for which we need the next level
  * @returns {Object} - Next level object containing 'Original' id and next level's stage.
  */
-export const getNextLevelForLevel = (level, capstoneStage) => {
+export const getNextLevelForLevel = (level, capstoneStage = 1) => {
   const nextLevels = level.nextLevels || {}
   let nextLevel = []
   if (capstoneStage && level.isPlayedInStages) {

--- a/ozaria/site/common/ozariaUtils.js
+++ b/ozaria/site/common/ozariaUtils.js
@@ -176,6 +176,9 @@ export const getNextLevelLink = (levelData, options) => {
     if (options.codeLanguage) {
       link += `&codeLanguage=${encodeURIComponent(options.codeLanguage)}`
     }
+    if (options.nextLevelStage) {
+      link += `&capstoneStage=${encodeURIComponent(options.nextLevelStage)}`
+    }
   } else if (options.campaignId) {
     link += `?campaignId=${encodeURIComponent(options.campaignId)}`
   }

--- a/ozaria/site/components/play/PageIntroLevel/index.vue
+++ b/ozaria/site/components/play/PageIntroLevel/index.vue
@@ -45,7 +45,8 @@
       language: '',
       campaignData: {},
       nextLevel: {},
-      dataLoaded: false
+      dataLoaded: false,
+      nextLevelStage: undefined
     }),
     computed: Object.assign(
       {},
@@ -152,10 +153,11 @@
         fetchNextLevel: async function () {
           try {
             const currentLevel = this.campaignData.levels[this.introLevelData.original]
-            const nextLevelOriginal = (getNextLevelForLevel(currentLevel) || {}).original
+            const nextLevelData = getNextLevelForLevel(currentLevel) || {}
+            const nextLevelOriginal = nextLevelData.original
+            this.nextLevelStage = nextLevelData.nextLevelStage
             if (nextLevelOriginal) {
               this.nextLevel = await api.levels.getByOriginal(nextLevelOriginal)
-              // TODO If next level is played in stages, how to load it from a certain stage if there is no level session, i.e. for teachers?
             }
           } catch (err) {
             console.error('Error in fetching next level', err)
@@ -169,7 +171,8 @@
               courseId: this.courseId,
               courseInstanceId: this.courseInstanceId,
               campaignId: this.campaignId,
-              codeLanguage: this.codeLanguage
+              codeLanguage: this.codeLanguage,
+              nextLevelStage: this.nextLevelStage
             }
             return getNextLevelLink(this.nextLevel, nextLevelOptions)
           } else {

--- a/ozaria/site/views/play/level/PlayLevelView.js
+++ b/ozaria/site/views/play/level/PlayLevelView.js
@@ -1127,6 +1127,7 @@ class PlayLevelView extends RootView {
       : VictoryModal
     if (this.isCourseMode() || me.isSessionless()) {
       ModalClass = CourseVictoryModal
+      options.capstoneStage = utils.getQueryVariable('capstoneStage')
     }
     if (this.level.isType('course-ladder')) {
       ModalClass = CourseVictoryModal

--- a/ozaria/site/views/play/level/PlayLevelView.js
+++ b/ozaria/site/views/play/level/PlayLevelView.js
@@ -1127,7 +1127,7 @@ class PlayLevelView extends RootView {
       : VictoryModal
     if (this.isCourseMode() || me.isSessionless()) {
       ModalClass = CourseVictoryModal
-      options.capstoneStage = utils.getQueryVariable('capstoneStage')
+      options.capstoneStage = Number(utils.getQueryVariable('capstoneStage'))
     }
     if (this.level.isType('course-ladder')) {
       ModalClass = CourseVictoryModal


### PR DESCRIPTION
For teachers playing through course guides, need to pass capstone stage in query params in order to determine the next levels in the 1fh capstone flow (i.e. back and forth with the intros)
- When an intro is completed and it unlocks a particular stage of capstone level, send the correct stage in capstone level's URL as param `capstoneStage`.
- When the capstone level is completed, its current stage can be determined from the query param `capstoneStage` and the next intro level can be determined based on that.