### PR TITLE
 Change UI for methods bank

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -722,6 +722,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     watch_a_video: "Watch a video on __concept_name__"
     concept_unlocked: "Concept Unlocked"
     use_at_least_one_concept: "Use at least one concept: "
+    command_bank: "Command Bank"
 
   apis:
     methods: "Methods"
@@ -1017,6 +1018,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     optional_parameters: "Optional Parameters"
     returns: "Returns"
     granted_by: "Granted by"
+    still_undocumented: "Still undocumented, sorry."
 
   save_load:
     granularity_saved_games: "Saved"

--- a/ozaria/site/styles/play/level/control-bar-view.sass
+++ b/ozaria/site/styles/play/level/control-bar-view.sass
@@ -1,0 +1,181 @@
+@import "app/styles/mixins"
+@import "app/styles/bootstrap/variables"
+@import "ozaria/site/styles/play/variables"
+
+#control-bar-view
+  $control-yellow: rgb(227, 173, 53)
+  $control-yellow-highlight: rgb(243, 211, 59)
+
+  width: $game-view-width
+  height: 50px
+  @include box-sizing(border-box)
+  overflow: visible
+  position: absolute
+  z-index: 8
+  text-transform: uppercase
+  font-family: $headings-font-family
+  font-weight: bold
+
+  &.controls-disabled
+    @include filter(brightness(50%))
+
+  .levels-link-area
+    position: absolute
+    left: 40px
+    width: 160px
+    text-align: center
+    cursor: pointer
+
+    a.levels-link
+      margin: 0
+      height: 50px
+      line-height: 50px
+      color: white
+      font-size: 16px
+
+      .glyphicon
+        margin-left: -20px
+        margin-right: 10px
+        @include scaleXY(-1.25, 1.25)
+        color: $control-yellow
+        text-shadow: 1px 1px 0px rgb(143, 123, 62)
+
+    &:hover
+      a.levels-link
+        text-decoration: underline
+        .glyphicon
+          color: $control-yellow-highlight
+
+  .left-cap, .right-cap, .center-chain, .right-chain, .wood-background
+    position: absolute
+    top: 0
+    pointer-events: none
+
+  .left-cap
+    background: transparent url(/images/level/control_bar_cap_left.png)
+    background-size: cover
+    width: 217px
+    height: 63px
+    left: 0
+
+  .right-cap
+    background: transparent url(/images/level/control_bar_cap_right.png)
+    background-size: cover
+    right: 0
+    width: 78px
+    height: 60px
+
+  .center-chain
+    background: transparent url(/images/level/control_bar_chain_center.png)
+    background-size: cover
+    left: 30%
+    width: 111px
+    height: 24px
+    z-index: 1
+
+  .right-chain
+    background: transparent url(/images/level/control_bar_chain_right.png)
+    background-size: cover
+    top: 30px
+    right: 0
+    width: 97px
+    height: 51px
+    z-index: -1
+
+  .wood-background
+    background: transparent url(/images/level/control_bar_background.png)
+    background-size: contain
+    width: 100%
+    height: 55px
+    z-index: -1
+
+  .level-name-area-container
+    position: relative
+    width: 100%
+    pointer-events: none
+    z-index: 1
+
+    .level-name-area
+      min-width: 200px
+      max-width: 320px
+      margin: 0 auto
+      padding: 8px
+      border-style: solid
+      border-image: url(/images/level/control_bar_level_name_background.png) 20 fill round
+      border-width: 0 10px 10px 10px
+      text-align: center
+      position: absolute
+      left: 50%
+      @include translate(-50%, 0)
+
+      .level-label
+        font-size: 12px
+        color: $control-yellow-highlight
+        margin-bottom: -5px
+
+      .level-name
+        color: white
+        font-size: 18px
+
+      .level-difficulty
+        font-size: 28px
+        color: $control-yellow-highlight
+        display: inline-block
+        @include rotate(-15deg)
+        vertical-align: middle
+
+  .buttons-area
+    position: absolute
+    right: 35px
+    top: 8px
+
+    button
+      float: right
+      margin-left: 10px
+      position: relative
+
+    #game-menu-button
+      background: transparent
+      border: 0
+      outline: 0
+      @include box-shadow(none)
+      text-transform: uppercase
+      font-size: 18px
+
+      .hamburger
+        display: inline-block
+
+        span.icon-bar
+          display: block
+          border-radius: 4px
+          width: 18px
+          height: 4px
+          margin: 4px
+          background: $control-yellow
+
+      .game-menu-text
+        display: inline-block
+        vertical-align: middle
+        margin-top: -18px
+
+      &:hover
+        @include scale(1.05)
+
+        .hamburger span.icon-bar
+          background-color: $control-yellow-highlight
+
+    #level-done-button, #next-game-button, #control-bar-sign-up-button, #version-switch-button
+      top: 7px
+      font-size: 13px
+      height: 24px
+
+    #level-done-button
+      display: none
+
+
+html.no-borderimage
+  #control-bar-view .level-name-area
+    border: 0
+    background: transparent url(/images/level/control_bar_level_name_background.png)
+    background-size: contain
+    background-repeat: no-repeat

--- a/ozaria/site/styles/play/level/game_dev_track_view.sass
+++ b/ozaria/site/styles/play/level/game_dev_track_view.sass
@@ -1,0 +1,32 @@
+@import "app/styles/mixins"
+@import "app/styles/bootstrap/variables"
+@import "ozaria/site/styles/play/variables"
+
+#game-dev-track-view
+  position: absolute
+  display: none
+  transition: right 0.25s, opacity 0.125s, z-index 1s
+  &:not(playback-float-right)
+    right: calc(43% + 10px + #{$api-bar-width})
+    z-index: 6
+  &.playback-float-right
+    right: calc(20% + 10px)
+    z-index: 10
+  top: 60px
+
+  border: 16px solid black
+  border-image: url(/images/pages/play/level-info-background.png) fill 20 stretch
+
+  #listings
+    .track-elem
+      display: flex
+      cursor: default
+      .track-icon, .track-text
+        display: flex
+        flex-direction: column
+        justify-content: center
+        align-items: center
+        overflow: hidden
+        text-align: center
+      .track-text
+        width: 48px

--- a/ozaria/site/styles/play/level/gold.sass
+++ b/ozaria/site/styles/play/level/gold.sass
@@ -1,0 +1,51 @@
+@import "app/styles/mixins"
+@import "app/styles/bootstrap/variables"
+@import "ozaria/site/styles/play/variables"
+
+#gold-view
+  display: none
+  position: absolute
+  right: calc(45% + 10px + #{$api-bar-width})
+  #level-view.no-api &
+    right: calc(50% + 20px)
+    z-index: 10
+  top: 62px
+  z-index: 6
+  @include transition(box-shadow .2s linear)
+  @include user-select(none)
+  padding: 0.4vw
+  background: transparent url(/images/level/gold_background.png) no-repeat
+  background-size: 100% 100%
+  border-radius: 4px
+
+  &:hover
+    box-shadow: 2px 2px 2px black
+
+  .team-gold
+    font-size: 1.4vw
+    line-height: 1.4vw
+    margin: 0
+    color: hsla(205,0%,51%,1)
+    display: inline-block
+    padding: 0px 4px
+
+    &.team-humans
+      color: hsla(4,80%,51%,1)
+
+    &.team-ogres
+      color: hsla(205,100%,51%,1)
+
+    &.team-allies, &.team-minions
+      color: hsla(116,80%,51%,1)
+
+    img
+      width: 1.2vw
+      height: 1.2vw
+      border-radius: 2px
+      padding: 0.1vw
+      margin-top: -0.2vw
+      margin-right: 0.1vw
+  
+    .gold-amount
+      display: inline-block
+      min-width: 20px

--- a/ozaria/site/styles/play/level/hud.sass
+++ b/ozaria/site/styles/play/level/hud.sass
@@ -1,0 +1,221 @@
+@import "app/styles/mixins"
+@import "app/styles/bootstrap/variables"
+@import "ozaria/site/styles/play/variables"
+
+#thang-hud
+  width: calc(#{$game-view-width} - #{$api-bar-width})
+  #level-view.no-api &
+    width: $game-view-width
+  height: 80px
+  position: relative
+  overflow: visible
+
+  &.controls-disabled
+    pointer-events: none
+
+    .wood-background, .hinge, .avatar-wrapper-container, .center
+      @include filter(brightness(50%))
+
+  .wood-background
+    position: absolute
+    left: 0
+    top: -2px
+    background: transparent url(/images/level/hud_wood_background.png)
+    background-size: auto 100%
+    width: 100%
+    height: 100px
+    z-index: 4
+
+  .hinge
+    position: absolute
+    top: -16px
+    background: transparent url(/images/level/hud_hinge.png)
+    width: 27px
+    height: 44px
+    background-size: contain
+    z-index: 4
+    pointer-events: none
+
+  .hinge-0
+    left: 3%
+  .hinge-1
+    left: 12%
+  .hinge-2
+    left: 86%
+    @include scaleX(-1)
+  .hinge-3
+    left: 95%
+    @include scaleX(-1)
+
+  .avatar-wrapper-container
+    position: absolute
+    width: 100px
+    height: 100px
+    top: 0
+    left: 18%
+    left: -webkit-calc(50% - (560px - 100px) / 2 - 10px)
+    left: calc(50% - (560px - 100px) / 2 - 10px)
+    z-index: 5
+
+    .thang-canvas-wrapper
+      width: 80px
+      height: 80px
+      position: relative
+      border-radius: 4px
+      @include gradient-radial-custom-stops(hsla(205,0%,74%,1), 20%, hsla(205,0%,31%,1), 70%)
+  
+      &.team-humans
+        border-color: darkred
+        @include gradient-radial-custom-stops(hsla(4,80%,74%,1), 20%, hsla(4,80%,51%,1), 70%)
+  
+      &.team-ogres
+        border-color: darkblue
+        @include gradient-radial-custom-stops(hsla(205,100%,74%,1), 20%, hsla(205,100%,31%,1), 70%)
+  
+      &.team-allies, &.team-minions
+        border-color: darkgreen
+        @include gradient-radial-custom-stops(hsla(116,80%,74%,1), 20%, hsla(116,80%,31%,1), 70%)
+  
+      .thang-canvas
+        width: 100%
+  
+      .avatar-frame
+        position: absolute
+        left: -18%
+        top: -19%
+        width: 145%
+
+  &.hide-hud-properties .center:hover
+    // Don't allow them to hover over confusing HUD stuff until later levels
+    top: 24px
+
+  .center
+    width: 560px
+    height: 166px
+    position: absolute
+    top: 24px
+    left: 13%
+    left: -webkit-calc(50% - 560px / 2)
+    left: calc(50% - 560px / 2)
+    padding: 10px 20px 0 145px
+    background-image: url(/images/level/hud_background.png)
+    color: white
+    text-transform: uppercase
+    font-family: $headings-font-family
+    font-weight: bold
+    font-size: 16px
+    z-index: 4
+    @include transition(0.5s ease)
+
+    &:hover
+      top: -36px
+
+    .thang-name
+      font-size: 18px
+      margin: 10px 0 0 0
+
+    .thang-props
+      margin: 24px 0 0 0
+      float: left
+      @include user-select(text)
+
+      .prop:not([name="health"])
+        min-width: 120px
+        display: inline-block
+        line-height: 16px
+
+      &.nonexistent
+        visibility: hidden
+
+      .text-prop
+        width: 50%
+
+      .prop-label-icon
+        $iconSize: 16px
+        display: inline-block
+        width: $iconSize
+        height: $iconSize
+        margin-right: 5px
+        background: transparent url(/images/level/hud_info_icons.png) no-repeat
+        background-size: auto $iconSize
+        float: left
+
+        &.prop-label-icon-pos
+          background-position: (-1 * $iconSize) 0px
+        &.prop-label-icon-target
+          background-position: (-2 * $iconSize) 0px
+        &.prop-label-icon-collectedThangIDs
+          background-position: (-3 * $iconSize) 0px
+        &.prop-label-icon-visualRange
+          background-position: (-4 * $iconSize) 0px
+        &.prop-label-icon-attackDamage
+          background-position: (-5 * $iconSize) 0px
+        &.prop-label-icon-attackRange, &.prop-label-icon-attackNearbyEnemyRange
+          background-position: (-6 * $iconSize) 0px
+        &.prop-label-icon-maxSpeed
+          background-position: (-7 * $iconSize) 0px
+        &.prop-label-icon-gold, &.prop-label-icon-bountyGold, &.prop-label-icon-value
+          background-position: (-8 * $iconSize) 0px
+
+      .prop[name="health"]
+        position: absolute
+        right: 35px
+        top: 23px
+        height: 18px
+        line-height: 18px
+        font-size: 18px
+
+        .prop-value.bar-prop
+          width: 150px
+          margin: 1px 10px 0 0
+          height: 16px
+          background: rgb(32, 27, 21)
+          padding: 4px
+          border-radius: 8px
+          border: 0
+
+          .bar
+            background: rgb(234, 35, 45)
+            height: 8px
+            border-radius: 4px
+
+        .bar-prop-value
+          vertical-align: top
+
+      .prop-value.bar-prop
+        width: 100px
+        display: inline-block
+        height: 6px
+        background: #ddd
+        border: 1px solid black
+        border-radius: 6px
+        overflow: hidden
+
+        .bar
+          background: black
+          width: 100%
+          height: 100%
+
+      .message
+        text-align: center
+        display: table
+        height: 100%
+        width: 100%
+
+        p
+          display: table-cell
+          vertical-align: middle
+          font-size: 20px
+
+  &.code-play
+    .avatar-wrapper-container
+      left: calc(50% - (560px - 100px) / 2 - 10px + 50px)
+
+    .center .thang-name
+      margin-left: 45px
+
+    .center .thang-props .prop[name="health"]
+      right: 90px
+      .prop-value.bar-prop
+        width: 100px
+        

--- a/ozaria/site/styles/play/level/level-dialogue-view.sass
+++ b/ozaria/site/styles/play/level/level-dialogue-view.sass
@@ -1,0 +1,145 @@
+@import "app/styles/mixins"
+@import "app/styles/bootstrap/variables"
+@import "ozaria/site/styles/play/variables"
+
+#level-dialogue-view
+  +keyframes(speakingPulse)
+    from
+      filter: drop-shadow(0px 0px 8px #333)
+      color: white
+    50%
+      filter: drop-shadow(0px 0px 35px skyblue)
+      color: skyblue
+    to
+      filter: drop-shadow(0px 0px 8px #333)
+      color: white
+
+  width: 417px
+  height: 296px
+  background: transparent url(/images/level/code_palette_wood_background.png)
+  background-size: 100% auto
+  position: absolute
+  bottom: -296px + 40px
+  left: 300px
+  left: calc(55% - 417px - #{$api-bar-width})
+  // Bounce in
+  @include transition(1s cubic-bezier(.17,.89,.42,1.36))
+  z-index: 1
+
+  &.active
+    display: block
+    bottom: -20px
+
+  &.debrief
+    bottom: -300px
+
+  &.active.debrief
+    bottom: -65px;
+
+  &.speaking
+    .dialogue-area
+      .bubble
+        @include animation(speakingPulse 1.5s infinite)
+
+  .dialogue-area
+    position: relative
+    height: 100%
+    width: 100%
+    z-index: 1
+
+    .bubble
+      position: relative
+      margin: 10px
+      padding: 20px 20px 40px 20px
+      color: white
+      font-weight: bold
+      background: transparent url(/images/level/dialogue_background.png)
+      background-size: 100% 100%
+      border: black solid 1px
+      border-radius: 10px
+      font-size: 18px
+      line-height: 20px
+
+      strong, a
+        color: #FFCCAA
+
+      a
+        text-decoration: underline
+
+      .hud-hint
+        font-weight: normal
+        color: #ddd
+        font-size: 14px
+        line-height: 16px
+        vertical-align: middle
+
+      .enter
+        position: absolute
+        right: 15px
+        bottom: 20px
+        div.dot
+          background: #337
+          width: 8px
+          height: 8px
+          position: absolute
+          right: 8px
+          top: 9px
+          border-radius: 5px
+
+      button, .alert
+        padding: 2px 5px
+
+      .enter button.with-dot
+        padding-right: 20px
+
+      h3
+        margin: 0
+        font-size: 16px
+        line-height: 16px
+        color: #338
+
+      button
+        margin-left: 10px
+  
+  &.debrief
+    z-index: 11
+    width: 100vw
+    max-width: 1024px
+    position: absolute
+    left: 50vw
+    transform: translateX(-50%)
+    img:not(.embiggen)
+      position: absolute
+      width: 20%
+      bottom: 25%
+      filter: drop-shadow(8px 8px 8px black)
+      left: 2.5%
+    .embiggen
+      position: absolute
+      left: 0
+      width: 25%
+      bottom: 0
+      filter: drop-shadow(8px 8px 8px black)
+    .bubble
+      border: initial
+      width: 75%
+      height: 66.66%
+      right: 16px
+      position: absolute
+      top: 50%
+      transform: translateY(-66.66%)
+      padding: 64px !important
+    @media (max-width: 800px)
+      height: 50%
+      .bubble > p
+        margin-top: -32px
+
+body.ipad #level-dialogue-view
+  left: auto
+  right: 0
+
+  &.active
+    bottom: -60px
+
+  .hud-hint
+    visibility: hidden

--- a/ozaria/site/styles/play/level/level-playback-view.sass
+++ b/ozaria/site/styles/play/level/level-playback-view.sass
@@ -1,0 +1,163 @@
+@import "app/styles/mixins"
+@import "app/styles/bootstrap/variables"
+@import "ozaria/site/styles/play/variables"
+
+#playback-view
+  $playback-button-color: rgb(248, 197, 146)
+  // When 75% alpha, it will look like the rgb(194, 154, 114) from Heald's design
+  width: calc(#{$game-view-width} -  #{$api-bar-width})
+  #level-view.no-api &
+    width: $game-view-width
+  height: 60px
+  padding-top: 17px
+  position: relative
+  background: transparent url(/images/level/scrubber_background.png)
+  background-size: 100% 100%
+  // Counteract 50px height of absolutely positioned control bar, but overlap by 10px of jagged transparent top.
+  margin-top: 50px - 10px
+  z-index: 3
+
+  &.controls-disabled
+    pointer-events: none
+    @include filter(brightness(50%))
+
+  button
+    font-size: 26px
+    margin-left: 10px
+    background: transparent
+    @include opacity(0.75)
+    color: $playback-button-color
+    text-shadow: 1px 1px 0px black
+
+    .glyphicon
+      position: relative
+
+  button:hover
+    @include opacity(1)
+
+  #play-button, #volume-button, #music-button
+    float: left
+    position: relative
+    
+  #music-button
+    @include opacity(0.5)
+    span
+      position: relative
+      left: -3px
+      top: -2px
+    &:hover
+      @include opacity(0.75)
+    &.music-on
+      @include opacity(0.75)
+      &:hover
+        @include opacity(1)
+    
+  #play-button, #volume-button
+    .glyphicon
+      display: none
+ 
+  #settings-button
+    padding-left: 4px
+    padding-right: 4px
+
+  #playback-settings
+    float: right
+    position: relative
+    margin-right: 10px
+    ul button
+      margin: 0 10px
+    li:hover
+      background: #add8e6
+
+  #play-button.disabled .glyphicon
+    @include opacity(0.75)
+  #play-button.playing .glyphicon-pause
+    display: inline-block
+  #play-button.paused .glyphicon-play
+    display: inline-block
+  #play-button.ended .glyphicon-repeat
+    display: inline-block
+
+  #volume-button.vol-up .glyphicon.glyphicon-volume-up
+    display: inline-block
+  #volume-button.vol-off .glyphicon.glyphicon-volume-off
+    display: inline-block
+    @include opacity(0.75)
+    &:hover
+      @include opacity(1)
+  #volume-button.vol-down .glyphicon.glyphicon-volume-down
+    display: inline-block
+
+  .scrubber
+    position: absolute
+    left: 170px
+    top: 21px
+    bottom: 0px
+    right: 175px
+    background: rgb(3, 3, 3)
+    height: 28px
+    border: 1px solid rgb(67, 67, 44)
+    border-radius: 14px
+
+    .scrubber-inner
+      border: 1px solid rgb(44, 38, 29)
+      width: 100%
+      height: 100%
+      border-radius: 14px
+      padding: 6px 8px
+
+    .progress
+      float: left
+      width: 100%
+      height: 12px
+      cursor: pointer
+      overflow: visible
+      border: 1px solid #444
+      background: rgb(80, 67, 53)
+      border-radius: 6px
+      border: 0
+      // Can't do this transition because handle then jitters, but would be good for streaming.
+      //@include transition(width .2s linear)
+
+      &.disabled, &.ui-slider-disabled
+        cursor: default
+
+        .progress-bar .scrubber-handle
+          cursor: default
+
+      .progress-bar
+        @include transition(width .0s linear)
+        position: relative
+        // Remove gradient background in favor of solid fill
+        background: rgb(245, 170, 49)
+        border: 1px solid rgb(62, 45, 16)
+        border-radius: 6px
+
+        .scrubber-handle
+          cursor: pointer
+          position: absolute
+          right: -18px
+          top: -11px
+          background: transparent url(/images/level/scrubber_knob.png)
+          background-size: contain
+          width: 36px
+          height: 36px
+
+      .ui-slider-handle
+        height: 100%
+        visibility: hidden
+        border: 0
+        top: 0
+        margin-left: -11px
+        margin-right: -11px
+        // Don't load jQuery UI background image here
+        background: transparent none
+
+body.ipad #playback-view
+  // Counteract 50px height of absolutely positioned control bar, but overlap by 20px of jagged transparent top.
+  margin-top: 50px - 30px
+
+  #playback-settings
+    display: none
+  .scrubber
+    right: 25px

--- a/ozaria/site/styles/play/level/tome/spell-palette-view.sass
+++ b/ozaria/site/styles/play/level/tome/spell-palette-view.sass
@@ -1,6 +1,6 @@
 @import "app/styles/mixins"
 @import "app/styles/bootstrap/variables"
-@import "app/styles/play/variables"
+@import "ozaria/site/styles/play/variables"
 
 #spell-palette-view
   position: absolute
@@ -8,13 +8,12 @@
   width: $api-bar-width
   bottom: 0px
   top: 0px
-  padding: 0 4px 0px 10px
-  background: transparent url(/images/level/wood_texture.png)
-  background-size: auto 100%
   z-index: 7
   @include transition(top 0.25s ease-in-out, width 0.25s ease-in-out)
   box-shadow: 10px 4px 4px black
   overflow: hidden
+  #spell-palette-api-bar
+    top: 40px
   #spell-palette-api-bar[disabled=disabled]
     pointer-events: none
     #palette-tab-api-area
@@ -23,9 +22,9 @@
     display: none
     visibility: hidden
   &.open
-    width: $api-bar-width + 360px
+    width: $api-bar-width + 384px
   .container
-    width: $api-bar-width + 360px
+    width: $api-bar-width + 384px
     height: 100%
     position: relative
     .left
@@ -34,11 +33,54 @@
       top: 80px
       bottom: 0px
       height: auto
-      width: $api-bar-width - 13
-      .section-header, .sub-section-header
+      width: $api-bar-width
+      background-color: #f7f9f9
+      .header, .section-header, .sub-section-header
         display: block
-        color: white
+        color: #000000
         margin-right: 10px
+        width: $api-bar-width
+
+        .white-glyphicon
+          color: #ffffff
+
+      .header
+        background-color: #b5b4b4
+        height: 44px
+        font-family: 'Open Sans'
+        font-size: 20px
+        font-weight: bold
+        letter-spacing: 0.69px
+        line-height: 27px
+        padding: 5px 6px 0px 15px
+      
+      .section-header
+        height: 35px
+        background-color: #d8d8d8
+        box-shadow: 2px 2px 2px 0 rgba(93,115,225,0.32)
+        font-family: 'Open Sans'
+        font-size: 16px
+        font-weight: bold
+        letter-spacing: 0.55px
+        line-height: 22px
+        padding: 5px 6px 0px 15px
+
+      .sub-section-header
+        height: 35px
+        background-color: #ffffff
+        box-shadow: inset 0 1px 3px 0 rgba(93,115,225,0.5), 2px 2px 2px 0 rgba(93,115,225,0.32)
+        font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+        font-size: 16px
+        line-height: 19px
+        padding: 7px 6px 0px 30px
+
+        .blue-glyphicon
+          color: #5d73e1
+
+        &.selected
+          box-shadow: 2px 2px 2px 0 rgba(93,115,225,0.32)
+          background-color: #e9ebeb
+          border-left: 5px solid #5d73e1
 
       .spell-palette-thang-entry-view
         display: inline-block
@@ -63,19 +105,16 @@
     .right
       position: absolute
       right: 20px
-      min-width: 200px
-      left: $api-bar-width - 10px
-      top: 60px
+      min-width: 384px
+      left: $api-bar-width
+      top: 80px
       bottom: 0px
+      background-color: #ffffff
       //width: calc(100% - #{$api-bar-width + 50px})
       @include box-shadow(0 0 0 #000)
       .scrollArea
         max-height: calc(100% - 20px)
         width: 100%
-        border-style: solid
-        border-image: url(/images/level/popover_border_background.png) 16 12 fill round
-        border-width: 16px 12px
-        margin-top: 20px
         margin-bottom: 20px
         position: relative
         overflow-y: auto
@@ -86,15 +125,30 @@
           img
             float: left
 
-      .closeBtn
-        position: absolute
-        right: -10px
-        top: 15px
-        width: 40px
-        height: 40px
-        cursor: pointer
-        font-size: 20px
-        z-index: 2
+      .popover-header
+        background-color: #5d73e1
+        height: 44px
+        color: #ffffff
+        font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+        font-size: 18px
+        line-height: 21px
+        padding: 11px 6px 0px 15px
+      
+      .popover-body
+        font-family: 'Open Sans'
+        color: #232323
+        padding: 5px 6px 0px 14px
+
+        .short-description, .example, .args, .returns
+          font-size: 18px
+          letter-spacing: 0.71px
+          line-height: 24px
+
+        .description
+          font-size: 16px
+          letter-spacing: 0.6px
+          line-height: 20px
+
 
       h1:not(.not-code), h2:not(.not-code), h3:not(.not-code), h4:not(.not-code), h5:not(.not-code), h6:not(.not-code)
         font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
@@ -129,11 +183,13 @@
 
       .docs-ace-container
         padding: 2px 4px
+        border: 0.5px solid #979797
         border-radius: 4px
+        padding: 5px
 
         &, .docs-ace
-          background-color: #f9f2f4
-          font-size: 12px
+          font-size: 16px
+          line-height: 19px
           font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
 
           body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
@@ -142,6 +198,16 @@
         .docs-ace
           .ace_cursor, .ace_bracket
             display: none
+          .ace_gutter-active-line
+            background: #ffffff
+
+      .ace-tm
+        color: #232323
+
+      .ace-tm .ace_gutter
+        background: #ffffff
+        border-right: 1px solid #979797
+        color: #232323
 
       code
         color: black
@@ -200,11 +266,10 @@
     @include flex-align-content-start()
 
     .property-entry-item-group, .property-entry-item-sub-group
-      min-height: 38px
+      min-height: 35px
       width: 212px
       position: relative
       background-color: rgb(20, 13, 8)
-      margin: 1px
 
       img.item-image
         width: 38px
@@ -218,21 +283,12 @@
 
   &.shortenize.hero .properties
     .property-entry-item-group, .property-entry-item-sub-group
-      width: 175px
+      width: $api-bar-width
 
       .spell-palette-entry-view
-        width: 137px
-        width: -webkit-calc(100% - 38px)
-        width: calc(100% - 38px)
-
-  &.web-dev.hero .properties
-    .property-entry-item-group
-      width: 100px
-
-      .spell-palette-entry-view
-        margin-left: 0
-        width: 100px
-
+        width: 100%
+        height: 35px
+        padding: 5px 6px 0px 45px
   //Fixes punctuation but puts comment marker on right, which is apparently worse.
   //body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
   //  .ace_text-layer .ace_comment

--- a/ozaria/site/styles/play/level/tome/spell_palette_entry.sass
+++ b/ozaria/site/styles/play/level/tome/spell_palette_entry.sass
@@ -1,0 +1,195 @@
+@import "app/styles/mixins"
+@import "app/styles/bootstrap/variables"
+
+#level-view.hero .spell-palette-entry-view
+  // Not clickable.
+  cursor: default
+
+.spell-palette-entry-view
+  display: block
+  padding: 0px 4px
+  font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+  font-size: 16px
+  border: 1px solid transparent
+  cursor: pointer
+  @include user-select(all)
+  line-height: 19px
+  text-overflow: ellipsis
+  overflow: hidden
+  white-space: nowrap
+  background-color: #ffffff
+  box-shadow: inset 0 1px 3px 0 rgba(93,115,225,0.5), 2px 2px 2px 0 rgba(93,115,225,0.32)
+  color: #232323
+
+  span
+    cursor: pointer
+    user-select: none
+
+  .blue-glyphicon
+    color: #5d73e1
+
+  &.selected
+    color: white
+    background-color: #5d73e1
+
+    .blue-glyphicon
+      color: #ffffff // change it to white
+
+  &.pinned
+    background-color: darken(#FFFFFF, 25%)
+
+  &.single-entry
+    height: 38px
+    line-height: 38px
+
+  body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
+    .rtl-right-aligned
+      text-align: right
+
+body.dialogue-view-active
+  .spell-palette-popover.popover
+    top: 50px !important
+  
+.spell-palette-popover.popover
+  // Only those popovers which are our direct children (spell documentation)
+  top: 80px !important
+  left: auto !important
+  right: 45%
+  max-width: 600px
+  min-width: 500px
+  padding: 0
+  border-style: solid
+  border-image: url(/images/level/popover_border_background.png) 16 12 fill round
+  border-width: 16px 12px
+  @include box-shadow(0 0 0 #000)
+  // Prevent flickering in weird scenarios where popover goes over its own property
+
+  //Fixes punctuation but puts comment marker on right, which is apparently worse.
+  //body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
+  //  .ace_text-layer .ace_comment
+  //    direction: rtl
+  //    unicode-bidi: embed
+
+  body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
+    .rtl-right-aligned
+      text-align: right
+
+  // Jiggle animation
+  // TODO: consolidate with problem_alert.sass jiggle
+  +keyframes(jiggle)
+    0%
+      transform: rotate(0deg)
+    25%
+      transform: rotate(1deg)
+    50%
+      transform: rotate(0deg)
+    75%
+      transform: rotate(-1deg)
+    100%
+      transform: rotate(0deg)
+
+  &.jiggling
+    @include animation(jiggle .3s infinite)
+
+  &.pinned
+    top: 50px !important
+    right: 45%
+    // bottom: 151px
+    @include user-select(text)
+    // Wish I could set max-width and max-height (and override Bootstrap's stuff)
+    // but without explicitly setting height, child overflow-y: scroll doesn't work
+    min-width: 45%
+    height: 60%
+
+    .arrow
+      display: none
+
+    .close
+      position: absolute
+      top: -7px
+      right: 2px
+      font-size: 28px
+      font-weight: bold
+      @include opacity(0.6)
+      text-shadow: 0 1px 0 white
+
+      &:hover
+        @include opacity(1)
+
+  h1:not(.not-code), h2:not(.not-code), h3:not(.not-code), h4:not(.not-code), h5:not(.not-code), h6:not(.not-code)
+    font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+    font-variant: normal
+
+    body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
+      font-family: "Cousine", "Courier", "Courier New", monospace !important
+
+  .popover-title
+    background-color: transparent
+    margin: 0 14px
+    padding: 8px 0
+    border-bottom-color: #ccc
+
+  .popover-content
+    max-height: 100%
+    overflow-y: auto
+    margin-right: 10px
+    img
+      float: right
+
+  &.top .arrow
+    bottom: -2%
+  &.bottom .arrow
+    top: -2%
+  &.left .arrow
+    right: 0%
+  &.right .arrow
+    left: -3%
+
+  .docs-ace-container
+    padding: 2px 4px
+    border-radius: 4px
+
+    &, .docs-ace
+      background-color: #f9f2f4
+      font-size: 12px
+      font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+
+    body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
+      font-family: "Cousine", "Courier", "Courier New", monospace !important
+
+    .docs-ace
+      .ace_cursor, .ace_bracket
+        display: none
+
+  code
+    color: black
+    font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+    font-size: 12px
+
+    body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
+      font-family: "Cousine", "Courier", "Courier New", monospace !important
+
+html.no-borderimage
+  .spell-palette-popover.popover
+    background: transparent url(/images/level/popover_background.png)
+    background-size: 100% 100%
+    border: 0
+
+html.fullscreen-editor
+  .spell-palette-popover.popover.pinned
+    min-width: 600px
+    bottom: inherit
+    right: 50%
+    margin-right: -300px
+
+// iPad property docs
+
+.tome-inventory-property-documentation
+  background-color: #e3d39a
+  padding: 10px
+  padding-bottom: 65px
+  width: 320px
+  min-height: 480px
+
+  h1:not(.not-code), h2:not(.not-code), h3:not(.not-code), h4:not(.not-code), h5:not(.not-code), h6:not(.not-code)
+    font-family: Menlo, Monaco, Consolas, "Courier New", monospace

--- a/ozaria/site/styles/play/play-level-view.sass
+++ b/ozaria/site/styles/play/play-level-view.sass
@@ -1,0 +1,461 @@
+@import "app/styles/mixins"
+@import "app/styles/bootstrap/variables"
+@import "ozaria/site/styles/play/variables"
+
+body.is-playing
+  background-color: black
+
+$level-resize-transition-time: 0.5s
+// TODO: use this for real-time playback but not cinematic playback
+
+#level-view
+  margin: 0 auto
+  position: absolute
+  overflow: hidden
+  left: 0
+  right: 0
+  bottom: 10px
+  top: 0
+  @include user-select(none)
+
+  &.real-time, &.cinematic
+    // Hmm, somehow the #page-container is cutting us off by ~17px on the right, looks a bit off.
+    
+    &.real-time.game-dev
+      #canvas-wrapper
+        width: 80%
+
+    #canvas-wrapper
+      width: 100%
+      canvas
+        margin: 0 auto
+      #normal-surface
+        left: 0
+        right: 0
+        margin-left: auto
+        margin-right: auto
+    #control-bar-view
+      width: 100%
+      button, h4
+        display: none
+    #code-area, #thang-hud, #goals-view
+      display: none
+      visibility: hidden
+    #gold-view
+      right: 1%
+      @include box-shadow(-1px 1px 10px cyan)
+      .team-gold
+        font-size: 2vw
+        line-height: 2vw
+        img
+          width: 1.8vw
+          height: 1.8vw
+    #duel-stats-view
+      right: calc(50% - 250px)
+      bottom: 50px
+      .duel-stats-background
+        opacity: 0.8
+    #control-bar-view .title
+      left: 20%
+      width: 60%
+      text-align: center
+    #level-dialogue-view
+      display: none
+
+    .level-content
+      margin: 0px auto
+
+  .level-content
+    position: relative
+    min-height: 555px
+    //background-color: black
+
+  &.real-time
+    &:not(.flags)
+      #playback-view
+        width: 100%
+
+    &.flags
+      #playback-view
+        $flags-width: 200px
+        width: 90%
+        width: -webkit-calc(100% - 200px)
+        width: calc(100% - 200px)
+        left: $flags-width
+
+    #stop-real-time-playback-button
+      display: block
+      z-index: 20
+
+  &.cinematic
+    #playback-view
+      width: 100%
+      margin-top: -10px
+
+    #stop-cinematic-playback-button
+      display: block
+      z-index: 20
+
+    #cinematic-code-display
+      display: block
+      z-index: 20
+      visibility: visible
+
+    #control-bar-view
+      display: none
+
+    #canvas-wrapper
+      top: 0
+
+  #canvas-wrapper
+    top: 50px
+    width: calc(#{$game-view-width} - #{$api-bar-width})
+    position: relative
+    overflow: hidden
+    background-color: black
+    //@include transition(all $level-resize-transition-time ease-out, z-index 1.2s linear)
+    z-index: 0
+
+    &.preview-overlay
+      z-index: 20
+      #goals-view
+        visibility: hidden
+    
+  canvas#webgl-surface
+    background-color: #333
+    z-index: 1
+
+  canvas#normal-surface
+    z-index: 1
+    position: absolute
+    top: 0
+    left: 0
+    pointer-events: none
+
+  canvas#webgl-surface, canvas#normal-surface
+    display: block
+    z-index: 2
+    //@include transition($level-resize-transition-time ease-out)
+
+    &.grabbable:not(.flag-color-selected)
+      cursor: -moz-grab
+      cursor: -webkit-grab
+      cursor: grab
+
+      &:active
+        cursor: -moz-grabbing
+        cursor: -webkit-grabbing
+        cursor: grabbing
+
+    &.flag-color-selected
+      cursor: crosshair
+
+  #ascii-surface
+    position: absolute
+    z-index: 3
+    top: 0
+    left: 0
+    pointer-events: none
+    white-space: pre
+    font-family: Courier, monospace
+    color: white
+    background-color: rgba(14, 59, 130, 0.25)
+    transform-origin: 0 0 0
+    line-height: 15px
+
+  min-width: 1024px
+
+  #code-area
+    @include box-sizing(border-box)
+    padding: 0px 0.9% 10px 0
+    width: 43.5%
+    background: transparent url(/images/level/wood_texture.png)
+    background-size: 100% 100%
+    position: absolute
+    right: 0
+    top: 0px
+    bottom: 0
+    //@include transition(width $level-resize-transition-time ease-in-out, right $level-resize-transition-time ease-in-out)
+    z-index: 2
+
+  #game-area
+    position: relative
+    overflow: hidden
+    
+  // Level Docs
+  .ui-effects-transfer
+    border: 2px dotted gray
+  
+  .modal
+    img
+      float: right
+
+    img.diagram
+      float: none
+
+  #multiplayer-join-link
+    font-size: 12px
+      
+  // Custom Buttons
+  .btn.banner
+    @include banner-button(#FFF, #333)
+    @include box-shadow(2px 2px 2px rgba(0, 0, 0, 0.5))
+    border: 1px solid black
+    text-shadow: none
+
+    $buttonConfig: 'primary' #6CA8EA, 'info' #71AACC, 'success' #90B236, 'warning' #CD6800, 'danger' #B43C20, 'inverse' #3A537F
+    @each $tuple in $buttonConfig
+      &.btn-#{nth($tuple, 1)}
+        @include banner-button(nth($tuple, 2), #FFF)
+
+  $GI: 0.5  // gradient intensity; can tweak this 0-1
+
+  .gradient
+    position: absolute
+    z-index: 5
+
+  #code-area-gradient
+    top: 0px
+    width: 3px
+    background: linear-gradient(to right, rgba(0,0,0,0) 0%,rgba(0,0,0,$GI) 100%)
+    left: -3px
+    bottom: 0
+    
+  #canvas-left-gradient
+    left: 0px
+    width: 5px
+    background: linear-gradient(to left, rgba(0,0,0,0) 0%,rgba(0,0,0,0.8*$GI) 100%)
+    bottom: -30px
+    top: 0
+
+  #canvas-top-gradient
+    top: 0
+    height: 5px
+    left: 0
+    right: 0
+    background: linear-gradient(to top, rgba(0,0,0,0) 0%,rgba(0,0,0,0.8*$GI) 100%)
+
+  #hud-left-gradient
+    background: linear-gradient(to right, rgba(0,0,0,$GI) 0%,rgba(0,0,0,0) 100%)
+    left: 0
+    top: 0
+    height: 100%
+    width: 2%
+
+  #hud-right-gradient
+    background: linear-gradient(to right, rgba(0,0,0,0) 0%,rgba(0,0,0,$GI) 100%)
+    right: 0
+    position: absolute
+    top: 0
+    height: 100%
+    width: 2%
+
+  #play-footer
+    position: absolute
+    bottom: 0px
+    width: calc(#{$game-view-width} - #{$api-bar-width})
+    text-align: center
+    font-family: $headings-font-family
+    font-variant: small-caps
+    font-size: 25px
+    padding: 0 0
+    @include transition(opacity .10s linear)
+    @include opacity(0.6)
+
+    &:hover
+      @include opacity(1)
+
+    a
+      @include opacity(0.75)
+      @include transition(opacity .10s linear)
+      color: white
+  
+      &:hover, &:active
+        @include opacity(1)
+    
+    @media screen and (min-aspect-ratio: 17/10)
+      &:not(.premium)
+        display: none
+
+  #level-footer-shadow
+    position: absolute
+    width: 100%
+    height: 30px
+    background: linear-gradient(to bottom, rgba(0,0,0,1) 0%, rgba(0,0,0,0) 100%)
+
+  #fullscreen-editor-background-screen
+    background-color: black
+    opacity: 0.5
+    cursor: pointer
+    display: none
+    position: absolute
+    left: 0
+    right: 0
+    bottom: 0
+    top: 0
+    z-index: 19
+
+  #stop-real-time-playback-button, #stop-cinematic-playback-button
+    display: none
+    position: absolute
+    // bottom: 70px // Set via javascript because of gamedev level sizing
+    right: 15px
+    font-size: 30px
+
+  #stop-cinematic-playback-button
+    bottom: 70px
+
+  #cinematic-code-display
+    display: none
+    position: absolute
+    left: 0px
+    top: 0px
+    padding: 10px
+    font-size: 1.1vw
+    text-align: left
+    background-color: rgba(0, 0, 0, 0.7)
+    border-bottom-right-radius: 8px
+    visibility: hidden
+    max-width: 35%
+
+    .code-line
+      line-height: 1.2em
+      overflow: hidden
+      text-overflow: ellipsis
+      white-space: nowrap
+
+    code
+      background-color: transparent
+      padding: 0
+      color: rgb(120, 255, 245)
+      white-space: pre
+      line-height: 0px
+
+      &.line-number
+        width: 2vw
+        display: inline-block
+
+    .code-line-2, .code-line-4
+      opacity: 0.7
+
+    .code-line-1, .code-line-5
+      opacity: 0.6
+
+    .code-line-0, .code-line-6
+      opacity: 0.5
+
+  .ad-container
+    width: 100%
+    height: 90px
+    text-align: center
+    
+  .hints-view
+    position: absolute
+    top: 10px
+    height: 93%
+    right: 45%
+    z-index: 1000000
+
+  .game-container, .level-content
+    height: 100%
+
+
+  &.no-api
+    #spell-palette-view
+      display: none
+    #canvas-wrapper
+      width: 60%
+
+  &.web-dev
+    position: absolute
+    top: 0
+    bottom: 0
+    left: 0
+    right: 0
+
+    #playback-view, #thang-hud, #level-dialogue-view, #play-footer, #level-footer-background, #level-footer-shadow
+      display: none
+
+    .game-container, .level-content, #game-area, #canvas-wrapper
+      height: 100%
+
+    #canvas-wrapper
+      height: calc(100% - 50px)
+
+    #canvas-wrapper canvas
+      display: none
+
+    #web-surface-view
+      position: absolute
+      top: 0
+      right: 0
+      left: 0
+      bottom: 0
+    
+  #how-to-play-game-dev-panel
+    position: absolute
+    right: 0
+    top: 52px
+    width: 20%
+    bottom: 38px
+    
+  #codeplay-product-banner
+    width: calc(58.5% - 250px)
+    max-width: 100vh
+    position: relative
+    left: 20px
+    top: -7px
+    z-index: 5
+
+html.fullscreen-editor
+  #level-view
+    #fullscreen-editor-background-screen
+      display: block
+
+    #code-area
+      position: fixed
+      width: 95%
+      height: 100%
+      right: 0
+
+body.ipad #level-view
+  // Full-width Surface, preserving aspect ratio, with space for control bar.
+  height: 1024px * (589 / 924) + 50px
+  overflow: hidden
+
+  #code-area, #play-footer, #thang-hud
+    display: none
+
+  #level-chat-view
+    bottom: 40px
+
+  #playback-view
+    background-color: transparent
+    z-index: 3
+    bottom: 30px
+
+    button
+      background-color: #333
+
+    .scrubber .progress
+      background-color: rgba(255, 255, 255, 0.4)
+
+  #canvas-wrapper, #control-bar-view, #playback-view, #thang-hud
+    width: 100%
+
+  #canvas-wrapper
+    height: 653px
+
+    canvas
+      margin: 0 auto
+      overflow: hidden
+
+#level-footer-background
+  display: none
+  position: absolute
+  background: linear-gradient( rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.75) ), url(/images/level/footer_background.jpg) no-repeat
+  bottom: 0
+  width: 100%
+  background-size: 100% 400px
+  height: 400px
+  z-index: -9001

--- a/ozaria/site/styles/play/variables.sass
+++ b/ozaria/site/styles/play/variables.sass
@@ -1,0 +1,3 @@
+$api-bar-width: 200px
+$game-view-width: 57%
+$spell-pallete-right: 100% - $game-view-width

--- a/ozaria/site/styles/play/variables.sass
+++ b/ozaria/site/styles/play/variables.sass
@@ -1,3 +1,3 @@
-$api-bar-width: 200px
+$api-bar-width: 279px
 $game-view-width: 57%
 $spell-pallete-right: 100% - $game-view-width

--- a/ozaria/site/templates/play/tome/spell-palette-view.jade
+++ b/ozaria/site/templates/play/tome/spell-palette-view.jade
@@ -1,8 +1,11 @@
 mixin header(label, name)
-  a.section-header.btn.btn-small.btn-illustrated.btn-warning(role="button", id="#palette-header-" + _.string.slugify(label), data-panel="#palette-tab-" + _.string.slugify(label))
+  div.section-header.text-capitalize(role="button", id="#palette-header-" + _.string.slugify(label), data-panel="#palette-tab-" + _.string.slugify(label))
     span= name
 div.container
   div.left.nano
+    div.header
+      span Command Bank
+      div.glyphicon.glyphicon-chevron-left.white-glyphicon(style="float: right; padding-top: 3px;")
     div.nano-content.panel-group#spell-palette-api-bar
       if entryGroups
         each entries, group in entryGroups
@@ -12,8 +15,6 @@ div.container
 
 
   div.right
-    .closeBtn.btn.btn-illustrated.btn-danger
-      span.glyphicon.glyphicon-remove
     if isIE
       .scrollArea.always-scroll-y
         .scrollableArea

--- a/ozaria/site/templates/play/tome/spell-palette-view.jade
+++ b/ozaria/site/templates/play/tome/spell-palette-view.jade
@@ -4,7 +4,7 @@ mixin header(label, name)
 div.container
   div.left.nano
     div.header
-      span Command Bank
+      span(data-i18n="play_level.command_bank")
       div.glyphicon.glyphicon-chevron-left.white-glyphicon(style="float: right; padding-top: 3px;")
     div.nano-content.panel-group#spell-palette-api-bar
       if entryGroups

--- a/ozaria/site/templates/play/tome/spell_palette_entry.jade
+++ b/ozaria/site/templates/play/tome/spell_palette_entry.jade
@@ -1,1 +1,2 @@
 span.doc-title(data-property-name=view.doc.name)= view.doc.title
+div.glyphicon.glyphicon-chevron-right.blue-glyphicon(style="float: right; padding-top: 3px;")

--- a/ozaria/site/templates/play/tome/spell_palette_entry_popover.jade
+++ b/ozaria/site/templates/play/tome/spell_palette_entry_popover.jade
@@ -47,7 +47,7 @@ div.popover-header.closeBtn(role="button" dir="ltr")
 
 .popover-body
   .short-description.rtl-allowed.rtl-right-aligned(dir="auto")
-    p(dir="auto")!= marked(doc.shortDescription || 'Still undocumented, sorry.')
+    p(dir="auto")!= marked(doc.shortDescription || $.i18n.t("skill_docs.still_undocumented"))
     div.clear(style="clear: both")
 
   if !selectedMethod

--- a/ozaria/site/templates/play/tome/spell_palette_entry_popover.jade
+++ b/ozaria/site/templates/play/tome/spell_palette_entry_popover.jade
@@ -1,116 +1,3 @@
-h4(dir="ltr")
-  span.prop-name= doc.shortName
-  |  - 
-  - var skillType = (doc.type == 'function' && doc.owner == 'this' ? 'method' : doc.type)
-  code.prop-type(data-i18n='skill_docs.' + skillType)
-    // In case there's no translation in en.coffee because we missed one
-    = skillType
-  // Redundant in case some tag docs are missing an owner
-  if !_.contains(['function', 'handler', 'basic tag', 'spawnable', 'event', 'snippet'], doc.type) && doc.owner != 'HTML'
-    |  (
-    if writable
-      span(data-i18n="skill_docs.writable") writable
-    else
-      span(data-i18n="skill_docs.read_only") read-only
-    | )
-
-if doc.translatedShortName
-  h5
-    span.translated-name= doc.translatedShortName
-
-.short-description.rtl-allowed.rtl-right-aligned(dir="auto")
-  p(dir="auto")!= marked(doc.shortDescription || 'Still undocumented, sorry.')
-  div.clear(style="clear: both")
-  if cooldowns && (cooldowns.cooldown || cooldowns.specificCooldown)
-    p
-      span
-        if cooldowns.type == 'spell'
-          span(data-i18n="skill_docs.spell") Spell
-        else
-          span(data-i18n="skill_docs.action") Action
-        span.spl(data-i18n="skill_docs.action_name") name
-        span.spr :
-        code "#{cooldowns.name}"
-        | .
-      span.spl
-        span(data-i18n="skill_docs.action_cooldown") Takes
-        span.spr :
-        code= cooldowns.cooldown
-        | s.
-        // TODO: localize seconds (ex. Hebrew should say שנ instead of s)
-      if cooldowns.specificCooldown
-        span.spl
-          span(data-i18n="skill_docs.action_specific_cooldown") Cooldown
-          span.spr :
-          code= cooldowns.specificCooldown
-          | s.
-      if cooldowns.damage
-        span.spl
-          span(data-i18n="skill_docs.action_damage") Damage
-          span.spr :
-          code= cooldowns.damage
-          | .
-      if cooldowns.range
-        span.spl
-          span(data-i18n="skill_docs.action_range") Range
-          span.spr :
-          code= cooldowns.range
-          | m.
-      if cooldowns.radius
-        span.spl
-          span(data-i18n="skill_docs.action_radius") Radius
-          span.spr :
-          code= cooldowns.radius
-          | m.
-      if cooldowns.duration
-        span.spl
-          span(data-i18n="skill_docs.action_duration") Duration
-          span.spr :
-          code= cooldowns.duration
-          | s.
-
-if !selectedMethod
-  if doc.example
-    p.example
-      strong
-        span(data-i18n="skill_docs.example") Example
-        | :
-      .docs-ace-container
-        .docs-ace= doc.example
-  else if doc.type == 'function' && argumentExamples.length
-    p.example
-      strong
-        span(data-i18n="skill_docs.example") Example
-        | :
-      div
-        .docs-ace-container
-          .docs-ace
-            if language == 'javascript'
-              span= doc.ownerName + '.' + docName + '(' + argumentExamples.join(', ') + ');'
-            else if language == 'coffeescript'
-              span= doc.ownerName + (doc.ownerName == '@' ? '' : '.') + docName + ' ' + argumentExamples.join(', ')
-            else if language == 'python'
-              span= doc.ownerName + '.' + docName + '(' + argumentExamples.join(', ') + ')'
-            else if language == 'clojure'
-              span= '(.' + docName + ' ' + doc.ownerName + ' ' + argumentExamples.join(', ') + ')'
-            else if language == 'lua'
-              span= doc.ownerName + ':' + docName + '(' + argumentExamples.join(', ') + ')'
-            else if language == 'io'
-              span= (doc.ownerName == 'this' ? '' : doc.ownerName + ' ') + docName + '(' + argumentExamples.join(', ') + ')'
-
-if doc.description
-  .description.rtl-allowed.rtl-right-aligned(dir="auto")
-    p(dir="auto")!= marked(doc.description)
-    div.clear(style="clear: both")
-
-if (doc.type != 'function' && doc.type != 'snippet' && doc.type != 'spawnable' && doc.type != 'event' && doc.type != 'handler' && doc.type != 'property' && !_.contains(['HTML', 'CSS', 'WebJavaScript', 'jQuery'], doc.owner)) || doc.name == 'now'
-  p.value
-    strong
-      span(data-i18n="skill_docs.current_value") Current Value
-      span.spr :
-    pre
-      code.current-value(data-prop=doc.name)= value
-
 mixin argumentEntry(arg)
   if ['he', 'ar', 'fa', 'ur'].indexOf(me.get('preferredLanguage', true)) == -1
     div
@@ -150,49 +37,88 @@ mixin argumentEntry(arg)
             span(dir="rtl")= ": "
           code(dir="ltr")= arg.default
 
-if doc.args && doc.args.length
-  - var hasOptionalArguments = _.any(doc.args, function(arg){ return arg.optional })
-  - var hasRequiredArguments = _.any(doc.args, function(arg){ return !arg.optional })
-  if hasRequiredArguments
-    p.args(dir="auto")
-      strong
-        span(data-i18n="skill_docs.required_parameters") Required Parameters
-        span.spr :
-    for arg in doc.args
-      unless arg.optional
-        +argumentEntry(arg)
-  if hasOptionalArguments
-    p.args(dir="auto")
-      strong
-        span(data-i18n="skill_docs.optional_parameters") Optional Parameters
-        span.spr :
+div.popover-header.closeBtn(role="button" dir="ltr")
+  span.prop-name= doc.shortName
+  if doc.translatedShortName
+    span.translated-name (
+      =doc.translatedShortName
+      | )
+  div.glyphicon.glyphicon-chevron-left(style="float: right;")
+
+.popover-body
+  .short-description.rtl-allowed.rtl-right-aligned(dir="auto")
+    p(dir="auto")!= marked(doc.shortDescription || 'Still undocumented, sorry.')
+    div.clear(style="clear: both")
+
+  if !selectedMethod
+    if doc.example
+      p.example
+        strong
+          span(data-i18n="skill_docs.example") Example
+          | :
+        .docs-ace-container
+          .docs-ace= doc.example
+    else if doc.type == 'function' && argumentExamples.length
+      p.example
+        strong
+          span(data-i18n="skill_docs.example") Example
+          | :
+        div
+          .docs-ace-container
+            .docs-ace
+              if language == 'javascript'
+                span= doc.ownerName + '.' + docName + '(' + argumentExamples.join(', ') + ');'
+              else if language == 'coffeescript'
+                span= doc.ownerName + (doc.ownerName == '@' ? '' : '.') + docName + ' ' + argumentExamples.join(', ')
+              else if language == 'python'
+                span= doc.ownerName + '.' + docName + '(' + argumentExamples.join(', ') + ')'
+              else if language == 'clojure'
+                span= '(.' + docName + ' ' + doc.ownerName + ' ' + argumentExamples.join(', ') + ')'
+              else if language == 'lua'
+                span= doc.ownerName + ':' + docName + '(' + argumentExamples.join(', ') + ')'
+              else if language == 'io'
+                span= (doc.ownerName == 'this' ? '' : doc.ownerName + ' ') + docName + '(' + argumentExamples.join(', ') + ')'
+
+  if doc.description
+    .description.rtl-allowed.rtl-right-aligned(dir="auto")
+      p(dir="auto")!= marked(doc.description)
+      div.clear(style="clear: both")
+
+  //- Args and returns are not there in 1FH/1UP - hence keeping their format and css as it is for now
+
+  if doc.args && doc.args.length
+    - var hasOptionalArguments = _.any(doc.args, function(arg){ return arg.optional })
+    - var hasRequiredArguments = _.any(doc.args, function(arg){ return !arg.optional })
+    if hasRequiredArguments
+      p.args(dir="auto")
+        strong
+          span(data-i18n="skill_docs.required_parameters") Required Parameters
+          span.spr :
       for arg in doc.args
-        if arg.optional
+        unless arg.optional
           +argumentEntry(arg)
+    if hasOptionalArguments
+      p.args(dir="auto")
+        strong
+          span(data-i18n="skill_docs.optional_parameters") Optional Parameters
+          span.spr :
+        for arg in doc.args
+          if arg.optional
+            +argumentEntry(arg)
 
 
-if doc.returns
-  p.returns(dir="auto")
-    strong
-      span(data-i18n="skill_docs.returns") Returns
-      span.spr :
-    div
-      code= doc.returns.type
-      if doc.returns.example
-        |  (
-        span(data-i18n="skill_docs.ex") ex
+  if doc.returns
+    p.returns(dir="auto")
+      strong
+        span(data-i18n="skill_docs.returns") Returns
         span.spr :
-        code= doc.returns.example
-        | )
-      if doc.returns.description
-        div!= marked(doc.returns.description)
-
-if item && (typeof item.get === 'function')
-  p
-    em
-      span.spr(data-i18n="skill_docs.granted_by") Granted by
-      | #{item.get('name')}.
-
-if selectedMethod
-  p
-    em Write the body of this method below.
+      div
+        code= doc.returns.type
+        if doc.returns.example
+          |  (
+          span(data-i18n="skill_docs.ex") ex
+          span.spr :
+          code= doc.returns.example
+          | )
+        if doc.returns.description
+          div!= marked(doc.returns.description)

--- a/ozaria/site/views/play/level/ControlBarView.coffee
+++ b/ozaria/site/views/play/level/ControlBarView.coffee
@@ -1,4 +1,4 @@
-require('app/styles/play/level/control-bar-view.sass')
+require('ozaria/site/styles/play/level/control-bar-view.sass')
 storage = require 'core/storage'
 
 CocoView = require 'views/core/CocoView'

--- a/ozaria/site/views/play/level/GameDevTrackView.coffee
+++ b/ozaria/site/views/play/level/GameDevTrackView.coffee
@@ -1,4 +1,4 @@
-require('app/styles/play/level/game_dev_track_view.sass')
+require('ozaria/site/styles/play/level/game_dev_track_view.sass')
 CocoView = require 'views/core/CocoView'
 template = require 'templates/play/level/game_dev_track_view'
 #teamTemplate = require 'templates/play/level/team_gold'

--- a/ozaria/site/views/play/level/LevelDialogueView.coffee
+++ b/ozaria/site/views/play/level/LevelDialogueView.coffee
@@ -1,4 +1,4 @@
-require('app/styles/play/level/level-dialogue-view.sass')
+require('ozaria/site/styles/play/level/level-dialogue-view.sass')
 CocoView = require 'views/core/CocoView'
 template = require 'templates/play/level/level-dialogue-view'
 DialogueAnimator = require './DialogueAnimator'

--- a/ozaria/site/views/play/level/LevelGoldView.coffee
+++ b/ozaria/site/views/play/level/LevelGoldView.coffee
@@ -1,4 +1,4 @@
-require('app/styles/play/level/gold.sass')
+require('ozaria/site/styles/play/level/gold.sass')
 CocoView = require 'views/core/CocoView'
 template = require 'templates/play/level/gold'
 teamTemplate = require 'templates/play/level/team_gold'

--- a/ozaria/site/views/play/level/LevelHUDView.coffee
+++ b/ozaria/site/views/play/level/LevelHUDView.coffee
@@ -1,4 +1,4 @@
-require('app/styles/play/level/hud.sass')
+require('ozaria/site/styles/play/level/hud.sass')
 CocoView = require 'views/core/CocoView'
 template = require 'templates/play/level/hud'
 prop_template = require 'templates/play/level/hud_prop'

--- a/ozaria/site/views/play/level/LevelPlaybackView.coffee
+++ b/ozaria/site/views/play/level/LevelPlaybackView.coffee
@@ -1,4 +1,4 @@
-require('app/styles/play/level/level-playback-view.sass')
+require('ozaria/site/styles/play/level/level-playback-view.sass')
 CocoView = require 'views/core/CocoView'
 template = require 'templates/play/level/level-playback-view'
 {me} = require 'core/auth'

--- a/ozaria/site/views/play/level/PlayLevelView.js
+++ b/ozaria/site/views/play/level/PlayLevelView.js
@@ -13,7 +13,7 @@ import CapstoneProgressModal from './modal/CapstoneProgressModal'
 import CapstoneVictoryModal from './modal/CapstoneVictoryModal'
 
 require('app/styles/play/level/level-loading-view.sass')
-require('app/styles/play/level/tome/spell_palette_entry.sass')
+require('ozaria/site/styles/play/level/tome/spell_palette_entry.sass')
 require('ozaria/site/styles/play/play-level-view.sass')
 const RootView = require('views/core/RootView')
 const template = require('../../../templates/play/play-level-view.pug')

--- a/ozaria/site/views/play/level/PlayLevelView.js
+++ b/ozaria/site/views/play/level/PlayLevelView.js
@@ -14,7 +14,7 @@ import CapstoneVictoryModal from './modal/CapstoneVictoryModal'
 
 require('app/styles/play/level/level-loading-view.sass')
 require('app/styles/play/level/tome/spell_palette_entry.sass')
-require('app/styles/play/play-level-view.sass')
+require('ozaria/site/styles/play/play-level-view.sass')
 const RootView = require('views/core/RootView')
 const template = require('../../../templates/play/play-level-view.pug')
 const { me } = require('core/auth')

--- a/ozaria/site/views/play/level/tome/SpellPaletteEntryView.coffee
+++ b/ozaria/site/views/play/level/tome/SpellPaletteEntryView.coffee
@@ -1,5 +1,5 @@
 CocoView = require 'views/core/CocoView'
-template = require 'templates/play/level/tome/spell_palette_entry'
+template = require 'ozaria/site/templates/play/tome/spell_palette_entry'
 {me} = require 'core/auth'
 filters = require 'lib/image_filter'
 DocFormatter = require './DocFormatter'

--- a/ozaria/site/views/play/level/tome/SpellPaletteView.coffee
+++ b/ozaria/site/views/play/level/tome/SpellPaletteView.coffee
@@ -46,9 +46,9 @@ module.exports = class SpellPaletteView extends CocoView
       entrySubGroups = _.groupBy entries, (entry) -> entry.doc.subSection || 'none'
       for subGroup, entries of entrySubGroups
         if subGroup != 'none'
-          header = $("<a class='sub-section-header btn btn-small btn-illustrated' data-panel='#sub-section-#{subGroup}-#{group}'>
+          header = $("<div class='sub-section-header' data-panel='#sub-section-#{subGroup}-#{group}'>
               <span>#{subGroup}</span>
-              <div style='float: right' class='glyphicon glyphicon-chevron-down'></div>
+              <div style='float: right; padding-top: 3px;' class='glyphicon glyphicon-chevron-down blue-glyphicon'></div>
             </a>").appendTo itemGroup
           itemSubGroup = $("<div class='property-entry-item-sub-group collapse' id='sub-section-#{subGroup}-#{group}'></div>").appendTo itemGroup
         for entry, entryIndex in entries
@@ -198,9 +198,11 @@ module.exports = class SpellPaletteView extends CocoView
     if isCollapsed
       target.collapse 'show'
       $et.find('.glyphicon').removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up')
+      $et.toggleClass('selected', true)
     else
       target.collapse 'hide'
       $et.find('.glyphicon').removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down')
+      $et.toggleClass('selected', false)
 
     setTimeout () =>
       @$('.nano').nanoScroller alwaysVisible: true
@@ -227,6 +229,7 @@ module.exports = class SpellPaletteView extends CocoView
     # Initialize Ace for each popover code snippet that still needs it
     content.find('.docs-ace').each ->
       aceEditor = aceUtils.initializeACE @, codeLanguage
+      aceEditor.renderer.setShowGutter true
       aceEditors.push aceEditor
 
   destroy: ->


### PR DESCRIPTION
This changes the look and feels of the spell palette view (methods bank) according to ozaria. It does not affect anything for the existing play level view and hence is safe to ship.
Also a lot of sass files have just been moved from legacy to ozaria folder and do not need a review (basically only second commit needs a review).

Screenshots of the new methods bank (this is the initial design implementation, I am sure there will be some polishing to it later):
<img width="415" alt="Screen Shot 2019-07-03 at 5 44 16 PM" src="https://user-images.githubusercontent.com/22322514/60632452-7b529b80-9dba-11e9-93f6-c6e8d075c5e0.png">
<img width="808" alt="Screen Shot 2019-07-03 at 5 44 55 PM" src="https://user-images.githubusercontent.com/22322514/60632453-7b529b80-9dba-11e9-8bc8-2c46219f8d15.png">


TODO: Change the position of methods bank to the left of the screen with a clickable handle to open and close the methods bank - Will do this in a separate PR next week after Shasha uploads assets for them.