### PR TITLE
Center cinematic and add i18n

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1344,6 +1344,9 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     beautify: "Beautify your code by standardizing its formatting."
     maximize_editor: "Maximize/minimize code editor."
 
+  cinematic:
+    click_anywhere_continue: "click anywhere to continue"
+
   community:
     main_title: "CodeCombat Community"
     introduction: "Check out the ways you can get involved below and decide what sounds the most fun. We look forward to working with you!"

--- a/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
+++ b/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
@@ -119,8 +119,7 @@ class SpeechBubble {
 
     const clickToContinue = document.createElement('div')
     clickToContinue.className = `cinematic-speech-bubble-click-continue`
-    // TODO punted i18n for Click to Continue.
-    clickToContinue.innerHTML = '<span>Click To Continue</span>'
+    clickToContinue.innerHTML = `<span>${window.i18n.t('cinematic.click_anywhere_continue')}</span>`
     clickToContinue.style.opacity = 0
 
     speechBubbleDiv.appendChild(clickToContinue)

--- a/ozaria/site/components/common/LayoutCenterContent.vue
+++ b/ozaria/site/components/common/LayoutCenterContent.vue
@@ -12,9 +12,7 @@ export default {
 
 <template>
   <div id="layout-center" :style="{ 'background-image': 'url(' + backgroundImage + ')' }">
-    <div class="middle">
-      <slot></slot>
-    </div>
+    <slot></slot>
   </div>
 </template>
 
@@ -22,18 +20,16 @@ export default {
 // Method for centering div:
 // https://stackoverflow.com/questions/396145/how-to-vertically-center-a-div-for-all-browsers#6182661
 #layout-center
-  display: table
-  position: absolute
-  top: 0
-  left: 0
   height: 100%
   width: 100%
   background-color: #F4E4AC
   background-size: 100%
 
-.middle
-  display: table-cell
-  vertical-align: middle
+  display: flex
+  flex-direction: column
+
+  align-items: center
+  justify-content: center
 
 </style>
 


### PR DESCRIPTION
## Features

 - Cinematic is constrained by the padding correctly. None of the cinematic is obscured.
 - "Click to Continue" has been changed to "click anywhere to continue" and supports i18n.


## How to manually test

Set up local proxy environment with `npm run dev` and `npm run proxy` running in parallel.

Navigate to localhost:3000 and log into your admin account.

Navigate to http://localhost:3000/cinematic/1fhl1c1 (or any cinematic) and observe that the bottom of the dialog bubble has `click anywhere to continue`.
While resizing the cinematic should stay within the bounds of the padding and not be obscured.
