### PR TITLE
Updating Facebook API to 3.2

### DIFF
--- a/app/core/social-handlers/FacebookHandler.coffee
+++ b/app/core/social-handlers/FacebookHandler.coffee
@@ -70,7 +70,7 @@ module.exports = FacebookHandler = class FacebookHandler extends CocoClass
           channelUrl: document.location.origin + '/channel.html' # Channel File
           cookie: true # enable cookies to allow the server to access the session
           xfbml: true # parse XFBML
-          version: 'v2.9'
+          version: 'v3.2'
         })
         FB.getLoginStatus (response) =>
           if response.status is 'connected'


### PR DESCRIPTION
# Maintenance

Required to ship together with PR https://github.com/codecombat/codecombat/pull/111

This changes the Facebook API from `v2.9` to `v3.2`, extending the time we have before the next update is required. 

There are no known breaking changes for this version bump. 

From now on, age restriction is also a factor for our Facebook usage. There are separate efforts for this here: https://github.com/codecombat/codecombat-server/pull/110