### PR TITLE
Correct Cinematic Defaults for content creation

### DIFF
--- a/app/schemas/models/selectors/cinematic.js
+++ b/app/schemas/models/selectors/cinematic.js
@@ -110,9 +110,9 @@ const setCharacterDefaults = ({ pos, scaleX, scaleY }) =>
  * @returns {Object|undefined} leftCharacter with default values set on thang.
  */
 const setLeftCharacterDefaults = setCharacterDefaults({
-  pos: { x: -30, y: -73 },
-  scaleX: 0.7,
-  scaleY: 0.7
+  pos: { x: -30, y: -72 },
+  scaleX: 0.82,
+  scaleY: 0.82
 })
 
 /**
@@ -121,9 +121,9 @@ const setLeftCharacterDefaults = setCharacterDefaults({
  * @returns {Object|undefined} rightCharacter with default values set on thang.
  */
 const setRightCharacterDefaults = setCharacterDefaults({
-  pos: { x: 35, y: -65 },
-  scaleX: 0.7,
-  scaleY: 0.7
+  pos: { x: 30, y: -72 },
+  scaleX: 0.82,
+  scaleY: 0.82
 })
 
 /**
@@ -274,13 +274,13 @@ const heroThangTypeOriginal = character => {
 }
 
 // A camera default setting.
-export const CAMERA_DEFAULT = {
+export const CAMERA_DEFAULT = () => ({
   pos: {
     x: 0,
     y: 0
   },
   zoom: 1
-}
+})
 
 /**
  * @param {ShotStup} shotSetup
@@ -290,7 +290,7 @@ const camera = shotSetup => {
   if (!(shotSetup || {}).camera) {
     return
   }
-  return _.merge(CAMERA_DEFAULT, shotSetup.camera)
+  return _.merge(CAMERA_DEFAULT(), shotSetup.camera)
 }
 
 /**

--- a/ozaria/engine/cinematic/CameraSystem.js
+++ b/ozaria/engine/cinematic/CameraSystem.js
@@ -1,5 +1,6 @@
 import { getCamera, CAMERA_DEFAULT, getSpeaker } from '../../../app/schemas/models/selectors/cinematic'
 import { SyncFunction } from './commands/commands'
+import { LEFT_SPEAKER_CAMERA_POS, RIGHT_SPEAKER_CAMERA_POS } from './constants'
 
 /**
  * Thin wrapper on the camera to provide additional command methods.
@@ -44,9 +45,9 @@ export class CameraSystem {
     }
     const speaker = getSpeaker(dialogNode)
     if (speaker === 'left') {
-      commands.push(this.zoomToCommand({ x: -165, y: -65 }, 2))
+      commands.push(this.zoomToCommand(LEFT_SPEAKER_CAMERA_POS, 2))
     } else if (speaker === 'right') {
-      commands.push(this.zoomToCommand({ x: 165, y: -65 }, 2))
+      commands.push(this.zoomToCommand(RIGHT_SPEAKER_CAMERA_POS, 2))
     }
     return commands
   }

--- a/ozaria/engine/cinematic/CameraSystem.js
+++ b/ozaria/engine/cinematic/CameraSystem.js
@@ -1,4 +1,4 @@
-import { getCamera, CAMERA_DEFAULT } from '../../../app/schemas/models/selectors/cinematic'
+import { getCamera, CAMERA_DEFAULT, getSpeaker } from '../../../app/schemas/models/selectors/cinematic'
 import { SyncFunction } from './commands/commands'
 
 /**
@@ -7,8 +7,14 @@ import { SyncFunction } from './commands/commands'
 export class CameraSystem {
   constructor (camera) {
     this.camera = camera
+    const { pos: { x, y }, zoom } = CAMERA_DEFAULT()
+    this.lastCameraMove = { pos: { x, y }, zoom }
+    this.camera.zoomTo({ x, y }, zoom, 0)
+  }
 
-    camera.zoomTo({ x: CAMERA_DEFAULT.pos.x, y: CAMERA_DEFAULT.pos.y }, CAMERA_DEFAULT.zoom, 0)
+  zoomToCommand ({ x, y }, zoom) {
+    this.lastCameraMove = { pos: { x, y }, zoom }
+    return new SyncFunction(() => this.camera.zoomTo({ x, y }, zoom, 0))
   }
 
   /**
@@ -21,7 +27,26 @@ export class CameraSystem {
     const cameraMove = getCamera(shot)
     if (cameraMove) {
       const { pos: { x, y }, zoom } = cameraMove
-      commands.push(new SyncFunction(() => this.camera.zoomTo({ x, y }, zoom, 0)))
+      commands.push(this.zoomToCommand({ x, y }, zoom))
+    }
+    return commands
+  }
+
+  parseDialogNode (dialogNode) {
+    const commands = []
+    // Take a good guess at setting the camera to a reasonable default
+    // if it hasn't been set. We only set defaults for a zoom of 2.
+    if (this.lastCameraMove.zoom !== 2) {
+      return commands
+    }
+    if (this.lastCameraMove.pos.x !== 0 || this.lastCameraMove.pos.y !== 0) {
+      return commands
+    }
+    const speaker = getSpeaker(dialogNode)
+    if (speaker === 'left') {
+      commands.push(this.zoomToCommand({ x: -165, y: -65 }, 2))
+    } else if (speaker === 'right') {
+      commands.push(this.zoomToCommand({ x: 165, y: -65 }, 2))
     }
     return commands
   }

--- a/ozaria/engine/cinematic/CinematicLankBoss.js
+++ b/ozaria/engine/cinematic/CinematicLankBoss.js
@@ -16,7 +16,7 @@ import {
   getSpeakingAnimationAction,
   getSpeaker
 } from '../../../app/schemas/models/selectors/cinematic'
-import { LETTER_ANIMATE_TIME } from './constants'
+import { LETTER_ANIMATE_TIME, getHeroSlug } from './constants'
 
 export const HERO_THANG_ID = '55527eb0b8abf4ba1fe9a107'
 const OFF_CAMERA_OFFSET = 20
@@ -85,7 +85,8 @@ export default class CinematicLankBoss {
     }
 
     const lHero = getLeftHero(shot)
-    const original = (me.get('heroConfig') || {}).thangType || HERO_THANG_ID
+    // TODO: Replace hard coded hero with user hero
+    const original = getHeroSlug()
     if (lHero) {
       const { enterOnStart, thang } = lHero
       addMoveCharacterCommand('left', original, enterOnStart, thang)

--- a/ozaria/engine/cinematic/Loader.js
+++ b/ozaria/engine/cinematic/Loader.js
@@ -1,6 +1,7 @@
 import { getThang, getThangTypeOriginal } from '../../../app/core/api/thang-types'
 import { getBackgroundSlug, getBackgroundObject, getRightCharacterThangTypeSlug, getLeftCharacterThangTypeSlug } from '../../../app/schemas/models/selectors/cinematic'
 import { HERO_THANG_ID } from './CinematicLankBoss'
+import { getHeroSlug } from './constants'
 
 /**
  * @typedef {import('../../../app/schemas/models/selectors/cinematic')} Cinematic
@@ -77,6 +78,8 @@ export default class Loader {
    */
   loadThangTypes (shots) {
     const slugs = []
+    // TODO: Remove hard coded hero slug used for content creation.
+    slugs.push(getHeroSlug())
     shots
       .forEach(shot => {
         const { slug } = getLeftCharacterThangTypeSlug(shot) || {}

--- a/ozaria/engine/cinematic/constants.js
+++ b/ozaria/engine/cinematic/constants.js
@@ -10,3 +10,6 @@ export const HEIGHT = 768
 export const CINEMATIC_ASPECT_RATIO = HEIGHT / WIDTH
 
 export const LETTER_ANIMATE_TIME = 90
+
+// TODO: This is for content generation purposes.
+export const getHeroSlug = () => 'hero-a-cinematic'

--- a/ozaria/engine/cinematic/constants.js
+++ b/ozaria/engine/cinematic/constants.js
@@ -11,5 +11,8 @@ export const CINEMATIC_ASPECT_RATIO = HEIGHT / WIDTH
 
 export const LETTER_ANIMATE_TIME = 90
 
+export const LEFT_SPEAKER_CAMERA_POS = { x: -165, y: -65 }
+export const RIGHT_SPEAKER_CAMERA_POS = { x: 165, y: -65 }
+
 // TODO: This is for content generation purposes.
 export const getHeroSlug = () => 'hero-a-cinematic'

--- a/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
+++ b/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
@@ -59,8 +59,8 @@ export default class DialogSystem {
 
     if (text) {
       // Use the camera setting from the shotSetup.
-      const { pos, zoom } = getCamera(shot)
-      const { x, y } = getTextPosition(dialogNode) || getDefaultTextPosition(side, zoom, pos)
+      const { zoom } = getCamera(shot)
+      const { x, y } = getTextPosition(dialogNode) || getDefaultTextPosition(side, zoom)
       commands.push((new SpeechBubble({
         div: this.div,
         htmlString: text,

--- a/ozaria/engine/cinematic/dialogsystem/helper.js
+++ b/ozaria/engine/cinematic/dialogsystem/helper.js
@@ -91,26 +91,20 @@ export function wrapText (htmlString, wrapLetterString, wrapWordString) {
  *
  * @param {'left'|'right'} speaker
  * @param {number} cameraZoom
- * @param {Object} cameraPosition
- * @param {number} cameraPosition.x
  */
-export function getDefaultTextPosition (speaker, cameraZoom, { x }) {
-  const cameraX = x
+export function getDefaultTextPosition (speaker, cameraZoom) {
   // Handling special cases of zoom, checking if speaker is in frame.
   if (speaker === 'left') {
     if (cameraZoom === 1) {
-      return { x: 550, y: 330 }
-    }
-    // Then zoom must be 2.
-    if (cameraX < -145) {
+      return { x: 540, y: 280 }
+    } else if (cameraZoom === 2) {
       return { x: 800, y: 250 }
     }
   } else if (speaker === 'right') {
     if (cameraZoom === 1) {
-      return { x: 850, y: 300 }
-    }
-    if (cameraX > 145) {
-      return { x: 550, y: 250 }
+      return { x: 875, y: 280 }
+    } else if (cameraZoom === 2) {
+      return { x: 600, y: 300 }
     }
   }
   // Default to center

--- a/test/app/models/Cinematic.spec.js
+++ b/test/app/models/Cinematic.spec.js
@@ -50,7 +50,7 @@ describe('Cinematic', () => {
       expect(result).toBeUndefined()
 
       const result2 = getLeftCharacterThangTypeSlug(shotFixture2)
-      expect(result2).toEqual({ slug: 'fake-slug-thangtype', enterOnStart: false, thang: { scaleX: 0.7, scaleY: 0.7, pos: { x: -30, y: -73 } } })
+      expect(result2).toEqual({ slug: 'fake-slug-thangtype', enterOnStart: false, thang: { scaleX: 0.82, scaleY: 0.82, pos: { x: -30, y: -72 } } })
     })
 
     it('getRightCharacterThangTypeSlug', () => {
@@ -58,7 +58,7 @@ describe('Cinematic', () => {
       expect(result).toBeUndefined()
 
       const result2 = getRightCharacterThangTypeSlug(shotFixture1)
-      expect(result2).toEqual({ slug: 'fake-slug-thangtype', enterOnStart: false, thang: { scaleX: 0.7, scaleY: 0.7, pos: { x: 35, y: -65 } } })
+      expect(result2).toEqual({ slug: 'fake-slug-thangtype', enterOnStart: false, thang: { scaleX: 0.82, scaleY: 0.82, pos: { x: 30, y: -72 } } })
     })
 
     it('getLeftHero', () => {


### PR DESCRIPTION
## Issue

Cinematic Hero A and B are both imported. As they have vastly different proportions from the isometric art, the defaults need to be updated.

## Fix

An additional default was added. This is the camera position used when camera is set on zoom 2. If the camera is at position 0, 0 and zoom is set on 2.

This default introduces some brittleness as it means the position 0,0 is treated as an unset condition. However the trade off is that content creation becomes even easier.