### PR TITLE
Fix cpp ace editor language mode

### DIFF
--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -505,7 +505,7 @@ module.exports = class SpellView extends CocoView
       autoLineEndings:
         javascript: ';'
         java: ';'
-        cpp: ';'
+        c_cpp: ';' # Match ace editor language mode
       popupFontSizePx: popupFontSizePx
       popupLineHeightPx: 1.5 * popupFontSizePx
       popupWidthPx: 380


### PR DESCRIPTION
# Issue

When language was set to C++ it wasn't adding semicolons.

# Fix

The snippet system checks the language based on the ace editor language mode which uses `c_cpp` instead of `cpp`.
