### PR TITLE
Parent page styling fix for Firefox

### DIFF
--- a/app/views/landing-pages/parents/PageParents.vue
+++ b/app/views/landing-pages/parents/PageParents.vue
@@ -674,6 +674,7 @@ export default {
     .row.equal-height {
         display: flex;
         flex-wrap: wrap;
+        width: 100%;
     }
 
     .row.equal-height > [class*='col-'] {


### PR DESCRIPTION
## Context
A row was malformed in Firefox on the parent page.
This explicit styling ensures page lays out correctly.

I tested on Firefox as well as Chrome to ensure no regressions occurred.

## Screenshots

**The issue:**
![image](https://user-images.githubusercontent.com/15080861/95368159-8ed89600-088a-11eb-96ac-1de31d871ebc.png)

Can be seen on codecombat.com/parents when using firefox browser.

With this fix:

![image](https://user-images.githubusercontent.com/15080861/95368210-a57eed00-088a-11eb-800a-4ae116a4a241.png)

