### PR TITLE
Add request a quote experiment

### DIFF
--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -5,6 +5,8 @@ CocoClass = require 'core/CocoClass'
 loadSegmentIo = require('core/services/segment')
 api = require('core/api')
 
+experiments = require('core/experiments')
+
 debugAnalytics = false
 
 module.exports = class Tracker extends CocoClass
@@ -81,7 +83,11 @@ module.exports = class Tracker extends CocoClass
     @explicitTraits ?= {}
     @explicitTraits[key] = value for key, value of traits
 
-    traitsToReport = ['email', 'anonymous', 'dateCreated', 'hourOfCode', 'name', 'referrer', 'testGroupNumber', 'testGroupNumberUS', 'gender', 'lastLevel', 'siteref', 'ageRange', 'schoolName', 'coursePrepaidID', 'role']
+    traitsToReport = [
+      'email', 'anonymous', 'dateCreated', 'hourOfCode', 'name', 'referrer', 'testGroupNumber', 'testGroupNumberUS',
+      'gender', 'lastLevel', 'siteref', 'ageRange', 'schoolName', 'coursePrepaidID', 'role'
+    ]
+
     if me.isTeacher(true)
       traitsToReport.push('firstName', 'lastName')
     for userTrait in traitsToReport
@@ -136,6 +142,9 @@ module.exports = class Tracker extends CocoClass
         eventAction: action
       gaFieldObject.eventLabel = properties.label if properties.label?
       gaFieldObject.eventValue = properties.value if properties.value?
+
+      gaFieldObject.dimmension0 = me.getHomePageTestGroup()
+      gaFieldObject.dimmension1 = experiments.getRequestAQuoteGroup(me)
 
       # Send trackABResult as true in the properties to track a/b test results in GA as the event label
       # TODO: what if gaFieldObject.label already exists

--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -144,7 +144,11 @@ module.exports = class Tracker extends CocoClass
       gaFieldObject.eventValue = properties.value if properties.value?
 
       # NOTE these custom dimensions need to be configured in GA prior to being reported
-      gaFieldObject.dimension1 = experiments.getRequestAQuoteGroup(me)
+      try
+        gaFieldObject.dimension1 = experiments.getRequestAQuoteGroup(me)
+      catch e
+        # TODO handle_error_ozaria
+        console.error(e)
 
       ga? 'send', gaFieldObject
       ga? 'codeplay.send', gaFieldObject if features.codePlay

--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -143,7 +143,7 @@ module.exports = class Tracker extends CocoClass
       gaFieldObject.eventLabel = properties.label if properties.label?
       gaFieldObject.eventValue = properties.value if properties.value?
 
-      gaFieldObject.dimension0 = experiments.getRequestAQuoteGroup(me)
+      gaFieldObject.dimension1 = experiments.getRequestAQuoteGroup(me)
 
       ga? 'send', gaFieldObject
       ga? 'codeplay.send', gaFieldObject if features.codePlay

--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -143,6 +143,7 @@ module.exports = class Tracker extends CocoClass
       gaFieldObject.eventLabel = properties.label if properties.label?
       gaFieldObject.eventValue = properties.value if properties.value?
 
+      # NOTE these custom dimensions need to be configured in GA prior to being reported
       gaFieldObject.dimension1 = experiments.getRequestAQuoteGroup(me)
 
       ga? 'send', gaFieldObject

--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -143,16 +143,7 @@ module.exports = class Tracker extends CocoClass
       gaFieldObject.eventLabel = properties.label if properties.label?
       gaFieldObject.eventValue = properties.value if properties.value?
 
-      gaFieldObject.dimmension0 = me.getHomePageTestGroup()
-      gaFieldObject.dimmension1 = experiments.getRequestAQuoteGroup(me)
-
-      # Send trackABResult as true in the properties to track a/b test results in GA as the event label
-      # TODO: what if gaFieldObject.label already exists
-      # As of now gaFieldObject.label doesnt exist for the specific events which are relevant for a/b test results, so not a concern for now
-      # Probably add multiple labels as keys in gaFieldObject.label in the future, if required.
-      if properties.trackABResult and not gaFieldObject.label
-        if me.getHomePageTestGroup()
-          gaFieldObject.eventLabel = "{testGroup:"+ me.getHomePageTestGroup() + "}"  # {testGroup:A} / {testGroup:B} / {testGroup:C}
+      gaFieldObject.dimension0 = experiments.getRequestAQuoteGroup(me)
 
       ga? 'send', gaFieldObject
       ga? 'codeplay.send', gaFieldObject if features.codePlay

--- a/app/core/experiments.js
+++ b/app/core/experiments.js
@@ -1,0 +1,9 @@
+export function getRequestAQuoteGroup (user) {
+  const bucket = user.get('testGroupNumber') % 10
+
+  if (bucket < 7) {
+    return 'request-a-quote-control'
+  } else {
+    return 'request-a-quote-header'
+  }
+}

--- a/app/core/experiments.js
+++ b/app/core/experiments.js
@@ -1,7 +1,7 @@
 export function getRequestAQuoteGroup (user) {
   const bucket = user.get('testGroupNumber') % 10
 
-  if (bucket < 7) {
+  if (bucket < 5) {
     return 'request-a-quote-control'
   } else {
     return 'request-a-quote-header'

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -241,6 +241,7 @@ module.exports = class User extends CocoModel
         return
     return errors
 
+  # TODO move to app/core/experiments when updated
   getCampaignAdsGroup: ->
     return @campaignAdsGroup if @campaignAdsGroup
     # group = me.get('testGroupNumber') % 2
@@ -253,6 +254,7 @@ module.exports = class User extends CocoModel
     @campaignAdsGroup
 
   # TODO: full removal of sub modal test
+  # TODO move to app/core/experiments when updated
   getSubModalGroup: () ->
     return @subModalGroup if @subModalGroup
     @subModalGroup = 'both-subs'
@@ -264,6 +266,7 @@ module.exports = class User extends CocoModel
   # Signs and Portents was receiving updates after test started, and also had a big bug on March 4, so just look at test from March 5 on.
   # ... and stopped working well until another update on March 10, so maybe March 11+...
   # ... and another round, and then basically it just isn't completing well, so we pause the test until we can fix it.
+  # TODO move to app/core/experiments when updated
   getFourthLevelGroup: ->
     return 'forgetful-gemsmith'
     return @fourthLevelGroup if @fourthLevelGroup
@@ -281,6 +284,7 @@ module.exports = class User extends CocoModel
     return 0 unless numVideos > 0
     return me.get('testGroupNumber') % numVideos
 
+  # TODO move to app/core/experiments when updated
   getHomePageTestGroup: () ->
     return  # ending A/B test on homepage for now.
     return unless me.get('country') == 'united-states'

--- a/app/templates/base-flat.jade
+++ b/app/templates/base-flat.jade
@@ -48,6 +48,9 @@ mixin accountLinks
                 .nav-spacer
                 if !me.hideTopRightNav()
                   ul.nav.navbar-nav
+                    if me.isAnonymous() && require('app/core/experiments').getRequestAQuoteGroup(me) === 'request-a-quote-header'
+                      li
+                        a.text-p(data-event-action="Header Request Quote CTA", data-i18n="new_home.request_quote")
                     li
                       if document.location.href.search('/about') >= 0
                         a.text-p.text-teal(href="/about", data-i18n="nav.about")

--- a/app/templates/base-flat.jade
+++ b/app/templates/base-flat.jade
@@ -50,7 +50,7 @@ mixin accountLinks
                   ul.nav.navbar-nav
                     if me.isAnonymous() && require('app/core/experiments').getRequestAQuoteGroup(me) === 'request-a-quote-header'
                       li
-                        a.text-p(data-event-action="Header Request Quote CTA", data-i18n="new_home.request_quote")
+                        a.text-p(data-event-action="Header Request Quote CTA", data-i18n="new_home.request_quote", href="/teachers/quote")
                     li
                       if document.location.href.search('/about') >= 0
                         a.text-p.text-teal(href="/about", data-i18n="nav.about")


### PR DESCRIPTION
- Adds an experiments module to capture grouping logic for future experiments.  Adds TODOs to existing experiment methods on User object to note that they should be migrated.
- Uses [GA custom dimensions](https://developers.google.com/analytics/devguides/collection/analyticsjs/custom-dims-mets) to track buckets.  This allows us to support up to 20 different configurations at any give time and allows us to continue using labels as intended.
- Add request a quote link to navbar when logged out
