### PR TITLE
Support for multi stage polls

### DIFF
--- a/app/schemas/models/poll.schema.coffee
+++ b/app/schemas/models/poll.schema.coffee
@@ -4,6 +4,7 @@ PollSchema = c.object {title: 'Poll'}
 c.extendNamedProperties PollSchema  # name first
 
 _.extend PollSchema.properties,
+  draft: {type: 'boolean', description: 'Prevents poll from being displayed to users.'}
   description: {type: 'string', title: 'Description', description: 'Optional: extra context or explanation', format: 'markdown' }
   answers: c.array {title: 'Answers'},
     c.object {required: ['key', 'text', 'i18n', 'votes']},
@@ -11,6 +12,7 @@ _.extend PollSchema.properties,
       text: c.shortString {title: 'Text', description: 'Answer that the player will see, like 14 - 17.', format: 'markdown'}
       i18n: {type: 'object', title: 'i18n', format: 'i18n', props: ['text']}
       votes: {title: 'Votes', type: 'integer', minimum: 0}
+      nextPoll: c.stringID( title: 'Next Poll', description: 'Which poll to show immediately after this one.')
   i18n: {type: 'object', title: 'i18n', format: 'i18n', props: ['name', 'description']}
   created: c.date {title: 'Created', readOnly: true}
   priority: {title: 'Priority', description: 'Lower numbers will show earlier.', type: 'integer'}

--- a/app/schemas/models/poll.schema.coffee
+++ b/app/schemas/models/poll.schema.coffee
@@ -4,7 +4,7 @@ PollSchema = c.object {title: 'Poll'}
 c.extendNamedProperties PollSchema  # name first
 
 _.extend PollSchema.properties,
-  draft: {type: 'boolean', description: 'Prevents poll from being displayed to users.'}
+  hidden: {type: 'boolean', description: 'Prevents poll from being displayed to users. Useful for a multi-poll or stopping a poll from showing up without deleting.'}
   description: {type: 'string', title: 'Description', description: 'Optional: extra context or explanation', format: 'markdown' }
   answers: c.array {title: 'Answers'},
     c.object {required: ['key', 'text', 'i18n', 'votes']},

--- a/app/styles/editor/poll/poll-edit-view.sass
+++ b/app/styles/editor/poll/poll-edit-view.sass
@@ -1,6 +1,6 @@
 #editor-poll-edit-view
   .treema-root
-    margin: 28px 0px 20px
+    margin: 28px 0px 100px
 
   .poll-tool-button
     float: right

--- a/app/templates/editor/poll/poll-edit-view.jade
+++ b/app/templates/editor/poll/poll-edit-view.jade
@@ -17,6 +17,9 @@ block content
     h3(data-i18n="poll.edit_poll_title") Edit Poll
       span
         |: "#{view.poll.attributes.name}"
+    h4 Poll Id
+      span
+        |: "#{view.poll.attributes._id}"
 
     #poll-treema
 

--- a/app/views/editor/poll/PollEditView.coffee
+++ b/app/views/editor/poll/PollEditView.coffee
@@ -88,19 +88,39 @@ module.exports = class PollEditView extends RootView
       @treema.set '/answers', @pollModal.poll.get('answers')
       @hush = false
 
+  # Validate that nextPoll is a valid poll, throwing if nextPoll is invalid.
+  validateNextPollIds: (data) ->
+    data ?= []
+    currentPollId = @poll.get('_id')
+    responsePromises = data
+      .filter(({ nextPoll }) -> nextPoll)
+      .map(({nextPoll, key}) ->
+        if nextPoll == currentPollId
+          throw new Error("Aborted save: Error with nextPoll in answer with key: '#{key}' - Do not reference the same poll in an answer.")
+        return fetch("/db/poll/#{nextPoll}")
+          .then((r) ->
+            if !r.ok
+              throw new Error("Aborted save: Error with nextPoll in answer with key: '#{key}' - Poll with this id doesn't exist.")
+          )
+      )
+
+    return Promise.all(responsePromises)
+
   savePoll: (e) ->
     @treema.endExistingEdits()
     for key, value of @treema.data
       @poll.set(key, value)
 
-    res = @poll.save()
+    @validateNextPollIds(@poll.get('answers')).then(() =>
+      res = @poll.save()
 
-    res.error (collection, response, options) =>
-      console.error response
+      res.error (collection, response, options) =>
+        console.error response
 
-    res.success =>
-      url = "/editor/poll/#{@poll.get('slug') or @poll.id}"
-      document.location.href = url
+      res.success =>
+        url = "/editor/poll/#{@poll.get('slug') or @poll.id}"
+        document.location.href = url
+    )
 
   confirmDeletion: ->
     renderData =

--- a/app/views/editor/poll/PollEditView.coffee
+++ b/app/views/editor/poll/PollEditView.coffee
@@ -41,6 +41,10 @@ module.exports = class PollEditView extends RootView
 
   onLoaded: ->
     super()
+
+    if @poll.get('answers') == undefined
+      @poll.set('draft', true)
+
     @buildTreema()
     @listenTo @poll, 'change', =>
       @poll.updateI18NCoverage()

--- a/app/views/editor/poll/PollEditView.coffee
+++ b/app/views/editor/poll/PollEditView.coffee
@@ -43,7 +43,7 @@ module.exports = class PollEditView extends RootView
     super()
 
     if @poll.get('answers') == undefined
-      @poll.set('draft', true)
+      @poll.set('hidden', true)
 
     @buildTreema()
     @listenTo @poll, 'change', =>

--- a/app/views/play/modal/PollModal.coffee
+++ b/app/views/play/modal/PollModal.coffee
@@ -83,13 +83,19 @@ module.exports = class PollModal extends ModalView
       myAnswer = (@userPollsRecord.get('polls') ? {})[@poll.id]
       answerObj = _.find(@poll.get('answers'), (answer) => answer.key == myAnswer) or {}
       nextPollId = answerObj.nextPoll
+      
+      # The following block allows for the user to be indecisive with their answer, updating UI accordingly.
+      btn = @$el.find('.btn.btn-illustrated.btn-lg.done-button')
       if nextPollId
         btn = @$el.find('.btn.btn-illustrated.btn-lg.done-button')
-        btn.text('Next')
+        btn.text(i18n.t('common.next'))
         btn.one('click', ()=>
           btn.prop('disabled', true);
           @trigger('trigger-next-poll', nextPollId)
         )
+      else
+        btn.text(i18n.t('play_level.done'))
+        btn.off('click')
     }
 
   awardRandomGems: ->

--- a/app/views/play/modal/PollModal.coffee
+++ b/app/views/play/modal/PollModal.coffee
@@ -77,7 +77,20 @@ module.exports = class PollModal extends ModalView
     pollVotes[@poll.id] = $selectedAnswer.data('answer').toString()
     @userPollsRecord.set 'polls', pollVotes
     @updateAnswers true
-    @userPollsRecord.save {polls: pollVotes}, {success: => @awardRandomGems?()}
+    @userPollsRecord.save {polls: pollVotes}, {success: => 
+      @awardRandomGems?()
+
+      myAnswer = (@userPollsRecord.get('polls') ? {})[@poll.id]
+      answerObj = _.find(@poll.get('answers'), (answer) => answer.key == myAnswer) or {}
+      nextPollId = answerObj.nextPoll
+      if nextPollId
+        btn = @$el.find('.btn.btn-illustrated.btn-lg.done-button')
+        btn.text('Next')
+        btn.one('click', ()=>
+          btn.prop('disabled', true);
+          @trigger('trigger-next-poll', nextPollId)
+        )
+    }
 
   awardRandomGems: ->
     return unless reward = (@userPollsRecord.get('rewards') ? {})[@poll.id]

--- a/app/views/play/modal/PollModal.coffee
+++ b/app/views/play/modal/PollModal.coffee
@@ -87,7 +87,6 @@ module.exports = class PollModal extends ModalView
       # The following block allows for the user to be indecisive with their answer, updating UI accordingly.
       btn = @$el.find('.btn.btn-illustrated.btn-lg.done-button')
       if nextPollId
-        btn = @$el.find('.btn.btn-illustrated.btn-lg.done-button')
         btn.text(i18n.t('common.next'))
         btn.one('click', ()=>
           btn.prop('disabled', true);


### PR DESCRIPTION
# Context

We want to support polls that are more than one view. This allows the content team to chain together polls from the answer given, allowing further info to be gained.

# How

Poll answers have been given an additional `nextPoll` property that contains the id of the next poll. If an answer is selected with this `nextPoll` property we trigger an event that forces the next poll to be loaded and shown immediately.

Therefore each poll is still independent and treated in isolation, but a poll can trigger another poll to load. The benefit of this is we can do minimal work to change how votes are collected and minimal UI work.

In order to support this feature some minor schema changes have been made.
- Add `nextPoll` property to the answer that accepts a stringID.
- Add `hidden` property that allows working on a poll without it being made live immediately after saving. This has two users. To hide polls during creation, and to keep polls that are used within the multi poll setup hidden. (Hidden polls can still be directly accessed, they just won't be automatically shown to the user on the campaign map).
- Add some additional verification to the poll editor to ensure the `nextPoll` is a valid poll to improve editor experience and prevent mistakes.

# How has this been tested

Manually with local environment & database.

### Tested the following user facing cases

- Having a poll with 3 answers. Each answer links either to a different poll or is the end of the poll.
- User selects an answer with a `nextPoll` and then changes mind to an answer without a nextPoll.
- User selects answer without `nextPoll`, and then changes mind to answer with a next poll.
- User changes mind between answers with nextPolls.
- User closes the modal. Returns and changes mind.

### Tested the following editor facing cases

- Hiding a poll.
- Creating a poll and making sure it is initialized with hidden = true.
- Trying to save a poll with an invalid nextPoll id.
- Trying to save a poll when an answer refers the nextPoll to itself.

# Screenshots of gifs

Shows behavior of going from poll 1 -> poll2
![e19b83230cf79bed47565d9b8903a7ab](https://user-images.githubusercontent.com/15080861/77810659-dcaa5100-7052-11ea-8f12-258d725ea0ba.gif)

This is the same poll 1, but the second answer navigates to its own poll.
![c1a47699e946cb125a47ffbf482df6c1](https://user-images.githubusercontent.com/15080861/77810664-e03dd800-7052-11ea-9290-b1b342490adb.gif)

The third answer in poll 1 is a dead end and concludes the poll.
![df7ac26436019d41a92a84f2bbeea7fc](https://user-images.githubusercontent.com/15080861/77810665-e338c880-7052-11ea-91d8-ca083c8ecb45.gif)

If a user navigates through some of the multi stage poll, we save the progress if the modal is closed. However if the user navigates off the page this information is lost.
![14f3a998f88b0681b3a71cb680be2f71](https://user-images.githubusercontent.com/15080861/77810668-e59b2280-7052-11ea-94f0-c97899391fbb.gif)


### Error handling in poll editor

Accidentally referencing the same poll:
![c962b8e9716f9b30f3033080471f7b0f](https://user-images.githubusercontent.com/15080861/77964228-955ed300-7293-11ea-80cc-fbe4d6fe3f28.gif)

Referencing a non existant poll:
![4702b487c1363212944c3735c2b9bcd1](https://user-images.githubusercontent.com/15080861/77964344-bb847300-7293-11ea-8d33-5c681290c5ac.gif)


