### PR TITLE
Level UX updates

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -176,7 +176,11 @@ module.exports = class CocoRouter extends Backbone.Router
     'logout': 'logout'
 
     'minigames/conditionals': go('minigames/ConditionalMinigameView')
-    'ozaria/play/level/:levelID': go('views/ozaria/site/play/level/PlayLevelView')
+    'ozaria/play/level/:levelID': (levelID) ->
+      props = {
+        levelID: levelID
+      }
+      @routeDirectly('ozaria/site/play/PagePlayLevel', [], {vueRoute: true, baseTemplate: 'base-empty', propsData: props})
     # TODO move to vue router after support for empty template is added there
     'ozaria/play/:campaign(?course-instance=:courseInstanceId)': (campaign, courseInstanceId) ->
       props = {

--- a/app/lib/dynamicRequire.js
+++ b/app/lib/dynamicRequire.js
@@ -134,7 +134,7 @@ module.exports = {
   // TODO: Why does chunk name `ozariaPlay` not work sporadically?
   'views/ozaria/site/play/PageUnitMap': function() { return import(/*webpackChunkName: "ozariaPlay" */ 'ozaria/site/components/play/PageUnitMap') },
   'views/ozaria/site/characterCustomization': function() { return import(/*webpackChunkName: "ozariaPlay" */ 'ozaria/site/components/char_customization/PageCharCustomization') },
-  'views/ozaria/site/play/level/PlayLevelView': function () { return import(/* webpackChunkName: "ozariaPlay" */ 'ozaria/site/views/play/level/PlayLevelView') },
+  'views/ozaria/site/play/PagePlayLevel': function () { return import(/* webpackChunkName: "ozariaPlay" */ 'ozaria/site/components/play/PagePlayLevel') },
   'views/cinematic': function() { return import(/* webpackChunkName: "ozariaPlay" */ 'ozaria/site/components/cinematic/PageCinematic') },
   'views/cutscene': function() { return import(/* webpackChunkName: "ozariaPlay" */ 'ozaria/site/components/cutscene/PageCutscene') },
   'views/interactive': function() { return import(/* webpackChunkName: "ozariaPlay" */ 'ozaria/site/components/interactive/PageInteractive') },

--- a/ozaria/site/components/common/LayoutAspectRatioContainer.vue
+++ b/ozaria/site/components/common/LayoutAspectRatioContainer.vue
@@ -25,8 +25,10 @@
     },
 
     mounted () {
-      window.addEventListener('resize', this.onResize)
-      this.onResize()
+      this.$nextTick(() => {
+        window.addEventListener('resize', this.onResize)
+        this.onResize()
+      })
     },
 
     beforeDestroy () {
@@ -57,7 +59,7 @@
         const paddingBottom = parseInt(computedStyle.getPropertyValue('padding-bottom') || 0, 10)
 
         this.parentWidth = this.parentWidth - paddingLeft - paddingRight
-        this.parentHeight = this.parentWidth - paddingTop - paddingBottom
+        this.parentHeight = this.parentHeight - paddingTop - paddingBottom
 
         this.$emit('resize')
       }
@@ -69,7 +71,13 @@
   <div
     ref="el"
     :style="{ width: finalWidth + 'px', height: finalHeight + 'px' }"
+    class="aspect-ratio-container"
   >
     <slot />
   </div>
 </template>
+
+<style lang="sass" scoped>
+  .aspect-ratio-container
+    position: relative
+</style>

--- a/ozaria/site/components/common/LayoutAspectRatioContainer.vue
+++ b/ozaria/site/components/common/LayoutAspectRatioContainer.vue
@@ -25,10 +25,9 @@
     },
 
     mounted () {
-      this.$nextTick(() => {
-        window.addEventListener('resize', this.onResize)
-        this.onResize()
-      })
+      window.addEventListener('resize', this.onResize)
+      this.onResize()
+      this.$nextTick(() => this.onResize())
     },
 
     beforeDestroy () {

--- a/ozaria/site/components/play/PagePlayLevel/index.vue
+++ b/ozaria/site/components/play/PagePlayLevel/index.vue
@@ -1,0 +1,43 @@
+<template>
+  <LayoutChrome>
+    <LayoutCenterContent>
+      <LayoutAspectRatioContainer
+        :aspect-ratio="1266 / 668"
+      >
+        <backbone-view-harness
+          :backbone-view="backboneView"
+          :backbone-options="{}"
+          :backbone-args="[ levelID ]"
+        />
+      </LayoutAspectRatioContainer>
+    </LayoutCenterContent>
+  </LayoutChrome>
+</template>
+
+<script>
+  import PlayLevelView from 'ozaria/site/views/play/level/PlayLevelView'
+  import BackboneViewHarness from 'app/views/common/BackboneViewHarness'
+  import LayoutAspectRatioContainer from 'ozaria/site/components/common/LayoutAspectRatioContainer'
+  import LayoutChrome from 'ozaria/site/components/common/LayoutChrome'
+  import LayoutCenterContent from '../../common/LayoutCenterContent'
+
+  module.exports = Vue.extend({
+    components: {
+      LayoutAspectRatioContainer,
+      LayoutChrome,
+      BackboneViewHarness,
+      LayoutCenterContent
+    },
+    props: {
+      levelID: {
+        type: String,
+        required: true
+      }
+    },
+    data: function () {
+      return {
+        backboneView: PlayLevelView
+      }
+    }
+  })
+</script>

--- a/ozaria/site/styles/common/common.sass
+++ b/ozaria/site/styles/common/common.sass
@@ -1,8 +1,10 @@
+@import "ozaria/site/styles/common/variables"
+
 .ozaria-primary-button
   background-image: url('/images/ozaria/level/primary_button.png')
   padding: 11px 19px
   color: #f7f9f9
-  font-family: "Open Sans"
+  font-family: $body-font-style
   font-size: 18px
   font-weight: bold
   letter-spacing: 0.71px

--- a/ozaria/site/styles/common/variables.sass
+++ b/ozaria/site/styles/common/variables.sass
@@ -1,5 +1,6 @@
 $title-font-style: 'Arvo', serif
 $body-font-style: 'Open Sans', sans-serif
+$code-font-style: 'Roboto Mono', monospace
 
 // Ozaria Chrome
 $chromeTopPadding: 69px

--- a/ozaria/site/styles/play/level/goals.sass
+++ b/ozaria/site/styles/play/level/goals.sass
@@ -1,8 +1,9 @@
 @import "app/styles/mixins"
 @import "app/styles/bootstrap/variables"
+@import "ozaria/site/styles/play/variables"
 
 #goals-view
-  height: 145px
+  height: $goals-vega-height
   width: 100%
   position: relative
   overflow-x: scroll

--- a/ozaria/site/styles/play/level/level-dialogue-view.sass
+++ b/ozaria/site/styles/play/level/level-dialogue-view.sass
@@ -1,60 +1,53 @@
 @import "app/styles/mixins"
 @import "app/styles/bootstrap/variables"
 @import "ozaria/site/styles/play/variables"
+@import "ozaria/site/styles/common/variables"
 
 #level-dialogue-view
   display: none
   position: absolute
   left: 0
   top: 0
-  width: 56.5%
-  height: 145px
-  background: transparentize(black, 0.6)
-  z-index: 22
+  width: $game-view-width
+  height: $goals-vega-height
+  background: #000000
+  z-index: 2
+  justify-content: center
+  align-items: center
 
   .dialogue-area
     display: flex
     position: relative
     justify-content: center
     align-items: center
-    height: 106px
-    width: 100%
+    height: 82%
+    width: 92%
     border: 4px solid #1FBAB4
     background-color: #FFFFFF
     box-shadow: 2px 2px 8px 0 #ACB9FC
-    margin-top: 20px
-    margin-bottom: 20px
-    margin-left: 30px
-    margin-right: 30px
 
     .vega-narrator
       position: absolute
-      width: 14.5%
-      width: 134px
+      width: 20%
       left: 0
-      top: -1px
-      height: 100px
+      height: 100%
 
     .vega-dialogue
       color: #232323
-      font-family: "Open Sans"
+      font-family: $body-font-style
       font-size: 18px
       letter-spacing: 0.71px
       line-height: 24px
-      margin-top: 9px
-      margin-bottom: 23px
-      margin-left: 151px
-      margin-right: 20px
+      margin: 0 20px 0 22%
 
     .continue
       position: absolute
       height: 17px
       width: 140px
-      top: 80px
-      bottom: 9px
+      bottom: 1%
       right: 20px
       color: #1FBAB4
-      font-family: "Open Sans"
+      font-family: $body-font-style
       font-size: 12px
       letter-spacing: 0.51px
       line-height: 17px

--- a/ozaria/site/styles/play/level/level-playback-view.sass
+++ b/ozaria/site/styles/play/level/level-playback-view.sass
@@ -5,14 +5,13 @@
 #playback-view
   $playback-button-color: #ffffff
   // When 75% alpha, it will look like the rgb(194, 154, 114) from Heald's design
-  width: calc(#{$game-view-width} -  #{$api-bar-width})
+  width: $game-view-width
   #level-view.no-api &
     width: $game-view-width
-  height: 60px
-  padding-top: 12px
-  position: relative
+  padding-top: 1.5%
+  position: absolute
+  bottom: 0px
   background-color: #000000
-  margin-top: 50px
   z-index: 3
 
   &.controls-disabled
@@ -35,7 +34,8 @@
 
   #play-button, #volume-button, #music-button
     float: left
-    position: relative
+    position: absolute
+    top: 15%
     
   #music-button
     @include opacity(0.5)
@@ -62,6 +62,7 @@
     float: right
     position: relative
     margin-right: 10px
+    top: -10px
     ul button
       margin: 0 10px
     li:hover
@@ -89,7 +90,7 @@
   .scrubber
     position: absolute
     left: 60px
-    top: 17px
+    top: 25%
     bottom: 0px
     right: 155px
     background: rgb(3, 3, 3)

--- a/ozaria/site/styles/play/level/tome/cast_button.sass
+++ b/ozaria/site/styles/play/level/tome/cast_button.sass
@@ -26,21 +26,16 @@
 #cast-button-view
   display: flex
   justify-content: center
+  align-items: center
   position: absolute
   width: 100%
-  height: 65px
-  bottom: 46px
+  height: 100%
   background: #ffffff
-  background-size: 100% 100%
   z-index: 2
 
   div.play-button
     position: relative
-    width: 107px
-    height: 45px
-    margin-right: 33px
-    margin-bottom: 10px
-    margin-top: 10px
+    width: 20.5%
     cursor: pointer
     img.active-button
       width: 100%

--- a/ozaria/site/styles/play/level/tome/spell-palette-view.sass
+++ b/ozaria/site/styles/play/level/tome/spell-palette-view.sass
@@ -2,6 +2,7 @@
 @import "app/styles/bootstrap/variables"
 @import "ozaria/site/styles/play/variables"
 @import "app/styles/style-flat-variables"
+@import "ozaria/site/styles/common/variables"
 
 #spell-palette-view
   position: absolute
@@ -9,7 +10,7 @@
   width: $api-bar-width
   bottom: 0px
   max-height: 504px
-  top: 145px
+  top: 30%
   z-index: 11
   @include transition(top 0.25s ease-in-out, width 0.25s ease-in-out)
   border: solid transparent
@@ -83,7 +84,7 @@
         height: 35px
         background-color: #ffffff
         box-shadow: inset 0 1px 3px 0 rgba(93,115,225,0.5), 2px 2px 2px 0 rgba(93,115,225,0.32)
-        font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+        font-family: $code-font-style !important
         font-size: 16px
         line-height: 19px
         padding: 7px 6px 0px 30px
@@ -143,7 +144,7 @@
         background-color: #5d73e1
         height: 44px
         color: #ffffff
-        font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+        font-family: $code-font-style !important
         font-size: 18px
         line-height: 21px
         padding: 11px 6px 0px 15px
@@ -165,13 +166,13 @@
 
 
       h1:not(.not-code), h2:not(.not-code), h3:not(.not-code), h4:not(.not-code), h5:not(.not-code), h6:not(.not-code)
-        font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+        font-family: $code-font-style !important
         font-variant: normal
         color: purple
         text-transform: auto
 
         body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
-          font-family: "Cousine", "Courier", "Courier New", monospace !important
+          font-family: $code-font-style !important
 
       .popover-title
         background-color: transparent
@@ -204,10 +205,10 @@
         &, .docs-ace
           font-size: 16px
           line-height: 19px
-          font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+          font-family: $code-font-style !important
 
           body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
-            font-family: "Cousine", "Courier", "Courier New", monospace !important
+            font-family: $code-font-style !important
 
         .docs-ace
           .ace_cursor, .ace_bracket
@@ -225,11 +226,11 @@
 
       code
         color: black
-        font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+        font-family: $code-font-style !important
         font-size: 12px
 
         body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
-          font-family: "Cousine", "Courier", "Courier New", monospace !important
+          font-family: $code-font-style !important
 
     h4.tab
       color: white

--- a/ozaria/site/styles/play/level/tome/spell.sass
+++ b/ozaria/site/styles/play/level/tome/spell.sass
@@ -1,17 +1,19 @@
 @import "app/styles/mixins"
 @import "app/styles/bootstrap/variables"
+@import "ozaria/site/styles/common/variables"
 
 @mixin editor-height($extraHeight)
   width: 98%
-  height: 83%
-  height: unquote("-webkit-calc(100% - 100px -")$extraHeight unquote(")")
-  height: unquote("calc(100% - 100px -")$extraHeight unquote(")")
+  height: 88%
+  height: unquote("-webkit-calc(88% - 50px -")$extraHeight unquote(")")
+  height: unquote("calc(88% - 50px -")$extraHeight unquote(")")
 
 #spell-view
   height: 100%
   display: none
   position: relative
   z-index: 1
+  overflow: hidden
 
   &.shown
     display: block
@@ -34,7 +36,7 @@
   .save-status
     display: none
     position: absolute
-    top: 10px
+    top: 5px
     left: 20px
     z-index: 4
 
@@ -68,19 +70,19 @@
   .ace_editor
     // When Firepad isn't active, .ace_editor needs the width/height set itself.
     @include editor-height(0px)
-    margin-top: 10px
-    width: 94%
+    margin: 25px 0px 10px 0px
+    width: 99%
     position: relative
     background-color: transparent
     line-height: 19px
     overflow: visible
     // https://github.com/codecombat/codecombat/issues/1411#issuecomment-60492750 -- trying to make sure system defaults don't mess up our monospace font.
-    font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+    font-family: $code-font-style !important
     font-size: 16px
     @include transition(height 0.25s ease-in-out)
 
     body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
-      font-family: "Cousine", "Courier", "Courier New", monospace !important
+      font-family: $code-font-style !important
 
     &.disabled
       @include opacity(0.8)
@@ -93,10 +95,7 @@
       //background-color: rgba(255, 255, 255, 0.25)
       width: 47px
       margin-left: 4px
-      
-    // override ace visible to get the experimental large current line executing arrow visible
-    .ace_gutter
-      overflow: visible
+      padding-top: 3px
       
     .ace_layer
       overflow: visible
@@ -105,6 +104,7 @@
     .ace_scroller
       background-color: transparent
       padding-left: 10px
+      padding-top: 3px
 
     .ace_active-line, .ace_gutter-active-line
       background-color: rgba(255, 255, 255, 0.4)

--- a/ozaria/site/styles/play/level/tome/spell_palette_entry.sass
+++ b/ozaria/site/styles/play/level/tome/spell_palette_entry.sass
@@ -1,6 +1,7 @@
 @import "app/styles/mixins"
 @import "app/styles/bootstrap/variables"
 @import "app/styles/style-flat-variables"
+@import "ozaria/site/styles/common/variables"
 
 #level-view.hero .spell-palette-entry-view
   // Not clickable.
@@ -9,7 +10,7 @@
 .spell-palette-entry-view
   display: block
   padding: 0px 4px
-  font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+  font-family: $code-font-style !important
   font-size: 16px
   border: 1px solid transparent
   cursor: pointer
@@ -118,11 +119,11 @@ body.dialogue-view-active
         @include opacity(1)
 
   h1:not(.not-code), h2:not(.not-code), h3:not(.not-code), h4:not(.not-code), h5:not(.not-code), h6:not(.not-code)
-    font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+    font-family: $code-font-style !important
     font-variant: normal
 
     body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
-      font-family: "Cousine", "Courier", "Courier New", monospace !important
+      font-family: $code-font-style !important
 
   .popover-title
     background-color: transparent
@@ -153,10 +154,10 @@ body.dialogue-view-active
     &, .docs-ace
       background-color: #f9f2f4
       font-size: 12px
-      font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+      font-family: $code-font-style !important
 
     body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
-      font-family: "Cousine", "Courier", "Courier New", monospace !important
+      font-family: $code-font-style !important
 
     .docs-ace
       .ace_cursor, .ace_bracket
@@ -164,11 +165,11 @@ body.dialogue-view-active
 
   code
     color: black
-    font-family: Monaco, Menlo, Ubuntu Mono, Consolas, "source-code-pro", monospace !important
+    font-family: $code-font-style !important
     font-size: 12px
 
     body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
-      font-family: "Cousine", "Courier", "Courier New", monospace !important
+      font-family: $code-font-style !important
 
 html.no-borderimage
   .spell-palette-popover.popover
@@ -193,4 +194,4 @@ html.fullscreen-editor
   min-height: 480px
 
   h1:not(.not-code), h2:not(.not-code), h3:not(.not-code), h4:not(.not-code), h5:not(.not-code), h6:not(.not-code)
-    font-family: Menlo, Monaco, Consolas, "Courier New", monospace
+    font-family: $code-font-style

--- a/ozaria/site/styles/play/level/tome/spell_toolbar.sass
+++ b/ozaria/site/styles/play/level/tome/spell_toolbar.sass
@@ -5,10 +5,10 @@
   position: absolute
   box-sizing: border-box
   margin: 4px 1%
-  height: 45px
+  height: 10%
   width: 100%
   z-index: 4
-  bottom: 93px // TODO: Update this when the overall structure is less of a mess
+  bottom: 0px
   //background-color: rgba(100, 45, 210, 0.15)
 
   .flow

--- a/ozaria/site/styles/play/level/tome/tome.sass
+++ b/ozaria/site/styles/play/level/tome/tome.sass
@@ -1,10 +1,12 @@
 @import "app/styles/mixins"
 @import "app/styles/bootstrap/variables"
+@import "ozaria/site/styles/play/variables"
+@import "ozaria/site/styles/common/variables"
 
 #tome-view
-  height: 100%
-  margin-bottom: -20px
+  height: calc(100% - #{$goals-vega-height})
   overflow: hidden
+  background: #ffffff
 
   > .popover
     // Only those popovers which are our direct children (spell documentation)
@@ -44,7 +46,7 @@
     @include box-shadow(0 0 0 #000)
 
     h1:not(.not-code), h2:not(.not-code), h3:not(.not-code), h4:not(.not-code), h5:not(.not-code), h6:not(.not-code)
-      font-family: Menlo, Monaco, Consolas, "Courier New", monospace
+      font-family: $code-font-style
 
     .popover-title
       background-color: transparent

--- a/ozaria/site/styles/play/play-level-view.sass
+++ b/ozaria/site/styles/play/play-level-view.sass
@@ -1,6 +1,7 @@
 @import "app/styles/mixins"
 @import "app/styles/bootstrap/variables"
 @import "ozaria/site/styles/play/variables"
+@import "ozaria/site/styles/common/variables.sass"
 
 body
   height: 100vh
@@ -11,19 +12,12 @@ body.is-playing
 $level-resize-transition-time: 0.5s
 // TODO: use this for real-time playback but not cinematic playback
 
-#canvas-wrapper
-  top: 0 !important
-  width: 58% !important
 
 #level-view
-  height: 100%
-  margin: 0 auto
   position: absolute
   overflow: hidden
-  left: 0
-  right: 0
-  bottom: 10px
-  top: 0
+  width: 100%
+  height: 100%
   @include user-select(none)
 
   &.real-time, &.cinematic
@@ -73,8 +67,6 @@ $level-resize-transition-time: 0.5s
 
   .level-content
     position: relative
-    min-height: 555px
-    //background-color: black
 
   &.real-time
     &:not(.flags)
@@ -114,8 +106,8 @@ $level-resize-transition-time: 0.5s
       top: 0
 
   #canvas-wrapper
-    top: 50px
-    width: calc(#{$game-view-width} - #{$api-bar-width})
+    top: $goals-vega-height
+    width: $game-view-width
     position: relative
     overflow: hidden
     background-color: black
@@ -167,11 +159,9 @@ $level-resize-transition-time: 0.5s
     transform-origin: 0 0 0
     line-height: 15px
 
-  min-width: 1024px
 
   #code-area
     @include box-sizing(border-box)
-    padding: 0px 0.9% 10px 0
     width: $code-area-width
     background-size: 100% 100%
     position: absolute
@@ -184,6 +174,7 @@ $level-resize-transition-time: 0.5s
   #game-area
     position: relative
     overflow: hidden
+    height: 100%
     
   // Level Docs
   .ui-effects-transfer

--- a/ozaria/site/styles/play/variables.sass
+++ b/ozaria/site/styles/play/variables.sass
@@ -1,6 +1,7 @@
 $api-bar-width: 30px
-$code-area-width: 41.7%
-$game-view-width: 59.3%
+$code-area-width: 41.55%
+$game-view-width: 58.45%
 $spell-pallete-left: 0%
 $spell-pallete-left-width: 279px
 $spell-pallete-right-width: 384px
+$goals-vega-height: 21.3%

--- a/ozaria/site/templates/play/level/tome/spell.jade
+++ b/ozaria/site/templates/play/level/tome/spell.jade
@@ -1,4 +1,2 @@
-img(src="/images/level/code_editor_background.png").code-background
-span.code-background
 .ace
 .save-status(data-i18n="play_level.code_saved")

--- a/ozaria/site/templates/play/level/tome/tome.jade
+++ b/ozaria/site/templates/play/level/tome/tome.jade
@@ -1,3 +1,1 @@
-#spell-top-bar-view
-
 #spell-view

--- a/ozaria/site/templates/play/play-level-view.pug
+++ b/ozaria/site/templates/play/play-level-view.pug
@@ -9,7 +9,6 @@ include game-dev-goals
 
     #code-area
       #goals-view
-      #code-area-gradient.gradient
       #tome-view
 
     #problem-alert-view

--- a/ozaria/site/views/play/level/LevelGoal.vue
+++ b/ozaria/site/views/play/level/LevelGoal.vue
@@ -44,31 +44,29 @@
   })
 </script>
 
-<style scoped>
-  .goal {
-    display: flex;
-    font-family: Open Sans;
-    height: 23px;
-    color: #FFFFFF;
-    font-size: 16px;
-    letter-spacing: 0.55px;
-    line-height: 22px;
-    font-weight: lighter;
-    margin-bottom: 7px;
-  }
+<style lang="sass" scoped>
+  @import "ozaria/site/styles/common/variables"
 
-  .rectangle {
-    height: 19px;
-    width: 18px;
-    border-radius: 4px;
-    margin-right: 10px;
-    background-color: #FFFFFF;
-    box-shadow: inset 1px 1px 3px 0 #5D73E1;
-  }
+  .goal
+    display: flex
+    font-family: $body-font-style
+    height: 23px
+    color: #FFFFFF
+    font-size: 16px
+    letter-spacing: 0.55px
+    line-height: 22px
+    font-weight: lighter
 
-  .check-mark {
-    position: absolute;
-    left: 1.2%;
-    width: 21px;
-  }
+  .rectangle
+    height: 19px
+    width: 18px
+    border-radius: 4px
+    margin-right: 10px
+    background-color: #FFFFFF
+    box-shadow: inset 1px 1px 3px 0 #5D73E1
+
+  .check-mark
+    position: absolute
+    left: 2.7%
+    width: 20px
 </style>

--- a/ozaria/site/views/play/level/LevelGoals.vue
+++ b/ozaria/site/views/play/level/LevelGoals.vue
@@ -48,7 +48,7 @@
       goalStatus: ->
         goalStatus = 'success' if @overallStatus is 'success'
         goalStatus = 'incomplete' if @overallStatus is 'failure'
-        goalStatus ?= 'timed-out' if @timedOut
+        goalStatus ?= 'timed_out' if @timedOut
         goalStatus ?= 'incomplete'
         goalStatus = 'running' if @casting
         return goalStatus
@@ -71,15 +71,16 @@
 </script>
 
 <style lang="sass" scoped>
+  @import "ozaria/site/styles/common/variables"
   .goals-status
-    position: fixed
+    position: absolute
     display: flex
     align-items: center
     width: 100%
     background: black
-    height: 39px
+    height: 30%
     color: #FFFFFF
-    font-family: Arvo
+    font-family: $title-font-style
     font-size: 20px
     letter-spacing: 0.69px
     line-height: 25px
@@ -87,12 +88,13 @@
     padding-left: 13px
 
   .level-goals
+    position: absolute
+    top: 30%
     display: inline-block
-    margin: 5px 0 0 0
     width: 100%
     background: rgb(60, 60, 60)
     white-space: nowrap
-    padding-top: 39px
+    padding: 2%
 
   ul
     list-style-type: none

--- a/ozaria/site/views/play/level/tome/ProblemAlertView.coffee
+++ b/ozaria/site/views/play/level/tome/ProblemAlertView.coffee
@@ -107,6 +107,6 @@ module.exports = class ProblemAlertView extends CocoView
       codeAreaWidth = $('#code-area').outerWidth(true)
       @$el.css('right', codeAreaWidth + 20 + 'px')
 
-      # 90px from top roughly aligns top of alert with top of first code line
       # TODO: calculate this in a more dynamic, less sketchy way
-      @$el.css('top', (90 + @lineOffsetPx) + 'px')
+      spellViewTop = $("#spell-view").position().top - 10 # roughly aligns top of alert with top of first code line
+      @$el.css('top', (spellViewTop + @lineOffsetPx) + 'px')


### PR DESCRIPTION
Did a lot of styling changes to polish the level UX and update dimensions of various level components: 
- Wrapped PlayLevelView in a Vue component
- Added chrome around the level view
- Set a fixed aspect ratio for the levels
- Used common font styles from common/variables.sass
- Updated dimensions of everything in the level UX as per updated specs

If you want to test manually, connect to the proxy server (`npm run proxy`) and go to `http://localhost:3000/ozaria/play/level/1fhm1l1l1` to see the updated level UX.
