### PR TITLE
Fix Cinematic positioning with multiple characters

### DIFF
--- a/app/schemas/models/selectors/cinematic.js
+++ b/app/schemas/models/selectors/cinematic.js
@@ -97,7 +97,7 @@ const setCharacterDefaults = ({ pos: { x, y }, scaleX, scaleY }) =>
     }
 
     const thang = character.thang || {}
-    thang.pos = { ...{ x, y }, ...thang.pos }
+    thang.pos = { ...{ x, y }, ...(thang.pos || {}) }
     thang.scaleX = thang.scaleX || scaleX
     thang.scaleY = thang.scaleY || scaleY
     character.thang = thang

--- a/app/schemas/models/selectors/cinematic.js
+++ b/app/schemas/models/selectors/cinematic.js
@@ -90,14 +90,14 @@ const DEFAULT_THANGTYPE = () => ({
  * @param {Object} thangDefaults
  * @returns {Function} sets thangDefaults on the thang property for a character.
  */
-const setCharacterDefaults = ({ pos, scaleX, scaleY }) =>
+const setCharacterDefaults = ({ pos: { x, y }, scaleX, scaleY }) =>
   character => {
     if (!character) {
       return
     }
 
     const thang = character.thang || {}
-    thang.pos = _.merge(pos, (thang.pos || {}))
+    thang.pos = { ...{ x, y }, ...thang.pos }
     thang.scaleX = thang.scaleX || scaleX
     thang.scaleY = thang.scaleY || scaleY
     character.thang = thang


### PR DESCRIPTION
## Issue

The default position could be mutated and thus change the position of the characters later in the cinematic.

## Fix

Use object assignment instead of lodash merge preventing mutation from occurring.
Manually tested the fix using proxy mode.
