### PR TITLE
Add ozaria property and rename customization property

### DIFF
--- a/app/lib/world/thang.coffee
+++ b/app/lib/world/thang.coffee
@@ -177,7 +177,7 @@ module.exports = class Thang
     if @id is 'Hero Placeholder' and not @world.getThangByID 'Hero Placeholder 1'
 
       # Single player color customization options
-      player_tints = me.get('customization')?.tints or []
+      player_tints = me.get('ozariaHeroConfig')?.tints or []
       player_tints.forEach((tint) =>
         for key,value of (tint.colorGroups or {})
           options.colorConfig[key] = _.clone(value)

--- a/app/schemas/models/thang_type.coffee
+++ b/app/schemas/models/thang_type.coffee
@@ -214,6 +214,7 @@ _.extend ThangTypeSchema.properties,
   restricted: {type: 'string', title: 'Restricted', description: 'If set, this ThangType will only be accessible by admins and whoever it is restricted to.'}
   releasePhase: { enum: ['beta', 'released'], description: "How far along the ThangType's development is, determining who sees it." }
   gender: { enum: ['female', 'male'], type: 'string', title: 'Hero Gender', description: 'Affects which paper doll image set and language pronouns to use.' }
+  ozaria: { type: 'boolean', description: 'Marks this thang as an Ozaria only type. Used to prevent Ozaria hero\'s from appearing in CodeCombat hero selector.'}
 
 ThangTypeSchema.required = []
 

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -148,11 +148,12 @@ _.extend UserSchema.properties,
   wizard: c.object {},
     colorConfig: c.object {additionalProperties: c.colorConfig()}
 
-  customization: c.object(
+  ozariaHeroConfig: c.object(
     {
-      title: 'Player Customization',
-      descipription: 'Individual player customization options'
+      title: 'Player Ozaria Customization',
+      descipription: 'Player customization options, including hero name, objectId and applied color tints.'
     }, {
+      thangType: c.objectId(links: [{rel: 'db', href: '/db/thang.type/{($)}/version'}], title: 'Thang Type', description: 'The ThangType of the hero.', format: 'thang-type'),
       tints: c.array(
         {
           title: 'Tints',

--- a/app/views/core/HeroSelectView.coffee
+++ b/app/views/core/HeroSelectView.coffee
@@ -28,7 +28,8 @@ module.exports = class HeroSelectView extends CocoView
     # @heroes = new ThangTypes({}, { project: ['original', 'name', 'heroClass, 'slug''] })
     # @supermodel.trackRequest @heroes.fetchHeroes()
 
-    api.thangTypes.getHeroes({ project: ['original', 'name', 'shortName', 'heroClass', 'slug'] }).then (@heroes) =>
+    api.thangTypes.getHeroes({ project: ['original', 'name', 'shortName', 'heroClass', 'slug', 'ozaria'] }).then (heroes) =>
+      @heroes = heroes.filter((h) => !h.ozaria)
       @debouncedRender()
 
     @listenTo @state, 'all', -> @debouncedRender()

--- a/app/views/play/modal/PlayHeroesModal.coffee
+++ b/app/views/play/modal/PlayHeroesModal.coffee
@@ -45,7 +45,7 @@ module.exports = class PlayHeroesModal extends ModalView
     @confirmButtonI18N = options.confirmButtonI18N ? "common.save"
     @heroes = new CocoCollection([], {model: ThangType})
     @heroes.url = '/db/thang.type?view=heroes'
-    @heroes.setProjection ['original','name','slug','soundTriggers','featureImages','gems','heroClass','description','components','extendedName','shortName','unlockLevelName','i18n','poseImage','tier','releasePhase']
+    @heroes.setProjection ['original','name','slug','soundTriggers','featureImages','gems','heroClass','description','components','extendedName','shortName','unlockLevelName','i18n','poseImage','tier','releasePhase','ozaria']
     @heroes.comparator = 'gems'
     @listenToOnce @heroes, 'sync', @onHeroesLoaded
     @supermodel.loadCollection(@heroes, 'heroes')
@@ -57,6 +57,7 @@ module.exports = class PlayHeroesModal extends ModalView
     @trackTimeVisible()
 
   onHeroesLoaded: ->
+    @heroes.reset(@heroes.filter((hero) => not hero.get('ozaria')))
     @formatHero hero for hero in @heroes.models
     if me.freeOnly() or application.getHocCampaign()
       @heroes.reset(@heroes.filter((hero) => !hero.locked))
@@ -94,6 +95,7 @@ module.exports = class PlayHeroesModal extends ModalView
       return null
 
   getRenderData: (context={}) ->
+    console.log('calling render', @heroes.models)
     context = super(context)
     context.heroes = @heroes.models
     context.level = @options.level

--- a/app/views/play/modal/PlayHeroesModal.coffee
+++ b/app/views/play/modal/PlayHeroesModal.coffee
@@ -95,7 +95,6 @@ module.exports = class PlayHeroesModal extends ModalView
       return null
 
   getRenderData: (context={}) ->
-    console.log('calling render', @heroes.models)
     context = super(context)
     context.heroes = @heroes.models
     context.level = @options.level


### PR DESCRIPTION
This is a tiny PR but touches some important legacy code paths. Must be merged with https://github.com/codecombat/codecombat-server/pull/105

## Issue

We want to start using new Ozaria heroes in levels. However we have behavior that adds these heroes to our legacy hero selectors.

## Feature

This change adds a flag `ozaria` that can be used to mark a thangType as ozaria specific. The two hero selectors then filter against this flag to hide any ozaria heroes.

There is also a small refactor that renames `customization` to `ozariaHeroConfig`. This renaming is happening to better capture that `ozariaHeroConfig` will contain the ozaria hero id, player's ozaria name, and any future properties related to their ozaria hero. Not just color tints.

## How to test

I recommend manually testing using your local developer environment or database.

The most important test to do is to check that without any changes you can still see all heroes in these three places:
 - Hero selector in /play/dungeon. Check by playing as anonymous and trying to play until you are provided the option to choose your hero. 

 - Hero selector for teachers. Navigate to http://localhost:3000/teachers/courses and try to play **Dungeon of Kithgard**. You should get a hero selector.

 - Hero selector for students. Spy on a student and then navigate to http://localhost:3000/students. Try to change hero. You should get the same hero selector that the teacher got.

**In your local environment**, add the `ozaria: true` property to one of the heroes and save. This hero should disappear from the hero selector.