### PR TITLE
Don't show 'Done' button when playing Resource Tycoon

### DIFF
--- a/app/templates/play/level/control-bar-view.jade
+++ b/app/templates/play/level/control-bar-view.jade
@@ -1,4 +1,7 @@
 - var includeHomeLink = application.getHocCampaign() || !((me.isStudent() || me.isTeacher()) && !view.course) || view.level.isType('course-ladder');
+// No "Done" button for standalone tournament game-dev project levels outside of a campaign
+- if (['resource-tycoon'].indexOf(view.level.get('slug')) != -1)
+-   includeHomeLink = false;
 if includeHomeLink
   .left-cap
 .right-cap

--- a/app/views/play/level/tome/CastButtonView.coffee
+++ b/app/views/play/level/tome/CastButtonView.coffee
@@ -125,7 +125,9 @@ module.exports = class CastButtonView extends CocoView
     @winnable = winnable
     @$el.toggleClass 'winnable', @winnable
     Backbone.Mediator.publish 'tome:winnability-updated', winnable: @winnable, level: @options.level
-    if @options.level.get('hidesRealTimePlayback') or @options.level.isType('web-dev', 'game-dev')
+    if @options.level.get('slug') in ['resource-tycoon']
+      null  # No "Done" button for standalone tournament game-dev project levels outside of a campaign
+    else if @options.level.get('hidesRealTimePlayback') or @options.level.isType('web-dev', 'game-dev')
       @$el.find('.done-button').toggle @winnable
     else if @winnable and @options.level.get('slug') in ['course-thornbush-farm', 'thornbush-farm']
       @$el.find('.submit-button').show()  # Hide submit until first win so that script can explain it.


### PR DESCRIPTION
This level is not in a campaign and has no victory rewards, so when you press the green Done button after succeeding during initial game testing, it shows a nearly empty HeroVictoryModal with a Continue button linking to last year's Hour of Code campaign.

This change makes it so that the Done button doesn't show up for that level. You can still get to its shareable link via the Game button at the top.