### PR TITLE
Fix media query for navbar collapsing

### DIFF
--- a/app/styles/style-flat-variables.sass
+++ b/app/styles/style-flat-variables.sass
@@ -7,3 +7,5 @@ $navy: #0E4C60
 $forest: #20572B
 $teal: #1FBAB4
 $gray: #232323
+
+$wider-breakpoint: 1160px

--- a/app/styles/style-flat.sass
+++ b/app/styles/style-flat.sass
@@ -152,12 +152,16 @@ body[lang='ru'], body[lang='uk'], body[lang='bg'], body[lang^='mk'], body[lang='
       @media (max-width: $screen-md-min)
         display: inline-block
         margin: 2px 10px 29.5px
+      @media (max-width: $wider-breakpoint)
+        margin-right: 10px
       & li
         display: inline-block
 
     a.navbar-brand
       padding: 14px 0 16px 70px
       margin: 0px
+      @media (max-width: $wider-breakpoint)
+        padding-left: 10px
 
       #logo-img
         height: 40px
@@ -206,6 +210,8 @@ body[lang='ru'], body[lang='uk'], body[lang='bg'], body[lang^='mk'], body[lang='
       font-family: $body-font
       text-shadow: unset
       padding: 10px 15px
+      @media (max-width: $wider-breakpoint)
+        padding: 10px 10px
       color: $navy
       &:hover
         color: $teal


### PR DESCRIPTION
# Context

The navbar collapses twice instead of once, which makes the navbar overlap downwards and cover any banner we may have showing underneath. 

# Fix

The navbar could have a wider logo and it could have additional navbar items. These are now covered by additional media queries that reduce their padding or margin so the total width can shrink further without wrapping downwards. 

# Visual explanation


### Before fix:

![media-query-broken-min](https://user-images.githubusercontent.com/1154150/88400903-97790e80-cdfb-11ea-8ee3-8d383d2ccfe0.gif)

### After fix:

![media-query-fixed-min](https://user-images.githubusercontent.com/1154150/88400935-a52e9400-cdfb-11ea-9333-9fe2fd6f8218.gif)


