### PR TITLE
Fix infinite loop in C++

### DIFF
--- a/app/lib/aether/interpreter.coffee
+++ b/app/lib/aether/interpreter.coffee
@@ -153,7 +153,8 @@ makeYieldFilter = (aether) -> (engine, evaluator, e) ->
 
   if e? and e.type is 'event' and e.event is 'loopBodyStart'
     
-    if top.srcAst.type is 'WhileStatement' and top.srcAst.test.type is 'Literal'
+    # Legacy programming languages use 'Literal' whilst C++ and Java use 'BooleanLiteral'.
+    if top.srcAst.type is 'WhileStatement' and (top.srcAst.test.type is 'Literal' or top.srcAst.test.type is 'BooleanLiteral')
       if aether.whileLoopMarker?
         currentMark = aether.whileLoopMarker(top)
         if currentMark is top.mark


### PR DESCRIPTION
## Issue

Infinite `while (true)` loops didn't yield when using C++ and would crash everything.

## Fix

C++ uses some different tokens. Instead of a `Literal` token, it's a `BooleanLiteral` token that represents the concrete value `true`. By updating the aether yielding function, it's possible to add yielding to infinite C++ loops. 

## Risk

Although this touches a lot of code, it's additive. I believe the only risk is that this somehow causes more yielding to happen in the context of `while (<Literal | BooleanLiteral>)`.
I cannot think of a situation where this happens.

## China

If china needs this asap, merge this change behind a feature flag.

## How to manually test

1. Check out this change locally.
2. Run against proxy
3. On the home page log into your admin/internal account.
4. Navigate to `http://localhost:3000/play/level/village-rover?codeLanguage=cpp`

Input the following code:

```cpp
void main() {
    while (true) {
        auto enemy = hero.findNearestEnemy();
        if(enemy){
            hero.attack(enemy);
        }
    }
}

```