### PR TITLE
Test out Drift chat integration

### DIFF
--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -64,6 +64,7 @@ module.exports = class Tracker extends CocoClass
     @updateRole() if me.get('role')
     if me.isTeacher(true) and not me.get('unsubscribedFromMarketingEmails')
       @updateIntercomRegularly()
+      drift.load('9h3pui39u2s3')
 
   trackReferrers: ->
     elapsed = new Date() - new Date(me.get('dateCreated'))

--- a/app/templates/static/layout.static.pug
+++ b/app/templates/static/layout.static.pug
@@ -80,6 +80,32 @@ html(lang='en')
       });
     if me.useStripe()
       script(src='https://checkout.stripe.com/checkout.js')
+
+    // Drift
+    script(type='text/javascript').
+      "use strict";
+      !function() {
+        var t = window.driftt = window.drift = window.driftt || [];
+        if (!t.init) {
+          if (t.invoked) return void (window.console && console.error && console.error("Drift snippet included twice."));
+          t.invoked = !0, t.methods = [ "identify", "config", "track", "reset", "debug", "show", "ping", "page", "hide", "off", "on" ], 
+          t.factory = function(e) {
+            return function() {
+              var n = Array.prototype.slice.call(arguments);
+              return n.unshift(e), t.push(n), t;
+            };
+          }, t.methods.forEach(function(e) {
+            t[e] = t.factory(e);
+          }), t.load = function(t) {
+            var e = 3e5, n = Math.ceil(new Date() / e) * e, o = document.createElement("script");
+            o.type = "text/javascript", o.async = !0, o.crossorigin = "anonymous", o.src = "https://js.driftt.com/include/" + n + "/" + t + ".js";
+            var i = document.getElementsByTagName("script")[0];
+            i.parentNode.insertBefore(o, i);
+          };
+        }
+      }();
+      drift.SNIPPET_VERSION = '0.3.1';
+
     // CodePlay Tags Header
 
     // Webpack-inserted CSS:


### PR DESCRIPTION
Simple Drift chat integration example. Note: we can't deploy this to production until we have some basic Drift workflows configured to replace our current important Intercom chat flows (marketing/sales/support to configure), because if we don't also turn off Intercom chat, there'll be double chat boxes.