### PR TITLE
Cinematic speech bubbles not clearing consistently

### DIFF
--- a/ozaria/engine/cinematic/commands/commands.js
+++ b/ozaria/engine/cinematic/commands/commands.js
@@ -47,11 +47,11 @@ export class Sleep extends AbstractCommand {
  */
 export class AnimeCommand extends AbstractCommand {
   /**
-   * @param {anime} animation The animation that will be run.
+   * @param {() => anime} animation A function that returns an animation
    */
   constructor (animation) {
     super()
-    this.animation = animation
+    this.animationFn = animation
   }
 
   /**
@@ -60,6 +60,7 @@ export class AnimeCommand extends AbstractCommand {
    */
   run () {
     return new Promise((resolve, reject) => {
+      this.animation = this.animationFn()
       this.animation.play()
       this.animation.complete = resolve
     })

--- a/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
+++ b/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
@@ -79,7 +79,7 @@ export default class DialogSystem {
    */
   clearShownDialogBubbles () {
     return new SyncFunction(() => {
-      this.shownDialogBubbles.forEach(el => el.remove())
+      this.shownDialogBubbles.forEach(el => { el.style.display = 'none' })
     })
   }
 }
@@ -148,37 +148,37 @@ class SpeechBubble {
     // We set up the animation but don't play it yet.
     // On completion we attach html node to the `shownDialogBubbles`
     // array for future cleanup.
-    this.animation = anime
-      .timeline({
-        autoplay: false
-      })
-      .add({
-        targets: `#${this.id}`,
-        opacity: 1,
-        duration: 100,
-        easing: 'easeInOutQuart'
-      })
-      .add({
-        targets: `#${this.id} .letter`,
-        opacity: 1,
-        duration: 20,
-        delay: anime.stagger(textDuration / letters, { easing: 'linear' }),
-        easing: 'easeOutQuad'
-      })
-      .add({
-        targets: `#${this.id} .cinematic-speech-bubble-click-continue`,
-        opacity: 1,
-        duration: 700,
-        complete: () => {
-          shownDialogBubbles.push(speechBubbleDiv)
-        }
-      })
+    this.animationFn = () => {
+      shownDialogBubbles.push(speechBubbleDiv)
+      return anime
+        .timeline({
+          autoplay: false
+        })
+        .add({
+          targets: `#${this.id}`,
+          opacity: 1,
+          duration: 100,
+          easing: 'easeInOutQuart'
+        })
+        .add({
+          targets: `#${this.id} .letter`,
+          opacity: 1,
+          duration: 20,
+          delay: anime.stagger(textDuration / letters, { easing: 'linear' }),
+          easing: 'easeOutQuad'
+        })
+        .add({
+          targets: `#${this.id} .cinematic-speech-bubble-click-continue`,
+          opacity: 1,
+          duration: 700
+        })
+    }
   }
 
   /**
    * @returns {AbstractCommand} command to play the animation revealing the speech bubble.
    */
   createBubbleCommand () {
-    return new AnimeCommand(this.animation)
+    return new AnimeCommand(this.animationFn)
   }
 }


### PR DESCRIPTION
## Issue

Anime.js callbacks not firing consistently, resulting in dialog bubbles that would become frozen on the cinematic.

## Fix

Pass the animation as a callback and separate the cleanup logic from the animation function.

## How to manually test

If you'd like to manually test their are two UX interactions that are affected by this change.

1. Wait till a dialog bubble has been completely revealed and then clicking to continue.
2. Clicking during the reveal of a dialog bubble to skip it. And then clicking to continue.

These can be tested in proxy mode by running `npm run dev` and `npm run proxy` simultaneously.
Then log in as admin and navigate to: http://localhost:3000/cinematic/1fhl1c1
Prior to this fix you should occasionally see dialog get frozen.