### PR TITLE
Course progress controll

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1641,6 +1641,8 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     classes: "Classes"
     certificate_btn_print: "Print"
     certificate_btn_toggle: "Toggle"
+    set_unblocked_level: "Set unblocked level"
+    no_block_level: "No limit"
 
   project_gallery:
     no_projects_published: "Be the first to publish a project in this course!"

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1641,7 +1641,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     classes: "Classes"
     certificate_btn_print: "Print"
     certificate_btn_toggle: "Toggle"
-    set_unblocked_level: "Set unblocked level"
+    set_last_unlocked_level: "Set last unlocked level"
     no_block_level: "No limit"
 
   project_gallery:

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1641,7 +1641,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     classes: "Classes"
     certificate_btn_print: "Print"
     certificate_btn_toggle: "Toggle"
-    set_last_unlocked_level: "Set last unlocked level"
+    set_start_locked_level: "Set start locked level"
     no_block_level: "No limit"
 
   project_gallery:

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1642,7 +1642,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     certificate_btn_print: "Print"
     certificate_btn_toggle: "Toggle"
     set_start_locked_level: "Set start locked level"
-    no_block_level: "No limit"
+    no_level_limit: "No limit"
 
   project_gallery:
     no_projects_published: "Be the first to publish a project in this course!"

--- a/app/locale/zh-HANS.coffee
+++ b/app/locale/zh-HANS.coffee
@@ -1641,7 +1641,7 @@ module.exports = nativeDescription: "简体中文", englishDescription: "Chinese
     classes: "班级"
     certificate_btn_print: "打印"
     certificate_btn_toggle: "中英切换"
-    set_unblocked_level: "设置本班学习进度"
+    set_last_unlocked_level: "设置本班学习进度"
     no_block_level: "无限制"
 
   project_gallery:

--- a/app/locale/zh-HANS.coffee
+++ b/app/locale/zh-HANS.coffee
@@ -1641,7 +1641,7 @@ module.exports = nativeDescription: "简体中文", englishDescription: "Chinese
     classes: "班级"
     certificate_btn_print: "打印"
     certificate_btn_toggle: "中英切换"
-    set_last_unlocked_level: "设置本班学习进度"
+    set_start_locked_level: "设置要锁定的起始关卡"
     no_block_level: "无限制"
 
   project_gallery:

--- a/app/locale/zh-HANS.coffee
+++ b/app/locale/zh-HANS.coffee
@@ -1642,7 +1642,7 @@ module.exports = nativeDescription: "简体中文", englishDescription: "Chinese
     certificate_btn_print: "打印"
     certificate_btn_toggle: "中英切换"
     set_start_locked_level: "设置要锁定的起始关卡"
-    no_block_level: "无限制"
+    no_level_limit: "无限制"
 
   project_gallery:
     no_projects_published: "成为第一个在这个课程中发布项目的人吧！"

--- a/app/locale/zh-HANS.coffee
+++ b/app/locale/zh-HANS.coffee
@@ -1641,6 +1641,8 @@ module.exports = nativeDescription: "简体中文", englishDescription: "Chinese
     classes: "班级"
     certificate_btn_print: "打印"
     certificate_btn_toggle: "中英切换"
+    set_unblocked_level: "设置本班学习进度"
+    no_block_level: "无限制"
 
   project_gallery:
     no_projects_published: "成为第一个在这个课程中发布项目的人吧！"

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -611,6 +611,7 @@ module.exports = class User extends CocoModel
   showChinaResourceInfo: -> features?.china ? false
   useChinaHomeView: -> features?.china ? false
   showChinaRegistration: -> features?.china ? false
+  showCourseProgressControll: -> features?.china ? false
 
   # Special flag to detect whether we're temporarily showing static html while loading full site
   showingStaticPagesWhileLoading: -> false

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -611,7 +611,7 @@ module.exports = class User extends CocoModel
   showChinaResourceInfo: -> features?.china ? false
   useChinaHomeView: -> features?.china ? false
   showChinaRegistration: -> features?.china ? false
-  showCourseProgressControll: -> features?.china ? false
+  showCourseProgressControl: -> features?.china ? false
 
   # Special flag to detect whether we're temporarily showing static html while loading full site
   showingStaticPagesWhileLoading: -> false

--- a/app/schemas/models/course_instance.schema.coffee
+++ b/app/schemas/models/course_instance.schema.coffee
@@ -19,6 +19,7 @@ _.extend CourseInstanceSchema.properties,
     language: {type: 'string', 'enum': ['python', 'javascript']}
   hourOfCode: { type: 'boolean', description: 'Deprecated, do not use.' }
   stats: c.object({ additionalProperties: true })
+  lastUnlockedLevel: {type: 'string'}
 
 c.extendBasicProperties CourseInstanceSchema, 'CourseInstance'
 

--- a/app/schemas/models/course_instance.schema.coffee
+++ b/app/schemas/models/course_instance.schema.coffee
@@ -17,9 +17,9 @@ _.extend CourseInstanceSchema.properties,
   prepaidID: c.objectId() # deprecated
   aceConfig:
     language: {type: 'string', 'enum': ['python', 'javascript']}
-  hourOfCode: { type: 'boolean', description: 'Deprecated, do not use.' }
-  stats: c.object({ additionalProperties: true })
-  startLockedLevel: c.shortString()
+  hourOfCode: {type: 'boolean', description: 'Deprecated, do not use.'}
+  stats: c.object({additionalProperties: true})
+  startLockedLevel: c.shortString(description: 'Updated by teacher, to lock levels after this one in a course')
 
 c.extendBasicProperties CourseInstanceSchema, 'CourseInstance'
 

--- a/app/schemas/models/course_instance.schema.coffee
+++ b/app/schemas/models/course_instance.schema.coffee
@@ -19,7 +19,7 @@ _.extend CourseInstanceSchema.properties,
     language: {type: 'string', 'enum': ['python', 'javascript']}
   hourOfCode: { type: 'boolean', description: 'Deprecated, do not use.' }
   stats: c.object({ additionalProperties: true })
-  lastUnlockedLevel: {type: 'string'}
+  startLockedLevel: {type: 'string'}
 
 c.extendBasicProperties CourseInstanceSchema, 'CourseInstance'
 

--- a/app/schemas/models/course_instance.schema.coffee
+++ b/app/schemas/models/course_instance.schema.coffee
@@ -19,7 +19,7 @@ _.extend CourseInstanceSchema.properties,
     language: {type: 'string', 'enum': ['python', 'javascript']}
   hourOfCode: { type: 'boolean', description: 'Deprecated, do not use.' }
   stats: c.object({ additionalProperties: true })
-  startLockedLevel: {type: 'string'}
+  startLockedLevel: c.shortString()
 
 c.extendBasicProperties CourseInstanceSchema, 'CourseInstance'
 

--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -140,7 +140,27 @@ mixin courseProgressTab
           span.small(data-i18n="teacher.level_not_started")
         .clearfix
     - var course = state.get('selectedCourse');
-    - var courseInstance = state.get('selectedCourseInstance');
+    - var courseInstance = view.getSelectedCourseInstance()
+    if courseInstance && course && view.campaignLevelNumberMap[course.get('campaignID')]
+      .text-center(data-course-id=course.id)
+        span(data-i18n="courses.set_unblocked_level")
+        span.spr :
+        select.level-select
+          option(data-i18n="courses.no_block_level" value='none' selected=('none' === courseInstance.get('lastUnlockedLevel')))
+          - var levels = view.classroom.getLevels({courseID: course.id}).models
+          each level, levelIndex in levels
+            option(value=level.get('slug') selected=(level.get('slug') === courseInstance.get('lastUnlockedLevel')))
+              if level.get('assessment')
+                if level.get('assessment') === 'cumulative'
+                  =$.t('play_level.combo_challenge')
+                else
+                  =$.t('play_level.concept_challenge')
+                =":"
+              else
+                span #{view.campaignLevelNumberMap[course.get('campaignID')][level.get('original')]}.
+              = " "
+              span
+                = i18n(level.attributes, 'name').replace('Course: ', '')
     // TODO: Refactor this to use Vue components like in the assessments tab
     if course && view.availableCourseMap[course.id] && courseInstance && courseInstance.get('members').length > 0
       .render-on-course-sync
@@ -175,30 +195,6 @@ mixin courseProgressTab
                 .col-sm-2
                   .assign-student-button.btn.btn-md.btn-navy.pull-right(data-user-id=student.id data-course-id=state.get('selectedCourse').id)
                     span(data-i18n='teacher.assign_course')
-    - var courseInstance = view.getSelectedCourseInstance()
-    if courseInstance && course && view.campaignLevelNumberMap[course.get('campaignID')]
-      .play-level-form(data-course-id=course.id)
-        .form-group
-          label.control-label
-            span(data-i18n="courses.select_level")
-            | :
-            select.level-select.form-control(disabled=disablePlayButtons)
-              option(data-i18n="courses.play_level" value='none' selected=('none'===courseInstance.get('lastUnlockedLevel')))
-              - var levels = view.classroom.getLevels({courseID: course.id}).models
-              - console.log(levels, view.campaignLevelNumberMap)
-              each level, levelIndex in levels
-                option(value=level.get('slug') selected=(level.get('slug')===courseInstance.get('lastUnlockedLevel')))
-                  if level.get('assessment')
-                    if level.get('assessment') === 'cumulative'
-                      =$.t('play_level.combo_challenge')
-                    else
-                      =$.t('play_level.concept_challenge')
-                    =":"
-                  else
-                    span #{view.campaignLevelNumberMap[course.get('campaignID')][level.get('original')]}.
-                  = " "
-                  span
-                    = i18n(level.attributes, 'name').replace('Course: ', '')
 
 mixin courseOverview(course)
   - var levels = view.classroom.getLevels({courseID: course.id}).models

--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -141,7 +141,7 @@ mixin courseProgressTab
         .clearfix
     - var course = state.get('selectedCourse');
     - var courseInstance = view.getSelectedCourseInstance()
-    if courseInstance && course && view.campaignLevelNumberMap[course.get('campaignID')]
+    if me.showCourseProgressControll() && courseInstance && course && view.campaignLevelNumberMap[course.get('campaignID')]
       .text-center(data-course-id=course.id)
         span(data-i18n="courses.set_unblocked_level")
         span.spr :
@@ -149,18 +149,12 @@ mixin courseProgressTab
           option(data-i18n="courses.no_block_level" value='none' selected=('none' === courseInstance.get('lastUnlockedLevel')))
           - var levels = view.classroom.getLevels({courseID: course.id}).models
           each level, levelIndex in levels
-            option(value=level.get('slug') selected=(level.get('slug') === courseInstance.get('lastUnlockedLevel')))
-              if level.get('assessment')
-                if level.get('assessment') === 'cumulative'
-                  =$.t('play_level.combo_challenge')
-                else
-                  =$.t('play_level.concept_challenge')
-                =":"
-              else
+            unless level.get('assessment') || level.get('practice')
+              option(value=level.get('slug') selected=(level.get('slug') === courseInstance.get('lastUnlockedLevel')))
                 span #{view.campaignLevelNumberMap[course.get('campaignID')][level.get('original')]}.
-              = " "
-              span
-                = i18n(level.attributes, 'name').replace('Course: ', '')
+                  = " "
+                span
+                  = i18n(level.attributes, 'name').replace('Course: ', '')
     // TODO: Refactor this to use Vue components like in the assessments tab
     if course && view.availableCourseMap[course.id] && courseInstance && courseInstance.get('members').length > 0
       .render-on-course-sync

--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -141,12 +141,12 @@ mixin courseProgressTab
         .clearfix
     - var course = state.get('selectedCourse');
     - var courseInstance = view.getSelectedCourseInstance()
-    if me.showCourseProgressControll() && courseInstance && course && view.campaignLevelNumberMap[course.get('campaignID')]
+    if me.showCourseProgressControl() && courseInstance && course && view.campaignLevelNumberMap[course.get('campaignID')]
       .text-center(data-course-id=course.id)
         span(data-i18n="courses.set_start_locked_level")
         span.spr :
-        select.level-select
-          option(data-i18n="courses.no_block_level" value='none' selected=('none' === courseInstance.get('startLockedLevel')))
+        select.locked-level-select
+          option(data-i18n="courses.no_level_limit" value='none')
           - var levels = view.classroom.getLevels({courseID: course.id}).models
           each level, levelIndex in levels
             unless level.get('assessment') || level.get('practice')

--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -143,7 +143,7 @@ mixin courseProgressTab
     - var courseInstance = view.getSelectedCourseInstance()
     if me.showCourseProgressControll() && courseInstance && course && view.campaignLevelNumberMap[course.get('campaignID')]
       .text-center(data-course-id=course.id)
-        span(data-i18n="courses.set_unblocked_level")
+        span(data-i18n="courses.set_last_unlocked_level")
         span.spr :
         select.level-select
           option(data-i18n="courses.no_block_level" value='none' selected=('none' === courseInstance.get('lastUnlockedLevel')))

--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -175,6 +175,30 @@ mixin courseProgressTab
                 .col-sm-2
                   .assign-student-button.btn.btn-md.btn-navy.pull-right(data-user-id=student.id data-course-id=state.get('selectedCourse').id)
                     span(data-i18n='teacher.assign_course')
+    - var courseInstance = view.getSelectedCourseInstance()
+    if courseInstance && course && view.campaignLevelNumberMap[course.get('campaignID')]
+      .play-level-form(data-course-id=course.id)
+        .form-group
+          label.control-label
+            span(data-i18n="courses.select_level")
+            | :
+            select.level-select.form-control(disabled=disablePlayButtons)
+              option(data-i18n="courses.play_level" value='none' selected=('none'===courseInstance.get('lastUnlockedLevel')))
+              - var levels = view.classroom.getLevels({courseID: course.id}).models
+              - console.log(levels, view.campaignLevelNumberMap)
+              each level, levelIndex in levels
+                option(value=level.get('slug') selected=(level.get('slug')===courseInstance.get('lastUnlockedLevel')))
+                  if level.get('assessment')
+                    if level.get('assessment') === 'cumulative'
+                      =$.t('play_level.combo_challenge')
+                    else
+                      =$.t('play_level.concept_challenge')
+                    =":"
+                  else
+                    span #{view.campaignLevelNumberMap[course.get('campaignID')][level.get('original')]}.
+                  = " "
+                  span
+                    = i18n(level.attributes, 'name').replace('Course: ', '')
 
 mixin courseOverview(course)
   - var levels = view.classroom.getLevels({courseID: course.id}).models

--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -143,14 +143,14 @@ mixin courseProgressTab
     - var courseInstance = view.getSelectedCourseInstance()
     if me.showCourseProgressControll() && courseInstance && course && view.campaignLevelNumberMap[course.get('campaignID')]
       .text-center(data-course-id=course.id)
-        span(data-i18n="courses.set_last_unlocked_level")
+        span(data-i18n="courses.set_start_locked_level")
         span.spr :
         select.level-select
-          option(data-i18n="courses.no_block_level" value='none' selected=('none' === courseInstance.get('lastUnlockedLevel')))
+          option(data-i18n="courses.no_block_level" value='none' selected=('none' === courseInstance.get('startLockedLevel')))
           - var levels = view.classroom.getLevels({courseID: course.id}).models
           each level, levelIndex in levels
             unless level.get('assessment') || level.get('practice')
-              option(value=level.get('slug') selected=(level.get('slug') === courseInstance.get('lastUnlockedLevel')))
+              option(value=level.get('slug') selected=(level.get('slug') === courseInstance.get('startLockedLevel')))
                 span #{view.campaignLevelNumberMap[course.get('campaignID')][level.get('original')]}.
                   = " "
                 span

--- a/app/views/courses/TeacherClassView.coffee
+++ b/app/views/courses/TeacherClassView.coffee
@@ -214,7 +214,7 @@ module.exports = class TeacherClassView extends RootView
     @listenTo @, 'course-select:change', ({ selectedCourse }) ->
       @state.set selectedCourse: selectedCourse
     @listenTo @, 'level-select:change', ({ selectedLevel }) ->
-      @setSelectedCourseUnlockLevel(selectedLevel)
+      @setSelectedCourseLockedLevel(selectedLevel)
     @listenTo @state, 'change:selectedCourse', (e) ->
       @setSelectedCourseInstance()
 
@@ -236,10 +236,10 @@ module.exports = class TeacherClassView extends RootView
       @setSelectedCourseInstance()
     return @state.get 'selectedCourseInstance'
 
-  setSelectedCourseUnlockLevel: (level) ->
+  setSelectedCourseLockedLevel: (level) ->
     courseInstance = @getSelectedCourseInstance()
     if courseInstance and level
-      courseInstance.set 'lastUnlockedLevel', level
+      courseInstance.set 'startLockedLevel', level
       courseInstance.save()
 
   onLoaded: ->

--- a/app/views/courses/TeacherClassView.coffee
+++ b/app/views/courses/TeacherClassView.coffee
@@ -62,7 +62,7 @@ module.exports = class TeacherClassView extends RootView
     'change .course-select, .bulk-course-select': 'onChangeCourseSelect'
     'click a.student-level-progress-dot': 'onClickStudentProgressDot'
     'click .sync-google-classroom-btn': 'onClickSyncGoogleClassroom'
-    'change .level-select': 'onChangeLevelSelect'
+    'change .locked-level-select': 'onChangeLockedLevelSelect'
 
   getInitialState: ->
     {
@@ -213,7 +213,7 @@ module.exports = class TeacherClassView extends RootView
       @state.set students: @students
     @listenTo @, 'course-select:change', ({ selectedCourse }) ->
       @state.set selectedCourse: selectedCourse
-    @listenTo @, 'level-select:change', ({ selectedLevel }) ->
+    @listenTo @, 'locked-level-select:change', ({ selectedLevel }) ->
       @setSelectedCourseLockedLevel(selectedLevel)
     @listenTo @state, 'change:selectedCourse', (e) ->
       @setSelectedCourseInstance()
@@ -445,8 +445,8 @@ module.exports = class TeacherClassView extends RootView
   onChangeCourseSelect: (e) ->
     @trigger 'course-select:change', { selectedCourse: @courses.get($(e.currentTarget).val()) }
 
-  onChangeLevelSelect: (e) ->
-    @trigger 'level-select:change', { selectedLevel: $(e.currentTarget).val() }
+  onChangeLockedLevelSelect: (e) ->
+    @trigger 'locked-level-select:change', { selectedLevel: $(e.currentTarget).val() }
 
   getSelectedStudentIDs: ->
     Object.keys(_.pick @state.get('checkboxStates'), (checked) -> checked)

--- a/app/views/courses/TeacherClassView.coffee
+++ b/app/views/courses/TeacherClassView.coffee
@@ -239,8 +239,8 @@ module.exports = class TeacherClassView extends RootView
   setSelectedCourseUnlockLevel: (level) ->
     courseInstance = @getSelectedCourseInstance()
     if courseInstance and level
-        courseInstance.set 'lastUnlockedLevel', level
-        courseInstance.save()
+      courseInstance.set 'lastUnlockedLevel', level
+      courseInstance.save()
 
   onLoaded: ->
     # Get latest courses for student assignment dropdowns
@@ -864,4 +864,3 @@ module.exports = class TeacherClassView extends RootView
     .then () =>
       $('.sync-google-classroom-btn').text($.i18n.t('teacher.sync_google_classroom'))
       $('.sync-google-classroom-btn').attr('disabled', false)
-

--- a/app/views/courses/TeacherClassView.coffee
+++ b/app/views/courses/TeacherClassView.coffee
@@ -237,6 +237,7 @@ module.exports = class TeacherClassView extends RootView
     return @state.get 'selectedCourseInstance'
 
   setSelectedCourseLockedLevel: (level) ->
+    return unless me.showCourseProgressControl()
     courseInstance = @getSelectedCourseInstance()
     if courseInstance and level
       courseInstance.set 'startLockedLevel', level

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -1393,6 +1393,12 @@ module.exports = class CampaignView extends RootView
           level.hidden = false
 
       level.noFlag = !level.next
+
+      if level.slug == @courseInstance.get('startLockedLevel') # lock level begin from startLockedLevel
+        lockedByTeacher = true
+      if lockedByTeacher and me.showCourseProgressControl()
+        level.locked = true
+
       if level.locked
         level.color = 'rgb(193, 193, 193)'
       else if level.practice
@@ -1406,11 +1412,6 @@ module.exports = class CampaignView extends RootView
       prev = level
       if not @campaign.levelIsPractice(level) and not @campaign.levelIsAssessment(level)
         lastNormalLevel = level
-
-      if level.slug == @courseInstance.get('startLockedLevel') # lock level begin from startLockedLevel
-        lockedByTeacher = true
-      level.locked = lockedByTeacher
-
 
     return true
 

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -1407,9 +1407,10 @@ module.exports = class CampaignView extends RootView
       if not @campaign.levelIsPractice(level) and not @campaign.levelIsAssessment(level)
         lastNormalLevel = level
 
-      level.locked = lockedByTeacher
-      if level.slug == @courseInstance.get('lastUnlockedLevel') # lock level after lastUnlockedLevel
+      if level.slug == @courseInstance.get('startLockedLevel') # lock level begin from startLockedLevel
         lockedByTeacher = true
+      level.locked = lockedByTeacher
+
 
     return true
 

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -22,7 +22,6 @@ ShareProgressModal = require 'views/play/modal/ShareProgressModal'
 UserPollsRecord = require 'models/UserPollsRecord'
 Poll = require 'models/Poll'
 PollModal = require 'views/play/modal/PollModal'
-CourseInstance = require 'models/CourseInstance'
 AnnouncementModal = require 'views/play/modal/AnnouncementModal'
 codePlay = require('lib/code-play')
 MineModal = require 'views/core/MineModal' # Minecraft modal
@@ -1361,6 +1360,7 @@ module.exports = class CampaignView extends RootView
     found = false
     prev = null
     lastNormalLevel = null
+    lockedByTeacher = false
     for level, levelIndex in courseOrder
       playerState = @levelStatusMap[level.slug]
       level.color = 'rgb(255, 80, 60)'
@@ -1406,6 +1406,11 @@ module.exports = class CampaignView extends RootView
       prev = level
       if not @campaign.levelIsPractice(level) and not @campaign.levelIsAssessment(level)
         lastNormalLevel = level
+
+      level.locked = lockedByTeacher
+      if level.slug == @courseInstance.get('lastUnlockedLevel') # lock level after lastUnlockedLevel
+        lockedByTeacher = true
+
     return true
 
   shouldShow: (what) ->

--- a/server_setup.coffee
+++ b/server_setup.coffee
@@ -335,8 +335,6 @@ setupProxyMiddleware = (app) ->
   target = 'https://very.direct.codecombat.com'
   headers = {}
 
-  target = 'http://staging.koudashijie.com'
-  headers['Host'] = 'staging.koudashijie.com'
   if (process.env.COCO_PROXY_NEXT)
     target = 'https://next.codecombat.com'
     headers['Host'] = 'next.codecombat.com'

--- a/server_setup.coffee
+++ b/server_setup.coffee
@@ -335,6 +335,8 @@ setupProxyMiddleware = (app) ->
   target = 'https://very.direct.codecombat.com'
   headers = {}
 
+  target = 'http://staging.koudashijie.com'
+  headers['Host'] = 'staging.koudashijie.com'
   if (process.env.COCO_PROXY_NEXT)
     target = 'https://next.codecombat.com'
     headers['Host'] = 'next.codecombat.com'


### PR DESCRIPTION
Allow teacher to assign certain level within a course under China.
Say we set `Enemy Mine` as `startLockedLevel`, then levels start from `Enemy Mine` will be locked, all other levels before including practice and assessment levels are available

For simplicity, currently can only support choosing main level, without practice and assessment level.

