### PR TITLE
Swap intercom for drift

### DIFF
--- a/app/core/Tracker2/DriftTracker.js
+++ b/app/core/Tracker2/DriftTracker.js
@@ -1,0 +1,101 @@
+import BaseTracker from './BaseTracker'
+
+function loadDrift () {
+  /* eslint-disable */
+
+  !function() {
+    var t = window.driftt = window.drift = window.driftt || [];
+    if (!t.init) {
+      if (t.invoked) return void (window.console && console.error && console.error("Drift snippet included twice."));
+      t.invoked = !0, t.methods = [ "identify", "config", "track", "reset", "debug", "show", "ping", "page", "hide", "off", "on" ],
+        t.factory = function(e) {
+          return function() {
+            var n = Array.prototype.slice.call(arguments);
+            return n.unshift(e), t.push(n), t;
+          };
+        }, t.methods.forEach(function(e) {
+        t[e] = t.factory(e);
+      }), t.load = function(t) {
+        var e = 3e5, n = Math.ceil(new Date() / e) * e, o = document.createElement("script");
+        o.type = "text/javascript", o.async = !0, o.crossorigin = "anonymous", o.src = "https://js.driftt.com/include/" + n + "/" + t + ".js";
+        var i = document.getElementsByTagName("script")[0];
+        i.parentNode.insertBefore(o, i);
+      };
+    }
+  }();
+
+  drift.SNIPPET_VERSION = '0.3.1';
+  drift.load('9h3pui39u2s3');
+}
+
+export default class DriftTracker extends BaseTracker {
+  constructor (store) {
+    super()
+
+    this.store = store
+  }
+
+  get drift () {
+    return this.driftApi
+  }
+
+  async _initializeTracker () {
+    loadDrift()
+
+    window.drift.on('ready', (api) => {
+      this.driftApi = api
+
+      this.initDriftOnLoad()
+      this.onInitializeSuccess()
+    })
+  }
+
+  initDriftOnLoad () {
+    // Hide by default
+    this.driftApi.widget.hide()
+
+    // Show when a message is received
+    window.drift.on('message', (e) => {
+      if (!e.data.sidebarOpen) {
+        this.driftApi.widget.show()
+      }
+    })
+  }
+
+  async identify (traits = {}) {
+    await this.initializationComplete
+
+    if (this.store.getters['me/isAnonymous']) {
+      return
+    }
+
+    const { me } = this.store.state
+
+    const {
+      id,
+      ...meAttrs
+    } = me
+
+    await window.drift.identify(
+      me._id.toString(),
+      {
+        ...meAttrs,
+        ...traits
+      }
+    )
+  }
+
+  async trackPageView (includeIntegrations = {}) {
+    await this.initializationComplete
+
+    const url = `/${Backbone.history.getFragment()}`
+    await window.drift.page(url)
+  }
+
+  async trackEvent (action, properties = {}) {
+    await this.initializationComplete
+
+    await window.drift.track(action, properties)
+  }
+}
+

--- a/app/core/Tracker2/index.js
+++ b/app/core/Tracker2/index.js
@@ -3,6 +3,7 @@ import CookieConsentTracker from './CookieConsentTracker'
 import LegacyTracker from './LegacyTracker'
 import BaseTracker from './BaseTracker'
 import GoogleAnalyticsTracker from './GoogleAnalyticsTracker'
+import DriftTracker from './DriftTracker'
 
 /**
  * Top level application tracker that handles sub tracker initialization and
@@ -20,10 +21,12 @@ export default class Tracker2 extends BaseTracker {
     this.legacyTracker = new LegacyTracker(this.store, this.cookieConsentTracker)
     this.segmentTracker = new SegmentTracker()
     this.googleAnalyticsTracker = new GoogleAnalyticsTracker()
+    this.driftTracker = new DriftTracker(this.store)
 
     this.trackers = [
       this.legacyTracker,
       this.googleAnalyticsTracker,
+      this.driftTracker,
 
       // Segment tracking is currently handled by the legacy tracker
       // this.segmentTracker,
@@ -74,5 +77,9 @@ export default class Tracker2 extends BaseTracker {
     await Promise.all(
       this.trackers.map(t => t.trackTiming(duration, category, variable, label))
     )
+  }
+
+  get drift () {
+    return this.driftTracker.drift
   }
 }

--- a/app/views/core/CocoView.coffee
+++ b/app/views/core/CocoView.coffee
@@ -246,11 +246,10 @@ module.exports = class CocoView extends Backbone.View
     if me.isStudent()
       console.error("Student clicked contact modal.")
       return
+
     if me.isTeacher(true)
       if application.isProduction()
-        window.Intercom?('show')
-      else
-        alert('Teachers, Intercom widget only available in production.')
+        application.tracker.drift.sidebar.open()
     else
       ContactModal = require 'views/core/ContactModal'
       @openModalView(new ContactModal())

--- a/app/views/teachers/CreateTeacherAccountView.coffee
+++ b/app/views/teachers/CreateTeacherAccountView.coffee
@@ -60,7 +60,6 @@ module.exports = class CreateTeacherAccountView extends RootView
     @listenTo @state, 'change:error', -> @renderSelectors('.error-area')
     @listenTo @state, 'change:showUsaStateDropdown', -> @renderSelectors('.state')
     @listenTo @state, 'change:stateValue', -> @renderSelectors('.state')
-#    loadSegment() unless @segmentLoaded
 
   onLeaveMessage: ->
     if @formChanged

--- a/package-lock.json
+++ b/package-lock.json
@@ -10263,11 +10263,6 @@
         }
       }
     },
-    "htmlencode": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/htmlencode/-/htmlencode-0.0.4.tgz",
-      "integrity": "sha1-9+LWr74YqHp45jujMI51N2Z0Dj8="
-    },
     "htmlparser2": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
@@ -10762,17 +10757,6 @@
             "ansi-regex": "^4.1.0"
           }
         }
-      }
-    },
-    "intercom-client": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/intercom-client/-/intercom-client-2.10.4.tgz",
-      "integrity": "sha1-4N/RFJ6H1/YEM6uFdcozLUd3eho=",
-      "requires": {
-        "bluebird": "^3.3.4",
-        "htmlencode": "^0.0.4",
-        "lodash.merge": "^4.6.1",
-        "request": "^2.83.0"
       }
     },
     "interpret": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "howler": "^2.1.2",
     "html-webpack-plugin": "^2.30.1",
     "htmlparser2": "^3.9.1",
-    "intercom-client": "^2.8.8",
     "jade": "^1.11.0",
     "jade-loader": "github:codecombat/pug-loader#fix-errors",
     "jquery": "~2.1.0",


### PR DESCRIPTION
Removes client side Intercom integration and replaces it with Drift.  Intercom identify calls and event calls will still be sent via segment integration.

- Wires contact us link to open drift chat for teachers
- Removes intercom-client dependency
- Disables intercom chat in segment calls within legacy tracker

**Testing**

I've been manually testing throughout the past week and the latest version of this is live at next.codecombat.com (including changes in #5782)