### PR TITLE
Intro level integration with cutscenes + intro level schema change

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -176,7 +176,6 @@ module.exports = class CocoRouter extends Backbone.Router
     'logout': 'logout'
 
     'minigames/conditionals': go('minigames/ConditionalMinigameView')
-    'ozaria/play/intro/:introLevelOriginalId': go('core/SingletonAppVueComponentView')
     'ozaria/play/level/:levelID': go('views/ozaria/site/play/level/PlayLevelView')
     # TODO move to vue router after support for empty template is added there
     'ozaria/play/:campaign(?course-instance=:courseInstanceId)': (campaign, courseInstanceId) ->
@@ -185,6 +184,11 @@ module.exports = class CocoRouter extends Backbone.Router
         courseInstanceId: courseInstanceId
       }
       @routeDirectly('ozaria/site/play/PageUnitMap', [], {vueRoute: true, baseTemplate: 'base-empty', propsData: props})
+    'ozaria/play/intro/:introLevelIdOrSlug': (introLevelIdOrSlug) ->
+      props = {
+        introLevelIdOrSlug: introLevelIdOrSlug
+      }
+      @routeDirectly('introLevel', [], {vueRoute: true, baseTemplate: 'base-empty', propsData: props})
     'parents': go('ParentsView')
 
     'paypal/subscribe-callback': go('play/CampaignView')

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -11,7 +11,6 @@ import PageCinematicEditor from '../../ozaria/site/components/cinematic/PageCine
 import PageCutsceneEditorList from '../../ozaria/site/components/cutscene/PageCutsceneEditorList'
 import PageCutsceneEditor from '../../ozaria/site/components/cutscene/PageCutsceneEditor'
 import PageInteractiveEditor from '../../ozaria/site/components/interactive/PageInteractiveEditor'
-import PageIntroLevel from '../../ozaria/site/components/play/PageIntroLevel'
 
 import CinematicPlaceholder from '../../ozaria/site/components/cinematic/CinematicPlaceholder'
 
@@ -44,19 +43,6 @@ export default function getVueRouter () {
           path: '/editor/interactive/:slug?',
           component: PageInteractiveEditor,
           props: true
-        },
-        {
-          path: '/ozaria/play/intro/:introLevelIdOrSlug?',
-          component: PageIntroLevel,
-          props: (route) => {
-            return {
-              introLevelIdOrSlug: route.params.introLevelIdOrSlug,
-              courseInstanceId: route.query['course-instance'],
-              codeLanguage: route.query.codeLanguage,
-              courseId: route.query.course,
-              campaignId: route.query.campaignId
-            }
-          }
         },
         {
           path: '/school-administrator',

--- a/app/lib/dynamicRequire.js
+++ b/app/lib/dynamicRequire.js
@@ -137,6 +137,7 @@ module.exports = {
   'views/cinematic': function() { return import(/* webpackChunkName: "ozariaPlay" */ 'ozaria/site/components/cinematic/PageCinematic') },
   'views/cutscene': function() { return import(/* webpackChunkName: "ozariaPlay" */ 'ozaria/site/components/cutscene/PageCutscene') },
   'views/interactive': function() { return import(/* webpackChunkName: "ozariaPlay" */ 'ozaria/site/components/interactive/PageInteractive') },
+  'views/introLevel': function() { return import(/* webpackChunkName: "ozariaPlay" */ 'ozaria/site/components/play/PageIntroLevel') },
 
   // Temporary
   'views/courses/StudentRankingView': function() { return import(/* webpackChunkName: "StudentRankingView" */ 'views/courses/StudentRankingView')}

--- a/app/schemas/models/level.coffee
+++ b/app/schemas/models/level.coffee
@@ -211,7 +211,17 @@ IntroContentObject = {
   additionalProperties: false,
   properties: {
     type: { title: 'Content type', enum: ['cinematic', 'interactive', 'cutscene-video', 'avatarSelectionScreen'] }
-    contentId: c.stringID(title: 'Content ID')
+    contentId: {
+      oneOf: [
+        c.stringID(title: 'Content ID for all languages')
+        {
+          type: 'object',
+          title: 'Content ID specific to languages',
+          additionalProperties: c.stringID(),
+          format: 'code-languages-object'
+        }
+      ]
+    }
   }
 }
 
@@ -377,16 +387,10 @@ _.extend LevelSchema.properties,
   password: { type: 'string', description: 'The password required to create a session for this level' }
   mirrorMatch: { type: 'boolean', description: 'Whether a multiplayer ladder arena is a mirror match' }
   introContent: { # valid for levels of type 'intro'
-    oneOf: [
-      {
-        title: 'Intro content object',
-        description: 'Intro content sequence for individual languages'
-        type: 'object',
-        format: 'code-languages-object',
-        additionalProperties: { type: 'array', items: IntroContentObject }
-      }
-      { title: 'Intro content array', description: 'Intro content sequence for all languages', type: 'array', items: IntroContentObject }
-    ]
+    title: 'Intro content',
+    description: 'Intro content sequence',
+    type: 'array',
+    items: IntroContentObject
   }
   additionalGoals: c.array { title: 'Additional Goals', description: 'Goals that are added after the first regular goals are completed' }, c.object {
     title: 'Goals',

--- a/ozaria/site/components/play/PageIntroLevel/index.vue
+++ b/ozaria/site/components/play/PageIntroLevel/index.vue
@@ -5,6 +5,7 @@
   import cutsceneVideoComponent from '../../cutscene/PageCutscene'
   import { defaultCodeLanguage, getNextLevelLink, getNextLevelForLevel } from 'ozaria/site/common/ozariaUtils'
   import { mapActions, mapGetters } from 'vuex'
+  import utils from 'core/utils'
 
   export default Vue.extend({
     components: {
@@ -75,6 +76,13 @@
       {
         loadIntroLevel: async function () {
           this.dataLoaded = false
+
+          // Reading query params because this is rendered via backbone router and cannot be directly passed in as props
+          // They need to be in a specific order in the url to read and send them as props directy from backbone router, hence using query params here.
+          this.courseInstanceId = this.courseInstanceId || utils.getQueryVariable('course-instance')
+          this.codeLanguage = this.codeLanguage || utils.getQueryVariable('code-language')
+          this.courseId = this.courseId || utils.getQueryVariable('course')
+          this.campaignId = this.campaignId || utils.getQueryVariable('campaign')
           try {
             this.introLevelData = await api.levels.getByIdOrSlug(this.introLevelIdOrSlug)
             if (me.isSessionless()) { // not saving progress/session for teachers

--- a/ozaria/site/components/play/PageIntroLevel/index.vue
+++ b/ozaria/site/components/play/PageIntroLevel/index.vue
@@ -140,10 +140,12 @@
             this.currentContent = this.introContent[this.currentIndex]
           } else { // whole intro content completed
             await this.setIntroLevelComplete()
-            await this.fetchNextLevel()
-            const link = this.fetchNextLevelLink()
-            if (link && !application.testing) {
-              return application.router.navigate(link, { trigger: true })
+            if ((this.campaignData || {}).levels) {
+              await this.fetchNextLevel()
+              const link = this.fetchNextLevelLink()
+              if (link && !application.testing) {
+                return application.router.navigate(link, { trigger: true })
+              }
             }
           }
         },

--- a/ozaria/site/components/play/PageIntroLevel/index.vue
+++ b/ozaria/site/components/play/PageIntroLevel/index.vue
@@ -2,15 +2,16 @@
   import api from 'core/api'
   import interactivesComponent from '../../interactive/PageInteractive'
   import cinematicsComponent from '../../cinematic/PageCinematic'
+  import cutsceneVideoComponent from '../../cutscene/PageCutscene'
   import { defaultCodeLanguage, getNextLevelLink, getNextLevelForLevel } from 'ozaria/site/common/ozariaUtils'
   import { mapActions, mapGetters } from 'vuex'
 
   export default Vue.extend({
     components: {
       'interactives-component': interactivesComponent,
-      'cinematics-component': cinematicsComponent
+      'cinematics-component': cinematicsComponent,
+      'cutscene-video-component': cutsceneVideoComponent
       // TODO add when ready
-      // 'cutscene-video-component': cutsceneVideoComponent,
       // 'avatar-selection-screen': avatarSelectionScreen
     },
     props: {
@@ -196,15 +197,16 @@
     <cinematics-component
       v-else-if="currentContent.type == 'cinematic'"
       :cinematic-id-or-slug="currentContent.contentId"
-      :userOptions="{ programmingLanguage: language }"
+      :user-options="{ programmingLanguage: language }"
+      @completed="onContentCompleted"
+    />
+    <cutscene-video-component
+      v-else-if="currentContent.type == 'cutscene-video'"
+      :cutscene-id="currentContent.contentId"
       @completed="onContentCompleted"
     />
     <!-- TODO add when ready -->
-    <!-- <cutscene-video-component
-      v-else-if="currentContent.type == 'cutscene-video'"
-      v-on:completed="onContentCompleted">
-    </cutscene-video-component>
-    <avatar-selection-screen
+    <!-- <avatar-selection-screen
       v-else-if="currentContent.type == 'avatarSelectionScreen'"
       v-on:completed="onContentCompleted">
     </avatar-selection-screen> -->

--- a/ozaria/site/components/play/PageIntroLevel/index.vue
+++ b/ozaria/site/components/play/PageIntroLevel/index.vue
@@ -99,7 +99,7 @@
             await this.loadCampaignData()
           } catch (err) {
             console.error('Error in creating data for intro level', err)
-            // TODO: update after a consistent error handling strategy is decided
+            // TODO handle_error_ozaria
             noty({ text: 'Error in creating data for intro level', type: 'error', timeout: 2000 })
             return
           }

--- a/ozaria/site/components/play/PageUnitMap/common/UnitMapLevelDot.vue
+++ b/ozaria/site/components/play/PageUnitMap/common/UnitMapLevelDot.vue
@@ -35,14 +35,7 @@
           return false
         }
         const introContent = this.levelData.introContent
-        if (_.isArray(introContent)) {
-          return introContent.length === 1 && introContent[0].type === 'cutscene-video'
-        } else if (_.isObject(introContent)) {
-          const language = this.codeLanguage || 'python'
-          const content = introContent[language] || []
-          return content.length === 1 && content[0].type === 'cutscene-video'
-        }
-        return false
+        return introContent.length === 1 && introContent[0].type === 'cutscene-video'
       },
       levelDotPosition: function () {
         let position = {

--- a/test/ozaria/site/components/play/PageIntroLevel.spec.js
+++ b/test/ozaria/site/components/play/PageIntroLevel.spec.js
@@ -18,7 +18,9 @@ const introLevel = {
     },
     {
       type: 'interactive',
-      contentId: 'interactive-slug-1'
+      contentId: {
+        python: 'interactive-slug-1'
+      }
     }
   ]
 }
@@ -26,7 +28,8 @@ const introLevel = {
 const introLevelSession = {
   state: {
     complete: false
-  }
+  },
+  codeLanguage: 'python'
 }
 
 const campaign = factories.makeCampaignObject({ type: 'course' }, { levels: [introLevel] })
@@ -67,5 +70,6 @@ describe('Intro level Page', () => {
   it('sets complete:true in the intro level session when all content completed', () => {
     pageIntroLevelWrapper.find(cinematicComponent).vm.$emit('completed')
     pageIntroLevelWrapper.find(interactiveComponent).vm.$emit('completed')
+    expect(api.levelSessions.update).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
- Moved intro level route from vue router to backbone router since we dont have support for empty templates in vue router.
- Added cutscene vue component to the intro level page.
- Changed the schema for introContent - instead of being an array or an object, it will always be an array. The content id can now either be a string id or an object with string ids for each language if its different. This is useful because some content ids can be the same in all languages while a few can be different. In this case, we do not need to repeat the content ids which are the same in all languages.