### PR TITLE
Fix condition for signup prompt on campaign view

### DIFF
--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -587,7 +587,7 @@ module.exports = class User extends CocoModel
   allowStudentHeroPurchase: -> features?.classroomItems ? false and @isStudent()
   canBuyGems: -> not (features?.chinaUx ? false)
   constrainHeroHealth: -> features?.classroomItems ? false and @isStudent()
-  promptForClassroomSignup: -> not (features?.chinaUx ? false or window.serverConfig?.codeNinjas ? false or features?.brainPop ? false)
+  promptForClassroomSignup: -> not ((features?.chinaUx ? false) or (window.serverConfig?.codeNinjas ? false) or (features?.brainPop ? false))
   showAvatarOnStudentDashboard: -> not (features?.classroomItems ? false) and @isStudent()
   showGearRestrictionsInClassroom: -> features?.classroomItems ? false and @isStudent()
   showGemsAndXp: -> features?.classroomItems ? false and @isStudent()

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -1482,7 +1482,7 @@ module.exports = class CampaignView extends RootView
       return not (me.isPremium() or isIOS or me.freeOnly() or isStudentOrTeacher or (application.getHocCampaign() and me.isAnonymous()))
 
     if what is 'anonymous-classroom-signup'
-      return me.isAnonymous() and me.level() < 8 and me.promptForClassroomSignup()
+      return me.isAnonymous() and me.level() < 8 and me.promptForClassroomSignup() and not @editorMode
 
     if what is 'amazon-campaign'
       return @campaign?.get('slug') is 'game-dev-hoc'


### PR DESCRIPTION
# What:
Need to make changes for the following:
- Do not show classroom signup prompt on campaign editor view.
- Do not show for code ninjas/brainpop.
Asana: https://app.asana.com/0/654820789891907/1153432423150975

# Fix:
We already have the check for hiding signup prompt for codeninja and brainpop however it was not working due to operator precedence.
The check was: `not (features?.chinaUx ? false or window.serverConfig?.codeNinjas ? false or features?.brainPop ? false)`. And the precedence for `or` operator is higher than the conditional `?` operator due to which it gives unexpected results.
See here for an example: https://coffeescript.org/#try:a%20%3D%2011%0Ab%20%3D%202%0Aalert((a%20%3D%3D%201%20%3F%20false)%20%7C%7C%20(b%20%3D%3D%202%20%3F%20false))%0Aalert(a%20%3D%3D%201%20%3F%20false%20%7C%7C%20b%20%3D%3D%202%20%3F%20false)

Hence fixed this by putting `?` operations in `()` so that they are executed before executing the `or`. Tested this by explicitly setting `features.brainPop = true` inside `promptForClassroomSignup`, and its working as expected.