### PR TITLE
Center Cinematic and add Click to Continue

### DIFF
--- a/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
+++ b/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
@@ -104,18 +104,30 @@ class SpeechBubble {
     this.id = `speech-${_id++}`
     const parser = new DOMParser()
     const html = parser.parseFromString(htmlString, 'text/html')
-    const textDiv = html.body.firstChild
-    textDiv.style.display = 'inline-block'
-    textDiv.style.position = 'absolute'
-    textDiv.style.maxWidth = SPEECH_BUBBLE_MAX_WIDTH
-    textDiv.style.opacity = 0
-    textDiv.id = this.id
-    textDiv.className = `cinematic-speech-bubble-${side}`
 
-    div.appendChild(textDiv)
+    const textDiv = html.body.firstChild
+    const speechBubbleDiv = document.createElement('div')
+
+    speechBubbleDiv.style.display = 'inline-block'
+    speechBubbleDiv.style.position = 'absolute'
+    speechBubbleDiv.style.maxWidth = SPEECH_BUBBLE_MAX_WIDTH
+    speechBubbleDiv.id = this.id
+    speechBubbleDiv.className = `cinematic-speech-bubble-${side}`
+    speechBubbleDiv.style.opacity = 0
+
+    speechBubbleDiv.appendChild(textDiv)
+
+    const clickToContinue = document.createElement('div')
+    clickToContinue.className = `cinematic-speech-bubble-click-continue`
+    // TODO punted i18n for Click to Continue.
+    clickToContinue.innerHTML = '<span>Click To Continue</span>'
+    clickToContinue.style.opacity = 0
+
+    speechBubbleDiv.appendChild(clickToContinue)
+    div.appendChild(speechBubbleDiv)
 
     // Calculate bounding box
-    const bbox = textDiv.getBoundingClientRect()
+    const bbox = speechBubbleDiv.getBoundingClientRect()
     const width = (bbox.right - bbox.left) + 2 * BUBBLE_PADDING
     const height = (bbox.bottom - bbox.top) + 2 * BUBBLE_PADDING
 
@@ -126,8 +138,8 @@ class SpeechBubble {
       x -= width
     }
 
-    textDiv.style.left = `${x / WIDTH * 100}%`
-    textDiv.style.top = `${y / HEIGHT * 100}%`
+    speechBubbleDiv.style.left = `${x / WIDTH * 100}%`
+    speechBubbleDiv.style.top = `${y / HEIGHT * 100}%`
 
     const letters = (document.querySelectorAll(`#${this.id} .letter`) || []).length || 1
     if (textDuration === undefined) {
@@ -151,9 +163,14 @@ class SpeechBubble {
         opacity: 1,
         duration: 20,
         delay: anime.stagger(textDuration / letters, { easing: 'linear' }),
-        easing: 'easeOutQuad',
+        easing: 'easeOutQuad'
+      })
+      .add({
+        targets: `#${this.id} .cinematic-speech-bubble-click-continue`,
+        opacity: 1,
+        duration: 700,
         complete: () => {
-          shownDialogBubbles.push(textDiv)
+          shownDialogBubbles.push(speechBubbleDiv)
         }
       })
   }

--- a/ozaria/site/components/cinematic/common/CinematicCanvas.vue
+++ b/ozaria/site/components/cinematic/common/CinematicCanvas.vue
@@ -89,16 +89,13 @@ export default {
       }
     },
     onResize: _.debounce(function(e) {
-      // TODO handle_error_ozaria - Not an error but brittle.
-      const hard_coded_chrome_padding = 105;
-
-      const userWidth = Math.min((window.innerWidth
+      const userWidth = Math.min(window.innerWidth
         || document.documentElement.clientWidth
-        || document.body.clientWidth) - hard_coded_chrome_padding, WIDTH)
+        || document.body.clientWidth, WIDTH)
 
-      const userHeight = Math.min((window.innerHeight
+      const userHeight = Math.min(window.innerHeight
         || document.documentElement.clientHeight
-        || document.body.clientHeight) - hard_coded_chrome_padding, HEIGHT)
+        || document.body.clientHeight, HEIGHT)
 
       const height = this.height = Math.min(userWidth * CINEMATIC_ASPECT_RATIO, HEIGHT, userHeight)
       const width = this.width = this.height / CINEMATIC_ASPECT_RATIO
@@ -122,7 +119,7 @@ export default {
 
 #cinematic-canvas-div
   // Changing this transform may cause artifacts in border-image-slice of speech bubbles.
-  transform: translate(-23px, 16px)
+  transform: translate(-24px, 16px)
 
 #cinematic-div
   margin-left: auto

--- a/ozaria/site/components/cinematic/common/CinematicCanvas.vue
+++ b/ozaria/site/components/cinematic/common/CinematicCanvas.vue
@@ -15,9 +15,6 @@
         :height="height"
         :style="{ width: width+'px', height: height+'px' }">
       </canvas>
-      <div id="click-anywhere">
-        <span>Click anywhere to Continue</span>
-      </div>
     </div>
   </div>
 </template>
@@ -91,20 +88,23 @@ export default {
         this.userInterruptionEvent()
       }
     },
-    onResize: function(e) {
-      const userWidth = Math.min(window.innerWidth
-        || document.documentElement.clientWidth
-        || document.body.clientWidth, WIDTH)
+    onResize: _.debounce(function(e) {
+      // TODO handle_error_ozaria - Not an error but brittle.
+      const hard_coded_chrome_padding = 105;
 
-      const userHeight = Math.min(window.innerHeight
+      const userWidth = Math.min((window.innerWidth
+        || document.documentElement.clientWidth
+        || document.body.clientWidth) - hard_coded_chrome_padding, WIDTH)
+
+      const userHeight = Math.min((window.innerHeight
         || document.documentElement.clientHeight
-        || document.body.clientHeight, HEIGHT)
+        || document.body.clientHeight) - hard_coded_chrome_padding, HEIGHT)
 
       const height = this.height = Math.min(userWidth * CINEMATIC_ASPECT_RATIO, HEIGHT, userHeight)
       const width = this.width = this.height / CINEMATIC_ASPECT_RATIO
 
       this.controller.onResize({ width, height })
-    }
+    }, 250)
   },
   beforeDestroy: function()  {
     if (this.controller) {
@@ -117,11 +117,12 @@ export default {
 </script>
 
 <style lang="sass">
-//   This should not be scoped so it works on
-//   programmatically created divs.
+// This should not be scoped so it works on programmatically created divs like
+// speech bubbles.
 
 #cinematic-canvas-div
-  transform: translateX(-20px)
+  // Changing this transform may cause artifacts in border-image-slice of speech bubbles.
+  transform: translate(-23px, 16px)
 
 #cinematic-div
   margin-left: auto
@@ -136,6 +137,10 @@ export default {
   display: block
   position: absolute
 
+.cinematic-speech-bubble-right, .cinematic-speech-bubble-left
+  // HACK: This transform fixes a speech bubble artifact - 9 slice is visible.
+  transform: translate(-2px, -1px)
+
 .cinematic-speech-bubble-right
   border-image: url('/images/ozaria/cinematic/bubble_right_slice.png')
   border-image-slice: 50 100 50 50 fill
@@ -148,21 +153,13 @@ export default {
   border-image-width: 40px 40px 40px 80px
   border-image-outset: 10px 15px 15px 58px
 
-#click-anywhere
-  font-size: 18px
+.cinematic-speech-bubble-click-continue
   text-align: center
-  color: #000000
-  letter-spacing: 0.75px
-  line-height: 24px
-  span
-    position: absolute
-    top: 5.1%
-    right: 5.1%
-    height: 38px
-    width: 303px
-    padding-top: 6px
-    border-radius: 19px
-    background-color: #D8DBE8
-    border: 1px solid #AAABAF
+  color: #1FBAB4
+  font-family: "Open Sans"
+  font-size: 12px
+  letter-spacing: 0.51px
+  line-height: 26px
+  font-style: italic
 
 </style>

--- a/ozaria/site/styles/common/variables.sass
+++ b/ozaria/site/styles/common/variables.sass
@@ -2,7 +2,6 @@ $title-font-style: 'Arvo', serif
 $body-font-style: 'Open Sans', sans-serif
 
 // Ozaria Chrome
-// - If updating chrome padding, there is a variable that must be updated in CinematicCanvas.vue
 $chromeTopPadding: 69px
 $chromeRightPadding: 76px
 $chromeBottomPadding: 37px

--- a/ozaria/site/styles/common/variables.sass
+++ b/ozaria/site/styles/common/variables.sass
@@ -2,6 +2,7 @@ $title-font-style: 'Arvo', serif
 $body-font-style: 'Open Sans', sans-serif
 
 // Ozaria Chrome
+// - If updating chrome padding, there is a variable that must be updated in CinematicCanvas.vue
 $chromeTopPadding: 69px
 $chromeRightPadding: 76px
 $chromeBottomPadding: 37px


### PR DESCRIPTION
- Update Cinematic to work with the new chrome padding as per discussion.
    - Manually checked that there is no border at 1366 by 768.
- Add "Click to Continue" to bottom of speech bubble. (Non final).
- Remove permanent Click to Continue from top right.
- Added debounce to resize to make it more performant.