### PR TITLE
Tracker error handling improvements

### DIFF
--- a/app/core/Tracker2/BaseTracker.js
+++ b/app/core/Tracker2/BaseTracker.js
@@ -132,6 +132,10 @@ export default class BaseTracker {
     const finishInitialization = (result) => {
       this.isInitialized = result
 
+      // We only want to resolve / reject the init promise once during the initialization flow.  Because some trackers
+      // do not support reporting "failures" we need to support timeouts that can result in race conditions in some
+      // situations.  In these situations we use the first success / fail callback to determine the tracker state and
+      // we change the callbacks to noops to prevent later calls from changing the init state.
       this.onInitializeSuccess = () => {}
       this.onInitializeFail = () => {}
     }

--- a/app/core/Tracker2/index.js
+++ b/app/core/Tracker2/index.js
@@ -10,6 +10,12 @@ import FullStoryTracker from './FullStoryTracker'
 const SESSION_STORAGE_IDENTIFIED_AT_SESSION_START_KEY = 'coco.tracker.identifiedAtSessionStart'
 const SESSION_STORAGE_IDENTIFY_ON_NEXT_PAGE_LOAD = 'coco.tracker.identifyOnNextPageLoad'
 
+// Promise.all rejects as soon as the first promise rejects, becomes tracker inits can fail intermittently
+// we want to ensure that we give all tracker promise calls time to finish (even if some fail) before we
+// resolve the promise representing the combined tracking call.  We use Promise.allSettled when available
+// and fall back to Promise.all to achieve this
+const allSettled = (Promise.allSettled || Promise.all).bind(Promise)
+
 /**
  * Top level application tracker that handles sub tracker initialization and
  * event routing.
@@ -41,18 +47,18 @@ export default class Tracker2 extends BaseTracker {
 
   async _initializeTracker () {
     try {
-      await Promise.all([
-        this.cookieConsentTracker.initialize(),
+      const allTrackers = [
+        this.cookieConsentTracker,
+        ...this.trackers
+      ]
 
-        ...this.trackers.map(t => t.initialize())
-      ])
-
-      this.onInitializeSuccess()
+      await allSettled(allTrackers.map(t => t.initialize()))
     } catch (e) {
-      this.onInitializeFail(e)
+      console.error('Tracker init failed', e)
+    } finally {
+      // We always allow the master tracker to continue because some sub trackers may have initialized correctly
+      this.onInitializeSuccess()
     }
-
-    await this.initializationComplete
 
     let callIdentify = false
 
@@ -76,45 +82,65 @@ export default class Tracker2 extends BaseTracker {
 
 
   async identify (traits = {}) {
-    await this.initializationComplete
+    try {
+      await this.initializationComplete
 
-    await Promise.all(
-      this.trackers.map(t => t.identify(traits))
-    )
+      await allSettled(
+        this.trackers.map(t => t.identify(traits))
+      )
+    } catch (e) {
+      this.log('identify call failed', e)
+    }
   }
 
   async resetIdentity () {
-    await this.initializationComplete
+    try  {
+      await this.initializationComplete
 
-    await Promise.all(
-      this.trackers.map(t => t.resetIdentity())
-    )
+      await allSettled(
+        this.trackers.map(t => t.resetIdentity())
+      )
+    } catch (e) {
+      this.log('resetIdentity call failed', e)
+    }
 
     window.sessionStorage.removeItem(SESSION_STORAGE_IDENTIFIED_AT_SESSION_START_KEY)
   }
 
   async trackPageView (includeIntegrations = {}) {
-    await this.initializationComplete
+    try {
+      await this.initializationComplete
 
-    await Promise.all(
-      this.trackers.map(t => t.trackPageView(includeIntegrations))
-    )
+      await allSettled(
+        this.trackers.map(t => t.trackPageView(includeIntegrations))
+      )
+    } catch (e) {
+      this.log('trackPageView call failed', e)
+    }
   }
 
   async trackEvent (action, properties = {}, includeIntegrations = {}) {
-    await this.initializationComplete
+    try {
+      await this.initializationComplete
 
-    await Promise.all(
-      this.trackers.map(t => t.trackEvent(action, properties, includeIntegrations))
-    )
+      await allSettled(
+        this.trackers.map(t => t.trackEvent(action, properties, includeIntegrations))
+      )
+    } catch (e) {
+      this.log('trackEvent call failed', e)
+    }
   }
 
   async trackTiming (duration, category, variable, label) {
-    await this.initializationComplete
+    try {
+      await this.initializationComplete
 
-    await Promise.all(
-      this.trackers.map(t => t.trackTiming(duration, category, variable, label))
-    )
+      await allSettled(
+        this.trackers.map(t => t.trackTiming(duration, category, variable, label))
+      )
+    } catch (e) {
+      this.log('trackTiming call failed', e)
+    }
   }
 
   get drift () {

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -409,8 +409,8 @@ module.exports = class User extends CocoModel
     options.url = '/auth/logout'
     FB?.logout?()
     options.success ?= ->
-      window.application.tracker.resetIdentity().then =>
-        window.application.tracker.identifyAfterNextPageLoad()
+      window.application.tracker.identifyAfterNextPageLoad()
+      window.application.tracker.resetIdentity().finally =>
         location = _.result(window.currentView, 'logoutRedirectURL')
         if location
           window.location = location

--- a/app/views/TestView.coffee
+++ b/app/views/TestView.coffee
@@ -137,10 +137,10 @@ module.exports = TestView = class TestView extends RootView
         jasmine.Ajax.requests.reset()
         Backbone.Mediator.init()
         Backbone.Mediator.setValidationEnabled false
-        spyOn(application.tracker, 'trackEvent')
-        spyOn(application.tracker, 'trackPageView')
-        spyOn(application.tracker, 'identify')
-        spyOn(application.tracker, 'identifyAfterNextPageLoad')
+        spyOn(application.tracker, 'trackEvent').and.returnValue(Promise.resolve())
+        spyOn(application.tracker, 'trackPageView').and.returnValue(Promise.resolve())
+        spyOn(application.tracker, 'identify').and.returnValue(Promise.resolve())
+        spyOn(application.tracker, 'identifyAfterNextPageLoad').and.returnValue(Promise.resolve())
         application.timeoutsToClear = []
         jasmine.addMatchers(customMatchers)
         @notySpy = spyOn(window, 'noty') # mainly to hide them

--- a/app/views/core/AuthModal.coffee
+++ b/app/views/core/AuthModal.coffee
@@ -54,16 +54,6 @@ module.exports = class AuthModal extends ModalView
     res = tv4.validateMultiple userObject, formSchema
     return forms.applyErrorsToForm(@$el, res.errors) unless res.valid
     new Promise(me.loginPasswordUser(userObject.emailOrUsername, userObject.password).then)
-    .then(=>
-      return application.tracker.identify()
-    )
-    .then(=>
-      application.tracker.identifyAfterNextPageLoad()
-      if window.nextURL
-        window.location.href = window.nextURL
-      else
-        loginNavigate(@subModalContinue)
-    )
     .catch((jqxhr) =>
       showingError = false
       if jqxhr.status is 401
@@ -77,6 +67,20 @@ module.exports = class AuthModal extends ModalView
 
       if not showingError
         @$('#unknown-error-alert').removeClass('hide')
+    )
+    .then(=>
+      console.log('identify')
+      application.tracker.identifyAfterNextPageLoad()
+      return application.tracker.identify().then(->
+        console.log('test out oidentify')
+      )
+    )
+    .finally(=>
+      console.log('finally redirect')
+      if window.nextURL
+        window.location.href = window.nextURL
+      else
+        loginNavigate(@subModalContinue)
     )
 
 
@@ -98,7 +102,7 @@ module.exports = class AuthModal extends ModalView
                 me.loginGPlusUser(gplusAttrs.gplusID, {
                   success: =>
                     application.tracker.identifyAfterNextPageLoad()
-                    application.tracker.identify().then(=>
+                    application.tracker.identify().finally(=>
                       loginNavigate(@subModalContinue)
                     )
                   error: @onGPlusLoginError
@@ -112,7 +116,7 @@ module.exports = class AuthModal extends ModalView
                         data: { merge: true, email: gplusAttrs.email }
                         success: =>
                           application.tracker.identifyAfterNextPageLoad()
-                          application.tracker.identify().then(=>
+                          application.tracker.identify().finally(=>
                             loginNavigate(@subModalContinue)
                           )
                         error: @onGPlusLoginError

--- a/app/views/core/AuthModal.coffee
+++ b/app/views/core/AuthModal.coffee
@@ -69,14 +69,10 @@ module.exports = class AuthModal extends ModalView
         @$('#unknown-error-alert').removeClass('hide')
     )
     .then(=>
-      console.log('identify')
       application.tracker.identifyAfterNextPageLoad()
-      return application.tracker.identify().then(->
-        console.log('test out oidentify')
-      )
+      return application.tracker.identify()
     )
     .finally(=>
-      console.log('finally redirect')
       if window.nextURL
         window.location.href = window.nextURL
       else

--- a/app/views/core/CreateAccountModal/BasicInfoView.coffee
+++ b/app/views/core/CreateAccountModal/BasicInfoView.coffee
@@ -296,7 +296,7 @@ module.exports = class BasicInfoView extends CocoView
         window.application.tracker?.trackEvent 'Finished Signup', category: "Signup", label: loginMethod
       )
 
-      return Promise.all(trackerCalls)
+      return Promise.all(trackerCalls).catch(->)
 
     .then =>
       { classCode, classroom } = @signupState.attributes

--- a/app/views/core/CreateAccountModal/teacher/TeacherSignupStoreModule.coffee
+++ b/app/views/core/CreateAccountModal/teacher/TeacherSignupStoreModule.coffee
@@ -105,6 +105,9 @@ module.exports = TeacherSignupStoreModule = {
 
         application.tracker.identifyAfterNextPageLoad()
         unless User.isSmokeTestUser({ email: state.signupForm.email })
+          # Delay auth flow until tracker call resolves so that we ensure any callbacks are fired but swallow errors
+          # so that we prevent the auth redirect from happning (we don't want to block auth because of tracking
+          # failures)
           return application.tracker.identify(trialRequestIdentifyData).catch(->)
 
       .then =>

--- a/app/views/core/CreateAccountModal/teacher/TeacherSignupStoreModule.coffee
+++ b/app/views/core/CreateAccountModal/teacher/TeacherSignupStoreModule.coffee
@@ -104,7 +104,8 @@ module.exports = TeacherSignupStoreModule = {
         trialRequestIdentifyData.educationLevel_college = _.contains state.trialRequestProperties.educationLevel, "College+"
 
         application.tracker.identifyAfterNextPageLoad()
-        return application.tracker.identify trialRequestIdentifyData unless User.isSmokeTestUser({ email: state.signupForm.email })
+        unless User.isSmokeTestUser({ email: state.signupForm.email })
+          return application.tracker.identify(trialRequestIdentifyData).catch(->)
 
       .then =>
         trackerCalls = []
@@ -125,7 +126,7 @@ module.exports = TeacherSignupStoreModule = {
           window.application.tracker?.trackEvent 'Finished Signup', category: "Signup", label: loginMethod
         )
 
-        return Promise.all(trackerCalls)
+        return Promise.all(trackerCalls).catch(->)
   }
 }
 

--- a/app/views/teachers/CreateTeacherAccountView.coffee
+++ b/app/views/teachers/CreateTeacherAccountView.coffee
@@ -314,7 +314,7 @@ module.exports = class CreateTeacherAccountView extends RootView
         window.application.tracker?.trackEvent 'Finished Signup', category: "Signup", label: loginMethod
       )
 
-      return Promise.all(trackerCalls)
+      return Promise.all(trackerCalls).catch(->)
 
     .then =>
       application.router.navigate(SIGNUP_REDIRECT, { trigger: true })


### PR DESCRIPTION
- Adds init timeout to all trackers to account for cases where trackers do not communicate error during init and result in waiting forever for init
- Catches all tracker errors and logs them instead of surfacing to user
- Use Promise.allSettled where possible to ensure every tracking call that is functional has time to complete