### PR TITLE
Parents page v2

### DIFF
--- a/app/collections/Products.coffee
+++ b/app/collections/Products.coffee
@@ -2,6 +2,9 @@ CocoCollection = require './CocoCollection'
 Product = require 'models/Product'
 utils = require 'core/utils'
 
+# This collection is also used by the Vuex products module, ideally we would
+# transfer the logic in this collection to the Vuex module but we're not doing
+# active work on this product so leaving as is for now.
 module.exports = class Products extends CocoCollection
   model: Product
   url: '/db/products'

--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -138,9 +138,6 @@ module.exports = class CocoRouter extends Backbone.Router
     'editor/article': go('editor/article/ArticleSearchView')
     'editor/article/preview': go('editor/article/ArticlePreviewView')
     'editor/article/:articleID': go('editor/article/ArticleEditView')
-    'editor/cinematic(/*subpath)': go('core/SingletonAppVueComponentView')
-    'editor/cutscene(/*subpath)': go('core/SingletonAppVueComponentView')
-    'editor/interactive(/*subpath)': go('core/SingletonAppVueComponentView')
     'editor/level': go('editor/level/LevelSearchView')
     'editor/level/:levelID': go('editor/level/LevelEditView')
     'editor/thang': go('editor/thang/ThangTypeSearchView')
@@ -212,6 +209,7 @@ module.exports = class CocoRouter extends Backbone.Router
       @routeDirectly('ozaria/site/avatarSelector', [], { vueRoute: true, baseTemplate: 'base-empty' })
 
     'parents': go('ParentsView')
+    'parents-v2': go('core/SingletonAppVueComponentView')
 
     'paypal/subscribe-callback': go('play/CampaignView')
     'paypal/cancel-callback': go('account/SubscriptionView')
@@ -230,27 +228,6 @@ module.exports = class CocoRouter extends Backbone.Router
       @navigate("play/web-dev-level/#{sessionID}?#{queryString}", { trigger: true, replace: true })
     'play/spectate/:levelID': go('play/SpectateView')
     'play/:map': go('play/CampaignView')
-
-    # Adding this route to test interactives until we have the intro levels implemented
-    # TODO: remove this route when intro level is ready to test the interactives.
-    'interactive/:interactiveIdOrSlug(?code-language=:codeLanguage)': (interactiveIdOrSlug, codeLanguage) ->
-      props = {
-        interactiveIdOrSlug: interactiveIdOrSlug,
-        codeLanguage: codeLanguage # This will also come from intro level page later
-      }
-      @routeDirectly('interactive', [], {vueRoute: true, baseTemplate: 'base-empty', propsData: props})
-
-    'cinematic/:cinematicIdOrSlug': (cinematicIdOrSlug) ->
-      props = {
-        cinematicIdOrSlug: cinematicIdOrSlug,
-      }
-      @routeDirectly('cinematic', [], {vueRoute: true, baseTemplate: 'base-empty', propsData: props})
-
-    'cutscene/:cutsceneId': (cutsceneId) ->
-      props = {
-        cutsceneId: cutsceneId,
-      }
-      @routeDirectly('cutscene', [], { vueRoute: true, baseTemplate: 'base-empty', propsData: props })
 
     'premium': go('PremiumFeaturesView', { redirectStudents: true, redirectTeachers: true })
     'Premium': go('PremiumFeaturesView', { redirectStudents: true, redirectTeachers: true })

--- a/app/core/store/index.coffee
+++ b/app/core/store/index.coffee
@@ -37,6 +37,7 @@ store = new Vuex.Store({
     layoutChrome: require('./modules/layoutChrome').default
     unitMap: require('./modules/unitMap').default
     tracker: require('./modules/tracker').default
+    products: require('./modules/products').default
   }
 })
 

--- a/app/core/store/modules/products.js
+++ b/app/core/store/modules/products.js
@@ -1,0 +1,63 @@
+import Products from 'app/collections/Products'
+
+/**
+ * This module acts as a simple proxy to the Products collection.  Ideally we'd move the products
+ * logic to this module but for now it allows the products module to be called via Vue components.
+ */
+export default {
+  namespaced: true,
+
+  state: {
+    loading: {
+      products: false
+    },
+
+    products: []
+  },
+
+  mutations: {
+    toggleLoadingProducts: (state) => {
+      state.loading.products = !state.loading.products
+    },
+
+    addProducts (state, { products }) {
+      state.products = products
+    }
+  },
+
+  actions: {
+    loadProducts ({ commit }) {
+      commit('toggleLoadingProducts')
+
+      return new Products()
+        .fetch()
+        .done(products => commit('addProducts', { products }))
+        .fail(() => noty({ text: 'Failed to load product pricing', type: 'error' }))
+        .always(() => commit('toggleLoadingProducts'))
+    }
+  },
+
+  getters: {
+    basicSubscriptionForCurrentUser (state) {
+      if (!Array.isArray(state.products) || state.products.length === 0) {
+        return undefined
+      }
+
+      const productsCollection = new Products()
+      productsCollection.add(state.products)
+
+      return productsCollection.getBasicSubscriptionForUser(window.me).toJSON()
+    },
+
+    lifetimeSubscriptionForCurrentUser (state) {
+      if (!Array.isArray(state.products) || state.products.length === 0) {
+        return undefined
+      }
+
+      const productsCollection = new Products()
+      productsCollection.add(state.products)
+
+      return productsCollection.getLifetimeSubscriptionForUser(window.me).toJSON()
+    }
+  }
+}

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -10,25 +10,8 @@ export default function getVueRouter () {
 
       routes: [
         {
-          // TODO: The cinematic editor route should use vue guards to check for admin access.
-          // TODO: Once we have a base editor component, use the nested route structure.
-          path: '/editor/cinematic/:slug?',
-          component: () => import(/* webpackChunkName: "editor" */ '../../ozaria/site/components/cinematic/PageCinematicEditor'),
-          props: true
-        },
-        {
-          path: '/editor/cutscene',
-          component: () => import(/* webpackChunkName: "editor" */ '../../ozaria/site/components/cutscene/PageCutsceneEditorList')
-        },
-        {
-          path: '/editor/cutscene/:slugOrId',
-          component: () => import(/* webpackChunkName: "editor" */ '../../ozaria/site/components/cutscene/PageCutsceneEditor'),
-          props: true
-        },
-        {
-          path: '/editor/interactive/:slug?',
-          component: () => import(/* webpackChunkName: "editor" */ '../../ozaria/site/components/interactive/PageInteractiveEditor'),
-          props: true
+          path: '/parents-v2',
+          component: () => import(/* webpackChunkName: "ParentsView" */ 'app/views/PageParents')
         },
         {
           path: '/school-administrator',
@@ -39,15 +22,6 @@ export default function getVueRouter () {
             { path: 'teacher/:teacherId/classroom/:classroomId', component: () => import(/* webpackChunkName: "teachers" */ 'app/views/courses/TeacherClassView.vue') },
             { path: 'teacher/:teacherId/classroom/:classroomId/:studentId', component: () => import(/* webpackChunkName: "teachers" */ 'app/views/teachers/classes/TeacherStudentView.vue') }
           ]
-        },
-        {
-          path: '/cinematicplaceholder/:levelSlug?',
-          component: () => import(/* webpackChunkName: "play" */ '../../ozaria/site/components/cinematic/CinematicPlaceholder'),
-          props: (route) => {
-            return {
-              levelSlug: route.params.levelSlug
-            }
-          }
         }
       ]
     })

--- a/app/views/PageParents.vue
+++ b/app/views/PageParents.vue
@@ -1,0 +1,79 @@
+<template>
+    <div>
+        <button @click="subscribeModalOpen = true">Subscribe to Premium</button>
+        <button @click="openDriftWelcomeCallPlaybook">Small Group Classes</button>
+        <button @click="openDriftWelcomeCallPlaybook">Private Lessons</button>
+        <backbone-modal-harness :modal-view="SubscribeModal" :open="subscribeModalOpen" @close="subscribeModalClosed" />
+
+        <p />
+
+        Products Loading: {{ productsLoading }}
+        <div v-if="!productsLoading && basicSubscriptionForCurrentUser">
+            Basic subscription: {{ basicSubscriptionForCurrentUser.amount / 100 }}
+        </div>
+        <div v-if="!productsLoading && lifetimeSubscriptionForCurrentUser">
+            Lifetime subscription: {{ lifetimeSubscriptionForCurrentUser.amount / 100 }}
+        </div>
+
+        <p />
+        <iframe
+          width="560"
+          height="315"
+          src="https://www.youtube.com/embed/rOXRBQIXvlI?modestBranding=1&rel=0"
+          frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>
+    </div>
+</template>
+
+<script>
+  import { mapActions, mapState, mapGetters } from 'vuex'
+
+  import SubscribeModal from 'views/core/SubscribeModal'
+  import BackboneModalHarness from './common/BackboneModalHarness'
+
+  export default {
+    inject: ['openLegacyModal'],
+
+    components: {
+      BackboneModalHarness,
+    },
+
+    data: () => ({
+      SubscribeModal,
+      subscribeModalOpen: false
+    }),
+
+    computed: {
+      ...mapState('products', {
+        productsLoading: (s) => s.loading.products,
+      }),
+
+      ...mapGetters('products', [
+        'basicSubscriptionForCurrentUser',
+        'lifetimeSubscriptionForCurrentUser'
+      ])
+    },
+
+    methods: {
+      openDriftWelcomeCallPlaybook () {
+        window.drift.api.startInteraction({ interactionId: 161673 });
+      },
+
+      subscribeModalClosed() {
+        this.subscribeModalOpen = false
+      },
+
+      ...mapActions({
+        loadProducts: 'products/loadProducts'
+      })
+    },
+
+    mounted () {
+      this.loadProducts()
+    }
+  }
+</script>
+
+<style>
+</style>

--- a/app/views/common/BackboneModalHarness.vue
+++ b/app/views/common/BackboneModalHarness.vue
@@ -1,0 +1,144 @@
+<template>
+    <div></div>
+</template>
+
+<script>
+  /**
+   * Note a known limitation of this harness is that it does not support swapping out the following props
+   * after initial render:
+   *   - modalView
+   *   - modalOptions
+   *   - modalArgs
+   *
+   * In order to change these you must unmount and remount the component.
+   */
+  export default {
+    inject: ['openLegacyModal', 'legacyModalClosed'],
+
+    props: {
+      modalView: Function,
+
+      modalOptions: {
+        type: Object,
+        default: () => ({}),
+      },
+
+      modalArgs: {
+        type: Array,
+        default: () => ([]),
+      },
+
+      open: {
+        type: Boolean,
+        default: true
+      }
+    },
+
+    data: function () {
+      return {
+        modalLoading: false,
+        modalLoadingProgress: 0,
+
+        modalViewInstance: undefined
+      }
+    },
+
+    methods: {
+      loadModal () {
+        if (this.modalViewInstance) {
+          return
+        }
+
+        this.modalViewInstance = new this.$props.modalView(
+          this.$props.modalOptions,
+          ...this.$props.modalArgs,
+        )
+
+        this.modalViewInstance.on('loading:show', this.showLoadingEvent)
+        this.modalViewInstance.on('loading:hide', this.hideLoadingEvent)
+        this.modalViewInstance.on('loading:progress', this.updateLoadingProgressEvent)
+        this.modalViewInstance.on('hide', this.modalHideEvent)
+        this.modalViewInstance.on('hidden', this.modalHideEvent)
+      },
+
+      openModal () {
+        this.loadModal()
+        this.openLegacyModal(this.modalViewInstance)
+      },
+
+      closeModal() {
+        if (!this.modalViewInstance) {
+          return
+        }
+
+        this.modalViewInstance.destroy()
+        this.cleanupModal()
+      },
+
+      cleanupModal () {
+        this.modalViewInstance.off('loading:show', this.showLoadingEvent)
+        this.modalViewInstance.off('loading:hide', this.hideLoadingEvent)
+        this.modalViewInstance.off('loading:progress', this.updateLoadingProgressEvent)
+        this.modalViewInstance.off('hide', this.modalHideEvent)
+        this.modalViewInstance.off('hidden', this.modalHideEvent)
+
+        this.modalViewInstance = undefined
+      },
+
+      showLoadingEvent: function () {
+        this.modalLoading = true
+        this.emitLoadingEvent()
+      },
+
+      hideLoadingEvent: function () {
+        this.modalLoading = false
+        this.emitLoadingEvent()
+      },
+
+      updateLoadingProgressEvent: function (progress) {
+        this.modalLoadingProgress = progress;
+        this.emitLoadingEvent()
+      },
+
+      emitLoadingEvent: function () {
+        this.$emit('loading', {
+          loading: this.modalLoading,
+          progress: this.modalLoadingProgress
+        })
+      },
+
+      modalHideEvent: function () {
+        this.$emit('close')
+        this.cleanupModal()
+      }
+    },
+
+    created () {
+      if (this.open) {
+        this.loadModal()
+      }
+    },
+
+    mounted () {
+      if (this.open) {
+        this.openModal()
+      }
+    },
+
+    destroyed () {
+      this.closeModal()
+    },
+
+    watch: {
+      open: function (newValue, oldValue) {
+        if (newValue !== oldValue) {
+          if (newValue) {
+            this.openModal()
+          } else {
+            this.closeModal()
+          }
+        }
+      },
+    }
+  }
+</script>

--- a/app/views/common/BackboneModalHarness.vue
+++ b/app/views/common/BackboneModalHarness.vue
@@ -1,5 +1,4 @@
 <template>
-    <div></div>
 </template>
 
 <script>
@@ -71,8 +70,10 @@
           return
         }
 
-        this.modalViewInstance.destroy()
+        const viewInstance = this.modalViewInstance
+
         this.cleanupModal()
+        viewInstance.destroy()
       },
 
       cleanupModal () {

--- a/app/views/common/BackboneViewHarness.vue
+++ b/app/views/common/BackboneViewHarness.vue
@@ -3,6 +3,15 @@
 </template>
 
 <script>
+  /**
+   * Note a known limitation of this harness is that it does not support swapping out the following props
+   * after initial render:
+   *   - backboneView
+   *   - backboneOptions
+   *   - backboneArgs
+   *
+   * In order to change these you must unmount and remount the component.
+   */
   export default {
     props: {
       backboneView: Function,
@@ -78,14 +87,5 @@
     destroyed () {
       this.cleanupBackbone()
     },
-
-    watch: {
-      // TODO can you watch all props like this
-      $props: function () {
-        this.cleanupBackbone()
-        this.loadBackbone()
-        this.renderBackbone()
-      }
-    }
   }
 </script>

--- a/app/views/core/ModalView.coffee
+++ b/app/views/core/ModalView.coffee
@@ -42,7 +42,7 @@ module.exports = class ModalView extends CocoView
     # This makes sure if you press enter right after opening the players guide,
     # it doesn't just reopen the modal.
     $(document.activeElement).blur()
-    
+
     if localStorage?.showViewNames
       title = @constructor.name
       setTimeout ->
@@ -70,5 +70,5 @@ module.exports = class ModalView extends CocoView
 
   destroy: ->
     @hide() unless @hidden
-    @$el.off 'hide.bs.modal'
+    @$el.off 'hide.bs.modal' if @$el
     super()

--- a/app/views/core/SingletonAppVueComponentView.js
+++ b/app/views/core/SingletonAppVueComponentView.js
@@ -24,7 +24,12 @@ export default class SingletonAppVueComponentView extends VueComponentView {
       store,
       router: this.router,
 
-      render: (h) => h(Root)
+      render: (h) => h(Root),
+
+      provide: {
+        openLegacyModal: this.openModalView.bind(this),
+        legacyModalClosed: this.modalClosed.bind(this)
+      }
     })
   }
 }


### PR DESCRIPTION
- Removes some old Vue routes that are for ozaria only
- Adds new parents-v2 route for new parent page design
- Adds a basic parents page with CTA hooks in place
- Adds a BackboneModalHarness Vue component to allow us to use Backbone modals in Vue