### PR TITLE
Integrate lazy chunk loading with Vue router

### DIFF
--- a/app/core/application.coffee
+++ b/app/core/application.coffee
@@ -55,6 +55,11 @@ Application = {
 
     # propagate changes from global 'me' User to 'me' vuex module
     store = require('core/store')
+
+    routerSync = require('vuex-router-sync')
+    vueRouter = require('app/core/vueRouter').default()
+    routerSync.sync(store, vueRouter)
+
     me.on('change', ->
       store.commit('me/updateUser', me.changedAttributes())
     )

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -1,19 +1,5 @@
 import VueRouter from 'vue-router'
 
-import SchoolAdminDashboard from 'app/views/school-administrator/SchoolAdministratorComponent'
-import SchoolAdminDashboardTeacherListView from 'app/views/school-administrator/teachers/SchoolAdminTeacherListView'
-import SchoolAdminTeacherView from 'app/views/school-administrator/dashboard/SchoolAdminDashboardTeacherView'
-
-import TeacherClassView from 'app/views/courses/TeacherClassView.vue'
-import TeacherStudentView from 'app/views/teachers/classes/TeacherStudentView.vue'
-
-import PageCinematicEditor from '../../ozaria/site/components/cinematic/PageCinematicEditor'
-import PageCutsceneEditorList from '../../ozaria/site/components/cutscene/PageCutsceneEditorList'
-import PageCutsceneEditor from '../../ozaria/site/components/cutscene/PageCutsceneEditor'
-import PageInteractiveEditor from '../../ozaria/site/components/interactive/PageInteractiveEditor'
-
-import CinematicPlaceholder from '../../ozaria/site/components/cinematic/CinematicPlaceholder'
-
 let vueRouter
 
 export default function getVueRouter () {
@@ -27,36 +13,36 @@ export default function getVueRouter () {
           // TODO: The cinematic editor route should use vue guards to check for admin access.
           // TODO: Once we have a base editor component, use the nested route structure.
           path: '/editor/cinematic/:slug?',
-          component: PageCinematicEditor,
+          component: () => import(/* webpackChunkName: "editor" */ '../../ozaria/site/components/cinematic/PageCinematicEditor'),
           props: true
         },
         {
           path: '/editor/cutscene',
-          component: PageCutsceneEditorList
+          component: () => import(/* webpackChunkName: "editor" */ '../../ozaria/site/components/cutscene/PageCutsceneEditorList')
         },
         {
           path: '/editor/cutscene/:slugOrId',
-          component: PageCutsceneEditor,
+          component: () => import(/* webpackChunkName: "editor" */ '../../ozaria/site/components/cutscene/PageCutsceneEditor'),
           props: true
         },
         {
           path: '/editor/interactive/:slug?',
-          component: PageInteractiveEditor,
+          component: () => import(/* webpackChunkName: "editor" */ '../../ozaria/site/components/interactive/PageInteractiveEditor'),
           props: true
         },
         {
           path: '/school-administrator',
-          component: SchoolAdminDashboard,
+          component: () => import(/* webpackChunkName: "teachers" */ 'app/views/school-administrator/SchoolAdministratorComponent'),
           children: [
-            { path: '', component: SchoolAdminDashboardTeacherListView },
-            { path: 'teacher/:teacherId', component: SchoolAdminTeacherView },
-            { path: 'teacher/:teacherId/classroom/:classroomId', component: TeacherClassView },
-            { path: 'teacher/:teacherId/classroom/:classroomId/:studentId', component: TeacherStudentView }
+            { path: '', component: () => import(/* webpackChunkName: "teachers" */ 'app/views/school-administrator/teachers/SchoolAdminTeacherListView') },
+            { path: 'teacher/:teacherId', component: () => import(/* webpackChunkName: "teachers" */ 'app/views/school-administrator/dashboard/SchoolAdminDashboardTeacherView') },
+            { path: 'teacher/:teacherId/classroom/:classroomId', component: () => import(/* webpackChunkName: "teachers" */ 'app/views/courses/TeacherClassView.vue') },
+            { path: 'teacher/:teacherId/classroom/:classroomId/:studentId', component: () => import(/* webpackChunkName: "teachers" */ 'app/views/teachers/classes/TeacherStudentView.vue') }
           ]
         },
         {
           path: '/cinematicplaceholder/:levelSlug?',
-          component: CinematicPlaceholder,
+          component: () => import(/* webpackChunkName: "play" */ '../../ozaria/site/components/cinematic/CinematicPlaceholder'),
           props: (route) => {
             return {
               levelSlug: route.params.levelSlug

--- a/package-lock.json
+++ b/package-lock.json
@@ -20837,6 +20837,11 @@
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-2.5.0.tgz",
       "integrity": "sha512-5oJPOJySBgSgSzoeO+gZB/BbN/XsapgIF6tz34UwJqnGZMQurzIO3B4KIBf862gfc9ya+oduY5sSkq+5/oOilQ=="
     },
+    "vuex-router-sync": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vuex-router-sync/-/vuex-router-sync-5.0.0.tgz",
+      "integrity": "sha512-Mry2sO4kiAG64714X1CFpTA/shUH1DmkZ26DFDtwoM/yyx6OtMrc+MxrU+7vvbNLO9LSpgwkiJ8W+rlmRtsM+w=="
+    },
     "warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "vue-youtube": "^1.3.5",
     "vuedraggable": "^2.21.0",
     "vuex": "^2.4.0",
+    "vuex-router-sync": "^5.0.0",
     "webpack": "git://github.com/codecombat/webpack.git#webpack-3",
     "webpack-shell-plugin": "^0.5.0",
     "winston": "0.6.x",


### PR DESCRIPTION
- Integrates lazy chunk loading with Vue router to ensure all views are loaded after application initialization
- Uses the same chunk names from `lib/dynamicRequire`
- Prevents an early load of vue router from loading views that have dependencies on application be initialized

Tested locally and going to deploy to next 