### PR TITLE
Codequest poll trigger and modal

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -789,6 +789,11 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     content: "Amazing! We just launched live online classes."
     link: "Ready to get ahead on your coding?"
 
+  code_quest:
+    great: "Great!"
+    join_paragraph: "Join the largest international Python AI coding tournament for all ages and compete for the top of the leaderboard! This month-long global battle starts August 1st and includes $5k worth of prizes and a virtual awards ceremony where we'll announce winners and recognize your coding skills."
+    link: "Click here to register and learn more"
+
   play_game_dev_level:
     created_by: "Created by {{name}}"
     created_during_hoc: "Created during Hour of Code"

--- a/app/styles/play/modal/codequest-2020-modal.sass
+++ b/app/styles/play/modal/codequest-2020-modal.sass
@@ -1,0 +1,69 @@
+@import "app/styles/mixins"
+@import "app/styles/bootstrap/variables"
+
+// Copied almost exactly from the amazon-hoc-modal.
+#codequest-2020-modal
+  .modal-dialog
+    margin: 60px auto 0 auto
+    padding: 0
+    width: 746px
+    height: 520px
+    background: none
+    
+  #codequest-background
+    position: absolute
+    top: -61px
+    left: 0px
+    
+  h1
+    position: absolute
+    left: 194px
+    top: 29px
+    margin: 0
+    width: 410px
+    text-align: center
+    color: rgb(254,188,68)
+    font-size: 30px
+    text-shadow: black 4px 4px 0, black -4px -4px 0, black 4px -4px 0, black -4px 4px 0, black 4px 0px 0, black 0px -4px 0, black -4px 0px 0, black 0px 4px 0, black 6px 6px 6px
+    font-variant: normal
+    text-transform: uppercase
+    margin-left: -30px
+
+  #close-modal
+    position: absolute
+    left: 568px
+    top: 17px
+    width: 60px
+    height: 60px
+    color: white
+    text-align: center
+    font-size: 30px
+    padding-top: 15px
+    cursor: pointer
+    @include rotate(-3deg)
+
+    &:hover
+      color: yellow
+
+  .paper-area
+    position: absolute
+    top: 114px
+    left: 31px
+    min-height: 370px
+    width: 684px
+    background: #d4c9b1
+    border: 3px solid black
+    display: flex
+    flex-direction: column
+    align-items: center
+    justify-content: center
+    padding: 20px
+    
+    h3
+      margin-top: 0
+      color: black
+
+    .btn
+      font-size: 20px
+      margin-top: 40px
+

--- a/app/templates/play/modal/codequest-2020-modal.jade
+++ b/app/templates/play/modal/codequest-2020-modal.jade
@@ -1,0 +1,14 @@
+.modal-dialog
+  .modal-content
+    img#codequest-background(src="/images/pages/play/modal/subscribe-background-blank.png")
+    
+    h1(data-i18n="code_quest.great")
+
+    div#close-modal
+      span.glyphicon.glyphicon-remove
+  
+    div.paper-area.text-center
+      h3
+        span(data-i18n="code_quest.join_paragraph")
+
+      a.btn.btn-primary#live-codecombat-link(href="https://codequest.codecombat.com/" data-i18n="code_quest.link" target="_blank" rel="noopener")

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -24,6 +24,7 @@ Poll = require 'models/Poll'
 PollModal = require 'views/play/modal/PollModal'
 AnnouncementModal = require 'views/play/modal/AnnouncementModal'
 LiveClassroomModal = require 'views/play/modal/LiveClassroomModal'
+Codequest2020Modal = require 'views/play/modal/Codequest2020Modal'
 MineModal = require 'views/core/MineModal' # Minecraft modal
 api = require 'core/api'
 Classroom = require 'models/Classroom'
@@ -1275,6 +1276,8 @@ module.exports = class CampaignView extends RootView
       @loadPoll('/db/poll/' + nextPollId, true)
     pollModal.once 'trigger-show-live-classes', () =>
       @openModalView new LiveClassroomModal
+    pollModal.once 'trigger-codequest-modal', () =>
+      @openModalView new Codequest2020Modal
 
   onClickPremiumButton: (e) ->
     @openModalView new SubscribeModal()

--- a/app/views/play/modal/Codequest2020Modal.coffee
+++ b/app/views/play/modal/Codequest2020Modal.coffee
@@ -8,7 +8,3 @@ module.exports = class LiveClassroomModal extends ModalView
 
   events:
     'click #close-modal': 'hide'
-    'mouseup #live-codecombat-link': 'onClickLiveClassesLink'
-  
-  onClickLiveClassesLink: ->
-    window.tracker?.trackEvent 'Click Live Classes link', label: 'live-classes-link'

--- a/app/views/play/modal/Codequest2020Modal.coffee
+++ b/app/views/play/modal/Codequest2020Modal.coffee
@@ -1,0 +1,14 @@
+require('app/styles/play/modal/codequest-2020-modal.sass')
+ModalView = require('views/core/ModalView')
+template = require 'templates/play/modal/codequest-2020-modal.jade'
+
+module.exports = class LiveClassroomModal extends ModalView
+  template: template
+  id: 'codequest-2020-modal'
+
+  events:
+    'click #close-modal': 'hide'
+    'mouseup #live-codecombat-link': 'onClickLiveClassesLink'
+  
+  onClickLiveClassesLink: ->
+    window.tracker?.trackEvent 'Click Live Classes link', label: 'live-classes-link'

--- a/app/views/play/modal/PollModal.coffee
+++ b/app/views/play/modal/PollModal.coffee
@@ -86,20 +86,28 @@ module.exports = class PollModal extends ModalView
       
       # The following block allows for the user to be indecisive with their answer, updating UI accordingly.
       btn = @$el.find('.btn.btn-illustrated.btn-lg.done-button')
+      btn.off('click')
+
       if nextPollId
         btn.text(i18n.t('common.next'))
-        btn.one('click', ()=>
+        btn.one('click', () =>
           btn.prop('disabled', true);
-
-          # Show live Class Modal
           if @poll.id is "5e84c7a519cb270028516687"
+            # Show live Class Modal
             @trigger('trigger-show-live-classes')
           else
             @trigger('trigger-next-poll', nextPollId)
         )
       else
         btn.text(i18n.t('play_level.done'))
-        btn.off('click')
+
+        # For code quest modal
+        btn.one('click', () =>
+          # TODO: Replace with production poll id once it is ready.
+          if @poll.id is "5f2058074cbd8c19861848fc"
+            btn.prop('disabled', true);
+            @trigger('trigger-codequest-modal')
+        )
     }
 
   awardRandomGems: ->

--- a/app/views/play/modal/PollModal.coffee
+++ b/app/views/play/modal/PollModal.coffee
@@ -103,8 +103,8 @@ module.exports = class PollModal extends ModalView
 
         # For code quest modal
         btn.one('click', () =>
-          # TODO: Replace with production poll id once it is ready.
-          if @poll.id is "5f2058074cbd8c19861848fc"
+          if @poll.id is "5f21e48ec22bdf002922cd8c"
+            # Id of codequest poll
             btn.prop('disabled', true);
             @trigger('trigger-codequest-modal')
         )


### PR DESCRIPTION
TODO:
 - [x] Fix poll id once it is added to database.
 - [x] Update styles based on feedback.
 - [x] Check for regressions in single polls & multi polls.

# Context

Adds the simple modal that will appear after a user answers the poll.

The poll needs to be added via the poll editor. This is something I will do manually, and release once this is deployed.

This builds upon work done in this PR: https://github.com/codecombat/codecombat/pull/5812

Link to the poll that will trigger this modal: https://codecombat.com/editor/poll/want-a-challenge


# Risks

There are some risks of regressions as this was done quite quickly. I tested manually and existing polls continue to work. The main touch point is the event that triggers the new modal. Thus I believe the regression risk is low.

# Testing

I tested this manually with local database and patching the id with the local version. Was able to answer the poll and get the codequest modal.
Then continued to refresh and load polls to also answer other poll questions.

![3165d29bbf64c01d5ff6bcad919217a8](https://user-images.githubusercontent.com/15080861/88710224-2cfdf200-d0cb-11ea-8a3f-9d30d6b94faf.gif)

