### PR TITLE
Make tooltips lazily improving dashboard render time by 1/3

### DIFF
--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -240,10 +240,10 @@ mixin studentCourseProgressDot(progress, levelsTotal, label, student, course, co
   - _.assign(progress, { levelsTotal: levelsTotal })
   if progress.completed
     a.open-certificate-btn(target='_blank', href='/certificates/' + student.id + '?class=' + view.classroom.id + '&course=' + course.id + '&course-instance=' + courseInstance.id, data-event-action="Teachers Click Certificates - Students tab")
-      .progress-dot(class=dotClass, data-html='true', data-title=view.singleStudentCourseProgressDotTemplate(progress))
+      .progress-dot.has-tooltip(class=dotClass, data-html='true', data-title=view.singleStudentCourseProgressDotTemplate(progress))
         +progressDotLabel(label)
   else
-    .progress-dot(class=dotClass, data-html='true', data-title=view.singleStudentCourseProgressDotTemplate(progress))
+    .progress-dot.has-tooltip(class=dotClass, data-html='true', data-title=view.singleStudentCourseProgressDotTemplate(progress))
       +progressDotLabel(label)
 
 mixin allStudentsLevelProgressDot(progress, level, levelNumber)
@@ -273,10 +273,10 @@ mixin allStudentsLevelProgressDot(progress, level, levelNumber)
   if link
     if state.get('readOnly')
       - link = link.replace('/teachers/classes/', '/school-administrator/teacher/' + view.classroom.get('ownerID') + '/classroom/')
-    a.progress-dot.level-progress-dot(class=dotClass, data-html='true', data-title=view.allStudentsLevelProgressDotTemplate(context), href=link)
+    a.progress-dot.has-tooltip.level-progress-dot(class=dotClass, data-html='true', data-title=view.allStudentsLevelProgressDotTemplate(context), href=link)
       +progressDotLabel(labelText)
   else
-    .progress-dot.level-progress-dot(class=dotClass, data-html='true', data-title=view.allStudentsLevelProgressDotTemplate(context))
+    .progress-dot.has-tooltip.level-progress-dot(class=dotClass, data-html='true', data-title=view.allStudentsLevelProgressDotTemplate(context))
       +progressDotLabel(labelText)
 
 
@@ -312,10 +312,10 @@ mixin studentLevelProgressDot(progress, level, levelNumber, student)
   if link
     if state.get('readOnly')
       - link = link.replace('/teachers/classes/', '/school-administrator/teacher/' + view.classroom.get('ownerID') + '/classroom/')
-    a.progress-dot.level-progress-dot.student-level-progress-dot(class=dotClass, data-html='true', data-title=view.singleStudentLevelProgressDotTemplate(context) href=link, data-student-id=student.id, data-level-slug=level.get('slug'), data-level-progress=(progress.completed ? 'complete' : progress.started ? 'started' : 'not started'), data-course-id=view.state.get('selectedCourse').id)
+    a.progress-dot.has-tooltip.level-progress-dot.student-level-progress-dot(class=dotClass, data-html='true', data-title=view.singleStudentLevelProgressDotTemplate(context) href=link, data-student-id=student.id, data-level-slug=level.get('slug'), data-level-progress=(progress.completed ? 'complete' : progress.started ? 'started' : 'not started'), data-course-id=view.state.get('selectedCourse').id)
       +progressDotLabel(labelText)
   else
-    .progress-dot.level-progress-dot(class=dotClass, data-html='true', data-title=view.singleStudentLevelProgressDotTemplate(context))
+    .progress-dot.has-tooltip.level-progress-dot(class=dotClass, data-html='true', data-title=view.singleStudentLevelProgressDotTemplate(context))
       +progressDotLabel(labelText)
   if topScore && topScore.thresholdAchieved
     br

--- a/app/views/courses/TeacherClassView.coffee
+++ b/app/views/courses/TeacherClassView.coffee
@@ -312,12 +312,14 @@ module.exports = class TeacherClassView extends RootView
           opacity: 1
         }
       })
-    $('.progress-dot, .btn-view-project-level').each (i, el) ->
-      dot = $(el)
-      dot.tooltip({
+
+    $('.has-tooltip').off('mouseenter')
+    $('.has-tooltip').mouseenter () ->
+      $(this).tooltip({
         html: true
-      }).delegate '.tooltip', 'mousemove', ->
-        dot.tooltip('hide')
+      })
+      $(this).tooltip('show')
+
 
   allStatsLoaded: ->
     @classroom?.loaded and @classroom?.get('members')?.length is 0 or (@students?.loaded and @classroom?.sessions?.loaded)


### PR DESCRIPTION
# Context

The tooltips on the teacher dashboard are rendered every single time state is changed on the page. On a large classroom with 80 students this can lead to 1 second of jquery rendering after any state change.

# Fix

Make the tooltips appear lazily. Only render the tooltip on demand.

# Impact

On the classroom with 80 students, each render initially took 1500ms. This was the time taken to render after pressing a checkbox.
<img width="753" alt="Screen Shot 2020-02-24 at 3 56 21 PM" src="https://user-images.githubusercontent.com/15080861/75201790-45ce3a00-571e-11ea-91bf-3368e99c0044.png">


After this change it takes 500ms. It's still not great, but overall it's much faster.
Notice that the initial render is still the same, but the long tail of tooltips no longer exists from the screenshot above.
<img width="612" alt="Screen Shot 2020-02-24 at 3 53 42 PM" src="https://user-images.githubusercontent.com/15080861/75201674-ef60fb80-571d-11ea-8302-896be056ad40.png">


# Testing

I manually tested on chrome, as well as drawing inspiration from our Ozaria teacher dashboard.

To test spin up a proxy environment.
Navigate to a classroom with many users.
Press the checkmark next to a student and notice how long it takes to render.

# Risks

There are risks that this has broken tooltips. In fact while testing this I believe the certificate tooltip may be broken in production & in also in this PR. However when testing on the classroom the 3 different tooltips, they all matched what is currently in production. I would appreciate another test and getting support to take a look as well on staging.

Would like input regarding whether it is in scope to fix the certificate tooltip as well or handle in a separate PR.
