### PR TITLE
Functional implementation for methods bank

### DIFF
--- a/app/schemas/models/level.coffee
+++ b/app/schemas/models/level.coffee
@@ -399,6 +399,14 @@ _.extend LevelSchema.properties,
     }
   }
   isPlayedInStages: {type: 'boolean', title: 'Is Played in Stages', description: 'Is this level played in stages and other content(cinematics) is loaded in between stages'}
+  methodsBankList: c.array {title: 'Methods Bank List'}, c.object {
+    properties: {
+      name: c.shortString(title: 'Name'),
+      section: c.shortString(title: 'Methods Bank Section', pattern: '^[a-z]+$'),
+      subSection: c.shortString(title: 'Methods Bank Sub-Section', pattern: '^[a-z]+$'),
+      componentName: c.shortString(title: 'Level Component Name', description: 'Level Component to use for documentation in case there are multiple components with same property\'s documentation'),
+    }
+  }
 
 c.extendBasicProperties LevelSchema, 'level'
 c.extendSearchableProperties LevelSchema

--- a/app/schemas/models/level_component.coffee
+++ b/app/schemas/models/level_component.coffee
@@ -106,8 +106,6 @@ PropertyDocumentationSchema = c.object {
         title: 'Variable Name'
         description: 'Variable name this property is autocompleted into.'
         default: 'result'
-  section: c.shortString(title: 'Methods Bank Section')
-  subSection: c.shortString(title: 'Methods Bank Sub-Section')
 
 DependencySchema = c.object {
   title: 'Component Dependency'

--- a/app/schemas/models/level_component.coffee
+++ b/app/schemas/models/level_component.coffee
@@ -32,6 +32,18 @@ PropertyDocumentationSchema = c.object {
   codeLanguages: c.array {title: 'Specific Code Languages', description: 'If present, then only the languages specified will show this documentation. Leave unset for language-independent documentation.', format: 'code-languages-array'}, c.shortString(title: 'Code Language', description: 'A specific code language to show this documentation for.', format: 'code-language')
   # not actual JS types, just whatever they describe...
   type: c.shortString(title: 'Type', description: 'Intended type of the property.')
+  shortDescription:
+    oneOf: [
+      {
+        type: 'object',
+        title: 'Language Descriptions (short)',
+        description: 'Property short-descriptions by code language.',
+        additionalProperties: {type: 'string', description: 'Short Description of the property.', maxLength: 1000, format: 'markdown'}
+        format: 'code-languages-object'
+        default: {javascript: ''}
+      }
+      {title: 'Short Description', type: 'string', description: 'Short Description of the property.', maxLength: 1000, format: 'markdown'}
+    ]
   description:
     oneOf: [
       {

--- a/app/views/editor/level/settings/SettingsTabView.coffee
+++ b/app/views/editor/level/settings/SettingsTabView.coffee
@@ -22,7 +22,7 @@ module.exports = class SettingsTabView extends CocoView
     'practiceThresholdMinutes', 'primerLanguage', 'shareable', 'studentPlayInstructions', 'requiredCode', 'suspectCode',
     'requiredGear', 'restrictedGear', 'requiredProperties', 'restrictedProperties', 'recommendedHealth', 'allowedHeroes',
     'maximumHealth', 'assessmentPlacement', 'password', 'mirrorMatch', 'autocompleteReplacement', 'introContent',
-    'additionalGoals', 'isPlayedInStages', 'ozariaType'
+    'additionalGoals', 'isPlayedInStages', 'ozariaType', 'methodsBankList'
   ]
 
   subscriptions:

--- a/ozaria/site/styles/play/level/tome/spell-palette-view.sass
+++ b/ozaria/site/styles/play/level/tome/spell-palette-view.sass
@@ -87,14 +87,14 @@
             float: left
 
       .closeBtn
-        position: absolute;
-        right: -10px;
-        top: 15px;
-        width: 40px;
-        height: 40px;
-        cursor: pointer;
+        position: absolute
+        right: -10px
+        top: 15px
+        width: 40px
+        height: 40px
+        cursor: pointer
         font-size: 20px
-        z-index: 2;
+        z-index: 2
 
       h1:not(.not-code), h2:not(.not-code), h3:not(.not-code), h4:not(.not-code), h5:not(.not-code), h6:not(.not-code)
         font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important

--- a/ozaria/site/styles/play/level/tome/spell-palette-view.sass
+++ b/ozaria/site/styles/play/level/tome/spell-palette-view.sass
@@ -1,0 +1,249 @@
+@import "app/styles/mixins"
+@import "app/styles/bootstrap/variables"
+@import "app/styles/play/variables"
+
+#spell-palette-view
+  position: absolute
+  right: $spell-pallete-right
+  width: $api-bar-width
+  bottom: 0px
+  top: 0px
+  padding: 0 4px 0px 10px
+  background: transparent url(/images/level/wood_texture.png)
+  background-size: auto 100%
+  z-index: 7
+  @include transition(top 0.25s ease-in-out, width 0.25s ease-in-out)
+  box-shadow: 10px 4px 4px black
+  overflow: hidden
+  #spell-palette-api-bar[disabled=disabled]
+    pointer-events: none
+    #palette-tab-api-area
+      opacity: 0.6
+  #level-view.real-time &, #level-view.cinematic &
+    display: none
+    visibility: hidden
+  &.open
+    width: $api-bar-width + 360px
+  .container
+    width: $api-bar-width + 360px
+    height: 100%
+    position: relative
+    .left
+      position: absolute
+      left: 0
+      top: 80px
+      bottom: 0px
+      height: auto
+      width: $api-bar-width - 13
+      .section-header, .sub-section-header
+        display: block
+        color: white
+        margin-right: 10px
+
+      .spell-palette-thang-entry-view
+        display: inline-block
+        border: 5px solid black
+        border-image: url(/images/level/thang_avatar_frame.png) 20 20 20 20 fill round
+        margin: 1px
+
+        img
+          background-color: black
+          width: 72px
+          height: 72px
+          border: 1px solid transparent
+          cursor: pointer
+        &:hover img
+          border: 1px solid #f3cd90
+        &.selected img
+          border: 1px solid white
+          cursor: auto
+
+      .nano-slider
+        background-color: rgba(243, 169, 49, 0.5)
+    .right
+      position: absolute
+      right: 20px
+      min-width: 200px
+      left: $api-bar-width - 10px
+      top: 60px
+      bottom: 0px
+      //width: calc(100% - #{$api-bar-width + 50px})
+      @include box-shadow(0 0 0 #000)
+      .scrollArea
+        max-height: calc(100% - 20px)
+        width: 100%
+        border-style: solid
+        border-image: url(/images/level/popover_border_background.png) 16 12 fill round
+        border-width: 16px 12px
+        margin-top: 20px
+        margin-bottom: 20px
+        position: relative
+        overflow-y: auto
+
+      .always-scroll-y
+        overflow-y: scroll
+        .description
+          img
+            float: left
+
+      .closeBtn
+        position: absolute;
+        right: -10px;
+        top: 15px;
+        width: 40px;
+        height: 40px;
+        cursor: pointer;
+        font-size: 20px
+        z-index: 2;
+
+      h1:not(.not-code), h2:not(.not-code), h3:not(.not-code), h4:not(.not-code), h5:not(.not-code), h6:not(.not-code)
+        font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+        font-variant: normal
+        color: purple
+        text-transform: auto
+
+        body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
+          font-family: "Cousine", "Courier", "Courier New", monospace !important
+
+      .popover-title
+        background-color: transparent
+        margin: 0 14px
+        padding: 8px 0
+        border-bottom-color: #ccc
+
+      .popover-content
+        max-height: 100%
+        overflow-y: auto
+        margin-right: 10px
+        img
+          float: right
+
+      &.top .arrow
+        bottom: -2%
+      &.bottom .arrow
+        top: -2%
+      &.left .arrow
+        right: 0%
+      &.right .arrow
+        left: -3%
+
+      .docs-ace-container
+        padding: 2px 4px
+        border-radius: 4px
+
+        &, .docs-ace
+          background-color: #f9f2f4
+          font-size: 12px
+          font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+
+          body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
+            font-family: "Cousine", "Courier", "Courier New", monospace !important
+
+        .docs-ace
+          .ace_cursor, .ace_bracket
+            display: none
+
+      code
+        color: black
+        font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+        font-size: 12px
+
+        body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
+          font-family: "Cousine", "Courier", "Courier New", monospace !important
+
+    h4.tab
+      color: white
+      font-size: 16px
+      line-height: 16px
+      margin: 25px 0 5px 2px
+      font-weight: normal
+      text-transform: uppercase
+
+    .nav > li > a
+      padding: 2px 20px 0px 20px
+      margin-bottom: 3px
+
+    ul.nav.nav-pills
+      margin-top: 3%
+
+      h4
+        margin-top: 2px
+      li.active a
+        background-color: transparent
+      &.multiple-tabs li.active a
+        background-color: darken(rgb(230, 212, 146), 30%)
+      &.multiple-tabs li:not(.active) a
+        cursor: pointer
+
+    &:not(.hero)
+      .tab-content
+        height: 80px
+        .nano-pane
+          width: 7px
+          right: 5px
+
+    //.nav-pills > li.active > a, .nav-pills > li.active > a:hover, .nav-pills > li.active > a:focus
+    //  background-color: lighten(rgb(230, 212, 146), 10%)
+
+    .property-entry-column
+      display: inline-block
+      margin-right: 3px
+      vertical-align: top
+
+  #spell-palette-help-button
+    margin: 3% 0px 4px
+
+  &.hero .properties
+    @include flexbox()
+    @include flex-wrap()
+    @include flex-column()
+    @include flex-align-content-start()
+
+    .property-entry-item-group, .property-entry-item-sub-group
+      min-height: 38px
+      width: 212px
+      position: relative
+      background-color: rgb(20, 13, 8)
+      margin: 1px
+
+      img.item-image
+        width: 38px
+        height: 38px
+        position: absolute
+        top: 0px
+
+      &:not(:hover) img.item-image
+        -webkit-filter: contrast(50%) sepia(100%) saturate(500%) hue-rotate(7deg)
+        filter: contrast(50%) sepia(100%) saturate(1000%) hue-rotate(7deg)
+
+  &.shortenize.hero .properties
+    .property-entry-item-group, .property-entry-item-sub-group
+      width: 175px
+
+      .spell-palette-entry-view
+        width: 137px
+        width: -webkit-calc(100% - 38px)
+        width: calc(100% - 38px)
+
+  &.web-dev.hero .properties
+    .property-entry-item-group
+      width: 100px
+
+      .spell-palette-entry-view
+        margin-left: 0
+        width: 100px
+
+  //Fixes punctuation but puts comment marker on right, which is apparently worse.
+  //body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
+  //  .ace_text-layer .ace_comment
+  //    direction: rtl
+  //    unicode-bidi: embed
+
+  body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
+    .rtl-right-aligned
+      text-align: right
+
+@media only screen and (max-width: 1100px)
+  #spell-palette-view
+    // Make sure we have enough room for at least two columns
+    padding-left: 12px

--- a/ozaria/site/templates/play/tome/spell-palette-view.jade
+++ b/ozaria/site/templates/play/tome/spell-palette-view.jade
@@ -1,43 +1,15 @@
 mixin header(label, name)
-  - var translatedName = translate('apis.' + _.string.slugify(name).replace('-', '_'));
   a.section-header.btn.btn-small.btn-illustrated.btn-warning(role="button", id="#palette-header-" + _.string.slugify(label), data-panel="#palette-tab-" + _.string.slugify(label))
-    if name.toLocaleLowerCase() == translatedName.toLocaleLowerCase() || ['Methods', 'Events', 'Spawnable'].indexOf(name) != -1
-      span= translatedName
-    else
-      span= name + ' (' + translatedName + ')'
-    if label == 'api-area' || label == 'stuff-area'
-      div.glyphicon.glyphicon-chevron-down(style="float: right")
-    else
-      div.glyphicon.glyphicon-chevron-right(style="float: right")
+    span= name
 div.container
   div.left.nano
     div.nano-content.panel-group#spell-palette-api-bar
-      if view.level.get('type') == 'web-dev'
-        +header('api-area', 'HTML')
-      else
-        +header('api-area', 'Methods')
-      div.apis.panel-collapse.collapse.in#palette-tab-api-area
-        .properties.properties-this
-      if tabs
-        each entries, tab in tabs
-          +header(tab, tab)
-          div.panel-collapse.collapse(id="palette-tab-" + _.string.slugify(tab))
-            div(class="properties properties-" + _.string.slugify(tab))
+      if entryGroups
+        each entries, group in entryGroups
+          +header(group, group)
+          div.apis.panel-collapse(id="palette-tab-" + _.string.slugify(group))
+            div(class="properties properties-" + _.string.slugify(group))
 
-      +header('events', 'Events')
-      div.apis.panel-collapse.collapse#palette-tab-events
-
-      +header('handlers', 'Handlers')
-      div.apis.panel-collapse.collapse#palette-tab-handlers
-
-      +header('properties', 'Properties')
-      div.apis.panel-collapse.collapse#palette-tab-properties
-
-      +header('snippets', 'Snippets')
-      div.apis.panel-collapse.collapse#palette-tab-snippets
-
-      +header('stuff-area', 'Spawnable')
-      div.apis.panel-collapse.collapse.in#palette-tab-stuff-area
 
   div.right
     .closeBtn.btn.btn-illustrated.btn-danger

--- a/ozaria/site/templates/play/tome/spell_palette_entry_popover.jade
+++ b/ozaria/site/templates/play/tome/spell_palette_entry_popover.jade
@@ -18,8 +18,8 @@ if doc.translatedShortName
   h5
     span.translated-name= doc.translatedShortName
 
-.description.rtl-allowed.rtl-right-aligned(dir="auto")
-  p(dir="auto")!= marked(doc.description || 'Still undocumented, sorry.')
+.short-description.rtl-allowed.rtl-right-aligned(dir="auto")
+  p(dir="auto")!= marked(doc.shortDescription || 'Still undocumented, sorry.')
   div.clear(style="clear: both")
   if cooldowns && (cooldowns.cooldown || cooldowns.specificCooldown)
     p
@@ -97,6 +97,11 @@ if !selectedMethod
               span= doc.ownerName + ':' + docName + '(' + argumentExamples.join(', ') + ')'
             else if language == 'io'
               span= (doc.ownerName == 'this' ? '' : doc.ownerName + ' ') + docName + '(' + argumentExamples.join(', ') + ')'
+
+if doc.description
+  .description.rtl-allowed.rtl-right-aligned(dir="auto")
+    p(dir="auto")!= marked(doc.description)
+    div.clear(style="clear: both")
 
 if (doc.type != 'function' && doc.type != 'snippet' && doc.type != 'spawnable' && doc.type != 'event' && doc.type != 'handler' && doc.type != 'property' && !_.contains(['HTML', 'CSS', 'WebJavaScript', 'jQuery'], doc.owner)) || doc.name == 'now'
   p.value

--- a/ozaria/site/views/play/level/tome/DocFormatter.coffee
+++ b/ozaria/site/views/play/level/tome/DocFormatter.coffee
@@ -99,6 +99,10 @@ module.exports = class DocFormatter
       if translatedName isnt @doc.name
         @doc.translatedShortName = @doc.shortName.replace(@doc.name, translatedName)
 
+    # Add section and sub-section for methods bank list on frontend
+    @doc.section = @options.section
+    @doc.subSection = @options.subSection
+
 
     # Grab the language-specific documentation for some sub-properties, if we have it.
     toTranslate = [{obj: @doc, prop: 'description'}, {obj: @doc, prop: 'example'}]

--- a/ozaria/site/views/play/level/tome/DocFormatter.coffee
+++ b/ozaria/site/views/play/level/tome/DocFormatter.coffee
@@ -1,4 +1,4 @@
-popoverTemplate = require 'templates/play/level/tome/spell_palette_entry_popover'
+popoverTemplate = require 'ozaria/site/templates/play/tome/spell_palette_entry_popover'
 {downTheChain} = require 'lib/world/world_utils'
 window.Vector = require 'lib/world/vector'  # So we can document it
 utils = require 'core/utils'

--- a/ozaria/site/views/play/level/tome/SpellPaletteThangEntryView.coffee
+++ b/ozaria/site/views/play/level/tome/SpellPaletteThangEntryView.coffee
@@ -1,6 +1,6 @@
 CocoView = require 'views/core/CocoView'
 template = require 'templates/play/level/tome/spell-palette-thang-entry'
-popoverTemplate = require 'templates/play/level/tome/spell_palette_entry_popover'
+popoverTemplate = require 'ozaria/site/templates/play/tome/spell_palette_entry_popover'
 {me} = require 'core/auth'
 filters = require 'lib/image_filter'
 DocFormatter = require './DocFormatter'

--- a/ozaria/site/views/play/level/tome/SpellPaletteThangEntryView.coffee
+++ b/ozaria/site/views/play/level/tome/SpellPaletteThangEntryView.coffee
@@ -40,6 +40,8 @@ module.exports = class SpellPaletteThangEntryView extends CocoView
         description: "![#{@thang.get('name')}](#{@thang.getPortraitURL()}) #{description}"
         example: example
       example: example
+      section: options.section
+      subSection: options.subSection
 
     #@aceEditors = []
 

--- a/ozaria/site/views/play/level/tome/SpellPaletteView.coffee
+++ b/ozaria/site/views/play/level/tome/SpellPaletteView.coffee
@@ -1,21 +1,16 @@
-require('app/styles/play/level/tome/spell-palette-view.sass')
+require('ozaria/site/styles/play/level/tome/spell-palette-view.sass')
 CocoView = require 'views/core/CocoView'
 {me} = require 'core/auth'
-filters = require 'lib/image_filter'
 SpellPaletteEntryView = require './SpellPaletteEntryView'
 SpellPaletteThangEntryView = require './SpellPaletteThangEntryView'
 LevelComponent = require 'models/LevelComponent'
 ThangType = require 'models/ThangType'
-GameMenuModal = require 'views/play/menu/GameMenuModal'
-LevelSetupManager = require 'lib/LevelSetupManager'
 ace = require('lib/aceContainer')
 aceUtils = require 'core/aceUtils'
 
-N_ROWS = 4
-
 module.exports = class SpellPaletteView extends CocoView
   id: 'spell-palette-view'
-  template: require 'templates/play/level/tome/spell-palette-view'
+  template: require 'ozaria/site/templates/play/tome/spell-palette-view'
   controlsEnabled: true
 
   subscriptions:
@@ -28,114 +23,39 @@ module.exports = class SpellPaletteView extends CocoView
 
 
   events:
-    'click #spell-palette-help-button': 'onClickHelp'
     'click .closeBtn': 'onClickClose'
-    'click .section-header': 'onSectionHeaderClick'
+    'click .sub-section-header': 'onSubSectionHeaderClick'
 
   initialize: (options) ->
     {@level, @session, @thang, @useHero} = options
     @aceEditors = []
-    docs = @options.level.get('documentation') ? {}
-    @showsHelp = docs.specificArticles?.length or docs.generalArticles?.length
     @createPalette()
     $(window).on 'resize', @onResize
 
   getRenderData: ->
     c = super()
     c.entryGroups = @entryGroups
-    c.entryGroupSlugs = @entryGroupSlugs
-    c.entryGroupNames = @entryGroupNames
-    c.tabbed = _.size(@entryGroups) > 1
-    c.defaultGroupSlug = @defaultGroupSlug
-    c.showsHelp = @showsHelp
-    c.tabs = @tabs  # For hero-based, non-this-owned tabs like Vector, Math, etc.
-    c.thisName = {coffeescript: '@', lua: 'self', python: 'self', java: 'hero'}[@options.language] or 'this'
     c._ = _
     c
 
   afterRender: ->
     super()
-    if @entryGroupSlugs
-      for group, entries of @entryGroups
-        groupSlug = @entryGroupSlugs[group]
-        for columnNumber, entryColumn of entries
-          col = $('<div class="property-entry-column"></div>').appendTo @$el.find(".properties-#{groupSlug}")
-          for entry in entryColumn
-            col.append entry.el
-            entry.render()  # Render after appending so that we can access parent container for popover
-      @$('.nano').nanoScroller alwaysVisible: true
-      @updateCodeLanguage @options.language
-    else
-      @entryGroupElements = {}
-      for group, entries of @entryGroups
-        @entryGroupElements[group] = itemGroup = $('<div class="property-entry-item-group"></div>').appendTo @$el.find('.properties-this')
-        if entries[0].options.item?.getPortraitURL
-          itemImage = $('<img class="item-image" draggable=false></img>').attr('src', entries[0].options.item.getPortraitURL())
-          itemGroup.append itemImage
-          firstEntry = entries[0]
-          do (firstEntry) ->
-            itemImage.on "mouseenter", (e) -> firstEntry.onMouseEnter e
-            itemImage.on "mouseleave", (e) -> firstEntry.onMouseLeave e
+    for group, entries of @entryGroups
+      group = _.string.slugify(group)
+      itemGroup = $('<div class="property-entry-item-group"></div>').appendTo @$el.find('.properties-'+group)
+      entrySubGroups = _.groupBy entries, (entry) -> entry.doc.subSection || 'none'
+      for subGroup, entries of entrySubGroups
+        if subGroup != 'none'
+          header = $("<a class='sub-section-header btn btn-small btn-illustrated' data-panel='#sub-section-#{subGroup}-#{group}'><span>#{subGroup}</span><div style='float: right' class='glyphicon glyphicon-chevron-down'></div></a>").appendTo itemGroup
+          itemSubGroup = $("<div class='property-entry-item-sub-group collapse' id='sub-section-#{subGroup}-#{group}'></div>").appendTo itemGroup
         for entry, entryIndex in entries
-          itemGroup.append entry.el
+          if subGroup != 'none'
+            itemSubGroup.append entry.el
+          else
+            itemGroup.append entry.el
           entry.render()  # Render after appending so that we can access parent container for popover
-          if entries.length is 1
-            entry.$el.addClass 'single-entry'
-          if entryIndex is 0
-            entry.$el.addClass 'first-entry'
-      for tab, entries of @tabs or {}
-        tabSlug = _.string.slugify tab
-        itemsInGroup = 0
-        for entry, entryIndex in entries
-          if itemsInGroup is 0 or (itemsInGroup is 2 and entryIndex isnt entries.length - 1)
-            itemGroup = $('<div class="property-entry-item-group"></div>').appendTo @$el.find(".properties-#{tabSlug}")
-            itemsInGroup = 0
-          ++itemsInGroup
-          itemGroup.append entry.el
-          entry.render()  # Render after appending so that we can access parent container for popover
-          if itemsInGroup is 0
-            entry.$el.addClass 'first-entry'
       @$el.addClass 'hero'
-      @$el.toggleClass 'shortenize', Boolean @shortenize
-      @$el.toggleClass 'web-dev', @options.level.isType('web-dev')
-
-    tts = @supermodel.getModels ThangType
-
-    for dn of @deferredDocs
-      doc = @deferredDocs[dn]
-      if doc.type is "spawnable"
-        thangName = doc.name
-        if @thang.spawnAliases[thangName]
-          thangName = @thang.spawnAliases[thangName][0]
-
-        info = @thang.buildables[thangName]
-        tt = _.find tts, (t) -> t.get('original') is info?.thangType
-        continue unless tt?
-        t = new SpellPaletteThangEntryView doc: doc, thang: tt, buildable: info, buildableName: doc.name, shortenize: true, language: @options.language, level: @options.level, useHero: @useHero
-        @$el.find("#palette-tab-stuff-area").append t.el
-        t.render()
-
-      if doc.type is "event"
-        t = new SpellPaletteEntryView doc: doc, thang: @thang, shortenize: true, language: @options.language, level: @options.level, useHero: @useHero
-        @$el.find("#palette-tab-events").append t.el
-        t.render()
-
-      if doc.type is "handler"
-        t = new SpellPaletteEntryView doc: doc, thang: @thang, shortenize: true, language: @options.language, level: @options.level, useHero: @useHero
-        @$el.find("#palette-tab-handlers").append t.el
-        t.render()
-
-      if doc.type is "property"
-        t = new SpellPaletteEntryView doc: doc, thang: @thang, shortenize: true, language: @options.language, level: @options.level, writable: true
-        @$el.find("#palette-tab-properties").append t.el
-        t.render()
-
-      if doc.type is "snippet" and @level.get('type') is 'game-dev'
-        t = new SpellPaletteEntryView doc: doc, thang: @thang, isSnippet: true, shortenize: true, language: @options.language, level: @options.level
-        @$el.find("#palette-tab-snippets").append t.el
-        t.render()
-
-    @$(".section-header:has(+.collapse:empty)").hide()
+      @$el.toggleClass 'shortenize', Boolean true
 
   afterInsert: ->
     super()
@@ -161,7 +81,54 @@ module.exports = class SpellPaletteView extends CocoView
         allDocs['__' + doc.name] ?= []
         allDocs['__' + doc.name].push doc
         if doc.type is 'snippet' then doc.owner = 'snippets'
+        doc.componentName = lc.get('name')
 
+    methodsBankList = @options.level.get('methodsBankList') || []
+    
+    @organizePaletteHero methodsBankList, allDocs, excludedDocs
+    @publishAutoCompleteEvent(allDocs)
+
+  # Reads the methods bank list and find its documentation from allDocs(i.e. docs coming from level components)
+  # This also groups the list based on the section
+  organizePaletteHero: (methodsBankList, allDocs, excludedDocs) ->
+    @entries = []
+    @tts = @supermodel.getModels ThangType
+    defaultSection = 'methods'
+    defaultSubSection = if @options.level.isType('game-dev') then 'game' else 'hero'
+    for prop, propIndex in methodsBankList
+      section = prop.section
+      subSection = prop.subSection
+      unless section # Set default section and sub-section for methods bank
+        section = defaultSection
+        subSection = defaultSubSection
+      propName = prop.name
+      doc = _.find (allDocs['__' + propName] ? []), (doc) ->
+        return true if !prop.componentName or (doc.componentName == prop.componentName)
+      if not doc and not excludedDocs['__' + propName] 
+        console.log 'could not find doc for', propName, 'from', allDocs['__' + propName]
+        doc = propName
+      if doc
+        @entries.push @addEntry(doc, section, subSection)
+    @entryGroups = _.groupBy @entries, (entry) -> entry.doc.section
+    
+
+  addEntry: (doc, section, subSection, shortenize=true, isSnippet=false, item=null, showImage=false) ->
+    if doc.type is 'spawnable'
+      thangName = doc.name
+      if @thang.spawnAliases[thangName]
+        thangName = @thang.spawnAliases[thangName][0]
+      info = @thang.buildables[thangName]
+      tt = _.find @tts, (t) -> t.get('original') is info?.thangType
+      if tt
+        new SpellPaletteThangEntryView doc: doc, section: section, subSection: subSection, thang: tt, buildable: info, buildableName: doc.name, shortenize: shortenize, language: @options.language, level: @options.level, useHero: @useHero
+    else
+      writable = (if _.isString(doc) then doc else doc.name) in (@thang.apiUserProperties ? [])
+      new SpellPaletteEntryView doc: doc, section: section, subSection: subSection, thang: @thang, shortenize: shortenize, isSnippet: isSnippet, language: @options.language, writable: writable, level: @options.level, item: item, showImage: showImage, useHero: @useHero
+
+  # This uses the legacy logic to publish event for auto completion in the code editor using programmable properties.
+  # This can potentially be merged with the logic in organizePaletteHero, but currently doing that makes it behave differently, so keeping it as it is for now
+  publishAutoCompleteEvent: (allDocs) ->
+    propsByItem = {}
     if @options.programmable
       propStorage =
         'this': 'programmableProperties'
@@ -186,154 +153,19 @@ module.exports = class SpellPaletteView extends CocoView
     else
       propStorage =
         'this': ['apiProperties', 'apiMethods']
-    if not @options.level.isType('hero', 'hero-ladder', 'hero-coop', 'course', 'course-ladder', 'game-dev', 'web-dev') or not @options.programmable
-      @organizePalette propStorage, allDocs, excludedDocs
-    else
-      @organizePaletteHero propStorage, allDocs, excludedDocs
-
-  organizePalette: (propStorage, allDocs, excludedDocs) ->
-    count = 0
-    propGroups = {}
-    for owner, storages of propStorage
-      storages = [storages] if _.isString storages
-      for storage in storages
-        props = _.reject @thang[storage] ? [], (prop) -> prop[0] is '_'  # no private properties
-        props = _.reject props, (prop) -> prop in @thang.excludedProperties if @thang.excludedProperties
-        props = _.uniq props
-        added = _.sortBy(props).slice()
-        propGroups[owner] = (propGroups[owner] ? []).concat added
-        count += added.length
-    Backbone.Mediator.publish 'tome:update-snippets', propGroups: propGroups, allDocs: allDocs, language: @options.language
-
-    @shortenize = count > 6
-    tabbify = count >= 10
-    @entries = []
-    for owner, props of propGroups
-      for prop in props
-        doc = _.find (allDocs['__' + prop] ? []), (doc) ->
-          return true if doc.owner is owner
-          return (owner is 'this' or owner is 'more') and (not doc.owner? or doc.owner is 'this')
-        if not doc and not excludedDocs['__' + prop]
-          console.log 'could not find doc for', prop, 'from', allDocs['__' + prop], 'for', owner, 'of', propGroups
-          doc ?= prop
-        if doc
-          @entries.push @addEntry(doc, @shortenize, owner is 'snippets')
-    groupForEntry = (entry) ->
-      return 'more' if entry.doc.owner is 'this' and entry.doc.name in (propGroups.more ? [])
-      entry.doc.owner
-    @entries = _.sortBy @entries, (entry) ->
-      order = ['this', 'more', 'Math', 'Vector', 'String', 'Object', 'Array', 'Function', 'HTML', 'CSS', 'WebJavaScript', 'jQuery', 'snippets']
-      index = order.indexOf groupForEntry entry
-      index = String.fromCharCode if index is -1 then order.length else index
-      index += entry.doc.name
-    if tabbify and _.find @entries, ((entry) -> entry.doc.owner isnt 'this')
-      @entryGroups = _.groupBy @entries, groupForEntry
-    else
-      i18nKey = if @options.level.isType('hero', 'hero-ladder', 'hero-coop', 'course', 'course-ladder', 'game-dev', 'web-dev') then 'play_level.tome_your_skills' else 'play_level.tome_available_spells'
-      defaultGroup = $.i18n.t i18nKey
-      @entryGroups = {}
-      @entryGroups[defaultGroup] = @entries
-      @defaultGroupSlug = _.string.slugify defaultGroup
-    @entryGroupSlugs = {}
-    @entryGroupNames = {}
-    for group, entries of @entryGroups
-      @entryGroups[group] = _.groupBy entries, (entry, i) -> Math.floor i / N_ROWS
-      @entryGroupSlugs[group] = _.string.slugify group
-      @entryGroupNames[group] = group
-    if thisName = {coffeescript: '@', lua: 'self', python: 'self'}[@options.language]
-      if @entryGroupNames.this
-        @entryGroupNames.this = thisName
-
-  organizePaletteHero: (propStorage, allDocs, excludedDocs) ->
-    # Assign any kind of programmable properties to the items that grant them.
-    @isHero = true
+    
     itemThangTypes = {}
     itemThangTypes[tt.get('name')] = tt for tt in @supermodel.getModels ThangType  # Also heroes
-    propsByItem = {}
-    propCount = 0
-    itemsByProp = {}
-    @deferredDocs = {}
-    # Make sure that we get the spellbook first, then the primary hand, then anything else.
-    slots = _.sortBy _.keys(@thang.inventoryThangTypeNames ? {}), (slot) ->
-      if slot is 'left-hand' then 0 else if slot is 'right-hand' then 1 else 2
-    for slot in slots
-      thangTypeName = @thang.inventoryThangTypeNames[slot]
-      if item = itemThangTypes[thangTypeName]
-        unless item.get('components')
-          console.error 'Item', item, 'did not have any components when we went to assemble docs.'
-        for component in item.get('components') ? [] when component.config
-          for owner, storages of propStorage
-            if props = component.config[storages]
-              for prop in _.sortBy(props) when prop[0] isnt '_' and not itemsByProp[prop]  # no private properties
-                continue if prop is 'moveXY' and @options.level.get('slug') is 'slalom'  # Hide for Slalom
-                continue if @thang.excludedProperties and prop in @thang.excludedProperties
-                propsByItem[item.get('name')] ?= []
-                propsByItem[item.get('name')].push owner: owner, prop: prop, item: item
-                itemsByProp[prop] = item
-                ++propCount
-      else
-        console.log @thang.id, "couldn't find item ThangType for", slot, thangTypeName
-
-    # Get any Math-, Vector-, etc.-owned properties into their own tabs
-    for owner, storage of propStorage when not (owner in ['this', 'more', 'snippets', 'HTML', 'CSS', 'WebJavaScript', 'jQuery'])
-      continue unless @thang[storage]?.length
-      @tabs ?= {}
-      @tabs[owner] = []
-      programmaticonName = @thang.inventoryThangTypeNames['programming-book']
-      programmaticon = itemThangTypes[programmaticonName]
-      sortedProps = @thang[storage].slice().sort()
-      for prop in sortedProps
-        continue if @thang.excludedProperties and prop in @thang.excludedProperties
-        if doc = _.find (allDocs['__' + prop] ? []), {owner: owner}  # Not all languages have all props
-          entry = @addEntry doc, false, false, programmaticon
-          @tabs[owner].push entry
-
-    # Assign any unassigned properties to the hero itself.
     for owner, storage of propStorage
       continue unless owner in ['this', 'more', 'snippets', 'HTML', 'CSS', 'WebJavaScript', 'jQuery']
-      for prop in _.reject(@thang[storage] ? [], (prop) -> itemsByProp[prop] or prop[0] is '_')  # no private properties
+      for prop in _.reject(@thang[storage] ? [], (prop) -> prop[0] is '_')  # no private properties
         continue if prop is 'say' and @options.level.get 'hidesSay'  # Hide for Dungeon Campaign
         continue if prop is 'moveXY' and @options.level.get('slug') is 'slalom'  # Hide for Slalom
         continue if @thang.excludedProperties and prop in @thang.excludedProperties
         propsByItem['Hero'] ?= []
         propsByItem['Hero'].push owner: owner, prop: prop, item: itemThangTypes[@thang.spriteName]
-        ++propCount
-
     Backbone.Mediator.publish 'tome:update-snippets', propGroups: propsByItem, allDocs: allDocs, language: @options.language
-
-    @shortenize = propCount > 6
-    @entries = []
-    for itemName, props of propsByItem
-      for prop, propIndex in props
-        item = prop.item
-        owner = prop.owner
-        prop = prop.prop
-        doc = _.find (allDocs['__' + prop] ? []), (doc) ->
-          return true if doc.owner is owner
-          return (owner is 'this' or owner is 'more') and (not doc.owner? or doc.owner is 'this' or doc.owner is 'ui')
-        if not doc and not excludedDocs['__' + prop]
-          console.log 'could not find doc for', prop, 'from', allDocs['__' + prop], 'for', owner, 'of', propsByItem, 'with item', item
-          doc ?= prop
-        if doc
-          if doc.type in ['spawnable', 'event', 'handler', 'property'] or (doc.type is 'snippet' and @level.get('type') is 'game-dev')
-            @deferredDocs[doc.name] = doc
-          else
-            @entries.push @addEntry(doc, @shortenize, owner is 'snippets', item, propIndex > 0)
-    if @options.level.isType('web-dev')
-      @entryGroups = _.groupBy @entries, (entry) -> entry.doc.type
-    else
-      @entryGroups = _.groupBy @entries, (entry) -> itemsByProp[entry.doc.name]?.get('name') ? 'Hero'
-    iOSEntryGroups = {}
-    for group, entries of @entryGroups
-      iOSEntryGroups[group] =
-        item: {name: group, imageURL: itemThangTypes[group]?.getPortraitURL()}
-        props: (entry.doc for entry in entries)
-    Backbone.Mediator.publish 'tome:palette-updated', thangID: @thang.id, entryGroups: JSON.stringify(iOSEntryGroups)
-
-  addEntry: (doc, shortenize, isSnippet=false, item=null, showImage=false) ->
-    writable = (if _.isString(doc) then doc else doc.name) in (@thang.apiUserProperties ? [])
-    new SpellPaletteEntryView doc: doc, thang: @thang, shortenize: shortenize, isSnippet: isSnippet, language: @options.language, writable: writable, level: @options.level, item: item, showImage: showImage, useHero: @useHero
-
+  
   onDisableControls: (e) -> @toggleControls e, false
   onEnableControls: (e) -> @toggleControls e, true
   toggleControls: (e, enabled) ->
@@ -353,30 +185,21 @@ module.exports = class SpellPaletteView extends CocoView
     @createPalette()
     @render()
 
-  onSectionHeaderClick: (e) ->
+  onSubSectionHeaderClick: (e) ->
     $et = @$(e.currentTarget)
     target = @$($et.attr('data-panel'))
     isCollapsed = !target.hasClass('in')
     if isCollapsed
       target.collapse 'show'
-      $et.find('.glyphicon').removeClass('glyphicon-chevron-right').addClass('glyphicon-chevron-down')
+      $et.find('.glyphicon').removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up')
     else
       target.collapse 'hide'
-      $et.find('.glyphicon').removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-right')
+      $et.find('.glyphicon').removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down')
 
     setTimeout () =>
       @$('.nano').nanoScroller alwaysVisible: true
     , 200
     e.preventDefault()
-
-  onClickHelp: (e) ->
-    application.tracker?.trackEvent 'Spell palette help clicked', levelID: @level.get('slug')
-    gameMenuModal = new GameMenuModal showTab: 'guide', level: @level, session: @session, supermodel: @supermodel
-    @openModalView gameMenuModal
-    @listenToOnce gameMenuModal, 'change-hero', ->
-      @setupManager?.destroy()
-      @setupManager = new LevelSetupManager({supermodel: @supermodel, level: @level, levelID: @level.get('slug'), parent: @, session: @session, courseID: @options.courseID, courseInstanceID: @options.courseInstanceID})
-      @setupManager.open()
 
   onClickClose: (e) ->
     @hide()

--- a/ozaria/site/views/play/level/tome/SpellPaletteView.coffee
+++ b/ozaria/site/views/play/level/tome/SpellPaletteView.coffee
@@ -85,7 +85,10 @@ module.exports = class SpellPaletteView extends CocoView
 
     methodsBankList = @options.level.get('methodsBankList') || []
     
-    @organizePaletteHero methodsBankList, allDocs, excludedDocs
+    if methodsBankList.length == 0
+      console.log("Methods Bank list is empty!!")
+    else
+      @organizePaletteHero methodsBankList, allDocs, excludedDocs
     @publishAutoCompleteEvent(allDocs)
 
   # Reads the methods bank list and find its documentation from allDocs(i.e. docs coming from level components)

--- a/ozaria/site/views/play/level/tome/SpellPaletteView.coffee
+++ b/ozaria/site/views/play/level/tome/SpellPaletteView.coffee
@@ -46,7 +46,10 @@ module.exports = class SpellPaletteView extends CocoView
       entrySubGroups = _.groupBy entries, (entry) -> entry.doc.subSection || 'none'
       for subGroup, entries of entrySubGroups
         if subGroup != 'none'
-          header = $("<a class='sub-section-header btn btn-small btn-illustrated' data-panel='#sub-section-#{subGroup}-#{group}'><span>#{subGroup}</span><div style='float: right' class='glyphicon glyphicon-chevron-down'></div></a>").appendTo itemGroup
+          header = $("<a class='sub-section-header btn btn-small btn-illustrated' data-panel='#sub-section-#{subGroup}-#{group}'>
+              <span>#{subGroup}</span>
+              <div style='float: right' class='glyphicon glyphicon-chevron-down'></div>
+            </a>").appendTo itemGroup
           itemSubGroup = $("<div class='property-entry-item-sub-group collapse' id='sub-section-#{subGroup}-#{group}'></div>").appendTo itemGroup
         for entry, entryIndex in entries
           if subGroup != 'none'


### PR DESCRIPTION
- Added methodsBankList to level schema which can be added from settings tab in level editor. We need to add this property to store the list for methods bank along with their section and sub-section name.
- Added shortDescription to level component property documentation schema, in order to save and show a short description for each documentation.
- Removed a bunch of code from SpellPaletteView.coffee and simplified the logic to read methodsBankList from level's settings and group them based on sections and sub-sections.

This is the first iteration of the new methods bank and it involves only the functional changes.
The pages changed in this PR are forked versions of the legacy pages and these are gated behind admin flags, so its safe to ship and test in prod with test ozaria levels. I have tested this with a test level that Bryukh created on 'direct' (o-method-bank-playground). Once this is shipped to prod, Bryukh will create more examples and we will be able to test it further with the design team to make sure this works as expected.