### PR TITLE
Revert "Make tooltips lazily improving dashboard render time by 1/3"

### DIFF
--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -240,10 +240,10 @@ mixin studentCourseProgressDot(progress, levelsTotal, label, student, course, co
   - _.assign(progress, { levelsTotal: levelsTotal })
   if progress.completed
     a.open-certificate-btn(target='_blank', href='/certificates/' + student.id + '?class=' + view.classroom.id + '&course=' + course.id + '&course-instance=' + courseInstance.id, data-event-action="Teachers Click Certificates - Students tab")
-      .progress-dot.has-tooltip(class=dotClass, data-html='true', data-title=view.singleStudentCourseProgressDotTemplate(progress))
+      .progress-dot(class=dotClass, data-html='true', data-title=view.singleStudentCourseProgressDotTemplate(progress))
         +progressDotLabel(label)
   else
-    .progress-dot.has-tooltip(class=dotClass, data-html='true', data-title=view.singleStudentCourseProgressDotTemplate(progress))
+    .progress-dot(class=dotClass, data-html='true', data-title=view.singleStudentCourseProgressDotTemplate(progress))
       +progressDotLabel(label)
 
 mixin allStudentsLevelProgressDot(progress, level, levelNumber)
@@ -273,10 +273,10 @@ mixin allStudentsLevelProgressDot(progress, level, levelNumber)
   if link
     if state.get('readOnly')
       - link = link.replace('/teachers/classes/', '/school-administrator/teacher/' + view.classroom.get('ownerID') + '/classroom/')
-    a.progress-dot.has-tooltip.level-progress-dot(class=dotClass, data-html='true', data-title=view.allStudentsLevelProgressDotTemplate(context), href=link)
+    a.progress-dot.level-progress-dot(class=dotClass, data-html='true', data-title=view.allStudentsLevelProgressDotTemplate(context), href=link)
       +progressDotLabel(labelText)
   else
-    .progress-dot.has-tooltip.level-progress-dot(class=dotClass, data-html='true', data-title=view.allStudentsLevelProgressDotTemplate(context))
+    .progress-dot.level-progress-dot(class=dotClass, data-html='true', data-title=view.allStudentsLevelProgressDotTemplate(context))
       +progressDotLabel(labelText)
 
 
@@ -312,10 +312,10 @@ mixin studentLevelProgressDot(progress, level, levelNumber, student)
   if link
     if state.get('readOnly')
       - link = link.replace('/teachers/classes/', '/school-administrator/teacher/' + view.classroom.get('ownerID') + '/classroom/')
-    a.progress-dot.has-tooltip.level-progress-dot.student-level-progress-dot(class=dotClass, data-html='true', data-title=view.singleStudentLevelProgressDotTemplate(context) href=link, data-student-id=student.id, data-level-slug=level.get('slug'), data-level-progress=(progress.completed ? 'complete' : progress.started ? 'started' : 'not started'), data-course-id=view.state.get('selectedCourse').id)
+    a.progress-dot.level-progress-dot.student-level-progress-dot(class=dotClass, data-html='true', data-title=view.singleStudentLevelProgressDotTemplate(context) href=link, data-student-id=student.id, data-level-slug=level.get('slug'), data-level-progress=(progress.completed ? 'complete' : progress.started ? 'started' : 'not started'), data-course-id=view.state.get('selectedCourse').id)
       +progressDotLabel(labelText)
   else
-    .progress-dot.has-tooltip.level-progress-dot(class=dotClass, data-html='true', data-title=view.singleStudentLevelProgressDotTemplate(context))
+    .progress-dot.level-progress-dot(class=dotClass, data-html='true', data-title=view.singleStudentLevelProgressDotTemplate(context))
       +progressDotLabel(labelText)
   if topScore && topScore.thresholdAchieved
     br

--- a/app/views/courses/TeacherClassView.coffee
+++ b/app/views/courses/TeacherClassView.coffee
@@ -312,14 +312,12 @@ module.exports = class TeacherClassView extends RootView
           opacity: 1
         }
       })
-
-    $('.has-tooltip').off('mouseenter')
-    $('.has-tooltip').mouseenter () ->
-      $(this).tooltip({
+    $('.progress-dot, .btn-view-project-level').each (i, el) ->
+      dot = $(el)
+      dot.tooltip({
         html: true
-      })
-      $(this).tooltip('show')
-
+      }).delegate '.tooltip', 'mousemove', ->
+        dot.tooltip('hide')
 
   allStatsLoaded: ->
     @classroom?.loaded and @classroom?.get('members')?.length is 0 or (@students?.loaded and @classroom?.sessions?.loaded)


### PR DESCRIPTION
Reverts codecombat/codecombat#5770

Tooltips position broken on slow internet. Can repro 100% via safari.
Caught it on staging using Safari. Although Chrome appears to work, a slower network may cause the issue to appear.