### PR TITLE
Tighten heuristic on which Thangs might need hit testing

### DIFF
--- a/vendor/scripts/createjs.js
+++ b/vendor/scripts/createjs.js
@@ -7737,8 +7737,13 @@ createjs.deprecate = function(fallbackMethod, name) {
 			var lank = this.lank || (this.parent ? (this.parent.lank || this.parent.parent ? this.parent.parent.lank : null) : null);
 			if (lank && lank.thang && lank.thang.pos && lank.thang.pos.distanceSquared) {
 				var thangWorldPos = lank.thang.pos;
-				if (thangWorldPos.distanceSquared(createjs.lastMouseWorldPos) > 100) {
-					// Not worth testing, too far. TODO: take zoom / thang size into account to be more precise?
+				// 2019-11-12: Chrome regression in hit testing performance makes us more aggressive on this check with some heuristics as to how big a Thang could be
+				var xDist = Math.abs(thangWorldPos.x - createjs.lastMouseWorldPos.x);
+				var yDist = Math.abs(thangWorldPos.y + ((lank.thang.depth || 1) / 2 + (lank.thang.height || 1) / 2) - createjs.lastMouseWorldPos.y);
+				var xDistThreshold = Math.min(10, 1.25 * Math.max(lank.thang.width || 1) + 1);
+				var yDistThreshold = Math.min(10, 1.25 * Math.max((lank.thang.height || 1) + (lank.thang.depth || 1), 1) + 1);
+				if (xDist > xDistThreshold || yDist > yDistThreshold) {
+					// Not worth testing, too far.
 					return null;
 				}
 			}


### PR DESCRIPTION
This would ease impact of Chrome EaselJS hit test performance regression.

Lance and China partners noticed that in Lernaean Hydra and other game dev levels, performance was very slow. I noticed this in any game dev levels where multiple Thangs were close together, in Chrome only, and profiled it to the hit testing method in EaselJS. Not sure if it was always this slow, but it was really slow, so that the game stuttered on every click if clicking near multiple Thangs.

We had a monkey patch to EaselJS to optimize how many Thangs would need hit testing (anything within 10m of the world position of the click), and this heuristic tightens it based on the physical world dimensions of the Thangs (usually significantly less than 10m, and narrower in the x vs. the y dimension). Note that physical dimensions and graphic dimensions are only loosely correlated, so we can't be too aggressive on this.

Note also that in my tests, I could return a list of no Thangs to hit test and the game behavior I saw still worked (the events in question must have been based on a different code path or perhaps didn't need to recursively test children in this case), so future work would be to test whether we need these Surface `mouseUp` and `mouseDown` events to do this hit test at all.