### PR TITLE
Update HOC pdf to 2020 and add url redirect

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -159,6 +159,7 @@ module.exports = class CocoRouter extends Backbone.Router
     'github/*path': 'routeToServer'
 
     'hoc': -> @navigate "/play/hoc-2018", {trigger: true, replace: true}
+    'play/hoc-2020': -> @navigate "/play/hoc-2018", {trigger: true, replace: true} # Added to handle HoC PDF
     'home': if me.useChinaHomeView() then go('HomeCNView') else go('HomeView')
 
     'i18n': go('i18n/I18NHomeView')

--- a/app/views/special_event/HoC2018Component.vue
+++ b/app/views/special_event/HoC2018Component.vue
@@ -24,7 +24,7 @@
         .col-md-4
           a.btn.btn-primary.btn-lg(href="/play/hoc-2018" data-i18n="hoc_2018.try_activity")
         .col-md-4
-          a.btn.btn-primary.btn-lg(href="http://files.codecombat.com/docs/resources/hourofcode/HourofCodeCodeCombatLessonPlan2018.pdf" target="_blank" data-i18n="hoc_2018.download_pdf")
+          a.btn.btn-primary.btn-lg(href="http://files.codecombat.com/docs/resources/hourofcode/HourofCodeCodeCombatLessonPlan2020.pdf" target="_blank" data-i18n="hoc_2018.download_pdf")
 
       .row
         br

--- a/ozaria/site/views/special_event/HoC2018Component.vue
+++ b/ozaria/site/views/special_event/HoC2018Component.vue
@@ -24,7 +24,7 @@
         .col-md-4
           a.btn.btn-primary.btn-lg(href="/play/hoc-2018" data-i18n="hoc_2018.try_activity")
         .col-md-4
-          a.btn.btn-primary.btn-lg(href="http://files.codecombat.com/docs/resources/hourofcode/HourofCodeCodeCombatLessonPlan2018.pdf" target="_blank" data-i18n="hoc_2018.download_pdf")
+          a.btn.btn-primary.btn-lg(href="http://files.codecombat.com/docs/resources/hourofcode/HourofCodeCodeCombatLessonPlan2020.pdf" target="_blank" data-i18n="hoc_2018.download_pdf")
 
       .row
         br


### PR DESCRIPTION
This PR adds:

- Link to a new 2020 HoC PDF.
- Adds a more specific route to match PDF expectation.


Tested manually:
 - Teacher through course guide.
 - Home user navigating through campaign views.
 - Clicking PDF link.
 - Navigating from PDF to campaign.