### PR TITLE
Fix bug in segment tracker preventing identity reset when segment not loaded

### DIFF
--- a/app/core/Tracker2/SegmentTracker.js
+++ b/app/core/Tracker2/SegmentTracker.js
@@ -198,6 +198,12 @@ export default class SegmentTracker extends BaseTracker {
   }
 
   async resetIdentity () {
+    await this.initializationComplete
+
+    if (!this.enabled || this.disableAllTracking) {
+      return
+    }
+
     window.analytics.reset();
   }
 


### PR DESCRIPTION
The SegmentTracker currently tries to call `window.analytics.reset()` regardless of if segment has been loaded onto the page.  This PR delays and / or prevents the call based on load state.