### PR TITLE
Tiny defaults update for Cinematics

### DIFF
--- a/app/schemas/models/selectors/cinematic.js
+++ b/app/schemas/models/selectors/cinematic.js
@@ -111,8 +111,8 @@ const setCharacterDefaults = ({ pos, scaleX, scaleY }) =>
  */
 const setLeftCharacterDefaults = setCharacterDefaults({
   pos: { x: -30, y: -72 },
-  scaleX: 0.82,
-  scaleY: 0.82
+  scaleX: 1.2,
+  scaleY: 1.2
 })
 
 /**
@@ -122,8 +122,8 @@ const setLeftCharacterDefaults = setCharacterDefaults({
  */
 const setRightCharacterDefaults = setCharacterDefaults({
   pos: { x: 30, y: -72 },
-  scaleX: 0.82,
-  scaleY: 0.82
+  scaleX: 1.2,
+  scaleY: 1.2
 })
 
 /**

--- a/test/app/models/Cinematic.spec.js
+++ b/test/app/models/Cinematic.spec.js
@@ -50,7 +50,7 @@ describe('Cinematic', () => {
       expect(result).toBeUndefined()
 
       const result2 = getLeftCharacterThangTypeSlug(shotFixture2)
-      expect(result2).toEqual({ slug: 'fake-slug-thangtype', enterOnStart: false, thang: { scaleX: 0.82, scaleY: 0.82, pos: { x: -30, y: -72 } } })
+      expect(result2).toEqual({ slug: 'fake-slug-thangtype', enterOnStart: false, thang: { scaleX: 1.2, scaleY: 1.2, pos: { x: -30, y: -72 } } })
     })
 
     it('getRightCharacterThangTypeSlug', () => {
@@ -58,7 +58,7 @@ describe('Cinematic', () => {
       expect(result).toBeUndefined()
 
       const result2 = getRightCharacterThangTypeSlug(shotFixture1)
-      expect(result2).toEqual({ slug: 'fake-slug-thangtype', enterOnStart: false, thang: { scaleX: 0.82, scaleY: 0.82, pos: { x: 30, y: -72 } } })
+      expect(result2).toEqual({ slug: 'fake-slug-thangtype', enterOnStart: false, thang: { scaleX: 1.2, scaleY: 1.2, pos: { x: 30, y: -72 } } })
     })
 
     it('getLeftHero', () => {


### PR DESCRIPTION
We've imported new and much more performant Adobe Animate Cinematic heroes.

Because they are also smaller, this tweaks their default scale so they remain a similar size.
Manually tested and internal only.