### PR TITLE
Changes to support GC in Ozaria

### DIFF
--- a/app/core/social-handlers/GoogleClassroomHandler.js
+++ b/app/core/social-handlers/GoogleClassroomHandler.js
@@ -81,7 +81,8 @@ module.exports = {
       })
 
       // classrooms that were imported to coco/ozaria but no more exist in importedClassroomNames, i.e. have been removed from google classroom
-      const extraClassroomsImported = classrooms.filter((c) => (c.importedToCoco || c.importedToOzaria) && !(mergedClassrooms.map((m) => m.id).includes(c.id)))
+      const mergedClassroomIds = mergedClassrooms.map((m) => m.id)
+      const extraClassroomsImported = classrooms.filter((c) => (c.importedToCoco || c.importedToOzaria) && !(mergedClassroomIds.includes(c.id)))
       // set deletedFromGC, so that it gets filtered from the dropdown on the create classroom modal
       // for example, a class that is importedToOzaria but deleted from GC should not be available in the dropdown on coco
       extraClassroomsImported.forEach((e) => e.deletedFromGC = true)

--- a/app/core/social-handlers/GoogleClassroomHandler.js
+++ b/app/core/social-handlers/GoogleClassroomHandler.js
@@ -64,6 +64,8 @@ module.exports = {
     }
   },
 
+  // import classrooms from GC and merge them into me.googleClassrooms
+  // this also sets `deletedFromGC` for classrooms that are removed from GC but had already been imported to coco/ozaria
   importClassrooms: async function() {
     try {
       const importedClassrooms = await this.gcApiHandler.loadClassroomsFromAPI()
@@ -71,13 +73,20 @@ module.exports = {
         return { id: c.id, name: c.name }
       })
      
-      const classrooms = (me.get('googleClassrooms') || []).filter((c) => c.importedToCoco == true)
+      const classrooms = me.get('googleClassrooms') || []
+      let mergedClassrooms = []
       importedClassroomsNames.forEach((imported) => {
-        if (!classrooms.find((c) => c.id == imported.id)) {
-          classrooms.push(imported)
-        }
+        const cl = classrooms.find((c) => c.id == imported.id)
+        mergedClassrooms.push({ ...cl, ...imported })
       })
-      me.set('googleClassrooms', classrooms)
+
+      // classrooms that were imported to coco/ozaria but no more exist in importedClassroomNames, i.e. have been removed from google classroom
+      const extraClassroomsImported = classrooms.filter((c) => (c.importedToCoco || c.importedToOzaria) && !(mergedClassrooms.map((m) => m.id).includes(c.id)))
+      // set deletedFromGC, so that it gets filtered from the dropdown on the create classroom modal
+      // for example, a class that is importedToOzaria but deleted from GC should not be available in the dropdown on coco
+      extraClassroomsImported.forEach((e) => e.deletedFromGC = true)
+      mergedClassrooms = mergedClassrooms.concat(extraClassroomsImported)
+      me.set('googleClassrooms', mergedClassrooms)
       await new Promise(me.save().then)
     }
     catch (err) {

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -198,6 +198,8 @@ _.extend UserSchema.properties,
       id: { type: 'string' }
       name: { type: 'string' }
       importedToCoco: { type: 'boolean', default: false }
+      importedToOzaria: { type: 'boolean', default: false }
+      deletedFromGC: { type: 'boolean', default: false, description: 'Set true for classrooms imported to coco/ozaria but deleted from GC' }
 
   importedBy: c.objectId { description: 'User ID of the teacher who imported this user' }
 

--- a/app/views/courses/ClassroomSettingsModal.coffee
+++ b/app/views/courses/ClassroomSettingsModal.coffee
@@ -102,7 +102,7 @@ module.exports = class ClassroomSettingsModal extends ModalView
     @isGoogleClassroom = true
     GoogleClassroomHandler.importClassrooms()
     .then(() =>
-      @googleClassrooms = me.get('googleClassrooms').filter((c) => !c.importedToCoco)
+      @googleClassrooms = me.get('googleClassrooms').filter((c) => !c.importedToCoco && !c.deletedFromGC)
       @render()
       $('.google-class-name').show()
       $('.class-name').hide()

--- a/test/app/core/social-handlers/GoogleClassroomHandler.spec.js
+++ b/test/app/core/social-handlers/GoogleClassroomHandler.spec.js
@@ -81,7 +81,7 @@ describe('importClassrooms()', () => {
     }
   });
 
-  it('updates the classrooms in me.googleClassrooms except the already imported classrooms', async function(done) {
+  it('updates the linked classrooms in me.googleClassrooms while keeping the importedToCoco value', async function(done) {
     
     me.set('googleClassrooms', gClassrooms)
 
@@ -110,10 +110,10 @@ describe('importClassrooms()', () => {
 
     try {
       await GoogleClassroomHandler.importClassrooms()
-      // name of id2 classroom should be updated, and everything else should remain same
+      // names of linked classroom should be updated, and importedToCoco field should remain same
       expect(me.get('googleClassrooms').length).toBe(2)
       expect(me.get('googleClassrooms').find((gc) => gc.id == importedClassroom.id)).toBeDefined()
-      expect(me.get('googleClassrooms').find((gc) => gc.id == importedClassroom.id).name).toBe(importedClassroom.name)
+      expect(me.get('googleClassrooms').find((gc) => gc.id == importedClassroom.id).name).toBe(newGClassrooms.find((gc) => gc.id==importedClassroom.id).name)
       expect(me.get('googleClassrooms').find((gc) => gc.id == importedClassroom.id).importedToCoco).toBe(true)
       expect(me.get('googleClassrooms').find((gc) => gc.id != importedClassroom.id)).toBeDefined()
       expect(me.get('googleClassrooms').find((gc) => gc.id != importedClassroom.id).name).toBe(newGClassrooms.find((gc) => gc.id!=importedClassroom.id).name)
@@ -125,7 +125,7 @@ describe('importClassrooms()', () => {
     }
   })
 
-  it('does not remove an already imported classroom from me.googleClassrooms if deleted from google classroom', async function(done) {
+  it('does not remove an already imported classroom from me.googleClassrooms if deleted from google classroom, and sets deletedFromGC flag', async function(done) {
     // mark gClassrooms[0] as imported
     me.set('googleClassrooms', [gClassrooms[0]])
     let importedClassroom = me.get('googleClassrooms').find((c) => c.id == gClassrooms[0].id)
@@ -146,9 +146,11 @@ describe('importClassrooms()', () => {
       expect(me.get('googleClassrooms').length).toBe(2)
       expect(me.get('googleClassrooms').find((gc) => gc.id == importedClassroom.id)).toBeDefined()
       expect(me.get('googleClassrooms').find((gc) => gc.id == importedClassroom.id).importedToCoco).toBe(true)
+      expect(me.get('googleClassrooms').find((gc) => gc.id == importedClassroom.id).deletedFromGC).toBe(true)
       expect(me.get('googleClassrooms').find((gc) => gc.id != importedClassroom.id)).toBeDefined()
       expect(me.get('googleClassrooms').find((gc) => gc.id != importedClassroom.id).name).toBe(newGClassrooms[0].name)
       expect(me.get('googleClassrooms').find((gc) => gc.id != importedClassroom.id).importedToCoco).toBeUndefined()
+      expect(me.get('googleClassrooms').find((gc) => gc.id != importedClassroom.id).deletedFromGC).toBeUndefined()
       done()
     }
     catch (err) {


### PR DESCRIPTION
Issue: Classrooms imported to Codecombat should be available to import on Ozaria as well, i.e. Codecombat GC import and Ozaria GC import should work independent of each other.

- Added `importedToOzaria` and `deletedFromGC` flag to user schema `googleClassrooms` property
- Updated `importClassrooms` method to merge imported classrooms and set `deletedFromGC` flag.
- Updated test cases

Related changes also done on ozaria client repo.

Tested some cases locally, but difficult to test everything since it involves schema updates in both coco and ozaria. Will test on staging before deploying to prod.