### PR TITLE
Remove intro level id prop from interactives pages

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -210,7 +210,6 @@ module.exports = class CocoRouter extends Backbone.Router
     'interactive/:interactiveIdOrSlug(?code-language=:codeLanguage)': (interactiveIdOrSlug, codeLanguage) ->
       props = {
         interactiveIdOrSlug: interactiveIdOrSlug,
-        introLevelId: '5411cb3769152f1707be029c' # TODO sending a random level id (dungeon of kithgard) for now, will be sent from intro level page later
         codeLanguage: codeLanguage # This will also come from intro level page later
       }
       @routeDirectly('interactive', [], {vueRoute: true, baseTemplate: 'base-empty', propsData: props})

--- a/ozaria/site/components/interactive/PageInteractive/draggableOrdering/index.vue
+++ b/ozaria/site/components/interactive/PageInteractive/draggableOrdering/index.vue
@@ -15,11 +15,6 @@
         required: true
       },
 
-      introLevelId: {
-        type: String,
-        required: true
-      },
-
       interactiveSession: {
         type: Object,
         default: undefined

--- a/ozaria/site/components/interactive/PageInteractive/draggableStatementCompletion/index.vue
+++ b/ozaria/site/components/interactive/PageInteractive/draggableStatementCompletion/index.vue
@@ -17,11 +17,6 @@
         required: true
       },
 
-      introLevelId: {
-        type: String,
-        required: true
-      },
-
       interactiveSession: {
         type: Object,
         default: undefined

--- a/ozaria/site/components/interactive/PageInteractive/index.vue
+++ b/ozaria/site/components/interactive/PageInteractive/index.vue
@@ -19,12 +19,6 @@
         default: ''
       },
 
-      introLevelId: {
-        type: String,
-        required: true,
-        default: ''
-      },
-
       codeLanguage: {
         type: String,
         default: defaultCodeLanguage
@@ -88,7 +82,6 @@
           }
           if (!me.isSessionless()) { // not saving progress/session for teachers
             const getSessionOptions = {
-              introLevelId: this.introLevelId,
               codeLanguage: this.codeLanguage
             }
             // TODO: throws error regarding intro and language session
@@ -115,7 +108,6 @@
       :is="interactiveComponent"
       v-else
       :interactive="interactive"
-      :intro-level-id="introLevelId"
       :interactive-session="interactiveSession"
       :code-language="codeLanguage"
       @completed="onCompleted"

--- a/ozaria/site/components/interactive/PageInteractive/insertCode/index.vue
+++ b/ozaria/site/components/interactive/PageInteractive/insertCode/index.vue
@@ -30,12 +30,6 @@
         default: () => ({})
       },
 
-      introLevelId: {
-        type: String,
-        required: true,
-        default: ''
-      },
-
       interactiveSession: {
         type: Object
       },

--- a/ozaria/site/components/play/PageIntroLevel/index.vue
+++ b/ozaria/site/components/play/PageIntroLevel/index.vue
@@ -190,7 +190,6 @@
     <interactives-component
       v-if="currentContent.type == 'interactive'"
       :interactive-id-or-slug="currentContent.contentId"
-      :intro-level-id="introLevelData.original"
       :code-language="language"
       @completed="onContentCompleted"
     />


### PR DESCRIPTION
Intro level ID is not required for interactive session API, therefore removing it from the frontend pages.
Server PR: https://github.com/codecombat/codecombat-server/pull/103