### PR TITLE
LevelUX bugs

### DIFF
--- a/app/schemas/models/level_component.coffee
+++ b/app/schemas/models/level_component.coffee
@@ -34,6 +34,7 @@ PropertyDocumentationSchema = c.object {
   type: c.shortString(title: 'Type', description: 'Intended type of the property.')
   shortDescription:
     oneOf: [
+      {title: 'Short Description', type: 'string', description: 'Short Description of the property.', maxLength: 1000, format: 'markdown'}
       {
         type: 'object',
         title: 'Language Descriptions (short)',
@@ -42,10 +43,10 @@ PropertyDocumentationSchema = c.object {
         format: 'code-languages-object'
         default: {javascript: ''}
       }
-      {title: 'Short Description', type: 'string', description: 'Short Description of the property.', maxLength: 1000, format: 'markdown'}
     ]
   description:
     oneOf: [
+      {title: 'Description', type: 'string', description: 'Description of the property.', maxLength: 1000, format: 'markdown'}
       {
         type: 'object',
         title: 'Language Descriptions',
@@ -54,7 +55,6 @@ PropertyDocumentationSchema = c.object {
         format: 'code-languages-object'
         default: {javascript: ''}
       }
-      {title: 'Description', type: 'string', description: 'Description of the property.', maxLength: 1000, format: 'markdown'}
     ]
   args: c.array {title: 'Arguments', description: 'If this property has type "function", then provide documentation for any function arguments.'}, c.FunctionArgumentSchema
   owner: {title: 'Owner', type: 'string', description: 'Owner of the property, like "this" or "Math".'}

--- a/ozaria/site/views/play/level/LevelPlaybackView.coffee
+++ b/ozaria/site/views/play/level/LevelPlaybackView.coffee
@@ -64,8 +64,7 @@ module.exports = class LevelPlaybackView extends CocoView
     @goto = t 'play_level.time_goto'
     @current = t 'play_level.time_current'
     @total = t 'play_level.time_total'
-    @$el.find('#play-button').css('visibility', 'hidden') if @options.level.get 'hidesPlayButton'  # Don't show for first few levels, confuses new players.
-
+    
   # These functions could go to some helper class
 
   pad2: (num) ->

--- a/ozaria/site/views/play/level/LevelPlaybackView.coffee
+++ b/ozaria/site/views/play/level/LevelPlaybackView.coffee
@@ -64,7 +64,8 @@ module.exports = class LevelPlaybackView extends CocoView
     @goto = t 'play_level.time_goto'
     @current = t 'play_level.time_current'
     @total = t 'play_level.time_total'
-    
+    @$el.find('#play-button').css('visibility', 'hidden') if @options.level.get 'hidesPlayButton'  # Don't show for first few levels, confuses new players.
+
   # These functions could go to some helper class
 
   pad2: (num) ->

--- a/ozaria/site/views/play/level/PlayLevelView.js
+++ b/ozaria/site/views/play/level/PlayLevelView.js
@@ -884,17 +884,9 @@ class PlayLevelView extends RootView {
       this.surface.showLevel()
     }
     Backbone.Mediator.publish('level:set-time', { time: 0 })
-    if (
-      (this.isEditorPreview || this.observing) &&
-      !utils.getQueryVariable('intro')
-    ) {
-      this.loadingView.startUnveiling()
-      return this.loadingView.unveil(true)
-    } else {
-      return this.scriptManager != null
-        ? this.scriptManager.initializeCamera()
-        : undefined
-    }
+    return this.scriptManager != null
+      ? this.scriptManager.initializeCamera()
+      : undefined
   }
 
   onLoadingViewUnveiling (e) {
@@ -910,9 +902,11 @@ class PlayLevelView extends RootView {
           // We used to autoplay by default, but now we only do it if the level says to in the introduction script.
           Backbone.Mediator.publish('level:set-playing', { playing: true })
         }
-        this.loadingView.$el.remove()
-        this.removeSubView(this.loadingView)
-        this.loadingView = null
+        if (this.loadingView) {
+          this.loadingView.$el.remove()
+          this.removeSubView(this.loadingView)
+          this.loadingView = null
+        }
         this.playAmbientSound()
         // TODO: Is it possible to create a Mongoose ObjectId for 'ls', instead of the string returned from get()?
         if (!this.observing) {

--- a/ozaria/site/views/play/level/modal/LevelIntroComponent.vue
+++ b/ozaria/site/views/play/level/modal/LevelIntroComponent.vue
@@ -5,7 +5,7 @@
         class="modal-header-content"
         style="text-align:center;"
       >
-        <span class="title">
+        <span class="title text-capitalize">
           {{ title }}
         </span>
       </div>

--- a/ozaria/site/views/play/level/tome/DocFormatter.coffee
+++ b/ozaria/site/views/play/level/tome/DocFormatter.coffee
@@ -101,7 +101,7 @@ module.exports = class DocFormatter
 
 
     # Grab the language-specific documentation for some sub-properties, if we have it.
-    toTranslate = [{obj: @doc, prop: 'description'}, {obj: @doc, prop: 'example'}]
+    toTranslate = [{obj: @doc, prop: 'description'}, {obj: @doc, prop: 'example'}, {obj: @doc, prop: 'shortDescription'}]
     for arg in (@doc.args ? [])
       toTranslate.push {obj: arg, prop: 'example'}, {obj: arg, prop: 'description'}
     if @doc.returns


### PR DESCRIPTION
- Language-specific short description not working in command bank
- Change default type for description and short description to be generic for all languages for the ease of content creation
- Play level view loading error in case of editor mode (i.e. query param dev=true)(because of the changes in loading view for ozaria and the new intro screen)