### PR TITLE
Extract Segment from legacy tracker and improve identify calls after page reloads during auth lifecycle

### DIFF
--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -57,7 +57,8 @@ module.exports = class Tracker extends CocoClass
     @trackEventInternal('Identify', {id: me.id, traits})
     return unless @shouldTrackExternalEvents()
 
-  trackPageView: (includeIntegrations=[]) ->
+  trackPageView: (includeIntegrations
+  =[]) ->
     name = Backbone.history.getFragment()
     url = "/#{name}"
 

--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -57,8 +57,7 @@ module.exports = class Tracker extends CocoClass
     @trackEventInternal('Identify', {id: me.id, traits})
     return unless @shouldTrackExternalEvents()
 
-  trackPageView: (includeIntegrations
-  =[]) ->
+  trackPageView: (includeIntegrations = []) ->
     name = Backbone.history.getFragment()
     url = "/#{name}"
 

--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -2,7 +2,6 @@
 SuperModel = require 'models/SuperModel'
 utils = require 'core/utils'
 CocoClass = require 'core/CocoClass'
-loadSegmentIo = require('core/services/segment')
 api = require('core/api')
 
 experiments = require('core/experiments')
@@ -22,7 +21,6 @@ module.exports = class Tracker extends CocoClass
     @initialized = true
     @trackReferrers()
     @identify() # Needs supermodel to exist first
-    @updateRole() if me.get('role')
 
   trackReferrers: ->
     elapsed = new Date() - new Date(me.get('dateCreated'))
@@ -59,12 +57,6 @@ module.exports = class Tracker extends CocoClass
     @trackEventInternal('Identify', {id: me.id, traits})
     return unless @shouldTrackExternalEvents()
 
-    if me.isTeacher(true) and @segmentLoaded and not me.get('unsubscribedFromMarketingEmails')
-      traits.createdAt = me.get 'dateCreated'  # Intercom, at least, wants this
-
-      # TODO remove intercom config once it's disabled in segment
-      analytics.identify me.id, traits, { Intercom: { hideDefaultLauncher: true } }
-
   trackPageView: (includeIntegrations=[]) ->
     name = Backbone.history.getFragment()
     url = "/#{name}"
@@ -78,18 +70,6 @@ module.exports = class Tracker extends CocoClass
     ga? 'send', 'pageview', url
     ga?('codeplay.send', 'pageview', url) if features.codePlay
     window.snowplow 'trackPageView'
-
-    if me.isTeacher(true) and @segmentLoaded
-      options = {}
-      if includeIntegrations?.length
-        options.integrations = All: false
-        for integration in includeIntegrations
-          options.integrations[integration] = true
-
-      # TODO remove config once it's disabled in segment
-      options.Intercom = { hideDefaultLauncher: true }
-
-      analytics.page url, {}, options
 
   trackEvent: (action, properties={}, includeIntegrations=[]) =>
     console.log 'Tracking external analytics event:', action, properties, includeIntegrations if debugAnalytics
@@ -117,15 +97,6 @@ module.exports = class Tracker extends CocoClass
 
       ga? 'send', gaFieldObject
       ga? 'codeplay.send', gaFieldObject if features.codePlay
-
-    if me.isTeacher(true) and @segmentLoaded
-      options = {}
-      if includeIntegrations
-        # https://segment.com/docs/libraries/analytics.js/#selecting-integrations
-        options.integrations = All: false
-        for integration in includeIntegrations
-          options.integrations[integration] = true
-      analytics?.track action, {}, options
 
   trackSnowplow: (event, properties) =>
     return if @shouldBlockAllTracking()
@@ -199,23 +170,6 @@ module.exports = class Tracker extends CocoClass
     console.log 'Would track timing event:', arguments if debugAnalytics
     if @shouldTrackExternalEvents()
       ga? 'send', 'timing', category, variable, duration, label
-
-  updateRole: ->
-    return if me.isAdmin() or @shouldBlockAllTracking()
-    return unless me.isTeacher(true)
-    loadSegmentIo()
-    .then =>
-      @segmentLoaded = true and me.useSocialSignOn()
-      @identify()
-    #analytics.page()  # It looks like we don't want to call this here because it somehow already gets called once in addition to this.
-    # TODO: record any events and pageviews that have built up before we knew we were a teacher.
-
-  updateTrialRequestData: (attrs) ->
-    return if @shouldBlockAllTracking()
-    loadSegmentIo()
-    .then =>
-      @segmentLoaded = true and me.useSocialSignOn()
-      @identify(attrs)
 
   shouldBlockAllTracking: ->
     doNotTrack = (navigator?.doNotTrack or window?.doNotTrack) and not (navigator?.doNotTrack is 'unspecified' or window?.doNotTrack is 'unspecified')

--- a/app/core/Tracker2/BaseTracker.js
+++ b/app/core/Tracker2/BaseTracker.js
@@ -23,9 +23,9 @@ export default class BaseTracker {
 
   async resetIdentity () {}
 
-  async trackPageView (includeIntegrations = {}) {}
+  async trackPageView (includeIntegrations = []) {}
 
-  async trackEvent (action, properties = {}, includeIntegrations = {}) {}
+  async trackEvent (action, properties = {}, includeIntegrations = []) {}
 
   async trackTiming (duration, category, variable, label) {}
 

--- a/app/core/Tracker2/DriftTracker.js
+++ b/app/core/Tracker2/DriftTracker.js
@@ -111,7 +111,7 @@ export default class DriftTracker extends BaseTracker {
     })
   }
 
-  async trackPageView (includeIntegrations = {}) {
+  async trackPageView (includeIntegrations = []) {
     if (this.disableAllTracking) {
       return
     }

--- a/app/core/Tracker2/DriftTracker.js
+++ b/app/core/Tracker2/DriftTracker.js
@@ -131,5 +131,9 @@ export default class DriftTracker extends BaseTracker {
 
     await window.drift.track(action, properties)
   }
+
+  async resetIdentity () {
+    window.drift.reset()
+  }
 }
 

--- a/app/core/Tracker2/DriftTracker.js
+++ b/app/core/Tracker2/DriftTracker.js
@@ -31,7 +31,7 @@ function loadDrift () {
 
 const DEFAULT_DRIFT_IDENTIFY_USER_PROPERTIES = [
   'email', 'anonymous', 'dateCreated', 'hourOfCode', 'name', 'referrer', 'testGroupNumber', 'testGroupNumberUS',
-  'gender', 'lastLevel', 'siteref', 'ageRange', 'schoolName', 'coursePrepaidID', 'role'
+  'gender', 'lastLevel', 'siteref', 'ageRange', 'schoolName', 'coursePrepaidID', 'role', 'firstName', 'lastName'
 ]
 
 export default class DriftTracker extends BaseTracker {

--- a/app/core/Tracker2/DriftTracker.js
+++ b/app/core/Tracker2/DriftTracker.js
@@ -91,14 +91,14 @@ export default class DriftTracker extends BaseTracker {
       ...meAttrs
     } = me
 
-    const filteredMeAttributes = Object.keys(meAttrs)
-      .reduce((obj, key) => {
-        if (DEFAULT_DRIFT_IDENTIFY_USER_PROPERTIES.includes(key) && meAttrs[key] !== null) {
-          obj[key] = meAttrs[key]
-        }
+    const filteredMeAttributes = DEFAULT_DRIFT_IDENTIFY_USER_PROPERTIES.reduce((obj, key) => {
+      const meAttr = meAttrs[key]
+      if (typeof meAttr !== 'undefined' && meAttr !== null) {
+        obj[key] = meAttr
+      }
 
-        return obj
-      }, {})
+      return obj;
+    }, {})
 
     retryOnPageUnload('drift', 'identify', [ traits ], () => {
       window.drift.identify(

--- a/app/core/Tracker2/LegacyTracker.js
+++ b/app/core/Tracker2/LegacyTracker.js
@@ -30,13 +30,7 @@ export default class LegacyTracker extends BaseTracker {
   }
 
   async identify (traits = {}) {
-    // The Tracker.coffee implementation of identify seems to assume that it is called through
-    // other internal methods like updateRole and updateTrialRequestAttributes (or at least
-    // that these other internal methods are called first).  The implementation of updateRole
-    // does some simple filtering, calls segment and then simply calls identify internally
-    // so instead of refactoring the tracker to load segment in identify, we just use this
-    // method in place of identify.
-    this.legacyTracker.updateRole(traits)
+    this.legacyTracker.identify(traits)
   }
 
   async trackPageView (includeIntegrations = {}) {

--- a/app/core/Tracker2/LegacyTracker.js
+++ b/app/core/Tracker2/LegacyTracker.js
@@ -33,7 +33,7 @@ export default class LegacyTracker extends BaseTracker {
     this.legacyTracker.identify(traits)
   }
 
-  async trackPageView (includeIntegrations = {}) {
+  async trackPageView (includeIntegrations = []) {
     this.legacyTracker.trackPageView(includeIntegrations)
   }
 

--- a/app/core/Tracker2/SegmentTracker.js
+++ b/app/core/Tracker2/SegmentTracker.js
@@ -145,7 +145,6 @@ export default class SegmentTracker extends BaseTracker {
     })
   }
 
-  // TODO legacy tracker filtered out identify calls when me.get('unsubscribedFromMarketingEmails') is true
   async identify (traits = {}) {
     await this.initializationComplete
 
@@ -160,19 +159,19 @@ export default class SegmentTracker extends BaseTracker {
       ...meAttrs
     } = me
 
-    const filteredMeAttributes = Object.keys(meAttrs)
-      .reduce((obj, key) => {
-        if (DEFAULT_SEGMENT_TRAITS_TO_REPORT.includes(key) && meAttrs[key] !== null) {
-          obj[key] = meAttrs[key]
-        }
+    const filteredMeAttributes = DEFAULT_SEGMENT_TRAITS_TO_REPORT.reduce((obj, key) => {
+      const meAttr = meAttrs[key]
+      if (typeof meAttr !== 'undefined' && meAttr !== null) {
+        obj[key] = meAttr
+      }
 
-        return obj
-      }, {})
+      return obj;
+    }, {})
 
     const options = { ...DEFAULT_SEGMENT_OPTIONS }
     return new Promise((resolve) => {
       window.analytics.identify(
-        this.store.state.me._id,
+        _id,
         {
           ...filteredMeAttributes,
           ...traits

--- a/app/core/Tracker2/SegmentTracker.js
+++ b/app/core/Tracker2/SegmentTracker.js
@@ -183,7 +183,7 @@ export default class SegmentTracker extends BaseTracker {
     })
   }
 
-  async trackEvent (action, properties = {}, includeIntegrations = {}) {
+  async trackEvent (action, properties = {}, includeIntegrations = []) {
     await this.initializationComplete
 
     if (!this.enabled || this.disableAllTracking) {

--- a/app/core/Tracker2/SegmentTracker.js
+++ b/app/core/Tracker2/SegmentTracker.js
@@ -122,7 +122,7 @@ export default class SegmentTracker extends BaseTracker {
     )
 
     if (this.store.getters['me/isTeacher']) {
-      loadSegment()
+      this.onIsTeacherChanged(true)
       window.analytics.ready(this.onInitializeSuccess)
     } else {
       this.onInitializeSuccess()
@@ -170,8 +170,6 @@ export default class SegmentTracker extends BaseTracker {
       }, {})
 
     const options = { ...DEFAULT_SEGMENT_OPTIONS }
-    this.addIntegrationsToSegmentOptions(options, includeIntegrations)
-
     return new Promise((resolve) => {
       window.analytics.identify(
         this.store.state.me._id,

--- a/app/core/Tracker2/SegmentTracker.js
+++ b/app/core/Tracker2/SegmentTracker.js
@@ -198,6 +198,10 @@ export default class SegmentTracker extends BaseTracker {
     })
   }
 
+  async resetIdentity () {
+    window.analytics.reset();
+  }
+
   onIsTeacherChanged (isTeacher) {
     if (this.enabled) {
       return

--- a/app/core/Tracker2/index.js
+++ b/app/core/Tracker2/index.js
@@ -22,7 +22,7 @@ export default class Tracker2 extends BaseTracker {
 
     this.legacyTracker = new LegacyTracker(this.store, this.cookieConsentTracker)
     this.segmentTracker = new SegmentTracker(this.store)
-    this.googleAnalyticsTracker = new GoogleAnalyticsTracker()
+    // this.googleAnalyticsTracker = new GoogleAnalyticsTracker()
     this.driftTracker = new DriftTracker(this.store)
 
     this.trackers = [

--- a/app/core/Tracker2/index.js
+++ b/app/core/Tracker2/index.js
@@ -18,21 +18,18 @@ export default class Tracker2 extends BaseTracker {
 
     this.store = store
 
-    // TODO consent status needs to be propagated to other trackers
     this.cookieConsentTracker = new CookieConsentTracker(this.store)
 
     this.legacyTracker = new LegacyTracker(this.store, this.cookieConsentTracker)
-    this.segmentTracker = new SegmentTracker()
+    this.segmentTracker = new SegmentTracker(this.store)
     this.googleAnalyticsTracker = new GoogleAnalyticsTracker()
     this.driftTracker = new DriftTracker(this.store)
 
     this.trackers = [
       this.legacyTracker,
-      this.googleAnalyticsTracker,
+      // this.googleAnalyticsTracker,
       this.driftTracker,
-
-      // Segment tracking is currently handled by the legacy tracker
-      // this.segmentTracker,
+      this.segmentTracker,
     ]
   }
 

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -410,6 +410,7 @@ module.exports = class User extends CocoModel
     FB?.logout?()
     options.success ?= ->
       window.application.tracker.resetIdentity().then =>
+        window.application.tracker.identifyAfterNextPageLoad()
         location = _.result(window.currentView, 'logoutRedirectURL')
         if location
           window.location = location

--- a/app/views/TestView.coffee
+++ b/app/views/TestView.coffee
@@ -138,6 +138,9 @@ module.exports = TestView = class TestView extends RootView
         Backbone.Mediator.init()
         Backbone.Mediator.setValidationEnabled false
         spyOn(application.tracker, 'trackEvent')
+        spyOn(application.tracker, 'trackPageView')
+        spyOn(application.tracker, 'identify')
+        spyOn(application.tracker, 'identifyAfterNextPageLoad')
         application.timeoutsToClear = []
         jasmine.addMatchers(customMatchers)
         @notySpy = spyOn(window, 'noty') # mainly to hide them

--- a/app/views/core/AuthModal.coffee
+++ b/app/views/core/AuthModal.coffee
@@ -58,6 +58,7 @@ module.exports = class AuthModal extends ModalView
       return application.tracker.identify()
     )
     .then(=>
+      application.tracker.identifyAfterNextPageLoad()
       if window.nextURL
         window.location.href = window.nextURL
       else
@@ -96,6 +97,7 @@ module.exports = class AuthModal extends ModalView
               success: =>
                 me.loginGPlusUser(gplusAttrs.gplusID, {
                   success: =>
+                    application.tracker.identifyAfterNextPageLoad()
                     application.tracker.identify().then(=>
                       loginNavigate(@subModalContinue)
                     )
@@ -130,6 +132,7 @@ module.exports = class AuthModal extends ModalView
               success: =>
                 me.loginFacebookUser(facebookAttrs.facebookID, {
                   success: =>
+                    application.tracker.identifyAfterNextPageLoad()
                     application.tracker.identify().then(=>
                       loginNavigate(@subModalContinue)
                     )

--- a/app/views/core/CreateAccountModal/teacher/TeacherSignupStoreModule.coffee
+++ b/app/views/core/CreateAccountModal/teacher/TeacherSignupStoreModule.coffee
@@ -99,6 +99,7 @@ module.exports = TeacherSignupStoreModule = {
         trialRequestIdentifyData.educationLevel_high = _.contains state.trialRequestProperties.educationLevel, "High"
         trialRequestIdentifyData.educationLevel_college = _.contains state.trialRequestProperties.educationLevel, "College+"
 
+        application.tracker.identifyAfterNextPageLoad()
         return application.tracker.identify trialRequestIdentifyData unless User.isSmokeTestUser({ email: state.signupForm.email })
 
       .then =>

--- a/app/views/teachers/CreateTeacherAccountView.coffee
+++ b/app/views/teachers/CreateTeacherAccountView.coffee
@@ -292,6 +292,7 @@ module.exports = class CreateTeacherAccountView extends RootView
       trialRequestIdentifyData.educationLevel_high = _.contains @trialRequest.attributes.properties.educationLevel, "High"
       trialRequestIdentifyData.educationLevel_college = _.contains @trialRequest.attributes.properties.educationLevel, "College+"
 
+      application.tracker.identifyAfterNextPageLoad()
       return window.application.tracker.identify trialRequestIdentifyData
 
     .then =>

--- a/test/app/views/core/CreateAccountModal.spec.coffee
+++ b/test/app/views/core/CreateAccountModal.spec.coffee
@@ -601,7 +601,6 @@ describe 'CreateAccountModal Vue Store', ->
       spyOn(api.users, 'signupWithFacebook').and.returnValue(Promise.resolve())
       spyOn(api.users, 'signupWithPassword').and.returnValue(Promise.resolve())
       spyOn(api.trialRequests, 'post').and.returnValue(Promise.resolve())
-      spyOn(application.tracker.legacyTracker.legacyTracker, 'updateTrialRequestData').and.returnValue(Promise.resolve())
       @dispatch = jasmine.createSpy()
       @commit = jasmine.createSpy()
       @rootState = {

--- a/test/app/views/core/CreateAccountModal.spec.coffee
+++ b/test/app/views/core/CreateAccountModal.spec.coffee
@@ -595,7 +595,8 @@ api = require 'core/api'
 describe 'CreateAccountModal Vue Store', ->
   describe 'actions.createAccount', ->
     beforeEach ->
-      spyOn(window, 'fetch')
+      spyOn(window, 'fetch').and.callFake ->
+        throw "This shouldn't be called!"
       spyOn(api.users, 'signupWithGPlus').and.returnValue(Promise.resolve())
       spyOn(api.users, 'signupWithFacebook').and.returnValue(Promise.resolve())
       spyOn(api.users, 'signupWithPassword').and.returnValue(Promise.resolve())

--- a/test/app/views/core/CreateAccountModal.spec.coffee
+++ b/test/app/views/core/CreateAccountModal.spec.coffee
@@ -595,8 +595,7 @@ api = require 'core/api'
 describe 'CreateAccountModal Vue Store', ->
   describe 'actions.createAccount', ->
     beforeEach ->
-      spyOn(window, 'fetch').and.callFake ->
-        throw "This shouldn't be called!"
+      spyOn(window, 'fetch')
       spyOn(api.users, 'signupWithGPlus').and.returnValue(Promise.resolve())
       spyOn(api.users, 'signupWithFacebook').and.returnValue(Promise.resolve())
       spyOn(api.users, 'signupWithPassword').and.returnValue(Promise.resolve())


### PR DESCRIPTION
- Finishes implementation of Segment tracker
- Removes segment integration from legacy tracker
- Triggers identify after page load during redirects related to auth changes
- Added firstName and lastName to drift identify traits

Tested manually