### PR TITLE
Added a PWA manifest file and ios touch icon

### DIFF
--- a/app/assets/pwa/manifest.json
+++ b/app/assets/pwa/manifest.json
@@ -1,0 +1,20 @@
+{
+  "short_name": "CodeCombat",
+  "name": "CodeCombat",
+  "icons": [
+    {
+      "src": "/images/pages/base/logo_square_120.png",
+      "type": "image/png",
+      "sizes": "120x120"
+    },
+    {
+      "src": "/images/pages/base/logo_square_250.png",
+      "type": "image/png",
+      "sizes": "250x250"
+    }
+  ],
+  "start_url": "/play",
+  "display": "standalone",
+  "orientation": "landscape",
+  "scope": "/play/"
+}

--- a/app/templates/static/layout.static.pug
+++ b/app/templates/static/layout.static.pug
@@ -20,6 +20,8 @@ html(lang='en')
     meta(name="p:domain_verify", content="f5afcb2c36bb8b1cbd70c44b65e5ec75")
     link(href='https://plus.google.com/115285980638641924488', rel='publisher')
     link(rel='shortcut icon', href='/images/favicon.ico')
+    link(rel='apple-touch-icon', href='/images/pages/base/logo_square_250.png')
+    link(rel='manifest', href='/pwa/manifest.json')
     link(rel='stylesheet', href='/' + shaTag + '/stylesheets/app.css')
     if me.useDexecure()
       script.


### PR DESCRIPTION
ISSUE
----

Currently there's no icon when you add CodeCombat to the home screen
on iOS (just a screenshot of the page). Also, the name of the icon on
the home screen is just the title of the page ("Play CodeCombat
Levels...").

SOLUTION
------

I've added a high-res favicon for iOS, and I've also added a [PWA](https://developers.google.com/web/fundamentals/web-app-manifest/)
manifest file so that the icon title defaults to "CodeCombat". This
should also work on Android (although I haven't been able to test it
myself). On iOS I've also configured the app to hire the address bar,
when you start it from a home-screen icon, which gives a bit more
vertical space on the page and should make it feel more like a real
app.

There are other css issues with CodeCombat on iOS (which I or someone
else may fix some day) but I thought it would be easy to fix these
right away.

SCREENSHOTS
-----

Here's before, when adding to the home screen from safari on iOS:

<img width="959" alt="Screenshot 2019-08-11 at 17 18 56" src="https://user-images.githubusercontent.com/111963/62836675-9fc55180-bc5d-11e9-98c7-4127fbaf3b78.png">

Here's after (with these changes):

<img width="959" alt="Screenshot 2019-08-12 at 13 39 22" src="https://user-images.githubusercontent.com/111963/62865546-b673b300-bd06-11e9-8e68-513f537f68c7.png">

Here's what it looks like on the iOS desktop:

<img width="959" alt="Screenshot 2019-08-12 at 13 39 31" src="https://user-images.githubusercontent.com/111963/62865566-bf648480-bd06-11e9-89b9-731aacb7098b.png">

and here's what it looks like inside the app, once added to the desktop (notice that there's no tool bar or address bar):

<img width="959" alt="Screenshot 2019-08-11 at 17 14 07" src="https://user-images.githubusercontent.com/111963/62836693-c84d4b80-bc5d-11e9-82a5-2799052a0546.png">
