### PR TITLE
Revert to using null values for defaults in me module in vuex store

### DIFF
--- a/app/core/store/modules/me.js
+++ b/app/core/store/modules/me.js
@@ -3,7 +3,7 @@ const userSchema = require('schemas/models/user')
 const api = require('core/api')
 const utils = require('core/utils')
 
-const emptyUser = _.zipObject((_.keys(userSchema.properties).map((key) => [key, userSchema.default[key] || null])))
+const emptyUser = _.zipObject((_.keys(userSchema.properties).map((key) => [key, null])))
 
 export default {
   namespaced: true,


### PR DESCRIPTION
This PR reverts a change that was incorrectly setting user state on anonymous users.  The change set the default values of the me store to the default values specified in the user schema.  When the me module is initialized with the user sent from the server, the updates are merged instead of updating the full user object.  This was causing the default values to persist on the client and eventually be written to the server.

This change was initially added to reset the client side user to an anonymous user after logout however we opted to use the logout redirect to do this.

Original code is here https://github.com/codecombat/codecombat/blob/9eb37d8df6b8bc4c938c37703b147b68b4274992/app/core/store/modules/me.js#L5 

This has been tested manually.