### PR TITLE
use i18n to show hero name in hero-select-view

### DIFF
--- a/app/views/core/HeroSelectView.coffee
+++ b/app/views/core/HeroSelectView.coffee
@@ -28,7 +28,7 @@ module.exports = class HeroSelectView extends CocoView
     # @heroes = new ThangTypes({}, { project: ['original', 'name', 'heroClass, 'slug''] })
     # @supermodel.trackRequest @heroes.fetchHeroes()
 
-    api.thangTypes.getHeroes({ project: ['original', 'name', 'shortName', 'heroClass', 'slug', 'ozaria'] }).then (heroes) =>
+    api.thangTypes.getHeroes({ project: ['original', 'name', 'shortName', 'i18n', 'heroClass', 'slug', 'ozaria'] }).then (heroes) =>
       @heroes = heroes.filter((h) => !h.ozaria)
       @debouncedRender()
 


### PR DESCRIPTION
in hero-select-view, we need i18n keys to translate hero short name in https://github.com/codecombat/codecombat/blob/4e2d519df51f25c12180a4c2b06bc309f70fa89e/app/templates/core/hero-select-view.jade#L14
and 
https://github.com/codecombat/codecombat/blob/4e2d519df51f25c12180a4c2b06bc309f70fa89e/app/lib/ThangTypeLib.coffee#L12-L15

while we do not get the i18n key in views
https://github.com/codecombat/codecombat/blob/4e2d519df51f25c12180a4c2b06bc309f70fa89e/app/views/core/HeroSelectView.coffee#L31-L33

so i add it