### PR TITLE
Add C++ level verifier tests

### DIFF
--- a/app/lib/aether/aether.coffee
+++ b/app/lib/aether/aether.coffee
@@ -132,8 +132,8 @@ module.exports = class Aether
         @pure = token.src
         @ast = token.ast
     else
-      if @language.id in ['cpp', 'java']
-        console.error('C++ code cannot be transpiled client side.')
+      if @language.id in ['cpp']
+        throw new Error('C++ code cannot be transpiled client side.')
       @problems = @lint rawCode
       @pure = @purifyCode rawCode
     @pure

--- a/app/lib/aether/aether.coffee
+++ b/app/lib/aether/aether.coffee
@@ -132,6 +132,8 @@ module.exports = class Aether
         @pure = token.src
         @ast = token.ast
     else
+      if @language.id in ['cpp', 'java']
+        console.error('C++ code cannot be transpiled client side.')
       @problems = @lint rawCode
       @pure = @purifyCode rawCode
     @pure

--- a/app/lib/aether_utils.coffee
+++ b/app/lib/aether_utils.coffee
@@ -64,12 +64,12 @@ functionParameters =
 
 # TODO Webpack: test to make sure this refactor works everywhere it's used
 module.exports.generateSpellsObject = (options) ->
-  {level, levelSession} = options
+  {level, levelSession, token} = options
   {createAetherOptions} = require 'lib/aether_utils'
   aetherOptions = createAetherOptions functionName: 'plan', codeLanguage: levelSession.get('codeLanguage'), skipProtectAPI: options.level?.isType('game-dev')
   spellThang = thang: {id: 'Hero Placeholder'}, aether: new Aether aetherOptions
   spells = "hero-placeholder/plan": thang: spellThang, name: 'plan'
-  source = levelSession.get('code')?['hero-placeholder']?.plan ? ''
+  source = token or levelSession.get('code')?['hero-placeholder']?.plan ? ''
   try
     spellThang.aether.transpile source
   catch e

--- a/app/views/editor/verifier/VerifierView.coffee
+++ b/app/views/editor/verifier/VerifierView.coffee
@@ -29,8 +29,7 @@ module.exports = class VerifierView extends RootView
       @supermodel.shouldSaveBackups = (model) ->  # Make sure to load possibly changed things from localStorage.
         model.constructor.className in ['Level', 'LevelComponent', 'LevelSystem', 'ThangType']
 
-    defaultCores = 1
-    @cores = Math.max(defaultCores) # 1 or 2 cores is more stable which is why we're not using `window.navigator.hardwareConcurrency`
+    @cores = 1 # 1 or 2 cores is more stable which is why we're not using `window.navigator.hardwareConcurrency`
     @careAboutFrames = true
 
     if @levelID

--- a/app/views/editor/verifier/VerifierView.coffee
+++ b/app/views/editor/verifier/VerifierView.coffee
@@ -109,14 +109,14 @@ module.exports = class VerifierView extends RootView
       level = @supermodel.getModel(Level, levelID)
       for codeLanguage in @testLanguages
         solutions = _.filter level?.getSolutions() ? [], language: codeLanguage
-        if codeLanguage is 'cpp'
+        # If there are no C++ solutions yet, generate them from JavaScript.
+        if codeLanguage is 'cpp' and solutions.length is 0
           transpiledSolutions = _.filter level?.getSolutions() ? [], language: 'javascript'
           transpiledSolutions.forEach((s) =>
-            console.log('Transpiling a solution from javascript to C++')
             s.language = 'cpp'
             s.source = utils.translatejs2cpp(s.source)
           )
-          solutions = solutions.concat(transpiledSolutions)
+          solutions = transpiledSolutions
         if solutions.length
           for solution in solutions
             @tasksList.push level: levelID, language: codeLanguage, solution: solution


### PR DESCRIPTION
# Context

This is in the same class of bugs that #5748 was in. We want to run C++ code in the level verifier to ensure that solutions work for students. However we cannot parse the C++ code on the client and need to add middleware to fetch the token from the server.

# Fix

The first issue is that we don't have C++ tests. Therefore if there are no C++ tests, we transpile the JS solutions into C++ and use them instead. This is reasonable as we currently use this transpiler to generate starter code as well as solutions for the teacher.

Now that we have a C++ solution we need to add a step to the VerifierTest to fetch a token from the server, but only if the code is C++ or Java.

Then this token can be passed into aether and transpile is able to handle both the obfuscated and regular case.

There was also a `solutionIndex` hack that had been added to run multiple solutions. I refactored that out because I could retain the functionality easily without it.

# Testing

### How has this been tested (unit, integration, manual)?

This was tested by running the C++ level verifier over CS1, CS2 & CS3. There were some levels that had errors but the vast majority were green.
I also ran the Python and JavaScript tests to ensure they still worked correctly. 

### How can reviewer manually repro issue?

1. Log into your codecombat admin account on codecombat.com
2. Navigate to codecombat.com/editor/verifier
3. Select the C++ language, set threads to 1, and click on `intro: 37`. 
4. Press start tests and observe that it hangs indefinitely.

### How can reviewer manually test changes?

1. Check out this code
2. Run a local proxy server to production
3. Log into your codecombat account on your local proxy
4. Follow from step 2 above, this time expect to see tests run.

You should see the tests start running:
![18981ae22d20c0f96dd407f922a24ca3](https://user-images.githubusercontent.com/15080861/73500184-e119fc80-4376-11ea-8fdd-143b20c091c1.gif)


# Risks?

The `generateSpellsObject` function is used in other places. Therefore I opted to add an additional `token` options property to prevent regressions in those other code paths. Only where the `token` is provided will aether transpile the c++ correctly.

The other places this method is used is:
 - Simulator.coffee
 - PlayGameDevLevelView.coffee

In both of these cases the default params should continue working.

The smoke tests should provide enough additional checks. If they look good everything should be fine as this change impacts an internal tool most directly.
