### PR TITLE
Make development environment match '172.' as well as localhost

### DIFF
--- a/app/core/application.coffee
+++ b/app/core/application.coffee
@@ -51,7 +51,7 @@ Application = {
 #      document.location.href = '//lenovogamestate.com/login/'
 
     Router = require('core/Router')
-    @isProduction = -> document.location.href.search('https?://localhost') is -1
+    @isProduction = -> document.location.href.search('https?://localhost') is -1 and document.location.href.search('172.') is not 0
     Vue.config.devtools = not @isProduction()
 
     # propagate changes from global 'me' User to 'me' vuex module


### PR DESCRIPTION
# Windows WSL development tweaks

This makes sure hitting a local host type of address, for example starting with `172.`, is treated as localhost. 

If WSL is used without transforming the linux subsystem, then the address would be on the `172` range. 