### PR TITLE
Make ozariaUserOptions more permissive

### DIFF
--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -151,7 +151,9 @@ _.extend UserSchema.properties,
   ozariaUserOptions: c.object(
     {
       title: 'Player Ozaria Customization',
-      description: 'Player customization options, including hero name, objectId and applied color tints.'
+      description: 'Player customization options, including hero name, objectId and applied color tints.',
+      # Ensure we can add new properties on the Ozaria server without breaking CodeCombat users.
+      additionalProperties: true
     }, {
       cinematicThangTypeOriginal: c.stringID(links: [{rel: 'db', href: '/db/thang.type/{($)}/version'}], title: 'Thang Type', description: 'The ThangType of the hero.', format: 'thang-type'),
       playerHeroName: c.shortString({ title: 'Ozaria Hero Name', description: 'The user set name for the ozaria hero. Used in cinematics.' }),

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -148,7 +148,7 @@ _.extend UserSchema.properties,
   wizard: c.object {},
     colorConfig: c.object {additionalProperties: c.colorConfig()}
 
-  ozariaUserOptions: c.object(
+  ozariaUserOptions: c.object( # 10/12/2019 Do not alter/remove or use this property on codecombat. Used on Ozaria.
     {
       title: 'Player Ozaria Customization',
       description: 'Player customization options, including hero name, objectId and applied color tints.',


### PR DESCRIPTION
This allows us to update the schema on the Ozaria server and not have users break when they navigate between the two websites.


## Manual test

Use your local database and codecombat server. Run `npm run dev` from the client and `npm run nodemon` from the server. Then try to save a new property like so:

`me.set('ozariaUserOptions', {playerHeroName: 'rawr', test: 123})`
`me.save()`


^ This saves a property on the schema and a property that is not on the schema.



After refreshing use `me.get('ozariaUserOptions')` and you should see both properties.