### PR TITLE
Remove duplicate license UI for pending and empty licenses

### DIFF
--- a/app/templates/courses/enrollments-view.jade
+++ b/app/templates/courses/enrollments-view.jade
@@ -66,22 +66,6 @@ block content
         a#how-to-enroll-link(data-i18n="teacher.how_to_apply_licenses")
 
       .row.m-t-3
-        #prepaids-col.col-md-8.rtl-allowed
-          if _.size(pending) > 0
-            h5.m-b-1.m-t-3(data-i18n="teacher.pending_credits")
-            .row
-              for prepaid in pending
-                .prepaid-card-container.col-sm-4.col-xs-6.rtl-allowed
-                  +prepaidCard(prepaid, 'pending-prepaid-card')
-
-          if _.size(empty) > 0
-            h5.m-b-1(data-i18n="teacher.empty_credits")
-            .row
-              for prepaid in empty
-                .prepaid-card-container.col-sm-4.col-xs-6.rtl-allowed
-                  +prepaidCard(prepaid, 'empty-prepaid-card')
-
-      .row.m-t-3
         if anyPrepaids
           #prepaids-col.col-md-8.rtl-allowed
             if _.size(available) > 0


### PR DESCRIPTION
## Context

Some duplicate UI was introduced into the license panel.
This is a visual only change.

## Risk

Minimal risk. I don't believe I have removed any information from the teacher, as directly below the `pending` and `empty` prepaid UI is handled. This is only reducing some duplicate markup.


# Screenshots

## Fix

There is on pending and one available license.

![81e22736be3e34b72825bb7a7487b26d](https://user-images.githubusercontent.com/15080861/90195520-7b271c80-dd7e-11ea-9819-1554c590ee0c.gif)

## Additional UI Bug

The available license is sandwiched between two pending licenses.

![966789ded1dd25f9602a10416424b890](https://user-images.githubusercontent.com/15080861/90195572-a01b8f80-dd7e-11ea-960e-7c7e2004f03a.gif)
