### PR TITLE
Completed event from cutscene

### DIFF
--- a/ozaria/site/components/cutscene/PageCutscene/index.vue
+++ b/ozaria/site/components/cutscene/PageCutscene/index.vue
@@ -2,7 +2,7 @@
 import LayoutChrome from '../../common/LayoutChrome'
 import LayoutCenterContent from '../../common/LayoutCenterContent'
 import BaseVideo from '../common/BaseVideo'
-import { getCutscene } from '../../../api/cutscene';
+import { getCutscene } from '../../../api/cutscene'
 
 const CUTSCENE_ASPECT_RATIO = 16 / 9
 
@@ -33,7 +33,7 @@ module.exports = Vue.extend({
     window.removeEventListener("resize", this.onResize)
   },
   methods: {
-    onResize: function() {
+    onResize () {
       const userWidth = window.innerWidth
         || document.documentElement.clientWidth
         || document.body.clientWidth
@@ -45,12 +45,15 @@ module.exports = Vue.extend({
       this.height = Math.min(userWidth / CUTSCENE_ASPECT_RATIO, userHeight)
       this.width = this.height * CUTSCENE_ASPECT_RATIO
     },
-    async loadCutscene() {
+    async loadCutscene () {
       const cutscene = await getCutscene(this.cutsceneId)
       this.vimeoId = cutscene.vimeoId
 
       window.addEventListener('resize', this.onResize)
       this.onResize()
+    },
+    onCompleted () {
+      this.$emit('completed')
     }
   }
 })
@@ -66,6 +69,8 @@ module.exports = Vue.extend({
           :vimeoId="vimeoId"
           :width="width"
           :height="height"
+
+          v-on:completed="onCompleted"
         />
       </div>
     </layout-center-content>

--- a/ozaria/site/components/cutscene/common/BaseVideo.vue
+++ b/ozaria/site/components/cutscene/common/BaseVideo.vue
@@ -37,6 +37,8 @@ export default {
       player.ready().then(() => {
         player.play()
       })
+      // TODO: Instead of emitting completed, requires end screen UI.
+      //        Currently a stop gap to provide Intro support.
       player.on('ended', () => this.$emit('completed'))
     } else if (this.videoSrc) {
       new Plyr(this.$refs['player'], { captions: {active: true } })

--- a/ozaria/site/components/cutscene/common/BaseVideo.vue
+++ b/ozaria/site/components/cutscene/common/BaseVideo.vue
@@ -6,7 +6,7 @@ import 'plyr/dist/plyr.css'
 export default {
   props: {
     vimeoId: {
-      type: Number,
+      type: String,
       required: false
     },
     width: {
@@ -23,7 +23,7 @@ export default {
     },
     captions: {
       type: Array,
-      default: [],
+      default: ()=>([]),
       required: false
     }
   },
@@ -33,7 +33,11 @@ export default {
     }
 
     if (this.vimeoId) {
-      new VimeoPlayer('vimeo-player')
+      const player = new VimeoPlayer('vimeo-player')
+      player.ready().then(() => {
+        player.play()
+      })
+      player.on('ended', () => this.$emit('completed'))
     } else if (this.videoSrc) {
       new Plyr(this.$refs['player'], { captions: {active: true } })
     }


### PR DESCRIPTION
Adds two small features to cutscenes:
 - Will try to auto play the cutscene. (This functionality is blocked by the browser until user interacts with the page).
 - Will emit completed event when video concludes. There should be a UI that appears instead, but this is a stop gap to include Cutscenes into the flow earlier.