### PR TITLE
Disable tracking for smoke test users and spying users

### DIFF
--- a/app/core/store/modules/me.js
+++ b/app/core/store/modules/me.js
@@ -52,6 +52,10 @@ export default {
       }
 
       return utils.inEU(state.country)
+    },
+
+    isSmokeTestUser (state) {
+      return utils.isSmokeTestEmail(state.email)
     }
   },
 

--- a/app/core/store/modules/tracker.js
+++ b/app/core/store/modules/tracker.js
@@ -3,6 +3,7 @@ export default {
 
   state: {
     doNotTrack: window.navigator && window.navigator.doNotTrack === "1",
+    spying: window.serverSession && typeof window.serverSession.amActually !== 'undefined',
 
     cookieConsent: {
       answered: false,
@@ -18,8 +19,8 @@ export default {
   },
 
   getters: {
-    disableAllTracking (state) {
-      return state.cookieConsent.declined || state.doNotTrack
+    disableAllTracking (state, getters, rootState, rootGetters) {
+      return state.cookieConsent.declined || state.doNotTrack || rootGetters['me/isSmokeTestUser'] || state.spying
     }
   },
 


### PR DESCRIPTION
- Adds an `isSmokeTestUser` getter to the me module of the Vuex store
- Disables tracking for smoke test users and for spying users