### PR TITLE
Add support for JSON bundle server config

### DIFF
--- a/server_config.coffee
+++ b/server_config.coffee
@@ -5,6 +5,10 @@ cluster = require 'cluster'
 
 config = {}
 
+if process.env.COCO_SECRETS_JSON_BUNDLE
+  for k, v of JSON.parse(process.env.COCO_SECRETS_JSON_BUNDLE)
+    process.env[k] = v
+
 config.clusterID = "#{os.hostname()}"
 if cluster.worker?
  config.clusterID += "/#{cluster.worker.id}"


### PR DESCRIPTION
This duplicates the Ozaria server config process have, allowing us to initialize config from a JSON bundle in an environment variable.  This allows us to pull secrets from a secret store (AWS Secret Manager) and not store them in our repos.  This is required to run CodeCombat on Fargate. 