### PR TITLE
Integrate Full Story

### DIFF
--- a/app/core/Tracker2/BaseTracker.js
+++ b/app/core/Tracker2/BaseTracker.js
@@ -37,7 +37,10 @@ export default class BaseTracker {
 
     this.setupInitialization()
 
-    this.loggineEnabled = (new URLSearchParams(window.location.search)).has(TRACKER_LOGGING_ENABLED_QUERY_PARAM);
+    this.loggingEnabled = false
+    try {
+      this.loggingEnabled = (new URLSearchParams(window.location.search)).has(TRACKER_LOGGING_ENABLED_QUERY_PARAM)
+    } catch (e) {}
   }
 
   async identify (traits = {}) {}
@@ -135,7 +138,7 @@ export default class BaseTracker {
   }
 
   log (...args) {
-    if (!this.loggineEnabled) {
+    if (!this.loggingEnabled) {
       return
     }
 

--- a/app/core/Tracker2/BaseTracker.js
+++ b/app/core/Tracker2/BaseTracker.js
@@ -1,3 +1,20 @@
+export const DEFAULT_USER_TRAITS_TO_REPORT = [
+  'email', 'anonymous', 'dateCreated', 'hourOfCode', 'name', 'referrer', 'testGroupNumber', 'testGroupNumberUS',
+  'gender', 'lastLevel', 'siteref', 'ageRange', 'schoolName', 'coursePrepaidID', 'role', 'firstName', 'lastName',
+  'dateCreated'
+]
+
+export function extractDefaultUserTraits(me) {
+  return DEFAULT_USER_TRAITS_TO_REPORT.reduce((obj, key) => {
+    const meAttr = me[key]
+    if (typeof meAttr !== 'undefined' && meAttr !== null) {
+      obj[key] = meAttr
+    }
+
+    return obj;
+  }, {})
+}
+
 /**
  * A baseline tracker that:
  *   1. Defines a standard initialization flow for all trackers

--- a/app/core/Tracker2/BaseTracker.js
+++ b/app/core/Tracker2/BaseTracker.js
@@ -1,3 +1,5 @@
+export const TRACKER_LOGGING_ENABLED_QUERY_PARAM = 'tracker_logging';
+
 export const DEFAULT_USER_TRAITS_TO_REPORT = [
   'email', 'anonymous', 'dateCreated', 'hourOfCode', 'name', 'referrer', 'testGroupNumber', 'testGroupNumberUS',
   'gender', 'lastLevel', 'siteref', 'ageRange', 'schoolName', 'coursePrepaidID', 'role', 'firstName', 'lastName',
@@ -34,6 +36,8 @@ export default class BaseTracker {
     this.initialized = false
 
     this.setupInitialization()
+
+    this.loggineEnabled = (new URLSearchParams(window.location.search)).has(TRACKER_LOGGING_ENABLED_QUERY_PARAM);
   }
 
   async identify (traits = {}) {}
@@ -128,5 +132,13 @@ export default class BaseTracker {
         finishInitialization(false)
       }
     })
+  }
+
+  log (...args) {
+    if (!this.loggineEnabled) {
+      return
+    }
+
+    console.info(`[tracker] [${this.constructor.name}]`, ...args)
   }
 }

--- a/app/core/Tracker2/FullStoryTracker.js
+++ b/app/core/Tracker2/FullStoryTracker.js
@@ -1,6 +1,7 @@
 import BaseTracker, { extractDefaultUserTraits } from './BaseTracker'
 
 const FULLSTORY_SESSION_TRACKING_ENALBED_KEY = 'coco.tracker.fullstory.enabled'
+const FULLSTORY_ENABLE_QUERY_PARAM = 'fullstory_enable'
 
 export function loadFullStory() {
   /* eslint-disable */
@@ -40,8 +41,11 @@ export default class ProofTracker extends BaseTracker {
   }
 
   async _initializeTracker () {
+    this.watchForDisableAllTrackingChanges(this.store)
+
+    // TODO handle disable all tracking
     window['_fs_ready'] = () => {
-      if ((new URLSearchParams(window.location.search)).has('fullstory_enable')) {
+      if ((new URLSearchParams(window.location.search)).has(FULLSTORY_ENABLE_QUERY_PARAM)) {
         this.enabled = true
       } else if (!this.enableDecisionMade) {
         this.enabled = this.decideEnabled()
@@ -90,7 +94,7 @@ export default class ProofTracker extends BaseTracker {
   async identify (traits = {}) {
     await this.initializationComplete
 
-    if (!this.enabled) {
+    if (!this.enabled || this.disableAllTracking) {
       return
     }
 
@@ -107,7 +111,7 @@ export default class ProofTracker extends BaseTracker {
   async trackPageView (includeIntegrations = []) {
     await this.initializationComplete
 
-    if (!this.enabled) {
+    if (!this.enabled || this.disableAllTracking) {
       return
     }
 
@@ -118,7 +122,7 @@ export default class ProofTracker extends BaseTracker {
   async trackEvent (action, properties = {}) {
     await this.initializationComplete
 
-    if (!this.enabled) {
+    if (!this.enabled || this.disableAllTracking) {
       return
     }
 
@@ -128,7 +132,7 @@ export default class ProofTracker extends BaseTracker {
   async resetIdentity () {
     await this.initializationComplete
 
-    if (!this.enabled) {
+    if (!this.enabled || this.disableAllTracking) {
       return
     }
 

--- a/app/core/Tracker2/FullStoryTracker.js
+++ b/app/core/Tracker2/FullStoryTracker.js
@@ -1,4 +1,4 @@
-import BaseTracker from './BaseTracker'
+import BaseTracker, { extractDefaultUserTraits } from './BaseTracker'
 
 const FULLSTORY_SESSION_TRACKING_ENALBED_KEY = 'coco.tracker.fullstory.enabled'
 
@@ -101,8 +101,7 @@ export default class ProofTracker extends BaseTracker {
     //      maybe when a user logs in we reset the recording decision logic?
     FS.identify(me._id)
 
-    // TODO determine what traits we want to send for all user types
-    FS.setUserVars({})
+    FS.setUserVars(extractDefaultUserTraits(me))
   }
 
   async trackPageView (includeIntegrations = []) {

--- a/app/core/Tracker2/FullStoryTracker.js
+++ b/app/core/Tracker2/FullStoryTracker.js
@@ -29,11 +29,12 @@ export function loadFullStory() {
   })(window,document,window['_fs_namespace'],'script','user');
 }
 
-export default class ProofTracker extends BaseTracker {
-  constructor (store) {
+export default class FullstoryTracker extends BaseTracker {
+  constructor (store, globalTracker) {
     super()
 
     this.store = store
+    this.globalTracker = globalTracker
 
     const sessionEnabled = window.sessionStorage.getItem(FULLSTORY_SESSION_TRACKING_ENALBED_KEY)
     this.enableDecisionMade = (sessionEnabled !== null)
@@ -49,6 +50,9 @@ export default class ProofTracker extends BaseTracker {
         this.enabled = true
       } else if (!this.enableDecisionMade) {
         this.enabled = this.decideEnabled()
+        if (this.enabled) {
+          this.globalTracker.trackEvent('FullStory Tracking Enabled')
+        }
       }
 
       if (this.enabled) {
@@ -82,9 +86,9 @@ export default class ProofTracker extends BaseTracker {
 
     const { me } = this.store.state
 
-    if (me.anonymous && Math.random() < 0.5) {
+    if (me.anonymous && Math.random() < 0.02) {
       return true
-    } else if (this.store.getters['me/isTeacher'] && !this.store.getters['me/isParent'] && Math.random() < 0.5) {
+    } else if (this.store.getters['me/isTeacher'] && !this.store.getters['me/isParent'] && Math.random() < 0.02) {
       return true
     }
 

--- a/app/core/Tracker2/FullStoryTracker.js
+++ b/app/core/Tracker2/FullStoryTracker.js
@@ -41,11 +41,11 @@ export default class ProofTracker extends BaseTracker {
 
   async _initializeTracker () {
     window['_fs_ready'] = () => {
-      if (!this.enableDecisionMade) {
+      if ((new URLSearchParams(window.location.search)).has('fullstory_enable')) {
+        this.enabled = true
+      } else if (!this.enableDecisionMade) {
         this.enabled = this.decideEnabled()
       }
-
-      this.enabled = true
 
       if (this.enabled) {
         this.enable()
@@ -79,14 +79,11 @@ export default class ProofTracker extends BaseTracker {
     const { me } = this.store.state
 
     if (me.anonymous && Math.random() < 0.5) {
-      console.log('anon enable')
       return true
     } else if (this.store.getters['me/isTeacher'] && !this.store.getters['me/isParent'] && Math.random() < 0.5) {
-      console.log('teacher enable')
       return true
     }
 
-    console.log(disable)
     return false
   }
 

--- a/app/core/Tracker2/FullStoryTracker.js
+++ b/app/core/Tracker2/FullStoryTracker.js
@@ -1,0 +1,141 @@
+import BaseTracker from './BaseTracker'
+
+const FULLSTORY_SESSION_TRACKING_ENALBED_KEY = 'coco.tracker.fullstory.enabled'
+
+export function loadFullStory() {
+  /* eslint-disable */
+
+  window['_fs_debug'] = false;
+  window['_fs_host'] = 'fullstory.com';
+  window['_fs_script'] = 'edge.fullstory.com/s/fs.js';
+  window['_fs_org'] = 'RQW5S';
+  window['_fs_namespace'] = 'FS';
+  (function(m,n,e,t,l,o,g,y){
+    if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
+    g=m[e]=function(a,b,s){g.q?g.q.push([a,b,s]):g._api(a,b,s);};g.q=[];
+    o=n.createElement(t);o.async=1;o.crossOrigin='anonymous';o.src='https://'+_fs_script;
+    y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
+    g.identify=function(i,v,s){g(l,{uid:i},s);if(v)g(l,v,s)};g.setUserVars=function(v,s){g(l,v,s)};g.event=function(i,v,s){g('event',{n:i,p:v},s)};
+    g.anonymize=function(){g.identify(!!0)};
+    g.shutdown=function(){g("rec",!1)};g.restart=function(){g("rec",!0)};
+    g.log = function(a,b){g("log",[a,b])};
+    g.consent=function(a){g("consent",!arguments.length||a)};
+    g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
+    g.clearUserCookie=function(){};
+    g._w={};y='XMLHttpRequest';g._w[y]=m[y];y='fetch';g._w[y]=m[y];
+    if(m[y])m[y]=function(){return g._w[y].apply(this,arguments)};
+    g._v="1.2.0";
+  })(window,document,window['_fs_namespace'],'script','user');
+}
+
+export default class ProofTracker extends BaseTracker {
+  constructor (store) {
+    super()
+
+    this.store = store
+
+    const sessionEnabled = window.sessionStorage.getItem(FULLSTORY_SESSION_TRACKING_ENALBED_KEY)
+    this.enableDecisionMade = (sessionEnabled !== null)
+    this.enabled = (sessionEnabled === true)
+  }
+
+  async _initializeTracker () {
+    window['_fs_ready'] = () => {
+      if (!this.enableDecisionMade) {
+        this.enabled = this.decideEnabled()
+      }
+
+      this.enabled = true
+
+      if (this.enabled) {
+        this.enable()
+      } else {
+        this.disable()
+      }
+
+      this.onInitializeSuccess()
+    }
+
+    loadFullStory()
+  }
+
+  enable () {
+    this.enabled = true
+    window.sessionStorage.setItem(FULLSTORY_SESSION_TRACKING_ENALBED_KEY, 'true')
+    FS.restart()
+  }
+
+  disable () {
+    this.enabled = false
+    window.sessionStorage.setItem(FULLSTORY_SESSION_TRACKING_ENALBED_KEY, 'false')
+    FS.shutdown()
+  }
+
+  decideEnabled () {
+    if (this.enabled) {
+      return true
+    }
+
+    const { me } = this.store.state
+
+    if (me.anonymous && Math.random() < 0.5) {
+      console.log('anon enable')
+      return true
+    } else if (this.store.getters['me/isTeacher'] && !this.store.getters['me/isParent'] && Math.random() < 0.5) {
+      console.log('teacher enable')
+      return true
+    }
+
+    console.log(disable)
+    return false
+  }
+
+  async identify (traits = {}) {
+    await this.initializationComplete
+
+    if (!this.enabled) {
+      return
+    }
+
+    const { me } = this.store.state
+
+    // TODO when a user transitions from anon to logged in we'll end up recording two different sessions
+    //      is this ok? using window.session to enable full story doesn't make sense in this case?
+    //      maybe when a user logs in we reset the recording decision logic?
+    FS.identify(me._id)
+
+    // TODO determine what traits we want to send for all user types
+    FS.setUserVars({})
+  }
+
+  async trackPageView (includeIntegrations = []) {
+    await this.initializationComplete
+
+    if (!this.enabled) {
+      return
+    }
+
+    const url = `/${Backbone.history.getFragment()}`
+    FS.event('page', { url })
+  }
+
+  async trackEvent (action, properties = {}) {
+    await this.initializationComplete
+
+    if (!this.enabled) {
+      return
+    }
+
+    FS.event(action, properties)
+  }
+
+  async resetIdentity () {
+    await this.initializationComplete
+
+    if (!this.enabled) {
+      return
+    }
+
+    FS.anonymize()
+  }
+}

--- a/app/core/Tracker2/FullStoryTracker.js
+++ b/app/core/Tracker2/FullStoryTracker.js
@@ -50,9 +50,14 @@ export default class FullstoryTracker extends BaseTracker {
 
     // TODO handle disable all tracking
     window['_fs_ready'] = () => {
+      let hasFullstoryEnableQueryParam = false
+      try {
+        hasFullstoryEnableQueryParam = (new URLSearchParams(window.location.search)).has(FULLSTORY_ENABLE_QUERY_PARAM)
+      } catch (e) {}
+
       try {
         this.log('ready')
-        if ((new URLSearchParams(window.location.search)).has(FULLSTORY_ENABLE_QUERY_PARAM)) {
+        if (hasFullstoryEnableQueryParam) {
           this.enabled = true
           this.log('query param force enable')
         } else if (!this.enableDecisionMade) {
@@ -101,7 +106,7 @@ export default class FullstoryTracker extends BaseTracker {
     if (this.disableAllTracking) {
       this.log('decide enabled', 'disable all tracking')
       return false
-    } else if (me.anonymous && Math.random() < 0.02) {
+    } else if (me.anonymous && Math.random() < 0.0025) {
       this.log('decide enabled', 'anon user')
       return true
     } else if (this.store.getters['me/isTeacher'] && !this.store.getters['me/isParent'] && Math.random() < 0.02) {

--- a/app/core/Tracker2/ProofTracker.js
+++ b/app/core/Tracker2/ProofTracker.js
@@ -1,4 +1,4 @@
-import BaseTracker from './BaseTracker'
+import BaseTracker, { extractDefaultUserTraits } from './BaseTracker'
 
 export function loadProof () {
   /* eslint-disable */
@@ -47,8 +47,7 @@ export default class ProofTracker extends BaseTracker {
 
     const { me } = this.store.state
 
-    // TODO determine what traits we want to send for all user types
-    proofx.identify(me._id)
+    proofx.identify(me._id, extractDefaultUserTraits(me))
   }
 
   async trackPageView (includeIntegrations = []) {

--- a/app/core/Tracker2/ProofTracker.js
+++ b/app/core/Tracker2/ProofTracker.js
@@ -30,6 +30,8 @@ export default class ProofTracker extends BaseTracker {
   }
 
   async _initializeTracker () {
+    this.watchForDisableAllTrackingChanges(this.store)
+
     if (!this.enabled) {
       return this.onInitializeSuccess()
     }
@@ -41,7 +43,7 @@ export default class ProofTracker extends BaseTracker {
   async identify (traits = {}) {
     await this.initializationComplete
 
-    if (!this.enabled) {
+    if (!this.enabled || this.disableAllTracking) {
       return
     }
 
@@ -53,7 +55,7 @@ export default class ProofTracker extends BaseTracker {
   async trackPageView (includeIntegrations = []) {
     await this.initializationComplete
 
-    if (!this.enabled) {
+    if (!this.enabled || this.disableAllTracking) {
       return
     }
 
@@ -63,7 +65,7 @@ export default class ProofTracker extends BaseTracker {
   async trackEvent (action, properties = {}) {
     await this.initializationComplete
 
-    if (!this.enabled) {
+    if (!this.enabled || this.disableAllTracking) {
       return
     }
 
@@ -73,7 +75,7 @@ export default class ProofTracker extends BaseTracker {
   async resetIdentity () {
     await this.initializationComplete
 
-    if (!this.enabled) {
+    if (!this.enabled || this.disableAllTracking) {
       return
     }
 

--- a/app/core/Tracker2/SegmentTracker.js
+++ b/app/core/Tracker2/SegmentTracker.js
@@ -1,4 +1,4 @@
-import BaseTracker from './BaseTracker'
+import BaseTracker, { DEFAULT_USER_TRAITS_TO_REPORT, extractDefaultUserTraits } from './BaseTracker'
 
 // Copied from Segment analytics-js getting started guide at:
 // https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/
@@ -99,12 +99,6 @@ const DEFAULT_SEGMENT_OPTIONS = {
   Intercom: { hideDefaultLauncher: true }
 }
 
-const DEFAULT_SEGMENT_TRAITS_TO_REPORT = [
-  'email', 'anonymous', 'dateCreated', 'hourOfCode', 'name', 'referrer', 'testGroupNumber', 'testGroupNumberUS',
-  'gender', 'lastLevel', 'siteref', 'ageRange', 'schoolName', 'coursePrepaidID', 'role', 'firstName', 'lastName',
-  'dateCreated'
-]
-
 export default class SegmentTracker extends BaseTracker {
   constructor (store) {
     super()
@@ -159,14 +153,7 @@ export default class SegmentTracker extends BaseTracker {
       ...meAttrs
     } = me
 
-    const filteredMeAttributes = DEFAULT_SEGMENT_TRAITS_TO_REPORT.reduce((obj, key) => {
-      const meAttr = meAttrs[key]
-      if (typeof meAttr !== 'undefined' && meAttr !== null) {
-        obj[key] = meAttr
-      }
-
-      return obj;
-    }, {})
+    const filteredMeAttributes = extractDefaultUserTraits(me)
 
     const options = { ...DEFAULT_SEGMENT_OPTIONS }
     return new Promise((resolve) => {

--- a/app/core/Tracker2/index.js
+++ b/app/core/Tracker2/index.js
@@ -5,6 +5,7 @@ import BaseTracker from './BaseTracker'
 import GoogleAnalyticsTracker from './GoogleAnalyticsTracker'
 import DriftTracker from './DriftTracker'
 import ProofTracker from './ProofTracker'
+import FullStoryTracker from './FullStoryTracker'
 
 const SESSION_STORAGE_IDENTIFIED_AT_SESSION_START_KEY = 'coco.tracker.identifiedAtSessionStart'
 const SESSION_STORAGE_IDENTIFY_ON_NEXT_PAGE_LOAD = 'coco.tracker.identifyOnNextPageLoad'
@@ -26,13 +27,15 @@ export default class Tracker2 extends BaseTracker {
     // this.googleAnalyticsTracker = new GoogleAnalyticsTracker()
     this.driftTracker = new DriftTracker(this.store)
     this.proofTracker = new ProofTracker(this.store)
+    this.fullStoryTracker = new FullStoryTracker(this.store)
 
     this.trackers = [
       this.legacyTracker,
       // this.googleAnalyticsTracker,
       this.driftTracker,
       this.segmentTracker,
-      this.proofTracker
+      this.proofTracker,
+      this.fullStoryTracker
     ]
   }
 

--- a/app/core/Tracker2/index.js
+++ b/app/core/Tracker2/index.js
@@ -27,7 +27,7 @@ export default class Tracker2 extends BaseTracker {
     // this.googleAnalyticsTracker = new GoogleAnalyticsTracker()
     this.driftTracker = new DriftTracker(this.store)
     this.proofTracker = new ProofTracker(this.store)
-    this.fullStoryTracker = new FullStoryTracker(this.store)
+    this.fullStoryTracker = new FullStoryTracker(this.store, this)
 
     this.trackers = [
       this.legacyTracker,

--- a/app/core/store/modules/me.js
+++ b/app/core/store/modules/me.js
@@ -20,6 +20,10 @@ export default {
       return (state != null ? state.role : undefined) === 'teacher'
     },
 
+    isParent (state) {
+      return (state != null ? state.role : undefined) === 'parent'
+    },
+
     forumLink (state) {
       let link = 'http://discourse.codecombat.com/'
       const lang = (state.preferredLanguage || 'en-US').split('-')[0]

--- a/app/core/store/modules/tracker.js
+++ b/app/core/store/modules/tracker.js
@@ -4,6 +4,12 @@ const DEFAULT_TRACKING_DOMAINS = [
 
 const COCO_ENABLE_TRACKING_OVERRIDE_QUERY_PARAM = 'coco_tracking'
 
+let hasTrackingOverrideQueryParameter = false
+try {
+  hasTrackingOverrideQueryParameter = (new URLSearchParams(window.location.search))
+    .has(COCO_ENABLE_TRACKING_OVERRIDE_QUERY_PARAM)
+} catch (e) {}
+
 export default {
   namespaced: true,
 
@@ -12,8 +18,7 @@ export default {
     spying: window.serverSession && typeof window.serverSession.amActually !== 'undefined',
     trackingEnabledForEnvironment: DEFAULT_TRACKING_DOMAINS.includes(window.location.hostname),
 
-    enableTrackingOverride: (new URLSearchParams(window.location.search))
-      .has(COCO_ENABLE_TRACKING_OVERRIDE_QUERY_PARAM),
+    enableTrackingOverride: hasTrackingOverrideQueryParameter,
 
     cookieConsent: {
       answered: false,

--- a/app/core/store/modules/tracker.js
+++ b/app/core/store/modules/tracker.js
@@ -1,9 +1,19 @@
+const DEFAULT_TRACKING_DOMAINS = [
+  'codecombat.com'
+];
+
+const COCO_ENABLE_TRACKING_OVERRIDE_QUERY_PARAM = 'coco_tracking'
+
 export default {
   namespaced: true,
 
   state: {
     doNotTrack: window.navigator && window.navigator.doNotTrack === "1",
     spying: window.serverSession && typeof window.serverSession.amActually !== 'undefined',
+    trackingEnabledForEnvironment: DEFAULT_TRACKING_DOMAINS.includes(window.location.hostname),
+
+    enableTrackingOverride: (new URLSearchParams(window.location.search))
+      .has(COCO_ENABLE_TRACKING_OVERRIDE_QUERY_PARAM),
 
     cookieConsent: {
       answered: false,
@@ -20,7 +30,12 @@ export default {
 
   getters: {
     disableAllTracking (state, getters, rootState, rootGetters) {
-      return state.cookieConsent.declined || state.doNotTrack || rootGetters['me/isSmokeTestUser'] || state.spying
+      if (state.enableTrackingOverride) {
+        return false;
+      }
+
+      return state.cookieConsent.declined || state.doNotTrack || rootGetters['me/isSmokeTestUser'] || state.spying ||
+        !state.trackingEnabledForEnvironment
     }
   },
 


### PR DESCRIPTION
- Integrates FullStory session tracking
- Enables for entire session of a user at the beginning of a session by looking at the user type and randomly selecting a percentage of users based on that user type

TODO: 
- [x] Change full story enable / disable status in response to user changes
- [x] Tune percentages for enabling by user type
- [x] Send full story enabled event?
- [x] Integrate with do not track
- [x] Send user attributes to full story
- [x] Only enable on production
