### PR TITLE
Tracker refactor

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -230,7 +230,7 @@ module.exports = class CocoRouter extends Backbone.Router
       @navigate("play/web-dev-level/#{sessionID}?#{queryString}", { trigger: true, replace: true })
     'play/spectate/:levelID': go('play/SpectateView')
     'play/:map': go('play/CampaignView')
-    
+
     # Adding this route to test interactives until we have the intro levels implemented
     # TODO: remove this route when intro level is ready to test the interactives.
     'interactive/:interactiveIdOrSlug(?code-language=:codeLanguage)': (interactiveIdOrSlug, codeLanguage) ->

--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -14,47 +14,8 @@ module.exports = class Tracker extends CocoClass
   cookies: {required: false, answered: false, consented: false, declined: false}
   constructor: ->
     super()
-    if window.tracker
-      console.error 'Overwrote our Tracker!', window.tracker
-    window.tracker = @
     @supermodel = new SuperModel()
     @isProduction = document.location.href.search('codecombat.com') isnt -1
-    @promptForCookieConsent()  # Will call finishInitialization
-
-  promptForCookieConsent: ->
-    return unless $.i18n.lng()  # Will initialize once we finish initializing translations
-    return @finishInitialization() unless me.get('country') and me.inEU()
-    @cookies.required = true
-    @cookiePopup?.close()
-    window.cookieconsent.hasTransition = false
-    window.cookieconsent.initialise
-      onPopupOpen: ->
-        window.tracker.cookiePopup = @
-      onInitialise: (status) ->
-        window.tracker.cookiePopup = @
-        window.tracker.cookies.answered = status in ['allow', 'dismiss', 'deny']
-        window.tracker.cookies.consented = status in ['allow', 'dismiss']
-        window.tracker.cookies.declined = status is 'deny'
-        console.log 'Initial cookie consent status:', status, window.tracker.cookies if debugAnalytics
-        window.tracker.finishInitialization()
-      onStatusChange: (status) ->
-        window.tracker.cookies.answered = status in ['allow', 'dismiss', 'deny']
-        window.tracker.cookies.consented = status in ['allow', 'dismiss']
-        window.tracker.cookies.declined = status is 'deny'
-        console.log 'Cookie consent status change:', status, window.tracker.cookies if debugAnalytics
-      container: document.getElementById('#page-container')
-      palette: {popup: {background: "#000"}, button: {background: "#f1d600"}}
-      hasTransition: false
-      revokable: true
-      law: false
-      location: false
-      type: 'opt-out'
-      content:
-        message: $.i18n.t 'legal.cookies_message'
-        dismiss: $.i18n.t 'general.accept'
-        deny: $.i18n.t 'legal.cookies_deny'
-        link: $.i18n.t 'nav.privacy'
-        href: '/privacy'
 
   finishInitialization: ->
     return if @initialized

--- a/app/core/Tracker2/BaseTracker.js
+++ b/app/core/Tracker2/BaseTracker.js
@@ -1,0 +1,108 @@
+import EventEmitter from 'events'
+
+/**
+ * A baseline tracker that:
+ *   1. Defines a standard initialization flow for all trackers
+ *   2. Exposes an event emitter interface for all trackers
+ *   3. Exposes a default tracker interface with a noop implementation.
+ *
+ * Standard initialization flow:
+ * The standard initialization flow is based around the this.initializationComplete promise
+ * that is exposed publicly by the tracker.  This promise should be resolved by the tracker
+ * by calling this.onInitializationSuccess (or this.onInitializationError) when the
+ * initialization process has been completed (or failed).  The initializationComplete
+ * promise should _never_ be overwritten as other external components can depend on it.
+ */
+export default class BaseTracker extends EventEmitter {
+  constructor () {
+    super()
+
+    this.initializing = false
+    this.initialized = false
+
+    this.setupInitialization()
+  }
+
+  async identify (traits = {}) {}
+
+  async trackPageView (includeIntegrations = {}) {}
+
+  async trackEvent (action, properties = {}, includeIntegrations = {}) {}
+
+  async trackTiming (duration, category, variable, label) {}
+
+  get isInitialized () {
+    return this.initialized
+  }
+
+  set isInitialized (initialized) {
+    return this.initialized = initialized
+  }
+
+  get isInitializing () {
+    return this.initializing
+  }
+
+  set isInitializing (initializing) {
+    return this.initializing = initializing
+  }
+
+  get initializationComplete () {
+    return this.initializationCompletePromise
+  }
+
+  /**
+   * Standard initialization method to be used to initialize the tracker.  Ensures that the
+   * initialize process is only called once and returns the initializationComplete promise.
+   *
+   * Calls internal initialize method
+   */
+  async initialize () {
+    if (this.isInitializing) {
+      return this.initializationComplete
+    }
+
+    this.isInitializing = true
+
+    await this._initializeTracker()
+
+    return this.initializationComplete
+  }
+
+  /**
+   * Internal tracker initialization method to be implemented by sub trackers.  This is
+   * called by the initialize method when the tracker is initialized.
+   *
+   * This method _must_ call onInitializeSuccess or onInitializeFail
+   */
+  async _initializeTracker () {
+    this.onInitializeSuccess()
+  }
+
+  /**
+   * Sets up initialization callbacks and top level promise so that
+   * all internal methods can wait on an internal initialize promise.
+   *
+   * This must be called from constructor _before_ initialize is called.
+   */
+  setupInitialization () {
+    const finishInitialization = (result) => {
+      this.isInitialized = result
+
+      delete this.onInitializeSuccess
+      delete this.onInitializeFail
+    }
+
+    this.initializationCompletePromise = new Promise((resolve, reject) => {
+      this.onInitializeSuccess = () => {
+        resolve()
+        finishInitialization(true)
+      }
+
+      this.onInitializeFail = () => {
+        reject()
+        finishInitialization(false)
+      }
+    })
+  }
+}

--- a/app/core/Tracker2/CookieConsentTracker.js
+++ b/app/core/Tracker2/CookieConsentTracker.js
@@ -1,0 +1,116 @@
+import cookieconsent from 'cookieconsent'
+import 'cookieconsent/build/cookieconsent.min.css'
+
+import BaseTracker from './BaseTracker'
+
+/**
+ * Not a true tracker in that this tracker does not report data but instead
+ * prompts the user to consent to tracking.  It shares the same initialization
+ * and event emitter characteristics of a tracker.
+ */
+export default class CookieConsentTracker extends BaseTracker {
+  constructor (store) {
+    super()
+
+    this.store = store
+    this.loadStatus(undefined)
+  }
+
+  /**
+   * Requires that user locale has already been loaded on the page
+   */
+  _initializeTracker () {
+    const preferredLocale =  this.store.getters['me/preferredLocale']
+    const preferredLocaleLoaded = this.store.getters['localeLoaded'](preferredLocale)
+
+    if (!preferredLocaleLoaded) {
+      console.error('Preferred locale not loaded for user, this will result in consent tracker showing in incorrect language.')
+    }
+
+    if (!this.store.getters['me/inEU']) {
+      this.onInitializeSuccess()
+      return
+    }
+
+    this.store.watch(
+      (state, getters) => getters['me/preferredLocale'],
+      () => this.onPreferredLocaleChanged()
+   )
+
+    this.initializeCookieConsent()
+    this.onInitializeSuccess()
+  }
+
+  getStatus () {
+    return this.status
+  }
+
+  loadStatus (status) {
+    this.status = {
+      answered: typeof status === 'string',
+      consented: status === 'allow' || status === 'dismiss',
+      declined: status === 'deny'
+    }
+  }
+
+  onStatusChange (status) {
+    this.loadStatus(status)
+    this.emit('change', this.getStatus())
+  }
+
+  onPreferredLocaleChanged () {
+    const preferredLocale =  this.store.getters['me/preferredLocale']
+    const preferredLocaleLoaded = this.store.getters['localeLoaded'](preferredLocale)
+
+    if (preferredLocaleLoaded) {
+      this.initializeCookieConsent()
+    } else {
+      let unsubscribe = this.store.watch(
+        (state, getters) => getters['localeLoaded'](preferredLocale),
+        () => {
+          unsubscribe()
+          this.initializeCookieConsent()
+        }
+      )
+    }
+  }
+
+  initializeCookieConsent () {
+    if (this.popup) {
+      this.popup.destroy()
+      this.popup = undefined
+    }
+
+    this.popup = new cookieconsent.Popup({
+      // Note the currently released version of cookieconsent has a bug that
+      // prevents onInitialise from being called when the popup is loaded
+      // before the user has interacted.
+      onInitialise: this.onStatusChange.bind(this),
+
+      onStatusChange: this.onStatusChange.bind(this),
+
+      container: document.body,
+
+      palette: {
+        popup: { background: '#000' },
+        button: { background: "#f1d600"
+        }
+      },
+
+      hasTransition: false,
+      revokeable: true,
+      law: false,
+      location: false,
+      type: 'opt-out',
+
+      content: {
+        allow: Vue.t('legal.cookies_allow'),
+        message: Vue.t('legal.cookies_message'),
+        dismiss: Vue.t('general.accept'),
+        deny: Vue.t('legal.cookies_deny'),
+        link: Vue.t('nav.privacy'),
+        href: '/privacy'
+      }
+    })
+  }
+}

--- a/app/core/Tracker2/GoogleAnalyticsTracker.js
+++ b/app/core/Tracker2/GoogleAnalyticsTracker.js
@@ -1,0 +1,5 @@
+import BaseTracker from './BaseTracker'
+
+export default class GoogleAnalyticsTracker extends BaseTracker {
+  // TODO Move Tracker.coffee GA logic into here
+}

--- a/app/core/Tracker2/LegacyTracker.js
+++ b/app/core/Tracker2/LegacyTracker.js
@@ -1,0 +1,53 @@
+import CocoLegacyTracker from '../Tracker'
+import BaseTracker from './BaseTracker'
+
+/**
+ * Acts as a proxy between our new tracker and our legacy Tracker.coffee
+ * which still handles segment.io and GA tracking.  This tracker also binds
+ * application events to the legacy tracker and exposes legacy tracker methods
+ * externally as necessary.
+ *
+ * TODO remove this tracker when tracker refactor is complete.
+ */
+export default class LegacyTracker extends BaseTracker {
+  constructor (store, cookieConsent) {
+    super()
+
+    this.store = store
+    this.cookieConsent = cookieConsent
+  }
+
+  async _initializeTracker () {
+    this.legacyTracker = new CocoLegacyTracker()
+
+    this.cookieConsent.on('change', () => {
+      this.legacyTracker.cookies = this.cookieConsent.getStatus()
+    })
+
+    this.legacyTracker.finishInitialization()
+
+    this.onInitializeSuccess()
+  }
+
+  async identify (traits = {}) {
+    // The Tracker.coffee implementation of identify seems to assume that it is called through
+    // other internal methods like updateRole and updateTrialRequestAttributes (or at least
+    // that these other internal methods are called first).  The implementation of updateRole
+    // does some simple filtering, calls segment and then simply calls identify internally
+    // so instead of refactoring the tracker to load segment in identify, we just use this
+    // method in place of identify.
+    this.legacyTracker.updateRole(traits)
+  }
+
+  async trackPageView (includeIntegrations = {}) {
+    this.legacyTracker.trackPageView(includeIntegrations)
+  }
+
+  async trackEvent (action, properties = {}, includeIntegrations = {}) {
+    this.legacyTracker.trackEvent(action, properties, includeIntegrations)
+  }
+
+  async trackTiming (duration, category, variable, label) {
+    this.legacyTracker.trackTiming(duration, category, variable, label)
+  }
+}

--- a/app/core/Tracker2/SegmentTracker.js
+++ b/app/core/Tracker2/SegmentTracker.js
@@ -1,0 +1,161 @@
+import BaseTracker from './BaseTracker'
+
+// Copied from Segment analytics-js getting started guide at:
+// https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/
+export function loadSegment () {
+  /* eslint-disable */
+
+  // Create a queue, but don't obliterate an existing one!
+  var analytics = window.analytics = window.analytics || [];
+
+  // If the real analytics.js is already on the page return.
+  if (analytics.initialize) return;
+
+  // If the snippet was invoked already show an error.
+  if (analytics.invoked) {
+    if (window.console && console.error) {
+      console.error('Segment snippet included twice.');
+    }
+    return;
+  }
+
+  // Invoked flag, to make sure the snippet
+  // is never invoked twice.
+  analytics.invoked = true;
+
+  // A list of the methods in Analytics.js to stub.
+  analytics.methods = [
+    'trackSubmit',
+    'trackClick',
+    'trackLink',
+    'trackForm',
+    'pageview',
+    'identify',
+    'reset',
+    'group',
+    'track',
+    'ready',
+    'alias',
+    'debug',
+    'page',
+    'once',
+    'off',
+    'on'
+  ];
+
+  // Define a factory to create stubs. These are placeholders
+  // for methods in Analytics.js so that you never have to wait
+  // for it to load to actually record data. The `method` is
+  // stored as the first argument, so we can replay the data.
+  analytics.factory = function(method){
+    return function(){
+      var args = Array.prototype.slice.call(arguments);
+      args.unshift(method);
+      analytics.push(args);
+      return analytics;
+    };
+  };
+
+  // For each of our methods, generate a queueing stub.
+  for (var i = 0; i < analytics.methods.length; i++) {
+    var key = analytics.methods[i];
+    analytics[key] = analytics.factory(key);
+  }
+
+  // Define a method to load Analytics.js from our CDN,
+  // and that will be sure to only ever load it once.
+  analytics.load = function(key, options){
+    // Create an async script element based on your key.
+    var script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.async = true;
+    script.src = 'https://cdn.segment.com/analytics.js/v1/'
+      + key + '/analytics.min.js';
+
+    // Insert our script next to the first script element.
+    var first = document.getElementsByTagName('script')[0];
+    first.parentNode.insertBefore(script, first);
+    analytics._loadOptions = options;
+  };
+
+  // Add a version to keep track of what's in the wild.
+  analytics.SNIPPET_VERSION = '4.1.0';
+
+  // Load Analytics.js with your key, which will automatically
+  // load the tools you've enabled for your account. Boosh!
+  analytics.load('yJpJZWBw68fEj0aPSv8ffMMgof5kFnU9');
+
+  // Make the first page call to load the integrations. If
+  // you'd like to manually name or tag the page, edit or
+  // move this call however you'd like.
+  //
+  // Do not track the first page view, we'll handle this manually
+  //
+  // analytics.page();
+}
+
+export default class SegmentTracker extends BaseTracker {
+  constructor (store) {
+    super()
+
+    this.store = store
+    this.enabled = false
+  }
+
+  async _initializeTracker () {
+    this.store.watch(
+      (state, getters) => getters['me/isTeacher'],
+      this.onIsTeacherChanged.bind(this)
+    )
+
+    if (this.store.getters['me/isTeacher']) {
+      loadSegment()
+      window.analytics.ready(this.onInitializeSuccess)
+    } else {
+      this.onInitializeSuccess()
+    }
+  }
+
+  async trackPageView (includeIntegrations = {}) {
+    await this.initializationComplete
+
+    if (!this.enabled) {
+      return
+    }
+
+    const url = `/${Backbone.history.getFragment()}`
+    window.analytics.page(url, {}, {
+      integrations: {
+        All: false,
+        'Google Analytics': false
+      }
+    })
+  }
+
+  async identify (traits = {}) {
+    await this.initializationComplete
+
+    if (!this.enabled) {
+      return
+    }
+  }
+
+  async trackEvent (action, properties = {}, includeIntegrations = {}) {
+    await this.initializationComplete
+
+    if (!this.enabled) {
+      return
+    }
+  }
+
+  onIsTeacherChanged (isTeacher) {
+    if (this.enabled) {
+      return
+    }
+
+    if (isTeacher) {
+      this.enabled = true
+      loadSegment()
+    }
+  }
+}

--- a/app/core/Tracker2/index.js
+++ b/app/core/Tracker2/index.js
@@ -1,0 +1,78 @@
+import SegmentTracker from './SegmentTracker'
+import CookieConsentTracker from './CookieConsentTracker'
+import LegacyTracker from './LegacyTracker'
+import BaseTracker from './BaseTracker'
+import GoogleAnalyticsTracker from './GoogleAnalyticsTracker'
+
+/**
+ * Top level application tracker that handles sub tracker initialization and
+ * event routing.
+ */
+export default class Tracker2 extends BaseTracker {
+  constructor (store) {
+    super()
+
+    this.store = store
+
+    // TODO consent status needs to be propagated to other trackers
+    this.cookieConsentTracker = new CookieConsentTracker(this.store)
+
+    this.legacyTracker = new LegacyTracker(this.store, this.cookieConsentTracker)
+    this.segmentTracker = new SegmentTracker()
+    this.googleAnalyticsTracker = new GoogleAnalyticsTracker()
+
+    this.trackers = [
+      this.legacyTracker,
+      this.googleAnalyticsTracker,
+
+      // Segment tracking is currently handled by the legacy tracker
+      // this.segmentTracker,
+    ]
+  }
+
+  async _initializeTracker () {
+    try {
+      await Promise.all([
+        this.cookieConsentTracker.initialize(),
+
+        ...this.trackers.map(t => t.initialize())
+      ])
+
+      this.onInitializeSuccess()
+    } catch (e) {
+      this.onInitializeFail(e)
+    }
+  }
+
+  async identify (traits = {}) {
+    await this.initializationComplete
+
+    await Promise.all(
+      this.trackers.map(t => t.identify(traits))
+    )
+  }
+
+  async trackPageView (includeIntegrations = {}) {
+    await this.initializationComplete
+
+    await Promise.all(
+      this.trackers.map(t => t.trackPageView(includeIntegrations))
+    )
+  }
+
+  async trackEvent (action, properties = {}, includeIntegrations = {}) {
+    await this.initializationComplete
+
+    await Promise.all(
+      this.trackers.map(t => t.trackEvent(action, properties, includeIntegrations))
+    )
+  }
+
+  async trackTiming (duration, category, variable, label) {
+    await this.initializationComplete
+
+    await Promise.all(
+      this.trackers.map(t => t.trackTiming(duration, category, variable, label))
+    )
+  }
+}

--- a/app/core/application.coffee
+++ b/app/core/application.coffee
@@ -4,7 +4,7 @@ GitHubHandler = require 'core/social-handlers/GitHubHandler'
 locale = require 'locale/locale'
 {me} = require 'core/auth'
 storage = require 'core/storage'
-Tracker = require 'core/Tracker'
+Tracker = require('core/Tracker2').default
 CocoModel = require 'models/CocoModel'
 api = require 'core/api'
 
@@ -78,14 +78,16 @@ Application = {
     $('body').addClass 'picoctf' if window.serverConfig.picoCTF
     if $.browser.msie and parseInt($.browser.version) is 10
       $("html").addClass("ie10")
-    @tracker = new Tracker()
+
+    @tracker = new Tracker(store)
+    window.tracker = @tracker
+    locale.load(me.get('preferredLanguage', true))
+      .then => @tracker.initialize()
+
     if me.useSocialSignOn()
       @facebookHandler = new FacebookHandler()
       @gplusHandler = new GPlusHandler()
       @githubHandler = new GitHubHandler()
-    locale.load(me.get('preferredLanguage', true)).then =>
-      @tracker.promptForCookieConsent()
-    preferredLanguage = me.get('preferredLanguage') or 'en'
     $(document).bind 'keydown', preventBackspace
     preload(COMMON_FILES)
     moment.relativeTimeThreshold('ss', 1) # do not return 'a few seconds' when calling 'humanize'

--- a/app/core/store/index.coffee
+++ b/app/core/store/index.coffee
@@ -17,6 +17,11 @@ store = new Vuex.Store({
     updateFeatures: (state, features) -> state.features = features
   }
 
+  getters: {
+    localeLoaded: (state) => (locale) =>
+      return state.localesLoaded[locale] == true
+  }
+
   modules: {
     me: require('./modules/me').default,
     courses: require('./modules/courses'),

--- a/app/core/store/modules/me.js
+++ b/app/core/store/modules/me.js
@@ -1,8 +1,9 @@
 import _ from 'lodash'
 const userSchema = require('schemas/models/user')
 const api = require('core/api')
+const utils = require('core/utils')
 
-const emptyUser = _.zipObject((_.keys(userSchema.properties).map((key) => [key, null])))
+const emptyUser = _.zipObject((_.keys(userSchema.properties).map((key) => [key, userSchema.default[key] || null])))
 
 export default {
   namespaced: true,
@@ -42,6 +43,14 @@ export default {
 
     preferredLocale (state) {
       return state.preferredLanguage
+    },
+
+    inEU (state) {
+      if (!state.country) {
+        return undefined
+      }
+
+      return utils.inEU(state.country)
     }
   },
 

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -2721,6 +2721,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     third_party_description: "CodeCombat uses the following third party services (among others):"
     cookies_message: 'CodeCombat uses a few essential and non-essential cookies.'
     cookies_deny: 'Decline non-essential cookies'
+    cookies_allow: 'Allow cookies' # {change}
 
   ladder_prizes:
     title: "Tournament Prizes"  # This section was for an old tournament and doesn't need new translations now.

--- a/app/locale/locale.coffee
+++ b/app/locale/locale.coffee
@@ -76,7 +76,10 @@ Object.defineProperties module.exports,
   load:
     enumerable: false
     value: (langCode) ->
-      return Promise.resolve() if langCode in ['en', 'en-US']
+      if langCode in ['en', 'en-US']
+        @storeLoadedLanguage(langCode, module.exports[langCode])
+        return Promise.resolve()
+
       console.log "Loading locale:", langCode
       promises = [
         new Promise (accept, reject) ->

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -174,7 +174,7 @@ module.exports = class User extends CocoModel
     return if oldRole is role or (oldRole and not force)
     @set 'role', role
     @patch()
-    application.tracker?.updateRole()
+    application.tracker.identify()
     return @get 'role'
 
   a = 5

--- a/app/vendor.js
+++ b/app/vendor.js
@@ -19,8 +19,6 @@ import 'bower_components/treema/treema.css'
 window.moment = require('bower_components/moment/min/moment-with-locales.min.js');
 window.moment.timezone = require('moment-timezone');
 window.$.i18n = window.i18n = require('bower_components/i18next/i18next.js');
-require('bower_components/cookieconsent/build/cookieconsent.min.js')// TODO webpack: Try to extract this
-import 'bower_components/cookieconsent/build/cookieconsent.min.css'// TODO webpack: Try to extract this
 require('vendor/scripts/idle.js').createjs;
 window.key = require('../vendor/scripts/keymaster.js');
 require('vendor/scripts/jquery.noty.packaged.min.js');
@@ -83,7 +81,7 @@ try {
   (0,eval("'use strict'; let test = WeakMap && (class Test { *gen(a=7) { yield yield * () => true ; } });"));
   console.log("Modern javascript detected, aw yeah!");
   loadScript(window.javascriptsPath + 'esper.modern.js')
-  
+
 } catch (e) {
   console.log("Legacy javascript detected, falling back...", e.message);
   loadScript(window.javascriptsPath + 'esper.js');

--- a/app/views/core/CreateAccountModal/teacher/TeacherSignupStoreModule.coffee
+++ b/app/views/core/CreateAccountModal/teacher/TeacherSignupStoreModule.coffee
@@ -2,7 +2,6 @@ api = require 'core/api'
 DISTRICT_NCES_KEYS = ['district', 'district_id', 'district_schools', 'district_students', 'phone']
 SCHOOL_NCES_KEYS = DISTRICT_NCES_KEYS.concat(['id', 'name', 'students'])
 ncesData = _.zipObject(['nces_'+key, ''] for key in SCHOOL_NCES_KEYS)
-require('core/services/segment')()
 User = require('models/User')
 
 module.exports = TeacherSignupStoreModule = {
@@ -55,7 +54,7 @@ module.exports = TeacherSignupStoreModule = {
   }
   actions: {
     createAccount: ({state, commit, dispatch, rootState}) ->
-      
+
       return Promise.resolve()
       .then =>
         return dispatch('me/save', {
@@ -72,19 +71,19 @@ module.exports = TeacherSignupStoreModule = {
         delete properties.otherEducationLevel
         delete properties.otherEducationLevelExplanation
         properties.email = state.signupForm.email
-        
+
         return api.trialRequests.post({
           type: 'course'
           properties
         })
-      
+
       .then =>
-        trialRequestIntercomData = _.pick state.trialRequestProperties, ["siteOrigin", "marketingReferrer", "referrer", "notes", "numStudentsTotal", "numStudents", "purchaserRole", "role", "phoneNumber", "country", "state", "city", "district", "organization", "nces_students", "nces_name", "nces_id", "nces_phone", "nces_district_students", "nces_district_schools", "nces_district_id", "nces_district"]
-        trialRequestIntercomData.educationLevel_elementary = _.contains state.trialRequestProperties.educationLevel, "Elementary"
-        trialRequestIntercomData.educationLevel_middle = _.contains state.trialRequestProperties.educationLevel, "Middle"
-        trialRequestIntercomData.educationLevel_high = _.contains state.trialRequestProperties.educationLevel, "High"
-        trialRequestIntercomData.educationLevel_college = _.contains state.trialRequestProperties.educationLevel, "College+"
-        application.tracker.updateTrialRequestData trialRequestIntercomData unless User.isSmokeTestUser({ email: state.signupForm.email })
+        trialRequestIdentifyData = _.pick state.trialRequestProperties, ["siteOrigin", "marketingReferrer", "referrer", "notes", "numStudentsTotal", "numStudents", "purchaserRole", "role", "phoneNumber", "country", "state", "city", "district", "organization", "nces_students", "nces_name", "nces_id", "nces_phone", "nces_district_students", "nces_district_schools", "nces_district_id", "nces_district"]
+        trialRequestIdentifyData.educationLevel_elementary = _.contains state.trialRequestProperties.educationLevel, "Elementary"
+        trialRequestIdentifyData.educationLevel_middle = _.contains state.trialRequestProperties.educationLevel, "Middle"
+        trialRequestIdentifyData.educationLevel_high = _.contains state.trialRequestProperties.educationLevel, "High"
+        trialRequestIdentifyData.educationLevel_college = _.contains state.trialRequestProperties.educationLevel, "College+"
+        application.tracker.identify trialRequestIdentifyData unless User.isSmokeTestUser({ email: state.signupForm.email })
 
       .then =>
         signupForm = _.omit(state.signupForm, (attr) -> attr is '')

--- a/app/views/core/RootView.coffee
+++ b/app/views/core/RootView.coffee
@@ -188,7 +188,6 @@ module.exports = class RootView extends CocoView
     @saveLanguage(newLang)
     locale.load(me.get('preferredLanguage', true)).then =>
       @onLanguageLoaded()
-      window.tracker.promptForCookieConsent()
 
   onLanguageLoaded: ->
     @render()

--- a/app/views/teachers/CreateTeacherAccountView.coffee
+++ b/app/views/teachers/CreateTeacherAccountView.coffee
@@ -8,7 +8,6 @@ errors = require 'core/errors'
 User = require 'models/User'
 algolia = require 'core/services/algolia'
 State = require 'models/State'
-loadSegment = require('core/services/segment')
 countryList = require('country-list')()
 UsaStates = require('usa-states').UsaStates
 
@@ -61,7 +60,7 @@ module.exports = class CreateTeacherAccountView extends RootView
     @listenTo @state, 'change:error', -> @renderSelectors('.error-area')
     @listenTo @state, 'change:showUsaStateDropdown', -> @renderSelectors('.state')
     @listenTo @state, 'change:stateValue', -> @renderSelectors('.state')
-    loadSegment() unless @segmentLoaded
+#    loadSegment() unless @segmentLoaded
 
   onLeaveMessage: ->
     if @formChanged
@@ -90,7 +89,7 @@ module.exports = class CreateTeacherAccountView extends RootView
     stateVal = stateElem.val()
     @state.set({stateValue: stateVal})
 
-    if e.target.value == 'United States' 
+    if e.target.value == 'United States'
       @state.set({showUsaStateDropdown: true})
       if !@usaStatesAbbreviations.includes(stateVal)
         @state.set({stateValue: ''})
@@ -251,7 +250,7 @@ module.exports = class CreateTeacherAccountView extends RootView
   onTrialRequestSubmit: ->
     window.tracker?.trackEvent 'Teachers Create Account Submitted', category: 'Teachers', ['Mixpanel']
     @formChanged = false
-    
+
     Promise.resolve()
     .then =>
       attrs = _.pick(forms.formToObject(@$('form')), 'role', 'firstName', 'lastName')
@@ -270,7 +269,7 @@ module.exports = class CreateTeacherAccountView extends RootView
         throw new Error('Could not save user')
       @trigger 'update-settings'
       return jqxhr
-      
+
     .then =>
       { name, email } = forms.formToObject(@$('form'))
       if @gplusAttrs
@@ -288,17 +287,17 @@ module.exports = class CreateTeacherAccountView extends RootView
       return jqxhr
 
     .then =>
-      trialRequestIntercomData = _.pick @trialRequest.attributes.properties, ["siteOrigin", "marketingReferrer", "referrer", "notes", "numStudentsTotal", "numStudents", "purchaserRole", "role", "phoneNumber", "country", "state", "city", "district", "organization", "nces_students", "nces_name", "nces_id", "nces_phone", "nces_district_students", "nces_district_schools", "nces_district_id", "nces_district"]
-      trialRequestIntercomData.educationLevel_elementary = _.contains @trialRequest.attributes.properties.educationLevel, "Elementary"
-      trialRequestIntercomData.educationLevel_middle = _.contains @trialRequest.attributes.properties.educationLevel, "Middle"
-      trialRequestIntercomData.educationLevel_high = _.contains @trialRequest.attributes.properties.educationLevel, "High"
-      trialRequestIntercomData.educationLevel_college = _.contains @trialRequest.attributes.properties.educationLevel, "College+"
-      application.tracker.updateTrialRequestData trialRequestIntercomData
-      
+      trialRequestIdentifyData = _.pick @trialRequest.attributes.properties, ["siteOrigin", "marketingReferrer", "referrer", "notes", "numStudentsTotal", "numStudents", "purchaserRole", "role", "phoneNumber", "country", "state", "city", "district", "organization", "nces_students", "nces_name", "nces_id", "nces_phone", "nces_district_students", "nces_district_schools", "nces_district_id", "nces_district"]
+      trialRequestIdentifyData.educationLevel_elementary = _.contains @trialRequest.attributes.properties.educationLevel, "Elementary"
+      trialRequestIdentifyData.educationLevel_middle = _.contains @trialRequest.attributes.properties.educationLevel, "Middle"
+      trialRequestIdentifyData.educationLevel_high = _.contains @trialRequest.attributes.properties.educationLevel, "High"
+      trialRequestIdentifyData.educationLevel_college = _.contains @trialRequest.attributes.properties.educationLevel, "College+"
+      application.tracker.identify trialRequestIdentifyData
+
     .then =>
       application.router.navigate(SIGNUP_REDIRECT, { trigger: true })
       application.router.reload()
-      
+
     .then =>
       @trigger 'on-trial-request-submit-complete'
 
@@ -317,7 +316,7 @@ module.exports = class CreateTeacherAccountView extends RootView
       else
         errors.showNotyNetworkError(arguments...)
       @$('#create-account-btn').text('Submit').attr('disabled', false)
-    
+
 
   # GPlus signup
 
@@ -449,10 +448,10 @@ module.exports = class CreateTeacherAccountView extends RootView
   onChangeEmail: (e) ->
     @updateAuthModalInitialValues { email: @$(e.currentTarget).val() }
     @checkEmail()
-    
+
   checkEmail: ->
     email = @$('[name="email"]').val()
-    
+
     if not _.isEmpty(email) and email is @state.get('checkEmailValue')
       return @state.get('checkEmailPromise')
 
@@ -463,11 +462,11 @@ module.exports = class CreateTeacherAccountView extends RootView
         checkEmailPromise: null
       })
       return Promise.resolve()
-      
+
     @state.set({
       checkEmailState: 'checking'
       checkEmailValue: email
-      
+
       checkEmailPromise: (User.checkEmailExists(email)
       .then ({exists}) =>
         return unless email is @$('[name="email"]').val()
@@ -481,7 +480,7 @@ module.exports = class CreateTeacherAccountView extends RootView
       )
     })
     return @state.get('checkEmailPromise')
-    
+
 
 formSchema = {
   type: 'object'

--- a/bower.json
+++ b/bower.json
@@ -49,8 +49,7 @@
     "promise-polyfill": "^5.2.1",
     "font-awesome": "fontawesome#^4.7.0",
     "fetch": "^2.0.2",
-    "vimeo-player-js": "^2.1.0",
-    "cookieconsent": "^3.0.6"
+    "vimeo-player-js": "^2.1.0"
   },
   "overrides": {
     "algolia-autocomplete.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2678,6 +2678,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
       "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -3368,13 +3369,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -3412,6 +3415,7 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
@@ -4828,6 +4832,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -5081,7 +5086,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
       "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "buffer-shims": {
       "version": "1.0.0",
@@ -6171,6 +6177,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookieconsent": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookieconsent/-/cookieconsent-3.1.1.tgz",
+      "integrity": "sha512-v8JWLJcI7Zs9NWrs8hiVldVtm3EBF70TJI231vxn6YToBGj0c9dvdnYwltydkAnrbBMOM/qX1xLFrnTfm5wTag=="
     },
     "cookies": {
       "version": "0.7.3",
@@ -7466,6 +7477,7 @@
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -8886,7 +8898,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8907,12 +8920,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8927,17 +8942,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9054,7 +9072,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9066,6 +9085,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9080,6 +9100,7 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9087,12 +9108,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9111,6 +9134,7 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9191,7 +9215,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9203,6 +9228,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9288,7 +9314,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9324,6 +9351,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9343,6 +9371,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9386,12 +9415,14 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "optional": true
         }
       }
     },
@@ -9792,20 +9823,20 @@
       }
     },
     "globule": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.1.tgz",
+      "integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
       "dev": true,
       "requires": {
         "glob": "~7.1.1",
-        "lodash": "~4.17.10",
+        "lodash": "~4.17.12",
         "minimatch": "~3.0.2"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         }
       }
@@ -10123,7 +10154,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "hoist-non-react-statics": {
       "version": "3.3.0",
@@ -10302,6 +10334,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "4",
         "debug": "3.1.0"
@@ -10312,6 +10345,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -10333,6 +10367,7 @@
       "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
       "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
       "dev": true,
+      "optional": true,
       "requires": {
         "httpreq": ">=0.4.22",
         "underscore": "~1.7.0"
@@ -10342,7 +10377,8 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
           "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10350,7 +10386,8 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz",
       "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "https-browserify": {
       "version": "1.0.0",
@@ -10362,6 +10399,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "^4.1.0",
         "debug": "^3.1.0"
@@ -10372,6 +10410,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -10380,7 +10419,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11039,7 +11079,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -11918,13 +11959,15 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
       "integrity": "sha1-YjUag5VjrF/1vSbxL2Dpgwu3UeY=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "libmime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/libmime/-/libmime-3.0.0.tgz",
       "integrity": "sha1-UaGp50SOy9Ms2lRCFnW7IbwJPaY=",
       "dev": true,
+      "optional": true,
       "requires": {
         "iconv-lite": "0.4.15",
         "libbase64": "0.1.0",
@@ -11935,7 +11978,8 @@
           "version": "0.4.15",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
           "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11943,7 +11987,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "livereload-js": {
       "version": "2.4.0",
@@ -12078,12 +12123,6 @@
       "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
       "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-      "dev": true
-    },
     "lodash.assignin": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
@@ -12106,12 +12145,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
       "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
     },
     "lodash.create": {
       "version": "4.2.0",
@@ -13575,9 +13608,9 @@
       },
       "dependencies": {
         "fstream": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+          "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -13587,9 +13620,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.1.15",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
           "dev": true
         },
         "semver": {
@@ -13599,13 +13632,13 @@
           "dev": true
         },
         "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
           "dev": true,
           "requires": {
             "block-stream": "*",
-            "fstream": "^1.0.2",
+            "fstream": "^1.0.12",
             "inherits": "2"
           }
         }
@@ -13718,9 +13751,9 @@
       }
     },
     "node-sass": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-      "integrity": "sha1-GD+uw5jpy+k7pDNi4naMqYimNpo=",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+      "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -13730,12 +13763,10 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
+        "lodash": "^4.17.15",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
+        "nan": "^2.13.2",
         "node-gyp": "^3.8.0",
         "npmlog": "^4.0.0",
         "request": "^2.88.0",
@@ -13754,10 +13785,16 @@
             "which": "^1.2.9"
           }
         },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
         "lru-cache": {
           "version": "4.1.5",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -13834,13 +13871,15 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz",
       "integrity": "sha1-ecSQihwPXzdbc/6IjamCj23JY6Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nodemailer-shared": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz",
       "integrity": "sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "nodemailer-fetch": "1.6.0"
       }
@@ -13873,7 +13912,8 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz",
       "integrity": "sha1-WG24EB2zDLRDjrVGc3pBqtDPE9U=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nodemon": {
       "version": "1.6.1",
@@ -17484,9 +17524,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.1.15",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -17512,9 +17552,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "os-locale": {
@@ -17977,13 +18017,15 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
       "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "smtp-connection": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz",
       "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME=",
       "dev": true,
+      "optional": true,
       "requires": {
         "httpntlm": "1.6.1",
         "nodemailer-shared": "1.1.0"
@@ -18205,6 +18247,7 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
       "integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "ip": "^1.1.5",
         "smart-buffer": "4.0.2"
@@ -18215,6 +18258,7 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
       "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "~4.2.1",
         "socks": "~2.3.2"
@@ -18769,15 +18813,15 @@
           "dev": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true
         },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "connect-timeout": "^1.9.0",
     "cookie-parser": "^1.4.3",
     "cookie-session": "^1.2.0",
+    "cookieconsent": "^3.1.1",
     "core-js": "^3.6.4",
     "country-list": "0.0.3",
     "css-loader": "^0.25.0",

--- a/test/app/views/core/CreateAccountModal.spec.coffee
+++ b/test/app/views/core/CreateAccountModal.spec.coffee
@@ -4,6 +4,8 @@ Classroom = require 'models/Classroom'
 forms = require 'core/forms'
 factories = require 'test/app/factories'
 
+Tracker = require('app/core/Tracker')
+
 SchoolInfoPanel = Vue.extend(require 'views/core/CreateAccountModal/teacher/SchoolInfoPanel')
 TeacherSignupStoreModule = require 'views/core/CreateAccountModal/teacher/TeacherSignupStoreModule'
 
@@ -599,7 +601,7 @@ describe 'CreateAccountModal Vue Store', ->
       spyOn(api.users, 'signupWithFacebook').and.returnValue(Promise.resolve())
       spyOn(api.users, 'signupWithPassword').and.returnValue(Promise.resolve())
       spyOn(api.trialRequests, 'post').and.returnValue(Promise.resolve())
-      spyOn(application.tracker, 'updateTrialRequestData').and.returnValue(Promise.resolve())
+      spyOn(application.tracker.legacyTracker.legacyTracker, 'updateTrialRequestData').and.returnValue(Promise.resolve())
       @dispatch = jasmine.createSpy()
       @commit = jasmine.createSpy()
       @rootState = {

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -50,6 +50,7 @@ module.exports = (env) => {
         ], (regex) => { return regex.test(name) })
       },
       rules: [
+        { test: require.resolve('cookieconsent'), use: 'exports-loader?cookieconsent' },
         { test: /\.vue$/, use: [{ loader: 'vue-loader' }] },
         { test: /vendor\/scripts\/async.js/, use: [ { loader: 'imports-loader?root=>window' } ] },
         { test: /\.js$/,


### PR DESCRIPTION
Base refactor of our client side tracking implementation.  This PR sets up the basic structure of the new tracker and integrates the legacy tracker with it but does not complete the refactor.  This PR should effectively be a noop in terms of functionality.  The legacy tracker is integrated with the new tracker such that it is still driving the core of the tracking calls.

**Summary of changes in this PR:**
- Create Tracker2 tracker and implement example tracker (SegmentTracker)
- Extract cookie consent out of legacy tracker and move into it's own tracker
- Import cookieconsent module with webpack instead of bower

**High level tasks still todo (in future PRs):**
- Automated tests
- Extract segment tracking from legacy tracker and move any remaining functionality into SegmentTracker
- Enable SegmentTracker in new Tracker
- Extract GA tracking logic from legacy tracker and implement in GoogleAnalyticsTracker
- Extract remaining logic from LegacyTracker and fully remove
- Rename Tracker2 to Tracker

**Testing**

I've been manually testing throughout the past week and the latest version of this is live at next.codecombat.com (including changes in #5777 and #5782)

**Release plan**

Release plan is TBD and we'll figure that out this week.  We'll either release this PR alone to ensure that there are no impacts to tracking before integrating other tracking related PRs or we'll merge #5777 and #5782 here before merging all in together.