### PR TITLE
Update Esper and include Pointer plugin for C++

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -42,7 +42,7 @@
     "fastclick": "~1.0.3",
     "three.js": "~0.71.0",
     "lscache": "~1.0.5",
-    "esper.js": "http://files.codecombat.com/esper-2019-03-08.tar.gz",
+    "esper.js": "http://files.codecombat.com/esper-pointer-danger-2019-12-18.tar.gz",
     "algoliasearch": "^3.13.1",
     "algolia-autocomplete.js": "^0.17.0",
     "algolia-autocomplete-no-conflict": "1.0.0",


### PR DESCRIPTION
This PR introduces a new version of esper. It's 2 versions ahead of what we had.

It should make Python much faster, but also includes the Pointer plugins.

It replaces #5669 .


## Risk

It's a high risk change as it includes many esper improvements that could break strange dependencies.

## Testing

This was deployed to next and tested very simply. We did not test every case or run the full verifier.