### PR TITLE
Update hoc banner to 2019

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -2941,7 +2941,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     send: "Send Email"
 
   hoc_2018:
-    banner: "Happy Computer Science Education Week 2018!"
+    banner: "Welcome to Hour of Code 2019!" #{change}
     page_heading: "Your students will learn to code by building their own game!"
     step_1: "Step 1: Watch Video Overview"
     step_2: "Step 2: Try it Yourself"


### PR DESCRIPTION
## Issue
Landing page has 2018 welcome.

## Fix

Update copy to 2019.
Change seen below:

<img width="452" alt="Screen Shot 2019-10-30 at 4 42 13 PM" src="https://user-images.githubusercontent.com/15080861/67907342-d744eb00-fb34-11e9-954d-45b84f50e6e5.png">
