### PR TITLE
Remove Ozaria encouragement modal AB test, always show Ozaria encouragement modal

### DIFF
--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -146,7 +146,6 @@ module.exports = class Tracker extends CocoClass
       # NOTE these custom dimensions need to be configured in GA prior to being reported
       try
         gaFieldObject.dimension1 = experiments.getRequestAQuoteGroup(me)
-        gaFieldObject.dimension2 = experiments.getOzariaEncouragementModalGroup(me)
       catch e
         # TODO handle_error_ozaria
         console.error(e)

--- a/app/core/experiments.js
+++ b/app/core/experiments.js
@@ -7,13 +7,3 @@ export function getRequestAQuoteGroup (user) {
     return 'request-a-quote-header'
   }
 }
-
-export function getOzariaEncouragementModalGroup (user) {
-  const bucket = user.get('testGroupNumber') % 10
-
-  if (bucket < 5) {
-    return 'ozaria-encouragement-modal-show'
-  } else {
-    return 'ozaria-encouragement-modal-no-show'
-  }
-}

--- a/app/templates/courses/teacher-classes-view.jade
+++ b/app/templates/courses/teacher-classes-view.jade
@@ -103,9 +103,8 @@ block content
 
 
     +createClassButton
-    if view.showOzariaLink
-      .container.try-ozaria
-        a(data-i18n="teacher.try_ozaria_footer")
+    .container.try-ozaria
+      a(data-i18n="teacher.try_ozaria_footer")
 
 
   - var archivedClassrooms = view.classrooms.where({archived: true});

--- a/app/views/courses/TeacherClassesView.coffee
+++ b/app/views/courses/TeacherClassesView.coffee
@@ -235,11 +235,7 @@ module.exports = class TeacherClassesView extends RootView
     if showOzariaEncouragementModal
       window.localStorage.removeItem('showOzariaEncouragementModal')
 
-    ozariaEncouragementModalGroup = experiments.getOzariaEncouragementModalGroup(window.me)
-    if ozariaEncouragementModalGroup == 'ozaria-encouragement-modal-show'
-      @showOzariaLink = true
-
-    if showOzariaEncouragementModal and ozariaEncouragementModalGroup == 'ozaria-encouragement-modal-show'
+    if showOzariaEncouragementModal
       @openOzariaEncouragementModal()
     else if me.isTeacher() and not @classrooms.length
       @openNewClassroomModal()


### PR DESCRIPTION
- Removes custom dimension from GA
- Removes experiment from experiments file
- Updates views to always display the modal