### PR TITLE
Request a quote form updates

### DIFF
--- a/app/core/forms.coffee
+++ b/app/core/forms.coffee
@@ -19,7 +19,7 @@ module.exports.formToObject = ($el, options) ->
       if value or (not options.ignoreEmptyString)
         obj[name] = value
   obj
-  
+
 module.exports.objectToForm = ($el, obj, options={}) ->
   options = _.extend({ overwriteExisting: false }, options)
   inputs = $('input, textarea, select', $el)
@@ -46,7 +46,7 @@ module.exports.applyErrorsToForm = (el, errors, warning=false) ->
     if error.code is tv4.errorCodes.OBJECT_REQUIRED
       prop = _.last(_.string.words(error.message)) # hack
       message = $.i18n.t('common.required_field')
-    
+
     else if error.dataPath
       prop = error.dataPath[1..]
       message = error.message
@@ -61,7 +61,7 @@ module.exports.applyErrorsToForm = (el, errors, warning=false) ->
       originalMessage = /Format validation failed \(([^\(\)]+)\)/.exec(message)[1]
       unless _.isEmpty(originalMessage)
         message = originalMessage
-    
+
     if error.code is 409 and error.property is 'email'
       message += ' <a class="login-link">Log in?</a>'
 
@@ -75,7 +75,7 @@ module.exports.setErrorToField = setErrorToField = (el, message, warning=false) 
     return console.error el, " did not contain a form group, so couldn't show message:", message
 
   kind = if warning then 'warning' else 'error'
-  afterEl = $(formGroup.find('.help-block, .form-control, input, select, textarea')[0])
+  afterEl = $(formGroup.find('.help-block, .form-control, input, select, textarea, .control-label')[0])
   formGroup.addClass "has-#{kind}"
   helpBlock = $("<span class='help-block #{kind}-help-block'>#{message}</span>")
   if afterEl.length
@@ -89,7 +89,7 @@ module.exports.setErrorToProperty = setErrorToProperty = (el, property, message,
     return console.error "#{property} not found in", el, "so couldn't show message:", message
 
   setErrorToField input, message, warning
-  
+
 module.exports.scrollToFirstError = ($el=$('body')) ->
   $first = $el.find('.has-error, .alert-danger, .error-help-block, .has-warning, .alert-warning, .warning-help-block').filter(':visible').first()
   if $first.length
@@ -102,12 +102,12 @@ module.exports.clearFormAlerts = (el) ->
   $('.alert.alert-warning', el).remove()
   el.find('.help-block.error-help-block').remove()
   el.find('.help-block.warning-help-block').remove()
-  
+
 module.exports.updateSelects = (el) ->
   el.find('select').each (i, select) ->
     value = $(select).attr('value')
     $(select).val(value)
-  
+
 module.exports.validateEmail = (email) ->
   filter = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,63}$/i  # https://news.ycombinator.com/item?id=5763990
   return filter.test(email)
@@ -120,7 +120,7 @@ module.exports.disableSubmit = (el, message='...') ->
   $el = $(el)
   $el.data('original-text', $el.text())
   $el.text(message).attr('disabled', true)
-  
+
 module.exports.enableSubmit = (el) ->
   $el = $(el)
   $el.text($el.data('original-text')).attr('disabled', false)

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1185,7 +1185,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     course_suffix: ""
 
   teachers_quote:
-    subtitle: "Learn more about CodeCombat with an interactive walk through of the product!" # {change}
+    subtitle: "Learn more about CodeCombat with an interactive walk through of the product, pricing, and implementation!" # {change}
     email_exists: "User exists with this email."
     phone_number: "Phone number"
     phone_number_help: "What's the best number to reach you?"

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -463,6 +463,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     submit_changes: "Submit Changes"
     save_changes: "Save Changes"
     required_field: "required"
+    submit: "Submit"
 
   general:
     and: "and"
@@ -515,6 +516,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     warrior: "Warrior"
     ranger: "Ranger"
     wizard: "Wizard"
+    name: "Name"
     first_name: "First Name"
     last_name: "Last Name"
     last_initial: "Last Initial"
@@ -1183,7 +1185,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     course_suffix: ""
 
   teachers_quote:
-    subtitle: "Get your students started in less than an hour. You'll be able to <strong>create a class, add students, and monitor their progress</strong> as they learn computer science."
+    subtitle: "Learn more about CodeCombat with an interactive walk through of the product!" # {change}
     email_exists: "User exists with this email."
     phone_number: "Phone number"
     phone_number_help: "What's the best number to reach you?"
@@ -1207,7 +1209,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     organization_label: "School"
     school_name: "School Name"
     city: "City"
-    state: "State"
+    state: "State / Region" # {change}
     country: "Country"
     num_students_help: "How many students will use CodeCombat?"
     num_students_default: "Select Range"
@@ -1244,6 +1246,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     create_account_subtitle: "Get access to teacher-only tools for using CodeCombat in the classroom.  <strong>Set up a class</strong>, add your students, and <strong>monitor their progress</strong>!"
     convert_account_title: "Update to Teacher Account"
     not: "Not"
+    full_name_required: 'First and last name required'
 
   versions:
     save_version_title: "Save New Version"

--- a/app/templates/teachers/request-quote-view.jade
+++ b/app/templates/teachers/request-quote-view.jade
@@ -32,6 +32,52 @@ block content
                   a(data-i18n="new_home.learn_more" data-toggle="modal" data-target="#learn-more-modal")
 
       #form-teacher-info
+        .row
+          .col-md-offset-2.col-md-4.col-sm-6
+            #full-name.form-group
+              span.control-label(data-i18n="general.name")
+              - var firstName = me.get('firstName') || '';
+              - var lastName = me.get('lastName') || '';
+              - var name = (firstName + ' ' + lastName).trim()
+              input.form-control(name="fullName" value=name, disabled=!!name)
+
+          .col-md-4.col-sm-6
+            #email-form-group.form-group
+              span.control-label(data-i18n="general.email")
+              - var email = me.get('email') || '';
+              span.email-check.fancy-error.pull-right
+                - var checkEmailState = view.state.get('checkEmailState');
+                if checkEmailState === 'checking'
+                  span.small(data-i18n="signup.checking")
+                if checkEmailState === 'exists'
+                  span.small
+                    span(data-i18n="signup.account_exists")
+                    =" "
+                    a#email-exists-login-link.login-link(data-i18n="signup.sign_in")
+
+                if checkEmailState === 'available'
+                  span.small
+                    span(data-i18n="signup.email_good")
+              input.form-control(name="email" type="email", value=email, disabled=!!email)
+
+        .row
+          .col-md-offset-2.col-md-4.col-sm-6
+            .form-group
+              span.control-label(data-i18n="teachers_quote.phone_number")
+              input.form-control(name="phoneNumber", data-i18n="[placeholder]teachers_quote.phone_number_help")
+
+          .col-md-4.col-sm-6
+            .form-group
+              span.control-label(data-i18n="teachers_quote.primary_role_label")
+              select.form-control(name="role")
+                option(data-i18n="teachers_quote.primary_role_default", , value='')
+                option(data-i18n="courses.teacher", value="Teacher")
+                option(data-i18n="teachers_quote.tech_coordinator", value="Technology coordinator")
+                option(data-i18n="teachers_quote.advisor", value="Advisor")
+                option(data-i18n="teachers_quote.principal", value="Principal")
+                option(data-i18n="teachers_quote.superintendent", value="Superintendent")
+                option(data-i18n="teachers_quote.parent", value="Parent")
+
         if !me.isAnonymous()
           .row
             .col-md-offset-2.col-md-4.col-sm-6
@@ -52,107 +98,11 @@ block content
                       span(data-i18n="signup.name_available")
                 input.form-control(name="name" value=name, disabled=!!name)
 
-            .col-md-4.col-sm-6
-              .form-group
-                span.control-label(data-i18n="share_progress_modal.form_label")
-                - var email = me.get('email') || '';
-                span.email-check.fancy-error.pull-right
-                  - var checkEmailState = view.state.get('checkEmailState');
-                  if checkEmailState === 'checking'
-                    span.small(data-i18n="signup.checking")
-                  if checkEmailState === 'exists'
-                    span.small
-                      span(data-i18n="signup.account_exists")
-                      =" "
-                      a#email-exists-login-link.login-link(data-i18n="signup.sign_in")
-
-                  if checkEmailState === 'available'
-                    span.small
-                      span(data-i18n="signup.email_good")
-                input.form-control(name="email" value=email, disabled=!!email)
-
-        .row
-          .col-md-offset-2.col-md-4.col-sm-6
-            .form-group
-              span.control-label(data-i18n="general.first_name")
-              - var firstName = me.get('firstName') || '';
-              input.form-control(name="firstName" value=firstName, disabled=!!firstName)
-
-          .col-md-4.col-sm-6
-            .form-group
-              span.control-label(data-i18n="general.last_name")
-              - var lastName = me.get('lastName') || '';
-              input.form-control(name="lastName" value=lastName, disabled=!!lastName)
-
-        if !me.isAnonymous()
-          .row
-            .col-md-offset-2.col-md-4.col-sm-6
-              .form-group
-                span.control-label(data-i18n="teachers_quote.phone_number")
-                span.spl.text-muted(data-i18n="signup.optional")
-                input.form-control(name="phoneNumber", data-i18n="[placeholder]teachers_quote.phone_number_help")
-
-        if me.isAnonymous()
-          .row
-            .col-md-offset-2.col-md-4.col-sm-6
-              #email-form-group.form-group
-                span.control-label(data-i18n="general.email")
-                - var email = me.get('email') || '';
-                span.email-check.fancy-error.pull-right
-                  - var checkEmailState = view.state.get('checkEmailState');
-                  if checkEmailState === 'checking'
-                    span.small(data-i18n="signup.checking")
-                  if checkEmailState === 'exists'
-                    span.small
-                      span(data-i18n="signup.account_exists")
-                      =" "
-                      a#email-exists-login-link.login-link(data-i18n="signup.sign_in")
-
-                  if checkEmailState === 'available'
-                    span.small
-                      span(data-i18n="signup.email_good")
-                input.form-control(name="email" type="email", value=email, disabled=!!email)
-
-            .col-md-4.col-sm-6
-              .form-group
-                span.control-label
-                  span(data-i18n="teachers_quote.phone_number")
-                  span.spl.text-muted(data-i18n="signup.optional")
-                .help-block.small
-                  em.text-info(data-i18n="teachers_quote.phone_number_help")
-                input.form-control(name="phoneNumber")
-
-
-        .row
-          .col-md-offset-2.col-md-4.col-sm-6
-            .form-group
-              span.control-label(data-i18n="teachers_quote.primary_role_label")
-              select.form-control(name="role")
-                option(data-i18n="teachers_quote.primary_role_default", , value='')
-                option(data-i18n="courses.teacher", value="Teacher")
-                option(data-i18n="teachers_quote.tech_coordinator", value="Technology coordinator")
-                option(data-i18n="teachers_quote.advisor", value="Advisor")
-                option(data-i18n="teachers_quote.principal", value="Principal")
-                option(data-i18n="teachers_quote.superintendent", value="Superintendent")
-                option(data-i18n="teachers_quote.parent", value="Parent")
-
-          .col-md-4.col-sm-6
-            .form-group
-              span.control-label(data-i18n="teachers_quote.purchaser_role_label")
-              select.form-control(name="purchaserRole")
-                option(data-i18n="teachers_quote.purchaser_role_default", , value='')
-                option(data-i18n="teachers_quote.influence_advocate", value="Influence/Advocate")
-                option(data-i18n="teachers_quote.evaluate_recommend", value="Evaluate/Recommend")
-                option(data-i18n="teachers_quote.approve_funds", value="Approve Funds")
-                option(data-i18n="teachers_quote.no_purchaser_role", value="No role in purchase decisions")
-
       #form-school-info
         .row.m-y-2
           .col-md-offset-2.col-md-4.col-sm-6
             .form-group
-              span.control-label
-                span(data-i18n="teachers_quote.organization_label")
-                span.spl.text-muted(data-i18n="signup.optional")
+              span.control-label(data-i18n="teachers_quote.organization_label")
               input.form-control#organization-control(name="organization")
 
           .col-md-4.col-sm-6
@@ -207,53 +157,17 @@ block content
                 option 5,000-10,000
                 option 10,000+
 
-        .form-group
-          .row.m-y-2
-            .col-md-offset-2.col-md-4
-              span.control-label(data-i18n="teachers_quote.education_level_label")
-              .help-block.small
-                em.text-info(data-i18n="teachers_quote.education_level_help")
-              .checkbox
-                label
-                  input(type="checkbox" name="educationLevel" value="Elementary")
-                  span(data-i18n="teachers_quote.elementary_school")
-              .checkbox
-                label
-                  input(type="checkbox" name="educationLevel" value="Middle")
-                  span(data-i18n="teachers_quote.middle_school")
-              .checkbox
-                label
-                  input(type="checkbox" name="educationLevel" value="High")
-                  span(data-i18n="teachers_quote.high_school")
-              .checkbox
-                label
-                  input(type="checkbox" name="educationLevel" value="College+")
-                  span(data-i18n="teachers_quote.college_plus")
-              .checkbox
-                label
-                  input#other-education-level-checkbox(type="checkbox")
-                  span(data-i18n="nav.other").spr
-                  span(data-i18n="teachers_quote.please_explain")
-              input#other-education-level-input.form-control
-
-      #anything-else-row.row
-        .col-md-offset-2.col-md-8
-          span.control-label
-            span(data-i18n="teachers_quote.anything_else")
-            span.spl.text-muted(data-i18n="signup.optional")
-
-          textarea.form-control(rows=8, name="notes")
-          input(type="hidden" name="nces_id")
-          input(type="hidden" name="nces_name")
-          input(type="hidden" name="nces_district")
-          input(type="hidden" name="nces_district_id")
-          input(type="hidden" name="nces_district_schools")
-          input(type="hidden" name="nces_district_students")
-          input(type="hidden" name="nces_students")
-          input(type="hidden" name="nces_phone")
+      input(type="hidden" name="nces_id")
+      input(type="hidden" name="nces_name")
+      input(type="hidden" name="nces_district")
+      input(type="hidden" name="nces_district_id")
+      input(type="hidden" name="nces_district_schools")
+      input(type="hidden" name="nces_district_students")
+      input(type="hidden" name="nces_students")
+      input(type="hidden" name="nces_phone")
 
       #buttons-row.row.m-y-2.text-center
-        input#submit-request-btn.btn.btn-lg.btn-primary(type="submit" data-i18n="[value]new_home.request_demo" data-event-action="Teachers Request Demo Submit Clicked")
+        input#submit-request-btn.btn.btn-lg.btn-primary(type="submit" data-i18n="common.submit" data-event-action="Teachers Request Demo Submit Clicked")
 
     #form-submit-success.text-center(class=showDone ? '' : 'hide')
       h3(data-i18n="teachers_quote.thanks_header")

--- a/app/views/teachers/RequestQuoteView.coffee
+++ b/app/views/teachers/RequestQuoteView.coffee
@@ -225,8 +225,9 @@ module.exports = class RequestQuoteView extends RootView
   onTrialRequestSubmit: ->
     window.tracker?.trackEvent 'Teachers Request Demo Form Submitted', category: 'Teachers', ['Mixpanel']
     @formChanged = false
-    me.setRole @trialRequest.get('properties').role.toLowerCase(), true
-    defaultName = [@trialRequest.get('firstName'), @trialRequest.get('lastName')].join(' ')
+    trialRequestProperties = @trialRequest.get('properties')
+    me.setRole trialRequestProperties.role.toLowerCase(), true
+    defaultName = [trialRequestProperties.firstName, trialRequestProperties.lastName].join(' ')
     @$('input[name="name"]').val(defaultName)
     @$('#request-form, #form-submit-success').toggleClass('hide')
     @scrollToTop(0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14604,6 +14604,11 @@
         "is-hexadecimal": "^1.0.0"
       }
     },
+    "parse-full-name": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/parse-full-name/-/parse-full-name-1.2.3.tgz",
+      "integrity": "sha1-WimDAbmpCkLqthGCgV8+E6Ofq+0="
+    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "node-force-domain": "~0.1.0",
     "node-statsd": "^0.1.1",
     "npm-modernizr": "~2.8.3",
+    "parse-full-name": "^1.2.3",
     "passport": "0.1.x",
     "passport-local": "0.1.x",
     "paypal-rest-sdk": "^1.7.1",

--- a/test/app/views/teachers/RequestQuoteView.spec.coffee
+++ b/test/app/views/teachers/RequestQuoteView.spec.coffee
@@ -6,7 +6,7 @@ describe 'RequestQuoteView', ->
   view = null
 
   successForm = {
-    firstName: 'A'
+    fullName: 'A B'
     lastName: 'B'
     email: 'C@D.com'
     phoneNumber: '555-555-5555'
@@ -18,8 +18,6 @@ describe 'RequestQuoteView', ->
     country: 'asdf'
     numStudents: '1-10'
     numStudentsTotal: '10,000+'
-    purchaserRole: 'Approve Funds'
-    educationLevel: ['Middle']
   }
 
   isSubmitRequest = (r) -> _.string.startsWith(r.url, '/db/trial.request') and r.method is 'POST'
@@ -153,7 +151,7 @@ describe 'RequestQuoteView', ->
         expect(view.$('#email-form-group').hasClass('has-error')).toBe(true)
         expect(view.$('#email-form-group .error-help-block').length).toBe(1)
 
-    describe 'submits the form without school', ->
+    describe 'does not submit the form without school', ->
       beforeEach ->
         view.$el.find('#request-form').trigger('change') # to confirm navigating away isn't prevented
         form = view.$('#request-form')
@@ -161,13 +159,8 @@ describe 'RequestQuoteView', ->
         forms.objectToForm(form, formData)
         form.submit()
 
-      it 'submits a trial request, which does not include school setting', ->
-        request = jasmine.Ajax.requests.mostRecent()
-        expect(request.url).toBe('/db/trial.request')
-        expect(request.method).toBe('POST')
-        attrs = JSON.parse(request.params)
-        expect(attrs.properties?.organization).toBeUndefined()
-        expect(attrs.properties?.district).toEqual('District')
+      it 'does not submit form when school is not present', ->
+        expect(view.$('#organization-control').closest('.form-group').hasClass('has-error')).toEqual(true)
 
     describe 'submits the form without district', ->
       beforeEach ->
@@ -185,7 +178,7 @@ describe 'RequestQuoteView', ->
       beforeEach ->
         view.$el.find('#request-form').trigger('change') # to confirm navigating away isn't prevented
         form = view.$('#request-form')
-        formData = _.omit(successForm, ['organization'])
+        formData = _.clone(successForm)
         formData.district = 'N/A'
         forms.objectToForm(form, formData)
         form.submit()
@@ -218,6 +211,7 @@ describe 'RequestQuoteView', ->
           responseText: JSON.stringify([{
             _id: '1'
             properties: {
+              fullName: 'First Last'
               firstName: 'First'
               lastName: 'Last'
             }
@@ -226,7 +220,7 @@ describe 'RequestQuoteView', ->
         view.supermodel.once('loaded-all', done)
 
       it 'shows form with data from the most recent request', ->
-        expect(view.$('input[name="firstName"]').val()).toBe('First')
+        expect(view.$('input[name="fullName"]').val()).toBe('First Last')
 
     describe 'has role "student"', ->
       beforeEach (done) ->


### PR DESCRIPTION
This PR implements the following changes to the request a quote page:

- Convert first / last name to full name via a `parse-full-name` module
- Remove purchaser role and education level
- Changes the ordering of fields in the form to look good with reduced number of elements
- Replace text below "Request a Quote" with: Learn more about CodeCombat with an interactive walkthrough of the product
-  Change CTA at the bottom from "Request a Demo" -> "Submit"
- Make "School" and "Phone Number" fields required instead of optional
- Change "State" to "State/Region"
- Remove "What kind of class..." question