### PR TITLE
Fix game dev goal states

### DIFF
--- a/app/lib/Angel.coffee
+++ b/app/lib/Angel.coffee
@@ -388,8 +388,10 @@ module.exports = class Angel extends CocoClass
     console.log 'Construction:', (work.t1 - work.t0).toFixed(0), 'ms. Simulation:', (work.t2 - work.t1).toFixed(0), 'ms --', ((work.t2 - work.t1) / work.world.frames.length).toFixed(3), 'ms per frame, profiled.'
 
     # If performance was really a priority in IE9, we would rework things to be able to skip this step.
-    goalStates = work.world.goalManager?.getGoalStates()
     work.world.goalManager.worldGenerationEnded() if work.world.ended
+    goalStates = work.world.goalManager.getGoalStates()
+    work.world.goalManager.notifyGoalChanges()
+
     @running = false
 
     if work.headless

--- a/app/lib/Angel.coffee
+++ b/app/lib/Angel.coffee
@@ -387,10 +387,10 @@ module.exports = class Angel extends CocoClass
     console?.profileEnd?() if imitateIE9?
     console.log 'Construction:', (work.t1 - work.t0).toFixed(0), 'ms. Simulation:', (work.t2 - work.t1).toFixed(0), 'ms --', ((work.t2 - work.t1) / work.world.frames.length).toFixed(3), 'ms per frame, profiled.'
 
-    # If performance was really a priority in IE9, we would rework things to be able to skip this step.
-    work.world.goalManager.worldGenerationEnded() if work.world.ended
+    if work.world.ended
+      work.world.goalManager.worldGenerationEnded()
+      work.world.goalManager.notifyGoalChanges()
     goalStates = work.world.goalManager.getGoalStates()
-    work.world.goalManager.notifyGoalChanges()
 
     @running = false
 


### PR DESCRIPTION
Without this, we'd often show incomplete goals in game dev even as the level was finished.
![incomplete-goals](https://user-images.githubusercontent.com/99704/61321665-d9bb4900-a7c0-11e9-8e67-54d0675e0e84.png)

The problem was that the goal manager needs to mark "don't fail" type goals as successful once the world ends, but we weren't updating the goals view in game dev after that happened.