### PR TITLE
Remove share prompt from classroom

### DIFF
--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -431,7 +431,7 @@ module.exports = class CampaignView extends RootView
           @openModalView new CodePlayCreateAccountModal()
       else if me.get('name') and me.get('lastLevel') in ['forgetful-gemsmith', 'signs-and-portents', 'true-names'] and
       me.level() < 5 and not (me.get('ageRange') in ['18-24', '25-34', '35-44', '45-100']) and
-      not storage.load('sent-parent-email') and not me.isPremium()
+      not storage.load('sent-parent-email') and not me.isPremium() and not me.isStudent()
         @openModalView new ShareProgressModal()
     else
       @maybeShowPendingAnnouncement()

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -431,7 +431,7 @@ module.exports = class CampaignView extends RootView
           @openModalView new CodePlayCreateAccountModal()
       else if me.get('name') and me.get('lastLevel') in ['forgetful-gemsmith', 'signs-and-portents', 'true-names'] and
       me.level() < 5 and not (me.get('ageRange') in ['18-24', '25-34', '35-44', '45-100']) and
-      not storage.load('sent-parent-email') and not me.isPremium() and not me.isStudent()
+      not storage.load('sent-parent-email') and not (me.isPremium() or me.isStudent() or me.isTeacher())
         @openModalView new ShareProgressModal()
     else
       @maybeShowPendingAnnouncement()


### PR DESCRIPTION
# Issue

A prompt comes up which lets the student enter in their parents email address to show progress. There isn't supposed to be a prompt in the classroom version for parents emails.

# Fix

Check to make sure the user is not a student before showing modal. This preserves behavior for home users.

Tested fix manually on Firefox.