### PR TITLE
Add / update identify calls for signup and auth flows

### DIFF
--- a/app/core/Tracker2/BaseTracker.js
+++ b/app/core/Tracker2/BaseTracker.js
@@ -25,6 +25,8 @@ export default class BaseTracker extends EventEmitter {
 
   async identify (traits = {}) {}
 
+  async resetIdentity () {}
+
   async trackPageView (includeIntegrations = {}) {}
 
   async trackEvent (action, properties = {}, includeIntegrations = {}) {}

--- a/app/core/Tracker2/index.js
+++ b/app/core/Tracker2/index.js
@@ -5,6 +5,9 @@ import BaseTracker from './BaseTracker'
 import GoogleAnalyticsTracker from './GoogleAnalyticsTracker'
 import DriftTracker from './DriftTracker'
 
+const SESSION_STORAGE_IDENTIFIED_AT_SESSION_START_KEY = 'coco.tracker.identifiedAtSessionStart'
+const SESSION_STORAGE_IDENTIFY_ON_NEXT_PAGE_LOAD = 'coco.tracker.identifyOnNextPageLoad'
+
 /**
  * Top level application tracker that handles sub tracker initialization and
  * event routing.
@@ -45,7 +48,29 @@ export default class Tracker2 extends BaseTracker {
     } catch (e) {
       this.onInitializeFail(e)
     }
+
+    await this.initializationComplete
+
+    let callIdentify = false
+
+    // Check initialize on page load
+    const initializeOnNextPageLoad = window.sessionStorage.getItem(SESSION_STORAGE_IDENTIFY_ON_NEXT_PAGE_LOAD)
+    if (initializeOnNextPageLoad === 'true') {
+      window.sessionStorage.removeItem(SESSION_STORAGE_IDENTIFY_ON_NEXT_PAGE_LOAD)
+      callIdentify = true
+    }
+
+    const identifiedThisSession = window.sessionStorage.getItem(SESSION_STORAGE_IDENTIFIED_AT_SESSION_START_KEY)
+    if (identifiedThisSession !== 'true') {
+      callIdentify = true
+      window.sessionStorage.setItem(SESSION_STORAGE_IDENTIFIED_AT_SESSION_START_KEY, 'true')
+    }
+
+    if (callIdentify) {
+      this.identify()
+    }
   }
+
 
   async identify (traits = {}) {
     await this.initializationComplete
@@ -53,6 +78,16 @@ export default class Tracker2 extends BaseTracker {
     await Promise.all(
       this.trackers.map(t => t.identify(traits))
     )
+  }
+
+  async resetIdentity () {
+    await this.initializationComplete
+
+    await Promise.all(
+      this.trackers.map(t => t.resetIdentity())
+    )
+
+    window.sessionStorage.removeItem(SESSION_STORAGE_IDENTIFIED_AT_SESSION_START_KEY)
   }
 
   async trackPageView (includeIntegrations = {}) {
@@ -81,5 +116,9 @@ export default class Tracker2 extends BaseTracker {
 
   get drift () {
     return this.driftTracker.drift
+  }
+
+  identifyAfterNextPageLoad () {
+    window.sessionStorage.setItem(SESSION_STORAGE_IDENTIFY_ON_NEXT_PAGE_LOAD, 'true')
   }
 }

--- a/app/core/Tracker2/pageUnload.js
+++ b/app/core/Tracker2/pageUnload.js
@@ -1,0 +1,81 @@
+function getKeyForNamespace (namespace) {
+  return `coco.tracker.pageUnloadRetries.${namespace}`;
+}
+
+function getNamespaceData (namespace) {
+  const namespaceKey = getKeyForNamespace(namespace)
+  const namespaceRetriesJson = window.sessionStorage.getItem(namespaceKey)
+
+  return JSON.parse(namespaceRetriesJson || '[]')
+}
+
+function setNamespaceData(namespace, data) {
+  window.sessionStorage.setItem(namespaceKey, JSON.stringify(data || []))
+}
+
+function deleteNamespaceData(namespace) {
+  const namespaceKey = getKeyForNamespace(namespace)
+  window.sessionStorage.removeItem(namespaceKey)
+}
+
+function runAfterPageLoad (namespace, identifier, args) {
+  const namespaceRetries = getNamespaceData(namespace)
+
+  namespaceRetries.push({
+    identifier,
+    args,
+    at: new Date().getTime()
+  })
+
+  setNamespaceData(namespace, namespaceRetries)
+}
+
+export async function watchForPageUnload (timeout = 500) {
+  let unloadCallback;
+  const unloadPromise = new Promise((resolve, reject) => {
+    unloadCallback = () => reject('unload')
+    window.addEventListener('beforeunload', unloadCallback)
+  })
+
+  const timeoutPromise = new Promise((resolve) => setTimeout(resolve, timeout));
+
+  try {
+    await Promise.race([ unloadPromise, timeoutPromise ])
+  } finally {
+    window.removeEventListener('beforeunload', unloadCallback)
+  }
+}
+
+/**
+ * Monitors the page for unload events for a specified timeout after calling the supplied function.
+ * If the page unloads before the timeout expires the function call is recorded in session storage and
+ * can be loaded with `getPageUnloadRetriesForNamespace`.  The function is not automatically rerun,
+ * it is the responsibility of the consumer to check for retries and to call the function again.
+ *
+ * This is useful for situations where an ongoing process (like a network call) may be interrupted by
+ * a reload.  For example, a tracking network call that is fired after successful login, right before
+ * the user is redirected to the dashboard.
+ */
+export async function retryOnPageUnload (namespace, identifier, args, func, timeout = 500) {
+  const unloadPromise = watchForPageUnload(timeout)
+
+  func()
+
+  try {
+    await unloadPromise
+  } catch (e) {
+    if (e !== 'unload') {
+      throw e
+    }
+
+    runAfterPageLoad(namespace, identifier, args)
+  }
+}
+
+export async function getPageUnloadRetriesForNamespace (namespace, timeout = 15000) {
+  const namespaceRetries = getNamespaceData(namespace) || []
+
+  deleteNamespaceData(namespace)
+  return namespaceRetries
+    .filter(retry => new Date().getTime() - retry.at < timeout)
+}

--- a/app/core/api/users.coffee
+++ b/app/core/api/users.coffee
@@ -15,8 +15,6 @@ module.exports = {
       credentials: 'include'
       json: { name, email, password }
     }))
-    .then ->
-      window.tracker?.trackEvent 'Finished Signup', category: "Signup", label: 'CodeCombat'
 
   signupWithFacebook: ({userID, name, email, facebookID}, options={}) ->
     fetchJson(@url(userID, 'signup-with-facebook'), _.assign({}, options, {
@@ -24,9 +22,6 @@ module.exports = {
       credentials: 'include'
       json: { name, email, facebookID, facebookAccessToken: application.facebookHandler.token() }
     }))
-    .then ->
-      window.tracker?.trackEvent 'Facebook Login', category: "Signup", label: 'Facebook'
-      window.tracker?.trackEvent 'Finished Signup', category: "Signup", label: 'Facebook'
 
   signupWithGPlus: ({userID, name, email, gplusID}, options={}) ->
     fetchJson(@url(userID, 'signup-with-gplus'), _.assign({}, options, {
@@ -34,9 +29,6 @@ module.exports = {
       credentials: 'include'
       json: { name, email, gplusID, gplusAccessToken: application.gplusHandler.token() }
     }))
-    .then ->
-      window.tracker?.trackEvent 'Google Login', category: "Signup", label: 'GPlus'
-      window.tracker?.trackEvent 'Finished Signup', category: "Signup", label: 'GPlus'
 
   signupFromGoogleClassroom: (attrs, options={}) ->
     fetchJson("/db/user/signup-from-google-classroom", _.assign({}, options, {
@@ -95,8 +87,8 @@ module.exports = {
         includeTrialRequests
       }
     })
-  
-  setCountryGeo: (options = {}) -> 
+
+  setCountryGeo: (options = {}) ->
     fetchJson("/db/user/setUserCountryGeo", _.assign({}, options, {
       method: 'PUT'
     }))

--- a/app/core/store/modules/me.js
+++ b/app/core/store/modules/me.js
@@ -7,7 +7,8 @@ const emptyUser = _.zipObject((_.keys(userSchema.properties).map((key) => [key, 
 
 export default {
   namespaced: true,
-  state: emptyUser,
+  state: _.cloneDeep(emptyUser),
+
   getters: {
     isAnonymous (state) { return state.anonymous === true },
 
@@ -81,6 +82,10 @@ export default {
       commit('updateUser', { ozariaUserOptions:
         { ...ozariaConfig, avatar: { levelThangTypeId, cinematicThangTypeId } }
       })
+    },
+
+    authenticated ({ commit }, user) {
+      commit('updateUser', user)
     }
   }
 }

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -409,11 +409,13 @@ module.exports = class User extends CocoModel
     options.url = '/auth/logout'
     FB?.logout?()
     options.success ?= ->
-      location = _.result(window.currentView, 'logoutRedirectURL')
-      if location
-        window.location = location
-      else
-        window.location.reload()
+      window.application.tracker.resetIdentity().then =>
+        location = _.result(window.currentView, 'logoutRedirectURL')
+        if location
+          window.location = location
+        else
+          window.location.reload()
+
     @fetch(options)
 
   signupWithPassword: (name, email, password, options={}) ->

--- a/app/views/core/AuthModal.coffee
+++ b/app/views/core/AuthModal.coffee
@@ -55,7 +55,13 @@ module.exports = class AuthModal extends ModalView
     return forms.applyErrorsToForm(@$el, res.errors) unless res.valid
     new Promise(me.loginPasswordUser(userObject.emailOrUsername, userObject.password).then)
     .then(=>
-      if window.nextURL then window.location.href = window.nextURL else loginNavigate(@subModalContinue)
+      return application.tracker.identify()
+    )
+    .then(=>
+      if window.nextURL
+        window.location.href = window.nextURL
+      else
+        loginNavigate(@subModalContinue)
     )
     .catch((jqxhr) =>
       showingError = false
@@ -89,7 +95,10 @@ module.exports = class AuthModal extends ModalView
             existingUser.fetchGPlusUser(gplusAttrs.gplusID, {
               success: =>
                 me.loginGPlusUser(gplusAttrs.gplusID, {
-                  success: => loginNavigate(@subModalContinue)
+                  success: =>
+                    application.tracker.identify().then(=>
+                      loginNavigate(@subModalContinue)
+                    )
                   error: @onGPlusLoginError
                 })
               error: @onGPlusLoginError
@@ -120,7 +129,10 @@ module.exports = class AuthModal extends ModalView
             existingUser.fetchFacebookUser(facebookAttrs.facebookID, {
               success: =>
                 me.loginFacebookUser(facebookAttrs.facebookID, {
-                  success: => loginNavigate(@subModalContinue)
+                  success: =>
+                    application.tracker.identify().then(=>
+                      loginNavigate(@subModalContinue)
+                    )
                   error: @onFacebookLoginError
                 })
               error: @onFacebookLoginError

--- a/app/views/core/CreateAccountModal/BasicInfoView.coffee
+++ b/app/views/core/CreateAccountModal/BasicInfoView.coffee
@@ -6,6 +6,7 @@ forms = require 'core/forms'
 errors = require 'core/errors'
 User = require 'models/User'
 State = require 'models/State'
+store = require 'core/store'
 
 ###
 This view handles the primary form for user details — name, email, password, etc,
@@ -243,7 +244,9 @@ module.exports = class BasicInfoView extends CocoView
 
       return new Promise(jqxhr.then)
 
-    .then =>
+    .then (newUser) =>
+      # More data will be added by the server so make sure to trigger an identify call after page reload
+      window.application.tracker.identifyAfterNextPageLoad()
 
       # Don't sign up, kick to TeacherComponent instead
       if @signupState.get('path') is 'teacher'
@@ -254,7 +257,11 @@ module.exports = class BasicInfoView extends CocoView
         return
 
       # Use signup method
-      window.tracker?.identify() unless User.isSmokeTestUser({ email: @signupState.get('signupForm').email })
+      unless User.isSmokeTestUser({ email: @signupState.get('signupForm').email })
+        # Set new user data and call initial identify
+        store.dispatch('me/authenticated', newUser)
+        window.application.tracker.identify()
+
       switch @signupState.get('ssoUsed')
         when 'gplus'
           { email, gplusID } = @signupState.get('ssoAttrs')
@@ -269,6 +276,27 @@ module.exports = class BasicInfoView extends CocoView
           jqxhr = me.signupWithPassword(name, email, password)
 
       return new Promise(jqxhr.then)
+
+    .then =>
+      trackerCalls = []
+
+      loginMethod = 'CodeCombat'
+      if @signupState.get('ssoUsed') is'gplus'
+        loginMethod = 'GPlus'
+        trackerCalls.push(
+          window.tracker?.trackEvent 'Google Login', category: "Signup", label: 'GPlus'
+        )
+      else if @signupState.get('ssoUsed') is 'facebook'
+        loginMethod = 'Facebook'
+        trackerCalls.push(
+          window.tracker?.trackEvent 'Facebook Login', category: "Signup", label: 'Facebook'
+        )
+
+      trackerCalls.push(
+        window.application.tracker?.trackEvent 'Finished Signup', category: "Signup", label: loginMethod
+      )
+
+      return Promise.all(trackerCalls)
 
     .then =>
       { classCode, classroom } = @signupState.attributes
@@ -286,7 +314,7 @@ module.exports = class BasicInfoView extends CocoView
         console.error 'BasicInfoView form submission Promise error:', e
         @state.set('error', e.responseJSON?.message or 'Unknown Error')
         # Adding event to detect if the error occurs in prod since it is not reproducible (https://app.asana.com/0/654820789891907/1113232508815667)
-        # TODO: Remove when not required. 
+        # TODO: Remove when not required.
         if @id == 'single-sign-on-confirm-view' and @signupState.get('path') is 'teacher'
           window.tracker?.trackEvent 'Error in ssoConfirmView', {category: 'Teachers', label: @state.get('error')}
 

--- a/app/views/teachers/CreateTeacherAccountView.coffee
+++ b/app/views/teachers/CreateTeacherAccountView.coffee
@@ -291,7 +291,29 @@ module.exports = class CreateTeacherAccountView extends RootView
       trialRequestIdentifyData.educationLevel_middle = _.contains @trialRequest.attributes.properties.educationLevel, "Middle"
       trialRequestIdentifyData.educationLevel_high = _.contains @trialRequest.attributes.properties.educationLevel, "High"
       trialRequestIdentifyData.educationLevel_college = _.contains @trialRequest.attributes.properties.educationLevel, "College+"
-      application.tracker.identify trialRequestIdentifyData
+
+      return window.application.tracker.identify trialRequestIdentifyData
+
+    .then =>
+      trackerCalls = []
+
+      loginMethod = 'CodeCombat'
+      if @gplusAttrs
+        loginMethod = 'GPlus'
+        trackerCalls.push(
+          window.tracker?.trackEvent 'Google Login', category: "Signup", label: 'GPlus'
+        )
+      else if @facebookAttrs
+        loginMethod = 'Facebook'
+        trackerCalls.push(
+          window.tracker?.trackEvent 'Facebook Login', category: "Signup", label: 'Facebook'
+        )
+
+      trackerCalls.push(
+        window.application.tracker?.trackEvent 'Finished Signup', category: "Signup", label: loginMethod
+      )
+
+      return Promise.all(trackerCalls)
 
     .then =>
       application.router.navigate(SIGNUP_REDIRECT, { trigger: true })


### PR DESCRIPTION
This PR integrates identify calls with our signup, login and logout flows to ensure that the user is always properly identified.

- Refactors location of track event calls in response to signup / login / logout events
- Ensures identify calls are properly sent prior to page redirecting
- Adds a workaround for a Drift SDK shortcoming that does not expose when API calls are sent

Identify should now be called at:
- First session visit
- Login
- Logout
- Teacher signup
- Student signup

Testing

I've been manually testing throughout the past week and the latest version of this is live at next.codecombat.com