### PR TITLE
Map restart event to new chrome restart button

### DIFF
--- a/app/schemas/subscriptions/editor.coffee
+++ b/app/schemas/subscriptions/editor.coffee
@@ -44,6 +44,8 @@ module.exports =
   'level:reload-thang-type': c.object {required: ['thangType']},
     thangType: {type: 'object'}
 
+  'level:open-restart-modal': c.object {title: 'Restart level modal about to open'}
+
   'editor:random-terrain-generated': c.object {required: ['thangs', 'terrain']},
     thangs: c.array {}, {type: 'object'}
     terrain: c.terrainString

--- a/ozaria/site/components/common/LayoutChrome.vue
+++ b/ozaria/site/components/common/LayoutChrome.vue
@@ -46,7 +46,7 @@
       },
 
       clickRestart () {
-        this.$emit('clickRestart')
+        this.$emit('click-restart')
       }
     }
   })

--- a/ozaria/site/components/play/PagePlayLevel/index.vue
+++ b/ozaria/site/components/play/PagePlayLevel/index.vue
@@ -1,5 +1,8 @@
 <template>
-  <LayoutChrome>
+  <LayoutChrome
+    :displayRestartMenuItem="true"
+    @click-restart="clickRestart"
+  >
     <LayoutCenterContent>
       <LayoutAspectRatioContainer
         :aspect-ratio="1266 / 668"
@@ -37,6 +40,11 @@
     data: function () {
       return {
         backboneView: PlayLevelView
+      }
+    },
+    methods: {
+      clickRestart: function () {
+        Backbone.Mediator.publish('level:open-restart-modal', {})
       }
     }
   })

--- a/ozaria/site/views/play/level/PlayLevelView.js
+++ b/ozaria/site/views/play/level/PlayLevelView.js
@@ -10,6 +10,7 @@
  */
 import LevelIntroModal from './modal/LevelIntroModal'
 import OzariaVictoryModal from '../modal/OzariaVictoryModal'
+import RestartLevelModal from 'ozaria/site/views/play/level/modal/RestartLevelModal'
 
 require('ozaria/site/styles/play/level/level-loading-view.sass')
 require('ozaria/site/styles/play/level/tome/spell_palette_entry.sass')
@@ -1018,6 +1019,10 @@ class PlayLevelView extends RootView {
     return Backbone.Mediator.publish('tome:cast-spell', {})
   }
 
+  onOpenRestartModal (e) {
+    this.openModalView(new RestartLevelModal())
+  }
+
   onWindowResize (e) {
     return this.endHighlight()
   }
@@ -1516,6 +1521,7 @@ PlayLevelView.prototype.subscriptions = {
   'god:infinite-loop': 'onInfiniteLoop',
   'level:reload-from-data': 'onLevelReloadFromData',
   'level:reload-thang-type': 'onLevelReloadThangType',
+  'level:open-restart-modal': 'onOpenRestartModal',
   'level:started': 'onLevelStarted',
   'level:loading-view-unveiling': 'onLoadingViewUnveiling',
   'level:loading-view-unveiled': 'onLoadingViewUnveiled',


### PR DESCRIPTION
# Feature

Level UX updated for restarting a level, and mapped to the new restart dialogue. 

This is important to ship to unblock design work, and let Vega be reset for a given level. 

@AndrewJakubowicz I renamed the event to be "kebab case" after reading this: https://vuejs.org/v2/guide/components-custom-events.html#Event-Names

# Changes

- Added a new event to open the restart level dialogue for the play level view
- Hooked up the event to the new restart button
- Made the restart visible for the PagePlayLevel