### PR TITLE
Set capstoneStage from query parameter

### DIFF
--- a/app/collections/Levels.coffee
+++ b/app/collections/Levels.coffee
@@ -27,7 +27,7 @@ module.exports = class LevelCollection extends CocoCollection
           return unless s.language is 'html'
           strippedSource = utils.extractPlayerCodeTag(s.source or '')
           s.source = strippedSource if strippedSource
-      map[level.get('original')] = solutions?.map((s) => {source: @fingerprint(s.source, s.language), description: s.description})
+      map[level.get('original')] = solutions?.map((s) => {source: @fingerprint(s.source, s.language), description: s.description, capstoneStage: s.capstoneStage})
       map
     , {})
 

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1637,6 +1637,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     no_code_yet: "Student has not written any code for this level yet."
     open_ended_level: "Open-Ended Level"
     partial_solution: "Partial Solution"
+    capstone_solution: "Capstone Solution"
     removing_course: "Removing course"
     solution_arena_blurb: "Students are encouraged to solve arena levels creatively. The solution provided below meets the requirements of the arena level."
     solution_challenge_blurb: "Students are encouraged to solve open-ended challenge levels creatively. One possible solution is displayed below."

--- a/app/templates/teachers/teacher-course-solution-view.jade
+++ b/app/templates/teachers/teacher-course-solution-view.jade
@@ -84,7 +84,12 @@ block content
                   li.nav-item(class=(index === 0 ? 'active' : ''))
                     - var target = level.get('original') + index;
                     a.nav-link(id="#{target}-tab", class=(index === 0 ? 'active' : ''), href="##{target}", role="tab", data-toggle="tab", aria-controls=target, aria-selected=(index === 0), data-level-slug=level.get('slug'), data-solution-index=index)
-                      if index === 0
+                      if solution.capstoneStage
+                        .text-center
+                          span(data-i18n="teacher.capstone_solution")
+                          =" "
+                          span= solution.capstoneStage
+                      else if index === 0
                         strong.text-center(data-i18n="teacher.complete_solution")
                       else
                         .text-center

--- a/app/templates/teachers/teacher-student-view.jade
+++ b/app/templates/teachers/teacher-student-view.jade
@@ -316,7 +316,12 @@ mixin breadcrumbs
                         li.nav-item(class=(index === 0 ? 'active' : ''))
                           - var target = level.get('original') + index;
                           a.nav-link(id="#{target}-tab", class=(index === 0 ? 'active' : ''), href="##{target}", role="tab", data-toggle="tab", aria-controls=target, aria-selected=(index === 0), data-level-slug=level.get('slug'), data-solution-index=index)
-                            if index === 0
+                            if solution.capstoneStage
+                              .text-center
+                                span(data-i18n="teacher.capstone_solution")
+                                =" "
+                                span= solution.capstoneStage
+                            else if index === 0
                               strong.text-center(data-i18n="teacher.complete_solution")
                             else
                               .text-center

--- a/ozaria/site/views/play/level/PlayLevelView.js
+++ b/ozaria/site/views/play/level/PlayLevelView.js
@@ -96,10 +96,10 @@ class PlayLevelView extends RootView {
     this.sessionID = utils.getQueryVariable('session') || this.options.sessionID
     this.observing = utils.getQueryVariable('observing')
     this.opponentSessionID = utils.getQueryVariable('opponent') || this.options.opponent
-    this.capstoneStage =
+    this.capstoneStage = parseInt(
       utils.getQueryVariable('capstoneStage') ||
       utils.getQueryVariable('capstonestage') || // Case sensitive, so this is easier to use
-      this.options.capstoneStage
+      this.options.capstoneStage, 10)
 
     this.gameUIState = new GameUIState()
 

--- a/ozaria/site/views/play/level/PlayLevelView.js
+++ b/ozaria/site/views/play/level/PlayLevelView.js
@@ -336,7 +336,12 @@ class PlayLevelView extends RootView {
 
   grabLevelLoaderData () {
     this.session = this.levelLoader.session
-    if (this.capstoneStage && me.isSessionless() && (me.isAdmin() || me.isTeacher())) {
+    console.log('CAPSTONE: grabLevelLoaderData with : ')
+    console.log(this.capstoneStage)
+    console.log(me.isSessionless())
+
+    // if (this.capstoneStage && me.isSessionless() && (me.isAdmin() || me.isTeacher())) {
+    if (this.capstoneStage && me.isAdmin()) {
       const state = this.session.get('state') || {}
       state.capstoneStage = this.capstoneStage
       this.session.set('state', state)

--- a/ozaria/site/views/play/level/PlayLevelView.js
+++ b/ozaria/site/views/play/level/PlayLevelView.js
@@ -336,10 +336,7 @@ class PlayLevelView extends RootView {
 
   grabLevelLoaderData () {
     this.session = this.levelLoader.session
-    console.log('CAPSTONE: grabLevelLoaderData with : ')
-    console.log(this.capstoneStage)
-    console.log(me.isSessionless())
-
+    // TODO: After Ozaria launch, comment this out to give proper access
     // if (this.capstoneStage && me.isSessionless() && (me.isAdmin() || me.isTeacher())) {
     if (this.capstoneStage && me.isAdmin()) {
       const state = this.session.get('state') || {}

--- a/ozaria/site/views/play/level/PlayLevelView.js
+++ b/ozaria/site/views/play/level/PlayLevelView.js
@@ -91,15 +91,16 @@ class PlayLevelView extends RootView {
     this.levelID = levelID
 
     this.courseID = options.courseID || utils.getQueryVariable('course')
-    this.courseInstanceID =
-      options.courseInstanceID || utils.getQueryVariable('course-instance')
-
+    this.courseInstanceID = options.courseInstanceID || utils.getQueryVariable('course-instance')
     this.isEditorPreview = utils.getQueryVariable('dev')
-    this.sessionID =
-      utils.getQueryVariable('session') || this.options.sessionID
+    this.sessionID = utils.getQueryVariable('session') || this.options.sessionID
     this.observing = utils.getQueryVariable('observing')
-
     this.opponentSessionID = utils.getQueryVariable('opponent') || this.options.opponent
+    this.capstoneStage =
+      utils.getQueryVariable('capstoneStage') ||
+      utils.getQueryVariable('capstonestage') || // Case sensitive, so this is easier to use
+      this.options.capstoneStage
+
     this.gameUIState = new GameUIState()
 
     $('flying-focus').remove() // Causes problems, so yank it out for play view.
@@ -335,6 +336,12 @@ class PlayLevelView extends RootView {
 
   grabLevelLoaderData () {
     this.session = this.levelLoader.session
+    if (this.capstoneStage && me.isSessionless() && (me.isAdmin() || me.isTeacher())) {
+      const state = this.session.get('state') || {}
+      state.capstoneStage = this.capstoneStage
+      this.session.set('state', state)
+    }
+
     this.level = this.levelLoader.level
     store.commit('game/setLevel', this.level.attributes)
     if (this.level.isType('web-dev')) {
@@ -1154,7 +1161,7 @@ class PlayLevelView extends RootView {
 
     if (additionalGoals) {
       const state = this.session.get('state')
-      options.capstoneStage = state ? state.capstoneStage : undefined
+      options.capstoneStage = (state || {}).capstoneStage
       options.remainingGoals = this.goalManager.getRemainingGoals()
       options.levelSlug = this.level.get('slug')
 


### PR DESCRIPTION
# Feature

Add a way for us as admins and for teachers and sessionless users in general to set the capstone stage for a level as it is being loaded. 

This is being implemented through a query parameter that will forcibly set the capstone stage directly, disregarding any goals. 

# How to test

1) Try to play https://next.codecombat.com/ozaria/play/level/capstone-test-1 by adding more munchkins
2) After having progressed through the stages, add `?capstoneStage=1` (for example) to the URL so it looks like this: https://next.codecombat.com/ozaria/play/level/capstone-test-1?capstoneStage=1
3) Expect the capstoneStage to have been set to the query parameter

This is live on Next now.