### PR TITLE
Tweaked hud styles on mobile so health, avatar and dialog are visible

### DIFF
--- a/app/styles/play/level/hud.sass
+++ b/app/styles/play/level/hud.sass
@@ -48,13 +48,11 @@
     @include scaleX(-1)
 
   .avatar-wrapper-container
-    position: absolute
+    position: relative
     width: 100px
     height: 100px
-    top: 0
-    left: 18%
-    left: -webkit-calc(50% - (560px - 100px) / 2 - 10px)
-    left: calc(50% - (560px - 100px) / 2 - 10px)
+    top: -35px
+    float: left
     z-index: 5
 
     .thang-canvas-wrapper
@@ -90,14 +88,12 @@
     top: 24px
 
   .center
-    width: 560px
+    width: 100%
+    max-width: 560px
     height: 166px
     position: absolute
     top: 24px
-    left: 13%
-    left: -webkit-calc(50% - 560px / 2)
-    left: calc(50% - 560px / 2)
-    padding: 10px 20px 0 145px
+    padding: 10px 20px 0 45px
     background-image: url(/images/level/hud_background.png)
     color: white
     text-transform: uppercase
@@ -106,6 +102,10 @@
     font-size: 16px
     z-index: 4
     @include transition(0.5s ease)
+    @media screen and (min-width: $screen-lg-min)
+      left: 13%
+      left: -webkit-calc(50% - 560px / 2)
+      left: calc(50% - 560px / 2)
 
     &:hover
       top: -36px
@@ -166,7 +166,7 @@
         font-size: 18px
 
         .prop-value.bar-prop
-          width: 150px
+          max-width: 150px
           margin: 1px 10px 0 0
           height: 16px
           background: rgb(32, 27, 21)

--- a/app/styles/play/level/level-dialogue-view.sass
+++ b/app/styles/play/level/level-dialogue-view.sass
@@ -15,16 +15,18 @@
       color: white
 
   width: 417px
+  max-width: calc(57% - 200px)
   height: 296px
   background: transparent url(/images/level/code_palette_wood_background.png)
   background-size: 100% auto
   position: absolute
   bottom: -296px + 40px
-  left: 300px
-  left: calc(55% - 417px - #{$api-bar-width})
   // Bounce in
   @include transition(1s cubic-bezier(.17,.89,.42,1.36))
   z-index: 1
+  @media screen and (min-width: $screen-lg-min)
+    left: 300px
+    left: calc(55% - 417px - #{$api-bar-width})
 
   &.active
     display: block

--- a/app/templates/play/level/hud.jade
+++ b/app/templates/play/level/hud.jade
@@ -5,10 +5,9 @@
 .hinge.hinge-2
 .hinge.hinge-3
 
-.avatar-wrapper-container
-  .thang-canvas-wrapper.thang-elem.hide
-    canvas.thang-canvas
-
 .center
+  .avatar-wrapper-container
+    .thang-canvas-wrapper.thang-elem.hide
+      canvas.thang-canvas
   .thang-name
   .thang-props.thang-elem

--- a/ozaria/site/styles/play/level/hud.sass
+++ b/ozaria/site/styles/play/level/hud.sass
@@ -48,13 +48,11 @@
     @include scaleX(-1)
 
   .avatar-wrapper-container
-    position: absolute
+    position: relative
     width: 100px
     height: 100px
-    top: 0
-    left: 18%
-    left: -webkit-calc(50% - (560px - 100px) / 2 - 10px)
-    left: calc(50% - (560px - 100px) / 2 - 10px)
+    top: -35px
+    float: left
     z-index: 5
 
     .thang-canvas-wrapper
@@ -90,14 +88,12 @@
     top: 24px
 
   .center
-    width: 560px
+    width: 100%
+    max-width: 560px
     height: 166px
     position: absolute
     top: 24px
-    left: 13%
-    left: -webkit-calc(50% - 560px / 2)
-    left: calc(50% - 560px / 2)
-    padding: 10px 20px 0 145px
+    padding: 10px 20px 0 45px
     background-image: url(/images/level/hud_background.png)
     color: white
     text-transform: uppercase
@@ -106,6 +102,10 @@
     font-size: 16px
     z-index: 4
     @include transition(0.5s ease)
+    @media screen and (min-width: $screen-lg-min)
+      left: 13%
+      left: -webkit-calc(50% - 560px / 2)
+      left: calc(50% - 560px / 2)
 
     &:hover
       top: -36px
@@ -166,7 +166,7 @@
         font-size: 18px
 
         .prop-value.bar-prop
-          width: 150px
+          max-width: 150px
           margin: 1px 10px 0 0
           height: 16px
           background: rgb(32, 27, 21)

--- a/ozaria/site/templates/play/level/hud.jade
+++ b/ozaria/site/templates/play/level/hud.jade
@@ -5,10 +5,9 @@
 .hinge.hinge-2
 .hinge.hinge-3
 
-.avatar-wrapper-container
-  .thang-canvas-wrapper.thang-elem.hide
-    canvas.thang-canvas
-
 .center
+  .avatar-wrapper-container
+    .thang-canvas-wrapper.thang-elem.hide
+      canvas.thang-canvas
   .thang-name
   .thang-props.thang-elem


### PR DESCRIPTION
ISSUE
-----

On an iPad sized screen the avatar image and much of the health bar are not visible, because there isn't enough space to show them.

Here's the hud on desktop (looks fine):

![Screenshot 2019-08-14 at 12 09 10](https://user-images.githubusercontent.com/111963/63017362-0c269780-be8e-11e9-9b0d-72b881508fae.png)

Here's the hud on an ipad (not very usable):

<img width="959" alt="Screenshot 2019-08-14 at 10 34 32" src="https://user-images.githubusercontent.com/111963/63011091-86035480-be7f-11e9-8279-a174174d4ecd.png">


SOLUTION
-----

I've tweaked the styles so they can scale more dynamically. It shouldn't look any different on desktop, but on mobile things will shrink down appropriately so that everything remains visible. As part of this I've moved the avatar image inside the hud center element so that it's a sibling of the thang's name and health bar (which makes conceptual sense as they are all side-by-side within the wooden bar).

Here's the hud on desktop (should be the same):

![Screenshot 2019-08-14 at 12 24 11](https://user-images.githubusercontent.com/111963/63017507-70495b80-be8e-11e9-9c8d-61b983908df9.png)


Here's the hud on an iPad (avatar, health and dialog are now visible):

![Screenshot 2019-08-14 at 12 23 01](https://user-images.githubusercontent.com/111963/63017459-4f810600-be8e-11e9-926e-42eeecce4b13.png)
