### PR TITLE
Normalize arena team order to ['humans', 'ogres'] to fix spectate and other bugs

### DIFF
--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -678,6 +678,8 @@ module.exports = class World
 
   teamForPlayer: (n) ->
     playableTeams = @playableTeams ? ['humans']
+    if playableTeams[0] is 'ogres' and playableTeams[1] is 'humans'
+      playableTeams = ['humans', 'ogres']  # Make sure they're in the right order, since our other code is frail to the ordering
     if n?
       playableTeams[n % playableTeams.length]
     else

--- a/app/views/ladder/utils.coffee
+++ b/app/views/ladder/utils.coffee
@@ -3,6 +3,8 @@
 module.exports.teamDataFromLevel = (level) ->
   alliedSystem = _.find level.get('systems', true), (value) -> value.config?.teams?
   teamNames = (teamName for teamName, teamConfig of alliedSystem.config.teams when teamConfig.playable)
+  if teamNames[0] is 'ogres' and teamNames[1] is 'humans'
+    teamNames = ['humans', 'ogres']  # Make sure they're in the right order, since our other code is frail to the ordering
   teamConfigs = alliedSystem.config.teams
 
   teams = []


### PR DESCRIPTION
Arena levels keep getting the ordering of their Alliance System teams flipped, so that ogres comes first in the `playableTeams` list. This flips the human/ogre sides of the ladder page, and also breaks spectate mode, where it tries to load the human session in the ogre session's place and vice versa, causing the heroes to just have default logic. I recall it causing other issues in the past. One thing that we've been doing is re-saving arenas with minor changes to the Alliance System to get them into the right order, but as the ordering of the object is indefinite, sometimes they get disordered again.

Since we never actually do different arena teams (it's always just `"humans"` and `"ogres"`), this adds a check to normalize the order to `["humans", "ogres"]` if we notice that it was `["ogres", "humans"]`, fixing arena pages, spectate mode, and whatever other edge case bugs incurred due to this code frailty.