### PR TITLE
Cinematic dialog text should be wider when zoomed in

### DIFF
--- a/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
+++ b/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
@@ -12,6 +12,7 @@ import { WIDTH, HEIGHT, LETTER_ANIMATE_TIME } from '../constants'
 
 const BUBBLE_PADDING = 10
 const SPEECH_BUBBLE_MAX_WIDTH = `300px` // Removed 20 px to account for padding.
+const SPEECH_BUBBLE_ZOOMED_MAX_WIDTH = `400px`
 
 /**
  * This system coordinates drawing HTML and SVG to the screen.
@@ -68,7 +69,8 @@ export default class DialogSystem {
         y,
         shownDialogBubbles: this.shownDialogBubbles,
         side,
-        textDuration: getTextAnimationLength(dialogNode)
+        textDuration: getTextAnimationLength(dialogNode),
+        zoom
       })).createBubbleCommand())
     }
     return commands
@@ -99,7 +101,8 @@ class SpeechBubble {
     y,
     shownDialogBubbles,
     side,
-    textDuration
+    textDuration,
+    zoom
   }) {
     this.id = `speech-${_id++}`
     const parser = new DOMParser()
@@ -110,7 +113,7 @@ class SpeechBubble {
 
     speechBubbleDiv.style.display = 'inline-block'
     speechBubbleDiv.style.position = 'absolute'
-    speechBubbleDiv.style.maxWidth = SPEECH_BUBBLE_MAX_WIDTH
+    speechBubbleDiv.style.maxWidth = zoom === 2 ? SPEECH_BUBBLE_ZOOMED_MAX_WIDTH : SPEECH_BUBBLE_MAX_WIDTH
     speechBubbleDiv.id = this.id
     speechBubbleDiv.className = `cinematic-speech-bubble-${side}`
     speechBubbleDiv.style.opacity = 0

--- a/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
+++ b/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
@@ -147,6 +147,8 @@ class SpeechBubble {
     if (textDuration === undefined) {
       textDuration = letters * LETTER_ANIMATE_TIME
     }
+
+    speechBubbleDiv.style.display = 'none'
     // We set up the animation but don't play it yet.
     // On completion we attach html node to the `shownDialogBubbles`
     // array for future cleanup.
@@ -160,7 +162,10 @@ class SpeechBubble {
           targets: `#${this.id}`,
           opacity: 1,
           duration: 100,
-          easing: 'easeInOutQuart'
+          easing: 'easeInOutQuart',
+          begin: () => {
+            speechBubbleDiv.style.display = 'inline-block'
+          }
         })
         .add({
           targets: `#${this.id} .letter`,
@@ -172,7 +177,7 @@ class SpeechBubble {
         .add({
           targets: `#${this.id} .cinematic-speech-bubble-click-continue`,
           opacity: 1,
-          duration: 700
+          duration: 100
         })
     }
   }

--- a/ozaria/site/components/cinematic/PageCinematicEditor/index.vue
+++ b/ozaria/site/components/cinematic/PageCinematicEditor/index.vue
@@ -197,7 +197,7 @@ module.exports = Vue.extend({
           </select>
           <div id="treema-editor" ref="treemaEditor" v-once></div>
         </div>
-        <div class="col-md-6" v-if="rawData">
+        <div class="col-md-6" v-if="rawData" style="width:1366px; height:768px;">
           <cinematic-canvas :cinematicData="rawData" :key="rerenderKey" :userOptions="{ programmingLanguage }" />
         </div>
       </div>

--- a/ozaria/site/components/cinematic/common/CinematicCanvas.vue
+++ b/ozaria/site/components/cinematic/common/CinematicCanvas.vue
@@ -151,12 +151,14 @@ export default {
 
 .cinematic-speech-bubble-right
   border-image: url('/images/ozaria/cinematic/bubble_right_slice.png')
+  background-color: white
   border-image-slice: 50 100 50 50 fill
   border-image-width: 40px 80px 40px 40px
   border-image-outset: 10px 58px 15px 15px
 
 .cinematic-speech-bubble-left
   border-image: url('/images/ozaria/cinematic/bubble_left_slice.png')
+  background-color: white
   border-image-slice: 50 50 50 100 fill
   border-image-width: 40px 40px 40px 80px
   border-image-outset: 10px 15px 15px 58px


### PR DESCRIPTION
## Features

 - Cinematic dialog bubble should be wider when zoomed in.
 - Fixed: Cinematic Editor should display the cinematic at the max dimensions.
 - Cinematic speech bubbles display none when not visible. This should make the bubbles slightly more performant on low end devices.