### PR TITLE
Don't allow right clicking during real-time playback

### DIFF
--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -733,8 +733,9 @@ module.exports = class PlayLevelView extends RootView
       contactModal.updateScreenshot?()
 
   onSurfaceContextMenu: (e) ->
-    return unless @surface.showCoordinates and ( navigator.clipboard or document.queryCommandSupported('copy') )
     e?.preventDefault?()
+    return if @$el.hasClass 'real-time'
+    return unless @surface.showCoordinates and ( navigator.clipboard or document.queryCommandSupported('copy') )
     pos = x: e.clientX, y: e.clientY
     wop = @surface.coordinateDisplay.lastPos
     Backbone.Mediator.publish 'level:surface-context-menu-pressed', posX: pos.x, posY: pos.y, wopX: wop.x, wopY: wop.y


### PR DESCRIPTION
Right-clicking the Surface shows either a copy coordinate context menu or the default browser context menu, depending on whether coordinates are shown in the level and the browser supports letting us copy to the clipboard.

Now, if in real-time playback mode (playing a game-dev level, for example), right-clicking won't do anything. This fixes development-mode interface elements from getting in the way during play mode.