### PR TITLE
Add validation against spam user account names

### DIFF
--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -55,8 +55,8 @@ _.extend UserSchema.properties,
   email: c.shortString({title: 'Email', format: 'email'})
   emailVerified: { type: 'boolean' }
   iosIdentifierForVendor: c.shortString({format: 'hidden'})
-  firstName: c.shortString({title: 'First Name'})
-  lastName: c.shortString({title: 'Last Name'})
+  firstName: c.shortString({title: 'First Name', not: {pattern: 'Q204384420'}})
+  lastName: c.shortString({title: 'Last Name', not: {pattern: 'Q204384420'}})
   gender: {type: 'string'} # , 'enum': ['male', 'female', 'secret', 'trans', 'other']
   # NOTE: ageRange enum changed on 4/27/16 from ['0-13', '14-17', '18-24', '25-34', '35-44', '45-100']
   ageRange: {type: 'string'}  # 'enum': ['13-15', '16-17', '18-24', '25-34', '35-44', '45-100']

--- a/app/views/core/CreateAccountModal/BasicInfoView.coffee
+++ b/app/views/core/CreateAccountModal/BasicInfoView.coffee
@@ -178,6 +178,8 @@ module.exports = class BasicInfoView extends CocoView
       email: User.schema.properties.email
       name: User.schema.properties.name
       password: User.schema.properties.password
+      firstName: User.schema.properties.firstName
+      lastName: User.schema.properties.lastName
     required: switch @signupState.get('path')
       when 'student' then ['name', 'password', 'firstName', 'lastName']
       when 'teacher' then ['password', 'email', 'firstName', 'lastName']


### PR DESCRIPTION
Seeing a lot of spam teacher users with firstName and lastName set to 玩游戏宋128圆菜金加Q204384420领取优惠专属网址604774. Seeing if this would thwart them.

<img width="913" alt="Screenshot 2019-08-21 13 33 12" src="https://user-images.githubusercontent.com/99704/63466513-422cc400-c418-11e9-853c-b66dd645be61.png">
