### PR TITLE
Update art parser package lock dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2540,7 +2540,7 @@
       "optional": true
     },
     "adobe-animate-parser": {
-      "version": "github:codecombat/adobe-animate-parser#5ad01d2c1aa51180a033b675f33c86d6a89ea1da",
+      "version": "github:codecombat/adobe-animate-parser#02d6048a15b4adf881e88f023eeb8527a3c7f16e",
       "from": "github:codecombat/adobe-animate-parser#master",
       "requires": {
         "lodash.clone": "^4.5.0",


### PR DESCRIPTION
Updates package lock with latest adobe animate parser.

Adds feature for importing containers without animations.