### PR TITLE
WIP: shortcut to easily scale Thangs

### DIFF
--- a/app/models/LevelComponent.coffee
+++ b/app/models/LevelComponent.coffee
@@ -18,6 +18,7 @@ module.exports = class LevelComponent extends CocoModel
   @FindsPathsID: '52872b0ead92b98561000002'
   @AttackableID: '524b7bab7fc0f6d519000017'
   @RefereeID: '54977ce657e90bd1903dea72'
+  @ScalesID: '52a399b98537a70000000003'
   urlRoot: '/db/level.component'
   editableByArtisans: true
 

--- a/app/views/editor/level/thangs/ThangsTabView.coffee
+++ b/app/views/editor/level/thangs/ThangsTabView.coffee
@@ -80,6 +80,8 @@ module.exports = class ThangsTabView extends CocoView
     'shift+right': -> @resizeSelectedThangBy 1, 0
     'shift+up': -> @resizeSelectedThangBy 0, 1
     'shift+down': -> @resizeSelectedThangBy 0, -1
+    'shift+=': -> @scaleSelectedThangBy 1
+    'shift+-': -> @scaleSelectedThangBy -1
 
   constructor: (options) ->
     super options
@@ -167,7 +169,7 @@ module.exports = class ThangsTabView extends CocoView
   openGenerateTerrainModal: (e) ->
     e.stopPropagation()
     @openModalView new GenerateTerrainModal()
-  
+
   onFilterExtantThangs: (e) ->
     @$el.find('#extant-thangs-filter button.active').button('toggle')
     button = $(e.target).closest('button')
@@ -799,6 +801,13 @@ module.exports = class ThangsTabView extends CocoView
         component.config.height = (component.config.height ? 4) + 0.5 * yDir
         selectedThang.width = component.config.width
         selectedThang.height = component.config.height
+
+  scaleSelectedThangBy: (scaleDir) ->
+    for singleSelected in @gameUIState.get('selected')
+      selectedThang = singleSelected.thang
+      @modifySelectedThangComponentConfig selectedThang, LevelComponent.ScalesID, (component) =>
+        oldScaleFactor = (component.config.scaleFactor ? 1)
+        component.config.scaleFactor = oldScaleFactor + 0.1 * scaleDir
 
   toggleSelectedThangCollision: ->
     for singleSelected in @gameUIState.get('selected')


### PR DESCRIPTION
Was looking to cost tools improvements and saw what looked to be an easy one. After a few minutes, this works except for redrawing the Lank at the new scale when you press the shortcut, so we'd need to fix that to finish this (and then port this to Ozaria as well).