### PR TITLE
Disable drift targeting for students and on /play/ pages

### DIFF
--- a/app/core/application.coffee
+++ b/app/core/application.coffee
@@ -55,6 +55,11 @@ Application = {
 
     # propagate changes from global 'me' User to 'me' vuex module
     store = require('core/store')
+
+    routerSync = require('vuex-router-sync')
+    vueRouter = require('app/core/vueRouter').default()
+    routerSync.sync(store, vueRouter)
+
     me.on('change', ->
       store.commit('me/updateUser', me.changedAttributes())
     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -20837,6 +20837,11 @@
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-2.5.0.tgz",
       "integrity": "sha512-5oJPOJySBgSgSzoeO+gZB/BbN/XsapgIF6tz34UwJqnGZMQurzIO3B4KIBf862gfc9ya+oduY5sSkq+5/oOilQ=="
     },
+    "vuex-router-sync": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vuex-router-sync/-/vuex-router-sync-5.0.0.tgz",
+      "integrity": "sha512-Mry2sO4kiAG64714X1CFpTA/shUH1DmkZ26DFDtwoM/yyx6OtMrc+MxrU+7vvbNLO9LSpgwkiJ8W+rlmRtsM+w=="
+    },
     "warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "vue-youtube": "^1.3.5",
     "vuedraggable": "^2.21.0",
     "vuex": "^2.4.0",
+    "vuex-router-sync": "^5.0.0",
     "webpack": "git://github.com/codecombat/webpack.git#webpack-3",
     "webpack-shell-plugin": "^0.5.0",
     "winston": "0.6.x",


### PR DESCRIPTION
Prevents Drift chat from showing in scenarios that we don't want it to.

- Adds a vuex module to sync vue router state to store so we can react to changes to it
- Disables drift targeting on /play/ pages
- Disables drift targeting for all students

Tested locally