### PR TITLE
Add linesOfCode goal C++ middleware

### DIFF
--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -392,7 +392,7 @@ module.exports = class PlayLevelView extends RootView
     options = {}
 
     # Add two lines to handle `void main() {}` in C++ for the linesOfCode goal.
-    if (me.get('aceConfig')?.language is 'cpp' and Array.isArray(@level.get('goals')))
+    if ((me.get('aceConfig')?.language is 'cpp' or @session?.get('codeLanguage') is 'cpp') and Array.isArray(@level.get('goals')))
       @level.get('goals').forEach((goal) =>
         if goal?.linesOfCode?.humans and typeof goal.linesOfCode.humans == 'number'
           goal.linesOfCode.humans += 2

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -390,6 +390,14 @@ module.exports = class PlayLevelView extends RootView
 
   initGoalManager: ->
     options = {}
+
+    # Add two lines to handle `void main() {}` in C++ for the linesOfCode goal.
+    if (me.get('aceConfig')?.language is 'cpp' and Array.isArray(@level.get('goals')))
+      @level.get('goals').forEach((goal) =>
+        if goal?.linesOfCode?.humans and typeof goal.linesOfCode.humans == 'number'
+          goal.linesOfCode.humans += 2
+      )
+
     if @level.get('assessment') is 'cumulative'
       options.minGoalsToComplete = 1
     @goalManager = new GoalManager(@world, @level.get('goals'), @team, options)

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -392,7 +392,7 @@ module.exports = class PlayLevelView extends RootView
     options = {}
 
     # Add two lines to handle `void main() {}` in C++ for the linesOfCode goal.
-    if ((me.get('aceConfig')?.language is 'cpp' or @session?.get('codeLanguage') is 'cpp') and Array.isArray(@level.get('goals')))
+    if ((@session?.get('codeLanguage') is 'cpp' or me.get('aceConfig')?.language is 'cpp') and Array.isArray(@level.get('goals')))
       @level.get('goals').forEach((goal) =>
         if goal?.linesOfCode?.humans and typeof goal.linesOfCode.humans == 'number'
           goal.linesOfCode.humans += 2


### PR DESCRIPTION
# Issue

When playing with C++ the lines of code goal doesn't take into account the function wrapper.

# Fix

Programmatically increase the lines of code by 2 to compensate.

# Manual testing

This was manually tested with production proxy on the following levels:

- descending-further
- the-second-kithmaze
- haunted-kithmaze

If testing with an admin account you should have access to the experimental language.