### PR TITLE
Upgraded ace editor to 1.4.x for better mobile support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "i18next": "https://github.com/nwinter/i18next.git",
     "marked": "~0.3.0",
     "moment": "~2.19.0",
-    "ace-builds": "ajaxorg/ace-builds#ba3b91e04a5aa559d56ac70964f9054baa0f4caf",
+    "ace-builds": "~1.4.5",
     "underscore.string": "~2.3.3",
     "jsondiffpatch": "^0.2.3",
     "nanoscroller": "~0.8.0",


### PR DESCRIPTION
ISSUE
-----

Right now it's not possible to use the editor on iOS. Although no javascript errors are thrown, the editor does not appear, making code combat unusable.

Here's what it looks like (note that the editor isn't visible and can't be used):

<img width="959" alt="before_small" src="https://user-images.githubusercontent.com/111963/62949163-9c58d400-bddd-11e9-9cee-e432e707930c.png">


SOLUTION
------

Code combat is using ace editor version 1.2.9, which is rather old and doesn't have good mobile support. There have been a lot of improvements for mobile in version 1.4, and upgrading to ace editor 1.4.5 makes it work perfectly on iOS with no code changes.

Here's what it looks like with the latest ace editor (see that the editor is working as it does on desktop):

<img width="959" alt="Screenshot 2019-08-13 at 15 16 54" src="https://user-images.githubusercontent.com/111963/62949201-ae3a7700-bddd-11e9-92d6-c8800bd7b28b.png">

These are the [changes](https://github.com/ajaxorg/ace/blob/d893a99a8bb317440080bd766288da4e8a7e9524/ChangeLog.txt) in ace editor between versions 1.2.9 and 1.4.5:

```
2019.06.17 Version 1.4.5
* improve scrolling and selection on mobile 
* improve type definitions

2019.04.24 Version 1.4.4
* add experimental command prompt
* add chrystal, nim and nginx highlight rules
* fix regression in vim mode on ios

2019.02.21 Version 1.4.3
* add sublime keybindings
* add rtl option
* implement ` and < textobjects in vim mode

2018.11.21 Version 1.4.2
* fix regression in vim mode
* improve keyboard input handling on ipad and IE
* add new syntax highlighters

2018.08.07 Version 1.4.1
* fix regression in autocomplete

2018.08.06 Version 1.4.0

* remove usage of innerHTML
* improved handling of textinput for IME and mobile
* add support for relative line numbers
* improve autocompletion popup 

2018.03.26 Version 1.3.3
* fix regession in static-highlight extension
* use css animation for cursor blinking

2018.03.21 Version 1.3.2
* add experimental support for using ace-builds with webpack

2018.02.11 Version 1.3.1

* fixed regression with selectionChange event not firing some times
* improved handling of non-ascii characters in vim normal mode

2018.01.31 Version 1.3.0

* added copy copyWithEmptySelection option 
* improved undoManager
* improved settings_menu plugin
* improved handling of files with very long lines
* fixed bug with scrolling editor out of view in transformed elements
```