### PR TITLE
fix(drift): prevent drift from appearing on play pages

### DIFF
--- a/app/core/Tracker2/DriftTracker.js
+++ b/app/core/Tracker2/DriftTracker.js
@@ -100,7 +100,7 @@ export default class DriftTracker extends BaseTracker {
 
   get onPlayPage () {
     const { route } = this.store.state
-    return (route.path || '').indexOf('/play/') === 0
+    return (route.path || '').indexOf('/play') === 0
   }
 
   get isChatEnabled () {


### PR DESCRIPTION
Remove trailing `/` so that it detects simple `/play` route