### PR TITLE
Fix campaign index update from campaign editor

### DIFF
--- a/app/views/editor/campaign/CampaignEditorView.coffee
+++ b/app/views/editor/campaign/CampaignEditorView.coffee
@@ -146,8 +146,6 @@ module.exports = class CampaignEditorView extends RootView
       # Save campaign to level if it's a main 'hero' campaign so HeroVictoryModal knows where to return.
       # (Not if it's a defaulted, typeless campaign like game-dev-hoc or auditions.)
       campaignLevel.campaign = @campaign.get 'slug' if @campaign.get('type') is 'hero' or @campaign.get('isOzaria')
-      # Save campaign index to level if it's a course campaign, since we show linear level order numbers for course levels.
-      campaignLevel.campaignIndex = (@levels.models.length - levelIndex - 1) if @campaign.get('type', true) is 'course'
       campaignLevels[levelOriginal] = campaignLevel
 
     @campaign.set('levels', campaignLevels)


### PR DESCRIPTION
Issue -> Once levels are added to a campaign and it is saved, then try to add more levels to the campaign. While saving the campaign again, the campaign index gets incorrectly updated for existing levels too, whereas it should only update for the new levels with an incremented value.

Mirroring the fix from Ozaria repo.