### PR TITLE
Integrate cookie consent with Vuex store and disable Drift tracking when cookie consent declined

### DIFF
--- a/app/core/Tracker2/BaseTracker.js
+++ b/app/core/Tracker2/BaseTracker.js
@@ -1,5 +1,3 @@
-import EventEmitter from 'events'
-
 /**
  * A baseline tracker that:
  *   1. Defines a standard initialization flow for all trackers
@@ -13,10 +11,8 @@ import EventEmitter from 'events'
  * initialization process has been completed (or failed).  The initializationComplete
  * promise should _never_ be overwritten as other external components can depend on it.
  */
-export default class BaseTracker extends EventEmitter {
+export default class BaseTracker {
   constructor () {
-    super()
-
     this.initializing = false
     this.initialized = false
 
@@ -32,6 +28,15 @@ export default class BaseTracker extends EventEmitter {
   async trackEvent (action, properties = {}, includeIntegrations = {}) {}
 
   async trackTiming (duration, category, variable, label) {}
+
+  watchForCookieConsentChanges (store) {
+    this.cookieConsentDeclined = store.getters['tracker/cookieConsentDeclined']
+
+    store.watch(
+      (state, getters) => getters['tracker/cookieConsentDeclined'],
+      (result) => { this.cookieConsentDeclined = result }
+    )
+  }
 
   get isInitialized () {
     return this.initialized

--- a/app/core/Tracker2/CookieConsentTracker.js
+++ b/app/core/Tracker2/CookieConsentTracker.js
@@ -13,7 +13,6 @@ export default class CookieConsentTracker extends BaseTracker {
     super()
 
     this.store = store
-    this.loadStatus(undefined)
   }
 
   /**
@@ -41,21 +40,8 @@ export default class CookieConsentTracker extends BaseTracker {
     this.onInitializeSuccess()
   }
 
-  getStatus () {
-    return this.status
-  }
-
-  loadStatus (status) {
-    this.status = {
-      answered: typeof status === 'string',
-      consented: status === 'allow' || status === 'dismiss',
-      declined: status === 'deny'
-    }
-  }
-
   onStatusChange (status) {
-    this.loadStatus(status)
-    this.emit('change', this.getStatus())
+    this.store.dispatch('tracker/cookieConsentStatusChange', status)
   }
 
   onPreferredLocaleChanged () {

--- a/app/core/Tracker2/DriftTracker.js
+++ b/app/core/Tracker2/DriftTracker.js
@@ -55,6 +55,8 @@ export default class DriftTracker extends BaseTracker {
       this.onInitializeSuccess()
     })
 
+    this.watchForCookieConsentChanges(this.store)
+
     await this.initializationComplete
 
     const retries = await getPageUnloadRetriesForNamespace('drift')
@@ -76,6 +78,10 @@ export default class DriftTracker extends BaseTracker {
   }
 
   async identify (traits = {}) {
+    if (this.cookieConsentDeclined) {
+      return
+    }
+
     await this.initializationComplete
 
     const { me } = this.store.state
@@ -106,6 +112,10 @@ export default class DriftTracker extends BaseTracker {
   }
 
   async trackPageView (includeIntegrations = {}) {
+    if (this.cookieConsentDeclined) {
+      return
+    }
+
     await this.initializationComplete
 
     const url = `/${Backbone.history.getFragment()}`
@@ -113,6 +123,10 @@ export default class DriftTracker extends BaseTracker {
   }
 
   async trackEvent (action, properties = {}) {
+    if (this.cookieConsentDeclined) {
+      return
+    }
+
     await this.initializationComplete
 
     await window.drift.track(action, properties)

--- a/app/core/Tracker2/LegacyTracker.js
+++ b/app/core/Tracker2/LegacyTracker.js
@@ -20,12 +20,12 @@ export default class LegacyTracker extends BaseTracker {
   async _initializeTracker () {
     this.legacyTracker = new CocoLegacyTracker()
 
-    this.cookieConsent.on('change', () => {
-      this.legacyTracker.cookies = this.cookieConsent.getStatus()
-    })
-
+    this.legacyTracker.cookies = this.store.state.tracker.cookieConsent
+    this.store.watch(
+      (state) => state.tracker.cookieConsent,
+      (status) => this.legacyTracker.cookies = status
+    )
     this.legacyTracker.finishInitialization()
-
     this.onInitializeSuccess()
   }
 

--- a/app/core/application.coffee
+++ b/app/core/application.coffee
@@ -83,6 +83,7 @@ Application = {
     window.tracker = @tracker
     locale.load(me.get('preferredLanguage', true))
       .then => @tracker.initialize()
+      .catch((e) => console.error('Tracker initialization failed', e))
 
     if me.useSocialSignOn()
       @facebookHandler = new FacebookHandler()

--- a/app/core/store/index.coffee
+++ b/app/core/store/index.coffee
@@ -36,6 +36,7 @@ store = new Vuex.Store({
     tints: require('./modules/tints').default
     layoutChrome: require('./modules/layoutChrome').default
     unitMap: require('./modules/unitMap').default
+    tracker: require('./modules/tracker').default
   }
 })
 

--- a/app/core/store/modules/tracker.js
+++ b/app/core/store/modules/tracker.js
@@ -1,0 +1,33 @@
+export default {
+  namespaced: true,
+
+  state: {
+    cookieConsent: {
+      answered: false,
+      consented: false,
+      declined: false
+    },
+  },
+
+  mutations: {
+    updateCookieConsentStatus: (state, status) => {
+      state.cookieConsent = status
+    }
+  },
+
+  getters: {
+    cookieConsentDeclined (state) {
+      return state.cookieConsent.declined === true
+    }
+  },
+
+  actions: {
+    cookieConsentStatusChange: ({ commit }, status) => {
+      commit('updateCookieConsentStatus', {
+        answered: typeof status === 'string',
+        consented: status === 'allow' || status === 'dismiss',
+        declined: status === 'deny'
+      })
+    }
+  }
+}


### PR DESCRIPTION
- Updates the cookie consent tracker to save state in Vuex store.  
- Adds a getter to pull consent declined status which is what drives tracker disabling.
- Integrates drift tracker with this new cookie consent status store
- Integrates legacy tracker with new cookie consent store
- Uses Vuex store watches to ensure that trackers are updated with latest cookie consent status.