### PR TITLE
Internal character cusomization color tool

### DIFF
--- a/app/views/editor/thang/ThangTypeEditView.coffee
+++ b/app/views/editor/thang/ThangTypeEditView.coffee
@@ -721,10 +721,10 @@ module.exports = class ThangTypeEditView extends RootView
   # ```
   # currentView.normalizeColorsForCustomization()
   # ```
-  # into the console. Used to normalize the shape colors for Ozaria Hero A and B
-  # to support customization.
+  # into the console. Used to normalize the shape colors for Ozaria Heroes to
+  # support character customization.
   normalizeColorsForCustomization: ->
-    replaceRgbaWithCustomizableHex(@thangType.attributes.raw.shapes)
+    @thangType.attributes.raw.shapes = replaceRgbaWithCustomizableHex(@thangType.attributes.raw.shapes)
     @treema.set('raw', @thangType.get('raw'))
 
   destroy: ->

--- a/app/views/editor/thang/ThangTypeEditView.coffee
+++ b/app/views/editor/thang/ThangTypeEditView.coffee
@@ -10,6 +10,7 @@ require 'lib/setupTreema'
 createjs = require 'lib/createjs-parts'
 LZString = require 'lz-string'
 initSlider = require 'lib/initSlider'
+replaceRgbaWithCustomizableHex = require('./replaceRgbaWithCustomizableHex.js').default
 
 # in the template, but need to require to load them
 require 'views/modal/RevertModal'
@@ -715,6 +716,16 @@ module.exports = class ThangTypeEditView extends RootView
   onClickExportSpriteSheetButton: ->
     modal = new ExportThangTypeModal({}, @thangType)
     @openModalView(modal)
+
+  # Run it in the editor/thang/<thang-type> view by inputting the following:
+  # ```
+  # currentView.normalizeColorsForCustomization()
+  # ```
+  # into the console. Used to normalize the shape colors for Ozaria Hero A and B
+  # to support customization.
+  normalizeColorsForCustomization: ->
+    replaceRgbaWithCustomizableHex(@thangType.attributes.raw.shapes)
+    @treema.set('raw', @thangType.get('raw'))
 
   destroy: ->
     @camera?.destroy()

--- a/app/views/editor/thang/replaceRgbaWithCustomizableHex.js
+++ b/app/views/editor/thang/replaceRgbaWithCustomizableHex.js
@@ -1,0 +1,58 @@
+/**
+ * This is an internal script that can be used in the thangEditor to normalize
+ * all the Adobe Animate colors in the shapes to hex values that can be customized.
+ */
+
+const colorBuckets = {
+  hairLight: '#752744',
+  hairMid: '#431D32',
+  hairDark: '#330A1D',
+  skinLight: '#DA6D46',
+  skinMid: '#703E31',
+  skinDark: '#58322A',
+  skinAccent: '#3A1E15'
+}
+
+const rgbaRegex = /rgba\((.*?),(.*?),(.*?),(.*?)\)/g
+
+function hexToRgb (hex) {
+  const extractHex = (start, end) => parseInt(hex.slice(start, end), 16)
+  return [extractHex(1, 3), extractHex(3, 5), extractHex(5, 7)]
+}
+
+// Used to check if two colors are similar.
+const isSimilar = (a, b) => Math.abs(a - b) <= 3
+
+/**
+ * Replaces rgba values with the bucketed hex value.
+ * Tries to detect if the value is similar to one of the bucket values.
+ * If so, will round into a bucket value.
+ * @param s text contents of the file
+ */
+function replaceRgbaWithHex (s) {
+  return s.replace(rgbaRegex, (matchedString, r, g, b, _a) => {
+    const r1 = parseInt(r, 10)
+    const g1 = parseInt(g, 10)
+    const b1 = parseInt(b, 10)
+    // const a1: number = parseFloat(a)
+    for (const hexColor of Object.values(colorBuckets)) {
+      const [r2, g2, b2] = hexToRgb(hexColor)
+      if ([[r1, r2], [g1, g2], [b1, b2]].every(([v1, v2]) => isSimilar(v1, v2))) {
+        console.log(`replacing ${matchedString} with normalized value: ${hexColor}`)
+        return `${hexColor}`
+      }
+    }
+    return matchedString
+  })
+}
+
+// Mutates the raw shapes object.
+export default function replaceRgbaWithCustomizableHex (shapesObject) {
+  console.group('Logs for replaceRgbaWithCustomizableHex execution')
+  for (const shape of Object.values(shapesObject)) {
+    if (shape.fc) {
+      shape.fc = replaceRgbaWithHex(shape.fc)
+    }
+  }
+  console.groupEnd()
+}

--- a/app/views/editor/thang/replaceRgbaWithCustomizableHex.js
+++ b/app/views/editor/thang/replaceRgbaWithCustomizableHex.js
@@ -2,6 +2,7 @@
  * This is an internal script that can be used in the thangEditor to normalize
  * all the Adobe Animate colors in the shapes to hex values that can be customized.
  */
+import _ from 'lodash'
 
 const colorBuckets = {
   hairLight: '#752744',
@@ -25,7 +26,7 @@ const isSimilar = (a, b) => Math.abs(a - b) <= 3
 
 /**
  * Replaces rgba values with the bucketed hex value.
- * Tries to detect if the value is similar to one of the bucket values.
+* Tries to detect if the value is similar to one of the bucket values.
  * If so, will round into a bucket value.
  * @param s text contents of the file
  */
@@ -34,7 +35,6 @@ function replaceRgbaWithHex (s) {
     const r1 = parseInt(r, 10)
     const g1 = parseInt(g, 10)
     const b1 = parseInt(b, 10)
-    // const a1: number = parseFloat(a)
     for (const hexColor of Object.values(colorBuckets)) {
       const [r2, g2, b2] = hexToRgb(hexColor)
       if ([[r1, r2], [g1, g2], [b1, b2]].every(([v1, v2]) => isSimilar(v1, v2))) {
@@ -46,13 +46,17 @@ function replaceRgbaWithHex (s) {
   })
 }
 
-// Mutates the raw shapes object.
+// Returns a new shapesObject with colors replaced.
 export default function replaceRgbaWithCustomizableHex (shapesObject) {
   console.group('Logs for replaceRgbaWithCustomizableHex execution')
-  for (const shape of Object.values(shapesObject)) {
+  const result = {}
+  for (const shapeKey of Object.keys(shapesObject)) {
+    const shape = _.cloneDeep(shapesObject[shapeKey])
     if (shape.fc) {
       shape.fc = replaceRgbaWithHex(shape.fc)
     }
+    result[shapeKey] = shape
   }
   console.groupEnd()
+  return result
 }


### PR DESCRIPTION
This tool has no interface by design. It will only be used on a tiny subset of the art that we'll be importing, but is a useful command. One that I have been using in proxy mode to fix art.

## How to use

Lets you run the command `currentView.normalizeColorsForCustomization()` in the console while in the thang editor on a thangtype. This will fix the Adobe Animate colors and make the character work with Character Customization.

## Why is this a useful command

Adobe Animate doesn't export the colors we have defined as hex values, but as either:

 - The hex value.
 - an `rgba` value where the `rgb` part is very close to or exactly the hex value.

Because the engine can't customize rgba values, this tool iterates through a thangTypes shapes and sees if the color is near one of the character customization colors.
If so, the colors representation becomes the hex value of the character customization.

This results is easy to select color groupings:

https://i.gyazo.com/201997eacecdac986bd786c5ffbee2df.mp4

[![Character Customization Selection of groups](https://i.gyazo.com/201997eacecdac986bd786c5ffbee2df.gif)](https://gyazo.com/201997eacecdac986bd786c5ffbee2df)