### PR TITLE
Split user queries into batches with max length 100 to fix 502 school admin dashboard

### DIFF
--- a/app/core/store/modules/schoolAdministrator.js
+++ b/app/core/store/modules/schoolAdministrator.js
@@ -30,18 +30,28 @@ export default {
 
       commit('toggleLoading', 'teachers')
 
-      return usersApi
-        .fetchByIds({
-          fetchByIds: administratedTeachers,
-          includeTrialRequests: true
-        })
-        .then(res =>  {
-          if (res) {
-            commit('addTeachers', res)
-          } else {
-            throw new Error('Unexpected response from teachers by ID API.')
-          }
-        })
+      const groups = Math.ceil(administratedTeachers.length / 100.0)
+      const userPromises = []
+      for (let i = 0; i < groups; i++) {
+        userPromises.push(
+          usersApi
+            .fetchByIds({
+              fetchByIds: administratedTeachers,
+              includeTrialRequests: true
+            })
+            .then(res => {
+              if (res) {
+                return res
+              } else {
+                throw new Error('Unexpected response from teachers by ID API.')
+              }
+            })
+        )
+      }
+
+      return Promise.all(userPromises)
+        .then(groupResults => groupResults.flat())
+        .then(combinedResults => commit('addTeachers', combinedResults))
         .catch((e) => noty({ text: 'Fetch teachers failure' + e, type: 'error' }))
         .finally(() => commit('toggleLoading', 'teachers'))
     },

--- a/app/core/store/modules/schoolAdministrator.js
+++ b/app/core/store/modules/schoolAdministrator.js
@@ -30,13 +30,18 @@ export default {
 
       commit('toggleLoading', 'teachers')
 
-      const groups = Math.ceil(administratedTeachers.length / 100.0)
+      const groupSize = 100
+      const groups = Math.ceil(administratedTeachers.length / (groupSize * 1.0))
       const userPromises = []
+      let lastStartIndex = 0
+
       for (let i = 0; i < groups; i++) {
+        let endIndex = lastStartIndex + groupSize
+
         userPromises.push(
           usersApi
             .fetchByIds({
-              fetchByIds: administratedTeachers,
+              fetchByIds: administratedTeachers.slice(lastStartIndex, endIndex),
               includeTrialRequests: true
             })
             .then(res => {
@@ -47,6 +52,8 @@ export default {
               }
             })
         )
+
+        lastStartIndex = endIndex
       }
 
       return Promise.all(userPromises)


### PR DESCRIPTION
When a teacher is administrating a large number of teachers the fetch users by ID call 502s.  This is due to the number of user IDs being passed in.  This PR splits the fetch users by ID call into batches so that we do not get the 502s.