### PR TITLE
Fix student signup flow for non-US/EU/Israel countries

### DIFF
--- a/app/views/core/CreateAccountModal/CreateAccountModal.coffee
+++ b/app/views/core/CreateAccountModal/CreateAccountModal.coffee
@@ -97,7 +97,7 @@ module.exports = class CreateAccountModal extends ModalView
       else
         if /^\/play/.test(location.pathname) and me.showIndividualRegister()
           @signupState.set({ path: 'individual', screen: 'segment-check' })
-    if @signupState.get('screen') is 'segment-check' and not @segmentCheckRequiredInCountry()
+    if @signupState.get('screen') is 'segment-check' and not @signupState.get('path') is 'student' and not @segmentCheckRequiredInCountry()
       @signupState.set screen: 'basic-info'
 
     @listenTo @signupState, 'all', _.debounce @render


### PR DESCRIPTION
SegmentCheckView asks for age for individual users, and class code for students. The view is restricted for non-US/EU/Israel countries, or if no country is set for the users, due to which the students in those countries are not able to get this screen to enter the class code during signup.
Hence fixing this by removing the check for `SegmentCheckView` for student signup flow.
Related asana: https://app.asana.com/0/654820789891907/1127558195120065