### PR TITLE
Fix Cutscene Padding to not obscure controls

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -15,6 +15,17 @@ module.exports = function({ config }) {
   });
 
   config.module.rules.push({
+    test: /\.scss$/,
+    use: [
+      'vue-style-loader',
+      'css-loader',
+      {
+        loader: 'sass-loader'
+      }
+    ],
+  });
+
+  config.module.rules.push({
     test: /\.stories\.jsx?$/,
     loaders: [require.resolve('@storybook/addon-storysource/loader')],
     enforce: 'pre',

--- a/ozaria/site/components/common/LayoutChrome.vue
+++ b/ozaria/site/components/common/LayoutChrome.vue
@@ -43,6 +43,7 @@
 </template>
 
 <style lang="sass" scoped>
+  @import "ozaria/site/styles/common/variables.sass"
   $topOffset: 25px
 
   .chrome-container
@@ -53,7 +54,7 @@
     right: 0
     bottom: 0
 
-    padding: 69px 76px 37px 30px
+    padding: $chromeTopPadding $chromeRightPadding $chromeBottomPadding $chromeLeftPadding
 
   .chrome-border
     position: absolute

--- a/ozaria/site/components/cutscene/PageCutscene/index.vue
+++ b/ozaria/site/components/cutscene/PageCutscene/index.vue
@@ -1,10 +1,8 @@
 <script>
 import LayoutChrome from '../../common/LayoutChrome'
-import LayoutCenterContent from '../../common/LayoutCenterContent'
+import LayoutAspectRatioContainer from '../../common/LayoutAspectRatioContainer'
 import BaseVideo from '../common/BaseVideo'
 import { getCutscene } from '../../../api/cutscene'
-
-const CUTSCENE_ASPECT_RATIO = 16 / 9
 
 module.exports = Vue.extend({
   props: {
@@ -13,46 +11,32 @@ module.exports = Vue.extend({
       required: true
     }
   },
+
   data: () => ({
-    width: 1920,
-    height: 1080,
     vimeoId: null
   }),
+
   components: {
-    'layout-chrome': LayoutChrome,
-    'layout-center-content': LayoutCenterContent,
-    'base-video': BaseVideo
+    LayoutAspectRatioContainer,
+    LayoutChrome,
+    BaseVideo
   },
+
   mounted: function() {
     if (!me.hasCutsceneAccess()) {
       return application.router.navigate('/', { trigger: true })
     }
     this.loadCutscene()
   },
-  destroyed() {
-    window.removeEventListener("resize", this.onResize)
-  },
+
   methods: {
-    onResize () {
-      const userWidth = window.innerWidth
-        || document.documentElement.clientWidth
-        || document.body.clientWidth
-
-      const userHeight = window.innerHeight
-        || document.documentElement.clientHeight
-        || document.body.clientHeight
-
-      this.height = Math.min(userWidth / CUTSCENE_ASPECT_RATIO, userHeight)
-      this.width = this.height * CUTSCENE_ASPECT_RATIO
-    },
-    async loadCutscene () {
+    async loadCutscene() {
+      // TODO handle_error_ozaria - What if unable to fetch cutscene?
       const cutscene = await getCutscene(this.cutsceneId)
       this.vimeoId = cutscene.vimeoId
-
-      window.addEventListener('resize', this.onResize)
-      this.onResize()
     },
-    onCompleted () {
+
+    onCompleted() {
       this.$emit('completed')
     }
   }
@@ -61,28 +45,22 @@ module.exports = Vue.extend({
 
 <template>
   <layout-chrome>
-    <layout-center-content>
-      <div id="cutscene-player"
-      :style="{ width: width+'px', height: height+'px' }" v-if="vimeoId">
-      <!-- Currently this video is a hard coded example, that will be fetched from Cutscene collection -->
-        <base-video
-          :vimeoId="vimeoId"
-          :width="width"
-          :height="height"
+    <LayoutAspectRatioContainer>
+      <base-video
+        :vimeoId="vimeoId"
+        :style="{ width: 'calc(100vw - 106px)', height: 'calc(100vh - 106px)' }"
 
-          v-on:completed="onCompleted"
-        />
-      </div>
-    </layout-center-content>
+        v-on:completed="onCompleted"
+      />
+    </LayoutAspectRatioContainer>
   </layout-chrome>
-
 </template>
 
 <style lang="sass">
 
-#cutscene-player
-  margin-left: auto
-  margin-right: auto
+  #cutscene-player
+    margin-left: auto
+    margin-right: auto
 
 </style>
 

--- a/ozaria/site/components/cutscene/PageCutscene/index.vue
+++ b/ozaria/site/components/cutscene/PageCutscene/index.vue
@@ -1,6 +1,5 @@
 <script>
 import LayoutChrome from '../../common/LayoutChrome'
-import LayoutAspectRatioContainer from '../../common/LayoutAspectRatioContainer'
 import BaseVideo from '../common/BaseVideo'
 import { getCutscene } from '../../../api/cutscene'
 
@@ -45,14 +44,12 @@ module.exports = Vue.extend({
 
 <template>
   <layout-chrome>
-    <LayoutAspectRatioContainer>
-      <base-video
-        :vimeoId="vimeoId"
-        :style="{ width: 'calc(100vw - 106px)', height: 'calc(100vh - 106px)' }"
+    <base-video
+      :vimeoId="vimeoId"
+      :style="{ width: 'calc(100vw - 106px)', height: 'calc(100vh - 106px)' }"
 
-        v-on:completed="onCompleted"
-      />
-    </LayoutAspectRatioContainer>
+      v-on:completed="onCompleted"
+    />
   </layout-chrome>
 </template>
 

--- a/ozaria/site/components/cutscene/PageCutscene/index.vue
+++ b/ozaria/site/components/cutscene/PageCutscene/index.vue
@@ -16,7 +16,6 @@ module.exports = Vue.extend({
   }),
 
   components: {
-    LayoutAspectRatioContainer,
     LayoutChrome,
     BaseVideo
   },
@@ -46,7 +45,7 @@ module.exports = Vue.extend({
   <layout-chrome>
     <base-video
       :vimeoId="vimeoId"
-      :style="{ width: 'calc(100vw - 106px)', height: 'calc(100vh - 106px)' }"
+      id="cutscene-player"
 
       v-on:completed="onCompleted"
     />
@@ -54,10 +53,11 @@ module.exports = Vue.extend({
 </template>
 
 <style lang="sass">
+  @import "ozaria/site/styles/common/variables.sass"
 
   #cutscene-player
-    margin-left: auto
-    margin-right: auto
+    width: calc(100vw - #{$chromeRightPadding + $chromeLeftPadding})
+    height: calc(100vh - #{$chromeTopPadding + $chromeBottomPadding})
 
 </style>
 

--- a/ozaria/site/components/cutscene/common/BaseVideo.vue
+++ b/ozaria/site/components/cutscene/common/BaseVideo.vue
@@ -9,14 +9,6 @@ export default {
       type: String,
       required: false
     },
-    width: {
-      type: Number,
-      required: true
-    },
-    height: {
-      type: Number,
-      required: true
-    },
     videoSrc: {
       type: String,
       required: false
@@ -49,18 +41,16 @@ export default {
 </script>
 
 <template>
-  <div>
-    <iframe v-if="vimeoId" id="vimeo-player" :src="`https://player.vimeo.com/video/${vimeoId}`" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen :width="width" :height="height"></iframe>
-    <div v-else :style="{ width: width+'px', height: height+'px' }">
-      <video id="player" ref="player" playsinline controls>
-        <source :src="videoSrc" type="video/mp4" />
+  <iframe v-if="vimeoId" id="vimeo-player" :src="`https://player.vimeo.com/video/${vimeoId}`" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+  <div v-else>
+    <video id="player" ref="player" playsinline controls>
+      <source :src="videoSrc" type="video/mp4" />
 
-        <!-- Captions are optional -->
-        <template v-for="caption in captions">
-          <track :key="caption.label" kind="captions" :label="caption.label" :src="caption.src" :srclang="caption.srclang" default />
-        </template>
-    </video>
-    </div>
+      <!-- Captions are optional -->
+      <template v-for="caption in captions">
+        <track :key="caption.label" kind="captions" :label="caption.label" :src="caption.src" :srclang="caption.srclang" default />
+      </template>
+  </video>
   </div>
 </template>
 

--- a/ozaria/site/styles/common/variables.sass
+++ b/ozaria/site/styles/common/variables.sass
@@ -1,2 +1,8 @@
 $title-font-style: 'Arvo', serif
 $body-font-style: 'Open Sans', sans-serif
+
+// Ozaria Chrome
+$chromeTopPadding: 69px
+$chromeRightPadding: 76px
+$chromeBottomPadding: 37px
+$chromeLeftPadding: 30px

--- a/stories/BaseVideo.stories.js
+++ b/stories/BaseVideo.stories.js
@@ -7,12 +7,12 @@ import BaseVideo from '../ozaria/site/components/cutscene/common/BaseVideo.vue'
 
 storiesOf('BaseVideo', module).add('vimeo at 1080p size', () => ({
   components: { BaseVideo },
-  template: '<base-video :vimeoId="341904732" :width="1920" :height="1080" />'
+  template: `<base-video :vimeoId="341904732" :style="{ width: '1920px', height: '1080px' }"/>`
 }))
 
 storiesOf('BaseVideo', module).add('vimeo at ~480p size', () => ({
   components: { BaseVideo },
-  template: '<base-video :vimeoId="341904732" :width="640" :height="360" />'
+  template: `<base-video :vimeoId="341904732" :style="{ width: '640px', height: '360px' }" />`
 }))
 
 storiesOf('BaseVideo', module).add('video file at 480p size', () => ({
@@ -24,8 +24,7 @@ storiesOf('BaseVideo', module).add('video file at 480p size', () => ({
       src:'/captions/example.vtt',
       srclang:'en'
     }]"
-    :width="640"
-    :height="480"
+    :style="{ width: '640px', height: '360px' }"
   />`
 }))
 
@@ -42,7 +41,6 @@ storiesOf('BaseVideo', module).add('video file at 1080p size', () => ({
       src:'/captions/example.vtt',
       srclang:'cn'
     }]"
-    :width="1920"
-    :height="1080"
+    :style="{ width: '1920px', height: '1080px' }"
   />`
 }))


### PR DESCRIPTION
## Issue

The cutscene controls were being obscured by the chrome.

Storybook wasn't working with `scss` styles in vue components, so I also updated that.

## Fix

Use @jmif aspect ratio container and set the chrome padding size using css `calc`.

The refactor can be tested both in proxy with Cutscenes, but also by checking the BaseVideo stories in Storybook. Because this is a visual change I don't believe there is a better way to check this currently.

## Known issues

~In a future PR will move the chrome padding to variables shared across ozaria.~

