### PR TITLE
localize page title

### DIFF
--- a/app/templates/static/layout.static.pug
+++ b/app/templates/static/layout.static.pug
@@ -5,7 +5,9 @@ html(lang='en')
     meta(charset='utf-8')
     meta(name='viewport', content='width=1024')
     meta(http-equiv='Accept-CH', content='Viewport-Width')
-    title CodeCombat - Learn how to code by playing a game
+    //- title CodeCombat - Learn how to code by playing a game
+    title(data-i18n="new_home.title")
+    meta(data-i18n="[content]new_home.meta_description")
     meta(property='og:title', content='CodeCombat: Learn to Code by Playing a Game')
     meta(property='og:url', content='http://codecombat.com')
     meta(property='og:type', content='game')

--- a/compile-static-templates.coffee
+++ b/compile-static-templates.coffee
@@ -2,6 +2,7 @@ pug = require 'pug'
 path = require 'path'
 cheerio = require 'cheerio'
 en = require './app/locale/en'
+zh = require './app/locale/zh-HANS'
 basePath = path.resolve('./app')
 _ = require 'lodash'
 fs = require('fs')
@@ -21,11 +22,18 @@ compile = (contents, locals, filename, cb) ->
     basedir: basePath
   })
 
-  translate = (key) ->
+  translate = (key, chinaInfra) ->
+    type = 'text'
+
     html = /^\[html\]/.test(key)
     key = key.substring(6) if html
+    type = 'html' if html
 
-    t = en.translation
+    content = /^\[content\]/.test(key)
+    key = key.substring(9) if content
+    type = 'content' if content
+
+    t = if chinaInfra then zh.translation else en.translation
     #TODO: Replace with _.property when we get modern lodash
     translationPath = key.split(/[.]/)
     while translationPath.length > 0
@@ -35,7 +43,7 @@ compile = (contents, locals, filename, cb) ->
 
     return out =
       text: t
-      html: html
+      type: type
 
   i18n = (k,v) ->
     return k.i18n.en[a] if 'i18n' in k
@@ -59,9 +67,11 @@ compile = (contents, locals, filename, cb) ->
   elms = c('[data-i18n]')
   elms.each (i, e) ->
     i = c(@)
-    t = translate(i.data('i18n'))
-    if t.html
+    t = translate(i.data('i18n'), locals.chinaInfra)
+    if t.type == 'html'
       i.html(t.text)
+    else if t.type == 'content'
+      i.attr("content", t.text)
     else
       i.text(t.text)
 


### PR DESCRIPTION
localize page title when compiling static template

search engines in China get fallback title in `layout.static.pug`, but google catch the another one which located in `i18n/en.coffee#new_home.title`, this pr unify these two titles and will help Chinese search engine get Chinese title.
![Screenshot_2019-11-15_09-22-39](https://user-images.githubusercontent.com/11417632/68910273-2709f000-078c-11ea-800b-d5a8f8e92e4d.png)
![Screenshot_2019-11-15_09-22-54](https://user-images.githubusercontent.com/11417632/68910275-27a28680-078c-11ea-983f-3147bb88d64e.png)
![Screenshot_2019-11-15_09-42-03](https://user-images.githubusercontent.com/11417632/68910276-283b1d00-078c-11ea-9317-2417da8d2823.png)
