### PR TITLE
Send codeLanguage from intros to interactives instead of course instance

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -207,11 +207,11 @@ module.exports = class CocoRouter extends Backbone.Router
     
     # Adding this route to test interactives until we have the intro levels implemented
     # TODO: remove this route when intro level is ready to test the interactives.
-    'interactive/:interactiveIdOrSlug(?course-instance=:courseInstanceId)': (interactiveIdOrSlug, courseInstanceId) ->
+    'interactive/:interactiveIdOrSlug(?code-language=:codeLanguage)': (interactiveIdOrSlug, codeLanguage) ->
       props = {
         interactiveIdOrSlug: interactiveIdOrSlug,
         introLevelId: '5411cb3769152f1707be029c' # TODO sending a random level id (dungeon of kithgard) for now, will be sent from intro level page later
-        courseInstanceId: courseInstanceId # This will also come from intro level page later
+        codeLanguage: codeLanguage # This will also come from intro level page later
       }
       @routeDirectly('interactive', [], {vueRoute: true, baseTemplate: 'base-empty', propsData: props})
 

--- a/ozaria/site/api/interactive.js
+++ b/ozaria/site/api/interactive.js
@@ -63,8 +63,8 @@ export const getSession = (idOrSlug, options = {}) => {
   if (!idOrSlug) {
     throw new Error(`No slug/id supplied`)
   }
-  return fetchJson(`/db/interactive/${idOrSlug}/session`, _.assign({}, {
+  return fetchJson(`/db/interactive/${idOrSlug}/session`, {
     method: 'GET',
     data: options
-  }))
+  })
 }

--- a/ozaria/site/api/interactive.js
+++ b/ozaria/site/api/interactive.js
@@ -63,9 +63,8 @@ export const getSession = (idOrSlug, options = {}) => {
   if (!idOrSlug) {
     throw new Error(`No slug/id supplied`)
   }
-  if (options.courseInstanceId) {
-    return fetchJson(`/db/interactive/${idOrSlug}/session?introLevelId=${options.introLevelId}&courseInstanceId=${options.courseInstanceId}`)
-  } else {
-    return fetchJson(`/db/interactive/${idOrSlug}/session?introLevelId=${options.introLevelId}`)
-  }
+  return fetchJson(`/db/interactive/${idOrSlug}/session`, _.assign({}, {
+    method: 'GET',
+    data: options
+  }))
 }

--- a/ozaria/site/components/interactive/PageInteractive/draggableOrdering.vue
+++ b/ozaria/site/components/interactive/PageInteractive/draggableOrdering.vue
@@ -14,7 +14,7 @@ export default {
     interactiveSession: {
       type: Object
     },
-    courseInstanceId: {
+    codeLanguage: {
       type: String
     }
   }

--- a/ozaria/site/components/interactive/PageInteractive/draggableStatementCompletion.vue
+++ b/ozaria/site/components/interactive/PageInteractive/draggableStatementCompletion.vue
@@ -14,7 +14,7 @@ export default {
     interactiveSession: {
       type: Object
     },
-    courseInstanceId: {
+    codeLanguage: {
       type: String
     }
   }

--- a/ozaria/site/components/interactive/PageInteractive/index.vue
+++ b/ozaria/site/components/interactive/PageInteractive/index.vue
@@ -4,6 +4,7 @@ import { getInteractive, getSession } from '../../../api/interactive'
 import draggableOrderingComponent from './draggableOrdering'
 import insertCodeComponent from './insertCode'
 import draggableStatementCompletionComponent from './draggableStatementCompletion'
+import { defaultCodeLanguage } from 'ozaria/site/common/ozariaUtils'
 
 module.exports = Vue.extend({
   props: {
@@ -17,8 +18,9 @@ module.exports = Vue.extend({
       required: true,
       default: ''
     },
-    courseInstanceId: {
-      type: String
+    codeLanguage: {
+      type: String,
+      default: defaultCodeLanguage
     }
   },
   data: () => ({
@@ -59,9 +61,9 @@ module.exports = Vue.extend({
         if (!me.isSessionless()) { // not saving progress/session for teachers
           const getSessionOptions = {
             introLevelId: this.introLevelId,
-            courseInstanceId: this.courseInstanceId
+            codeLanguage: this.codeLanguage
           }
-          this.interactiveSession = await getSession(this.interactiveIdOrSlug, getSessionOptions )
+          this.interactiveSession = await getSession(this.interactiveIdOrSlug, getSessionOptions)
         }
       } catch (err) {
         console.error("Error:", err)
@@ -79,7 +81,7 @@ module.exports = Vue.extend({
       :interactive="interactive"
       :introLevelId="introLevelId"
       :interactiveSession="interactiveSession"
-      :courseInstanceId="courseInstanceId"
+      :codeLanguage="codeLanguage"
       v-on:completed="onCompleted">
     </draggable-ordering>
     <insert-code
@@ -87,7 +89,7 @@ module.exports = Vue.extend({
       :interactive="interactive"
       :introLevelId="introLevelId"
       :interactiveSession="interactiveSession"
-      :courseInstanceId="courseInstanceId"
+      :codeLanguage="codeLanguage"
       v-on:completed="onCompleted">
     </insert-code>
     <draggable-statement-completion
@@ -95,7 +97,7 @@ module.exports = Vue.extend({
       :interactive="interactive"
       :introLevelId="introLevelId"
       :interactiveSession="interactiveSession"
-      :courseInstanceId="courseInstanceId"
+      :codeLanguage="codeLanguage"
       v-on:completed="onCompleted">
     </draggable-statement-completion>
   </div>

--- a/ozaria/site/components/interactive/PageInteractive/insertCode.vue
+++ b/ozaria/site/components/interactive/PageInteractive/insertCode.vue
@@ -14,7 +14,7 @@ export default {
     interactiveSession: {
       type: Object
     },
-    courseInstanceId: {
+    codeLanguage: {
       type: String
     }
   }

--- a/ozaria/site/components/play/PageIntroLevel/index.vue
+++ b/ozaria/site/components/play/PageIntroLevel/index.vue
@@ -191,7 +191,7 @@
       v-if="currentContent.type == 'interactive'"
       :interactive-id-or-slug="currentContent.contentId"
       :intro-level-id="introLevelData.original"
-      :course-instance-id="courseInstanceId"
+      :code-language="language"
       @completed="onContentCompleted"
     />
     <cinematics-component


### PR DESCRIPTION
Course instance is no longer required for interactive session's APIs since it was being used to determine code language in the APIs, but since we already know the intro level's session's code language on the frontend interactive page, sending that directly to the interactive session's APIs.

Related server PR: https://github.com/codecombat/codecombat-server/pull/102