### PR TITLE
Fix C++ error displaying every second time

### DIFF
--- a/app/lib/aether/aether.coffee
+++ b/app/lib/aether/aether.coffee
@@ -99,6 +99,8 @@ module.exports = class Aether
   # If careAboutLineNumbers, we strip trailing comments and whitespace and compare line count.
   # If careAboutLint, we also lint and make sure lint problems are the same.
   hasChangedSignificantly: (a, b, careAboutLineNumbers=false, careAboutLint=false) ->
+    a = Aether.getTokenSource(a)
+    b = Aether.getTokenSource(b)
     return true unless a? and b?
     return false if a is b
     return true if careAboutLineNumbers and @language.hasChangedLineNumbers a, b
@@ -249,6 +251,13 @@ module.exports = class Aether
       ]
         ++count
     return count
+
+Aether.getTokenSource = (raw) ->
+  if /^\u56E7[a-zA-Z0-9+/=]+\f$/.test raw
+    token = JSON.parse Unibabel.base64ToUtf8(raw.substr(1, raw.length-2))
+    token.src
+  else
+    raw
 
 self.Aether = Aether if self?
 window.Aether = Aether if window?

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -18,6 +18,7 @@ Autocomplete = require './editor/autocomplete'
 TokenIterator = ace.require('ace/token_iterator').TokenIterator
 LZString = require 'lz-string'
 utils = require 'core/utils'
+Aether = require 'lib/aether/aether'
 
 module.exports = class SpellView extends CocoView
   id: 'spell-view'
@@ -711,7 +712,8 @@ module.exports = class SpellView extends CocoView
 
   recompile: (cast=true, realTime=false, cinematic=false) ->
     @fetchTokenForSource().then (source) =>
-      hasChanged = @spell.source isnt source
+      readableSource = Aether.getTokenSource(source)
+      hasChanged = @spell.source isnt readableSource
       if hasChanged
         @spell.transpile source
         @updateAether true, false
@@ -803,12 +805,13 @@ module.exports = class SpellView extends CocoView
     # to a new spellThang, we may want to refresh our Aether display.
     return unless aether = @spellThang?.aether
     @fetchTokenForSource().then (source) =>
+      readableSource = Aether.getTokenSource(source)
       @spell.hasChangedSignificantly source, aether.raw, (hasChanged) =>
         codeHasChangedSignificantly = force or hasChanged
         needsUpdate = codeHasChangedSignificantly or @spellThang isnt @lastUpdatedAetherSpellThang
         return if not needsUpdate and aether is @displayedAether
         castAether = @spellThang.castAether
-        codeIsAsCast = (castAether and source is castAether.raw) or @spell.language in ['java', 'cpp']
+        codeIsAsCast = castAether and readableSource is castAether.raw
         aether = castAether if codeIsAsCast
         return if not needsUpdate and aether is @displayedAether
 
@@ -833,7 +836,7 @@ module.exports = class SpellView extends CocoView
               if workerData.function is 'transpile' and workerData.spellKey is @spell.spellKey
                 @worker.removeEventListener 'message', arguments.callee, false
                 aether.problems = workerData.problems
-                aether.raw = source
+                aether.raw = readableSource
                 finishUpdatingAether(aether)
             @worker.postMessage JSON.stringify(workerMessage)
           else

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -808,7 +808,7 @@ module.exports = class SpellView extends CocoView
         needsUpdate = codeHasChangedSignificantly or @spellThang isnt @lastUpdatedAetherSpellThang
         return if not needsUpdate and aether is @displayedAether
         castAether = @spellThang.castAether
-        codeIsAsCast = castAether and source is castAether.raw
+        codeIsAsCast = (castAether and source is castAether.raw) or @spell.language in ['java', 'cpp']
         aether = castAether if codeIsAsCast
         return if not needsUpdate and aether is @displayedAether
 


### PR DESCRIPTION
# Issue
The c++ error is only displayed every second time, and doesn't clear if there is a correct solution.

Basically when writing C++ the error messages don't appear correctly.

## Why

It is because we only show errors if the source code is the same as what is transpiled. However this is not ideal in this case because the C++ code is an obfuscated token string.

The code was correctly working every second time because there is another code path that sets the `aether.raw` property to the source, in the case that they don't initially match...
This happens here: https://github.com/codecombat/codecombat/blob/9d3ea135088b618f9db07c3e98959faa05faf432/app/views/play/level/tome/SpellView.coffee#L836

The effect of this is the error appearing every second run, but this is really not good because `aether.raw` should be human readable code and not the obfuscated token.


# Fix

The first commit is a naive fix to check for c++ and display errors. However this fix is **too** naive, and doesn't correctly clear errors because other code paths aren't fixed. It also cannot tell if the source code is changed or not. Checking the language is C++ and then always triggering that the source code has changed is also expensive.

Thus in the second commit I follow the code paths where the token is created and intercept checks that match if the source code is the same as what is in the users editor. Instead of checking the obfuscated token against the human readable code, we instead decode the token and pull out the readable code. This adds some overhead for C++, without changing javascript or python behavior.

With this fix the errors work correctly in C++.

# How to repro the bug

Please find a gif showing the bug occurring (notice specifically how quickly the error appears the second time)
![1e805248f92f6161afeef31ff0f52273](https://user-images.githubusercontent.com/15080861/73319621-cbc79580-41f1-11ea-8a66-8d8078fb8a02.gif)
:


### Steps to repro

Log in as admin to codecombat.com
Navigate to https://codecombat.com/play/level/gems-in-the-deep?codeLanguage=cpp
Remove the semi colon and press run. Note that no error appears.
Click the run button a second time and observe the error.


# Testing

Running the same gif as before we now get the following correct behavior.
![1e805248f92f6161afeef31ff0f52273](https://user-images.githubusercontent.com/15080861/73320013-f403c400-41f2-11ea-92fc-5cdd76ef9310.gif)

The error also goes away correctly if the correct code runs.

I manually tested and regression tested some Python levels.

gif of Python level after this change:
![c4255b4241569a08fced31af75f27ac1](https://user-images.githubusercontent.com/15080861/73319059-1cd68a00-41f0-11ea-8ea8-ba12f8b41f8b.gif)

I also compared behavior of Python between https://codecombat.com/play/level/behavior-driven-development?codeLanguage=python and the local environment with the bug fix. It seems fine.

I also ran the level verifier against javascript and python in order to check for regressions.
Over `intro` and campaign-game-dev-1 got 124 passed and 0 problems or errors.

# Risks

I did not check this with C++ in game dev because game dev is out of scope for C++ initially. However I am unsure the whole architecture we have for code parsing will work out of the box. I suspect there will be issues with too many requests to the server.

There is also a risk that this creates a regression in javascript and python, however I believe it is minimal as the main code paths changed are really only if the code is an obfuscated c++ token. Normal strings should be unchanged.