### PR TITLE
About page team updates

### DIFF
--- a/app/templates/about.jade
+++ b/app/templates/about.jade
@@ -66,17 +66,6 @@ block content
 
           li
             .profile-pic
-              a(href="http://www.mattlott.com/" rel="external")
-                img(src="/images/pages/about/team-avatars/matt-avatar.png").img-thumbnail.avatar
-                img(src="/images/pages/about/team-headshots/matt-headshot.png").img-thumbnail.headshot
-            .team-bio
-              h6.label.team-name
-                a(href="http://www.mattlott.com/" rel="external") Matt Lott
-              small(data-i18n="about.matt_title")
-              br
-
-          li
-            .profile-pic
               a(href="http://bryukh.com" rel="external")
                 img(src="/images/pages/about/team-avatars/bryukh-avatar.png").img-thumbnail.avatar
                 img(src="/images/pages/about/team-headshots/bryukh-headshot.jpg").img-thumbnail.headshot
@@ -112,16 +101,7 @@ block content
             .team-bio
               h6.label.team-name
                 a(href="https://www.linkedin.com/in/jane-park-90bb11b/" rel="external") Jane Park
-              small Associate Product Manager
-              br
-
-          li
-            .profile-pic
-              img(src="/images/pages/about/team-avatars/shubhangi-avatar.png").img-thumbnail.avatar
-              img(src="/images/pages/about/team-headshots/shubhangi-headshot.jpg").img-thumbnail.headshot
-            .team-bio
-              h6.label.team-name Shubhangi Gupta
-              small(data-i18n="about.shubhangi_title")
+              small Product Manager
               br
 
           li
@@ -251,15 +231,6 @@ block content
 
           li
             .profile-pic
-              img(src="/images/pages/about/team-avatars/maya-avatar.png").img-thumbnail.avatar
-              img(src="/images/pages/about/team-headshots/maya-headshot.jpg").img-thumbnail.headshot
-            .team-bio
-              h6.label.team-name Maya McCoy
-              small(data-i18n="about.maya_title")
-              br
-
-          li
-            .profile-pic
               img(src="/images/pages/about/team-avatars/matias-avatar.png").img-thumbnail.avatar
               img(src="/images/pages/about/team-headshots/matias-headshot.jpg").img-thumbnail.headshot
             .team-bio
@@ -310,15 +281,6 @@ block content
             .team-bio
               h6.label.team-name Lance Wu
               small(data-i18n="about.lance_title")
-              br
-
-          li
-            .profile-pic
-              img(src="/images/pages/about/team-avatars/ashley-avatar.png").img-thumbnail.avatar
-              img(src="/images/pages/about/team-headshots/ashley-headshot.jpg").img-thumbnail.headshot
-            .team-bio
-              h6.label.team-name Ashley Stoddard
-              small Senior Artist
               br
 
           li


### PR DESCRIPTION
Small change to update team on about page.
Can be checked on /about route.


# Screenshot of change

![image](https://user-images.githubusercontent.com/15080861/93542377-b385c180-f90d-11ea-8c49-47767da615be.png)
