### PR TITLE
Fix a course-ladder race condition bug

### DIFF
--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -405,6 +405,7 @@ module.exports = class LevelLoader extends CocoClass
     return 'not all session dependencies registered' if @sessionDependenciesRegistered and not @sessionDependenciesRegistered[@session.id] and not @sessionless
     return 'not all opponent session dependencies registered' if @sessionDependenciesRegistered and @opponentSession and not @sessionDependenciesRegistered[@opponentSession.id] and not @sessionless
     return 'session is not loaded' unless @session?.loaded or @sessionless
+    return 'opponent session is not loaded' if @opponentSession and not @opponentSession.loaded
     return 'have not published level loaded' unless @publishedLevelLoaded or @sessionless
     return ''
 

--- a/app/views/play/level/tome/Spell.coffee
+++ b/app/views/play/level/tome/Spell.coffee
@@ -55,7 +55,11 @@ module.exports = class Spell
 
     @source = @originalSource
     @parameters = p.parameters
-    if @permissions.readwrite.length and sessionSource = @session.getSourceFor(@spellKey)
+    if @otherSession and @team is @otherSession.get('team') and sessionSource = @otherSession.getSourceFor(@spellKey)
+      # Load opponent code from other session (new way, not relying on PlayLevelView loadOpponentTeam)
+      @source = sessionSource
+    else if @permissions.readwrite.length and sessionSource = @session.getSourceFor(@spellKey)
+      # Load either our code or opponent code (old way, opponent code copied into our session in PlayLevelView loadOpponentTeam)
       if sessionSource isnt '// Should fill in some default source\n'  # TODO: figure out why session is getting this default source in there and stop it
         @source = sessionSource
     if p.aiSource and not @otherSession and not @canWrite()


### PR DESCRIPTION
Several players [on the forum](https://discourse.codecombat.com/t/battle-of-red-cliffs-questions/23374/10) and via email support have noticed that opponents often load sample code (all archers) on the Battle of Red Cliffs. I dug in and it seems to be a race condition that involves `course-ladder` type levels, made much more likely because there are no dependent ThangTypes to load for hero equipment in this particular course ladder level, whereby the opponent session loads after everything else is loaded, too late to get its code inserted into the other team's Spell, which reverts to default code.

Race condition only appears in production. If I'm right, then the LevelLoader fix to check for a non-loaded `opponentSession` will take care of this. I also added a paranoid check in `Spell.coffee` to make loading of opponent code a little more straightforward.

I've manually tested that this method of loading code doesn't break anything for our other common level types/scenarios.