### PR TITLE
Interactives UX: Make draggable ordering swappable

### DIFF
--- a/ozaria/site/components/common/SwappingVueDraggable.vue
+++ b/ozaria/site/components/common/SwappingVueDraggable.vue
@@ -1,0 +1,36 @@
+<script>
+  import VueDraggable from 'vuedraggable'
+  import { Sortable, Swap } from 'sortablejs/modular/sortable.core.esm'
+
+  Sortable.mount(new Swap())
+
+  /**
+   * This is a hack to allow vuedraggable to support element swapping.  SortableJS, the
+   * library that drives Vue Draggable will support swap as of 1.10.0 (a release
+   * candidate currently exists for it at the time of this writing.
+   *
+   * It works by loading a newer version of Sortable in place of the _sortable
+   * objected used in VueDraggable.
+   *
+   * TODO when this is released, update VueDraggable version and use the built in swapping.  Remove this component.,
+   */
+  export default {
+    extends: VueDraggable,
+
+    mounted () {
+      if (this._sortable) {
+        this._sortable.destroy()
+      }
+
+      this._sortable = new Sortable(
+        this.rootContainer,
+        {
+          ...this.options,
+          swap: true
+        }
+      )
+
+      this.computeIndexes()
+    }
+  }
+</script>

--- a/ozaria/site/components/interactive/PageInteractive/draggableOrdering/index.vue
+++ b/ozaria/site/components/interactive/PageInteractive/draggableOrdering/index.vue
@@ -1,5 +1,5 @@
 <script>
-  import VueDraggable from 'vuedraggable'
+  import SwappingVueDraggable from '../../../common/SwappingVueDraggable'
   import { mapGetters } from 'vuex'
 
   import BaseInteractiveLayout from '../common/BaseInteractiveLayout'
@@ -17,7 +17,7 @@
       ModalInteractive,
       BaseInteractiveLayout,
 
-      'draggable': VueDraggable
+      SwappingVueDraggable
     },
 
     props: {
@@ -204,13 +204,10 @@
   >
     <div class="draggable-ordering-content">
       <div class="draggable-ordering-lists">
-        <draggable
+        <swapping-vue-draggable
           :list="promptSlots"
           class="slots-container prompt-slots"
-          ghost-class="ghost-slot"
           tag="ul"
-          :force-fallback="true"
-          fallback-class="dragging-slot"
         >
           <li
             v-for="prompt in promptSlots"
@@ -219,7 +216,7 @@
           >
             {{ prompt.text }}
           </li>
-        </draggable>
+        </swapping-vue-draggable>
 
         <ul
           class="slots-container"


### PR DESCRIPTION
- Adds temporary SwappingVueDraggable component until swap functionality is released
- Sets draggable ordering to use it so elements swap instead of sort