### PR TITLE
Add sendgrid validation data to user schema

### DIFF
--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -112,7 +112,7 @@ _.extend UserSchema.properties,
         email: c.shortString()
         sent: c.date() # Set when sent
 
-    validations: c.array, { title: 'Sendgrid email validation results'},
+    validations: c.array, { title: 'Sendgrid email validation results' },
       c.object {},
         validationDate: c.date()
         result: c.object()

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -111,6 +111,12 @@ _.extend UserSchema.properties,
         type: c.shortString() # E.g 'share progress modal parent'
         email: c.shortString()
         sent: c.date() # Set when sent
+
+    validations: c.array, { title: 'Sendgrid email validation results'},
+      c.object {},
+        validationDate: c.date()
+        result: c.object()
+
   unsubscribedFromMarketingEmails: { type: 'boolean' }
 
   consentHistory: c.array {title: 'History of consent actions'},

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -115,7 +115,7 @@ _.extend UserSchema.properties,
     validations: c.array, { title: 'Sendgrid email validation results' },
       c.object {},
         validationDate: c.date()
-        result: c.object()
+        result: c.object({ additionalProperties: true })
 
   unsubscribedFromMarketingEmails: { type: 'boolean' }
 


### PR DESCRIPTION
Adds a new field to the `user.emails` object that captures the validation response from sendgrid so that we can save this data for future use (each API call to sendgrid costs us $$).