### PR TITLE
Redirect certain poll responses to Live Classes page

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -778,6 +778,11 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     future_eng_4: "Amazon Future Engineer"
     future_eng_5: "program which creates learning and work opportunities for all K-12 students in the United States who wish to pursue computer science."
 
+  live_class:
+    title: "Thank you!"
+    content: "Amazing! We just launched live online classes."
+    link: "Ready to get ahead on your coding?"
+
   play_game_dev_level:
     created_by: "Created by {{name}}"
     created_during_hoc: "Created during Hour of Code"

--- a/app/styles/play/modal/live-classroom-modal.sass
+++ b/app/styles/play/modal/live-classroom-modal.sass
@@ -1,0 +1,64 @@
+@import "app/styles/mixins"
+@import "app/styles/bootstrap/variables"
+
+// Copied almost exactly from the amazon-hoc-modal.
+#live-classroom-modal
+  .modal-dialog
+    margin: 60px auto 0 auto
+    padding: 0
+    width: 746px
+    height: 520px
+    background: none
+    
+  #live-classroom-background
+    position: absolute
+    top: -61px
+    left: 0px
+    
+  h1
+    position: absolute
+    left: 194px
+    top: 29px
+    margin: 0
+    width: 410px
+    text-align: center
+    color: rgb(254,188,68)
+    font-size: 30px
+    text-shadow: black 4px 4px 0, black -4px -4px 0, black 4px -4px 0, black -4px 4px 0, black 4px 0px 0, black 0px -4px 0, black -4px 0px 0, black 0px 4px 0, black 6px 6px 6px
+    font-variant: normal
+    text-transform: uppercase
+    margin-left: -30px
+
+  #close-modal
+    position: absolute
+    left: 568px
+    top: 17px
+    width: 60px
+    height: 60px
+    color: white
+    text-align: center
+    font-size: 30px
+    padding-top: 15px
+    cursor: pointer
+    @include rotate(-3deg)
+
+    &:hover
+      color: yellow
+
+  .paper-area
+    position: absolute
+    top: 114px
+    left: 31px
+    min-height: 370px
+    width: 684px
+    background: #d4c9b1
+    border: 3px solid black
+    display: flex
+    flex-direction: column
+    justify-content: center
+    padding: 20px
+    
+    h3
+      margin-top: 0
+      color: black
+

--- a/app/styles/play/modal/live-classroom-modal.sass
+++ b/app/styles/play/modal/live-classroom-modal.sass
@@ -55,6 +55,7 @@
     border: 3px solid black
     display: flex
     flex-direction: column
+    align-items: center
     justify-content: center
     padding: 20px
     

--- a/app/styles/play/modal/live-classroom-modal.sass
+++ b/app/styles/play/modal/live-classroom-modal.sass
@@ -62,3 +62,7 @@
       margin-top: 0
       color: black
 
+    .btn
+      font-size: 20px
+      margin-top: 40px
+

--- a/app/templates/play/modal/live-classroom-modal.jade
+++ b/app/templates/play/modal/live-classroom-modal.jade
@@ -1,0 +1,15 @@
+.modal-dialog
+  .modal-content
+    img#live-classroom-background(src="/images/pages/play/modal/subscribe-background-blank.png")
+    
+    h1(data-i18n="live_class.title")
+
+    div#close-modal
+      span.glyphicon.glyphicon-remove
+  
+    div.paper-area.text-center
+      h3
+        span(data-i18n="live_class.content")
+
+      h3
+        a#live-codecombat-link(href="https://live.codecombat.com" data-i18n="live_class.link" target="_blank" rel="noopener")

--- a/app/templates/play/modal/live-classroom-modal.jade
+++ b/app/templates/play/modal/live-classroom-modal.jade
@@ -11,5 +11,4 @@
       h3
         span(data-i18n="live_class.content")
 
-      h3
-        a#live-codecombat-link(href="https://live.codecombat.com" data-i18n="live_class.link" target="_blank" rel="noopener")
+      a.btn.btn-primary#live-codecombat-link(href="https://live.codecombat.com" data-i18n="live_class.link" target="_blank" rel="noopener")

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -23,6 +23,7 @@ UserPollsRecord = require 'models/UserPollsRecord'
 Poll = require 'models/Poll'
 PollModal = require 'views/play/modal/PollModal'
 AnnouncementModal = require 'views/play/modal/AnnouncementModal'
+LiveClassroomModal = require 'views/play/modal/LiveClassroomModal'
 codePlay = require('lib/code-play')
 MineModal = require 'views/core/MineModal' # Minecraft modal
 CodePlayCreateAccountModal = require 'views/play/modal/CodePlayCreateAccountModal'
@@ -1280,6 +1281,8 @@ module.exports = class CampaignView extends RootView
       $pollButton.removeClass('highlighted').tooltip 'hide'
     pollModal.once 'trigger-next-poll', (nextPollId) =>
       @loadPoll('/db/poll/' + nextPollId, true)
+    pollModal.once 'trigger-show-live-classes', () =>
+      @openModalView new LiveClassroomModal
 
   onClickPremiumButton: (e) ->
     @openModalView new SubscribeModal()

--- a/app/views/play/modal/LiveClassroomModal.coffee
+++ b/app/views/play/modal/LiveClassroomModal.coffee
@@ -1,0 +1,14 @@
+require('app/styles/play/modal/live-classroom-modal.sass')
+ModalView = require('views/core/ModalView')
+template = require 'templates/play/modal/live-classroom-modal'
+
+module.exports = class LiveClassroomModal extends ModalView
+  template: template
+  id: 'live-classroom-modal'
+
+  events:
+    'click #close-modal': 'hide'
+    'mouseup #live-codecombat-link': 'onClickLiveClassesLink'
+  
+  onClickLiveClassesLink: ->
+    window.tracker?.trackEvent 'Click Live Classes link', label: 'live-classes-link'

--- a/app/views/play/modal/PollModal.coffee
+++ b/app/views/play/modal/PollModal.coffee
@@ -90,7 +90,12 @@ module.exports = class PollModal extends ModalView
         btn.text(i18n.t('common.next'))
         btn.one('click', ()=>
           btn.prop('disabled', true);
-          @trigger('trigger-next-poll', nextPollId)
+
+          # Show live Class Modal
+          if @poll.id is "5e84c7a519cb270028516687"
+            @trigger('trigger-show-live-classes')
+          else
+            @trigger('trigger-next-poll', nextPollId)
         )
       else
         btn.text(i18n.t('play_level.done'))


### PR DESCRIPTION
# Context

Currently we are running a poll to ask if users would like live classroom sessions.
We have set up a page at https://live.codecombat.com that provides much more information.

This change flashes a message to users who opt into wanting to learn more about these live classrooms.

# How

The behavior we want intercepts either poll answer of a specific poll. This change adds a check for the poll being answered, and in the case of the "What kind of Course are you interested in?" poll triggers the live classes modal.

# Risks

There are minimal risks as this is specific to the poll being answered. It shouldn't affect other polls or the campaign view in any way I am aware of. I tested it manually using incognito mode and anonymous users. We've also opted to go with speed > design, so the implementation attempts to be light.

# How to test

Run the local proxy.
Start an incognito window and go to the campaign map: http://localhost:3000/play/dungeon

If there is no poll showing, open the console and run the command: `this.currentView.loadUserPollsRecord()`

This should trigger the poll.
Navigate the poll saying you are interested in live teaching. You should hit the call to action in the second poll modal after the "What kind of Course are you interested in?" poll.


# Gif of flow:
![646315df7fbbcbb1062061fa22372e61 (1)](https://user-images.githubusercontent.com/15080861/81214610-f5c8ea80-8f8c-11ea-8e0a-e7fa3725fb16.gif)

# Final Design
![Screen Shot 2020-05-06 at 1 05 18 PM](https://user-images.githubusercontent.com/15080861/81223402-c8833900-8f9a-11ea-8e9a-afa6280ad4d7.png)
