### PR TITLE
Update Contact page to a newer version of FAQ

### DIFF
--- a/ozaria/site/templates/core/contact.jade
+++ b/ozaria/site/templates/core/contact.jade
@@ -10,7 +10,7 @@ block modal-body-content
     a(href="http://discourse.codecombat.com/", data-i18n="contact.forum_page") our forum
     span(data-i18n="contact.forum_suffix")  instead.
     span.spl.spr(data-i18n="contact.faq_prefix") There's also a
-    a(data-i18n="contact.faq", href="http://discourse.codecombat.com/t/faq-check-before-posting/1027") FAQ
+    a(data-i18n="contact.faq", href="https://discourse.codecombat.com/t/frequently-asked-questions/18174") FAQ
     | .
   if me.isPremium()
     p(data-i18n="contact.subscriber_support") Since you're a CodeCombat subscriber, your email will get our priority support.


### PR DESCRIPTION
The old FAQ only applies to forums. The newer one covers more questions.