### PR TITLE
Avatar Schema Update

### DIFF
--- a/app/schemas/models/cinematic.schema.js
+++ b/app/schemas/models/cinematic.schema.js
@@ -9,8 +9,8 @@ const ThangTypeSchema = (title, description) => c.object({
     oneOf: [
       c.shortString({
         title: 'Hero',
-        description: 'Marker to inform us that this will be the players hero.',
-        enum: ['hero']
+        description: 'Hero ThangType Id computed at runtime',
+        enum: ['hero', 'avatar']
       }),
       c.object({
         title: 'Character Slug',

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -174,8 +174,9 @@ _.extend UserSchema.properties,
         title: '1FH Avatar Choice',
         description: 'The 1FH avatar that was chosen by the user'
       }, {
-        thangId: c.stringID(links: [{rel: 'db', href: '/db/thang.type/{($)}/version'}], title: 'Avatar ThangType', description: 'The in-level avatar thangType', format: 'thang-type'),
-        cinematicThangId: c.stringID(links: [{rel: 'db', href: '/db/thang.type/{($)}/version'}], title: 'Cinematic ThangType', description: 'The cinematic avatar thangType', format: 'thang-type'),
+        cinematicThangTypeId: c.stringID(links: [{rel: 'db', href: '/db/thang.type/{($)}/version'}], title: 'Cinematic ThangType', description: 'The cinematic avatar thangType original Id', format: 'thang-type'),
+        cinematicPetThangId: c.stringID(links: [{rel: 'db', href: '/db/thang.type/{($)}/version'}], title: 'Cinematic Pet ThangType', description: 'The cinematic avatar pet thangType original Id', format: 'thang-type'),
+        avatarCodeString: c.shortString({ title: 'Avatar Capstone String', description: 'The string representation of the avatar for the capstone.' })
       })
     })
 


### PR DESCRIPTION
Adds required avatar schema to ensure that schema stays consistent between the two products.

Renaming `ozariaHeroConfig` is being punted to next week. Tricky to make the change while some other PRs are open.