### PR TITLE
Remove old A/B test code, including picking winning variant for request a quote

### DIFF
--- a/app/core/Tracker.coffee
+++ b/app/core/Tracker.coffee
@@ -4,8 +4,6 @@ utils = require 'core/utils'
 CocoClass = require 'core/CocoClass'
 api = require('core/api')
 
-experiments = require('core/experiments')
-
 debugAnalytics = false
 
 module.exports = class Tracker extends CocoClass
@@ -86,13 +84,6 @@ module.exports = class Tracker extends CocoClass
         eventAction: action
       gaFieldObject.eventLabel = properties.label if properties.label?
       gaFieldObject.eventValue = properties.value if properties.value?
-
-      # NOTE these custom dimensions need to be configured in GA prior to being reported
-      try
-        gaFieldObject.dimension1 = experiments.getRequestAQuoteGroup(me)
-      catch e
-        # TODO handle_error_ozaria
-        console.error(e)
 
       ga? 'send', gaFieldObject
 

--- a/app/core/experiments.js
+++ b/app/core/experiments.js
@@ -1,9 +1,0 @@
-export function getRequestAQuoteGroup (user) {
-  const bucket = user.get('testGroupNumber') % 10
-
-  if (bucket < 5) {
-    return 'request-a-quote-control'
-  } else {
-    return 'request-a-quote-header'
-  }
-}

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -250,55 +250,6 @@ module.exports = class User extends CocoModel
         return
     return errors
 
-  # TODO move to app/core/experiments when updated
-  getCampaignAdsGroup: ->
-    return @campaignAdsGroup if @campaignAdsGroup
-    # group = me.get('testGroupNumber') % 2
-    # @campaignAdsGroup = switch group
-    #   when 0 then 'no-ads'
-    #   when 1 then 'leaderboard-ads'
-    @campaignAdsGroup = 'leaderboard-ads'
-    @campaignAdsGroup = 'no-ads' if me.isAdmin()
-    application.tracker.identify campaignAdsGroup: @campaignAdsGroup unless me.isAdmin()
-    @campaignAdsGroup
-
-  # TODO: full removal of sub modal test
-  # TODO move to app/core/experiments when updated
-  getSubModalGroup: () ->
-    return @subModalGroup if @subModalGroup
-    @subModalGroup = 'both-subs'
-    @subModalGroup
-  setSubModalGroup: (val) ->
-    @subModalGroup = if me.isAdmin() then 'both-subs' else val
-    @subModalGroup
-
-  # Signs and Portents was receiving updates after test started, and also had a big bug on March 4, so just look at test from March 5 on.
-  # ... and stopped working well until another update on March 10, so maybe March 11+...
-  # ... and another round, and then basically it just isn't completing well, so we pause the test until we can fix it.
-  # TODO move to app/core/experiments when updated
-  getFourthLevelGroup: ->
-    return 'forgetful-gemsmith'
-    return @fourthLevelGroup if @fourthLevelGroup
-    group = me.get('testGroupNumber') % 8
-    @fourthLevelGroup = switch group
-      when 0, 1, 2, 3 then 'signs-and-portents'
-      when 4, 5, 6, 7 then 'forgetful-gemsmith'
-    @fourthLevelGroup = 'signs-and-portents' if me.isAdmin()
-    application.tracker.identify fourthLevelGroup: @fourthLevelGroup unless me.isAdmin()
-    @fourthLevelGroup
-
-  getVideoTutorialStylesIndex: (numVideos=0)->
-    # A/B Testing video tutorial styles
-    # Not a constant number of videos available (e.g. could be 0, 1, 3, or 4 currently)
-    return 0 unless numVideos > 0
-    return me.get('testGroupNumber') % numVideos
-
-  # TODO move to app/core/experiments when updated
-  getHomePageTestGroup: () ->
-    return  # ending A/B test on homepage for now.
-    return unless me.get('country') == 'united-states'
-    # testGroupNumberUS is a random number from 0-255, use it to run A/B tests for US users.
-
   hasSubscription: ->
     return false if me.isStudent() or me.isTeacher()
     if payPal = @get('payPal')
@@ -381,7 +332,7 @@ module.exports = class User extends CocoModel
         return (courses.map (id) -> utils.courseAcronyms[id]).join('+')
     # NOTE: Default type is 'course' if no type is marked on the user's copy
     return type or 'course'
-    
+
   prepaidIncludesCourse: (course) ->
     return false unless @get('coursePrepaid') or @get('coursePrepaidID')
     includedCourseIDs = @get('coursePrepaid')?.includedCourseIDs
@@ -652,4 +603,3 @@ tiersByLevel = [-1, 0, 0.05, 0.14, 0.18, 0.32, 0.41, 0.5, 0.64, 0.82, 0.91, 1.04
 
 # Make UserLib accessible via eg. User.broadName(userObj)
 _.assign(User, UserLib)
-

--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -957,11 +957,6 @@ $gameControlMargin: 30px
     top: calc(1% + 5px)
     left: calc(1% + 200px)
 
-  .ad-container
-    width: 100%
-    height: 90px
-    text-align: center
-
   .gameplay-container
     position: absolute
     height: 100%

--- a/app/styles/play/play-level-view.sass
+++ b/app/styles/play/play-level-view.sass
@@ -344,11 +344,6 @@ $level-resize-transition-time: 0.5s
     .code-line-0, .code-line-6
       opacity: 0.5
 
-  .ad-container
-    width: 100%
-    height: 90px
-    text-align: center
-
   .hints-view
     position: absolute
     top: 10px

--- a/app/templates/base-flat.jade
+++ b/app/templates/base-flat.jade
@@ -61,7 +61,7 @@ mixin accountLinks
                         a.text-p(data-i18n="nav.blog", href="https://blog.koudashijie.com")
                       li
                         a.text-p(data-event-action="Header Request Quote CTA", data-i18n="new_home.request_quote", href="/contact-cn")
-                    else if me.isAnonymous() && require('app/core/experiments').getRequestAQuoteGroup(me) === 'request-a-quote-header'
+                    else if me.isAnonymous()
                       li
                         a.text-p(data-event-action="Header Request Quote CTA", data-i18n="new_home.request_quote", href="/teachers/quote")
                     li

--- a/app/templates/core/subscribe-modal.jade
+++ b/app/templates/core/subscribe-modal.jade
@@ -32,76 +32,52 @@ mixin price(name, p)
         span.glyphicon.glyphicon-remove
 
       div.paper-area
-        if view.subType === 'both-subs'
-          div.benefits-header.text-center(data-i18n="[html]subscribe.comparison_blurb")
+       div.benefits-header.text-center(data-i18n="[html]subscribe.comparison_blurb")
 
-          .container-fluid
-            .row
-              .col-xs-5.option-col.col-xs-offset-1
-                img(src="/images/pages/play/modal/three-pets.png")
-              .col-xs-6
-                ul.features-list
-                  li(data-i18n="subscribe.feature_level_access")
-                  li(data-i18n="subscribe.feature_heroes")
-                  li(data-i18n="subscribe.feature_learn")
+       .container-fluid
+         .row
+           .col-xs-5.option-col.col-xs-offset-1
+             img(src="/images/pages/play/modal/three-pets.png")
+           .col-xs-6
+             ul.features-list
+               li(data-i18n="subscribe.feature_level_access")
+               li(data-i18n="subscribe.feature_heroes")
+               li(data-i18n="subscribe.feature_learn")
 
-            hr
+         hr
 
-            if view.lifetimeProduct
-              .short-row.row
-                if view.basicProduct
-                  .col-xs-5.option-col.col-xs-offset-1
-                  .option-col(class='.col-xs-5')
-                    .option-header.best-deal(data-i18n="subscribe.best_deal")
-                else
-                  .option-col(class='.col-xs-12')
-                    .option-header.best-deal(data-i18n="subscribe.best_deal")
-            .row
-              - var secondRowClass = '.col-xs-5'
-              if view.basicProduct
-                .col-xs-5.option-col.col-xs-offset-1
-                  +price("subscribe.month_price", view.basicProduct)
-                  .option-header.price-subtext.text-center(data-i18n="subscribe.stripe_description")
-                  button.btn.btn-lg.btn-illustrated.purchase-button
-                    span.buy-now-text(data-i18n="subscribe.buy_now")
-                    span.buy-lock-icon &#x1F512;
+         if view.lifetimeProduct
+           .short-row.row
+             if view.basicProduct
+               .col-xs-5.option-col.col-xs-offset-1
+               .option-col(class='.col-xs-5')
+                 .option-header.best-deal(data-i18n="subscribe.best_deal")
+             else
+               .option-col(class='.col-xs-12')
+                 .option-header.best-deal(data-i18n="subscribe.best_deal")
+         .row
+           - var secondRowClass = '.col-xs-5'
+           if view.basicProduct
+             .col-xs-5.option-col.col-xs-offset-1
+               +price("subscribe.month_price", view.basicProduct)
+               .option-header.price-subtext.text-center(data-i18n="subscribe.stripe_description")
+               button.btn.btn-lg.btn-illustrated.purchase-button
+                 span.buy-now-text(data-i18n="subscribe.buy_now")
+                 span.buy-lock-icon &#x1F512;
 
-              else
-                - var secondRowClass = '.col-xs-12'
+           else
+             - var secondRowClass = '.col-xs-12'
 
-              if view.lifetimeProduct
-                .option-col(class=secondRowClass)
-                  +price("subscribe.lifetime_price", view.lifetimeProduct)
-                  .option-header.price-subtext.text-center(data-i18n="subscribe.lifetime")
-                  if view.paymentProcessor === 'PayPal'
-                    #paypal-button-container
-                  else
-                    button.stripe-lifetime-button.btn.btn-lg.btn-illustrated
-                      span.buy-now-text(data-i18n="subscribe.buy_now")
-                      span.buy-lock-icon &#x1F512;
-
-        else
-          //- lifetime-only modal
-          .container-fluid
-            .row
-              .col-xs-5.text-center
-                img.left-image(src="/images/pages/play/modal/heroes-and-pets.png")
-              .col-xs-7
-                div.benefits-header.text-center(data-i18n="[html]subscribe.comparison_blurb")
-                ul
-                  li(data-i18n="subscribe.feature_level_access")
-                  li(data-i18n="subscribe.feature_heroes")
-                  li(data-i18n="subscribe.feature_learn")
-                if view.lifetimeProduct
-                  .option-col(class=secondRowClass)
-                    +price("subscribe.lifetime_price", view.lifetimeProduct)
-                    .option-header.text-center(data-i18n="subscribe.lifetime")
-                    if view.paymentProcessor === 'PayPal'
-                      #paypal-button-container
-                    else
-                      button.stripe-lifetime-button.btn.btn-lg.btn-illustrated
-                        span.buy-now-text(data-i18n="subscribe.buy_now")
-                        span.buy-lock-icon &#x1F512;
+           if view.lifetimeProduct
+             .option-col(class=secondRowClass)
+               +price("subscribe.lifetime_price", view.lifetimeProduct)
+               .option-header.price-subtext.text-center(data-i18n="subscribe.lifetime")
+               if view.paymentProcessor === 'PayPal'
+                 #paypal-button-container
+               else
+                 button.stripe-lifetime-button.btn.btn-lg.btn-illustrated
+                   span.buy-now-text(data-i18n="subscribe.buy_now")
+                   span.buy-lock-icon &#x1F512;
 
         div.support-blurb.text-center
           p

--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -1,19 +1,3 @@
-if view.showAds()
-  // TODO: loading this multiple times yields script error:
-  // Uncaught TagError: adsbygoogle.push() error: All ins elements in the DOM with class=adsbygoogle already have ads in them.
-  .ad-container
-    if campaign
-      script(async, src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js")
-      ins.adsbygoogle(style="display:inline-block;width:728px;height:90px", data-ad-client="ca-pub-6640930638193614", data-ad-slot="4924994487")
-      script.
-        (adsbygoogle = window.adsbygoogle || []).push({});
-    else
-      script(async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js")
-      ins.adsbygoogle(style="display:inline-block;width:728px;height:90px", data-ad-client="ca-pub-6640930638193614", data-ad-slot="4469166082")
-      script.
-        (adsbygoogle = window.adsbygoogle || []).push({});
-
-
 if showGameDevAlert
   #game-dev-hoc-license-alert.alert.alert-success
     span(data-i18n="play.get_course_for_class")

--- a/app/templates/play/play-level-view.jade
+++ b/app/templates/play/play-level-view.jade
@@ -1,12 +1,3 @@
-if view.showAds()
-  // TODO: loading this multiple times yields script error:
-  // Uncaught TagError: adsbygoogle.push() error: All ins elements in the DOM with class=adsbygoogle already have ads in them.
-  .ad-container
-    script(async, src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js")
-    ins.adsbygoogle(style="display:inline-block;width:728px;height:90px", data-ad-client="ca-pub-6640930638193614", data-ad-slot="5527096883")
-    script.
-      (adsbygoogle = window.adsbygoogle || []).push({});
-
 include game-dev-goals
 
 .game-container

--- a/app/views/core/SubscribeModal.coffee
+++ b/app/views/core/SubscribeModal.coffee
@@ -29,7 +29,6 @@ module.exports = class SubscribeModal extends ModalView
     super(options)
     @state = 'standby'
     @couponID = utils.getQueryVariable('coupon')
-    @subType = utils.getQueryVariable('subtype', 'both-subs')
     @subModalContinue = options.subModalContinue
     if options.products
       # this is just to get the test demo to work
@@ -49,16 +48,6 @@ module.exports = class SubscribeModal extends ModalView
     # Process basic product coupons unless custom region pricing
     if @couponID and @basicProduct.get('coupons')? and @basicProduct?.get('name') is 'basic_subscription'
       @basicCoupon = _.find(@basicProduct.get('coupons'), {code: @couponID})
-
-      # Always use both-subs UX test group when basic product coupon, and delay identify until we can decide
-      @subType = if utils.getQueryVariable('subtype')?
-        me.setSubModalGroup(utils.getQueryVariable('subtype'))
-      else if @basicCoupon
-        me.setSubModalGroup('both-subs')
-      else
-        me.getSubModalGroup()
-    else
-      @subType = utils.getQueryVariable('subtype', me.getSubModalGroup())
     @lifetimeProduct = @products.getLifetimeSubscriptionForUser(me)
     if @lifetimeProduct?.get('name') isnt 'lifetime_subscription'
       # Use PayPal for international users with regional pricing

--- a/app/views/courses/TeacherClassesView.coffee
+++ b/app/views/courses/TeacherClassesView.coffee
@@ -19,7 +19,6 @@ storage = require 'core/storage'
 GoogleClassroomHandler = require('core/social-handlers/GoogleClassroomHandler')
 co = require('co')
 OzariaEncouragementModal = require('app/views/teachers/OzariaEncouragementModal').default
-experiments = require('core/experiments')
 
 helper = require 'lib/coursesHelper'
 

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -503,8 +503,7 @@ module.exports = class CampaignView extends RootView
     context.campaign = @campaign
     context.levels = _.values($.extend true, {}, @getLevels() ? {})
     if me.level() < 12 and @terrain is 'dungeon' and not @editorMode
-      reject = if me.getFourthLevelGroup() is 'signs-and-portents' then 'forgetful-gemsmith' else 'signs-and-portents'
-      context.levels = _.reject context.levels, slug: reject
+      context.levels = _.reject context.levels, slug: 'signs-and-portents'
     if me.freeOnly()
       context.levels = _.reject context.levels, (level) ->
         return level.requiresSubscription
@@ -556,8 +555,7 @@ module.exports = class CampaignView extends RootView
         if @sessions?.loaded
           levels = _.values($.extend true, {}, campaign.get('levels') ? {})
           if me.level() < 12 and campaign.get('slug') is 'dungeon' and not @editorMode
-            reject = if me.getFourthLevelGroup() is 'signs-and-portents' then 'forgetful-gemsmith' else 'signs-and-portents'
-            levels = _.reject levels, slug: reject
+            levels = _.reject levels, slug: 'signs-and-portents'
           if me.freeOnly()
             levels = _.reject levels, (level) ->
               return level.requiresSubscription
@@ -695,12 +693,6 @@ module.exports = class CampaignView extends RootView
     return unless slug
     return false if 'hoc' in slug
     /campaign-(game|web)-dev-\d/.test slug
-
-  showAds: ->
-    return false # No ads for now.
-    if application.isProduction() && !me.isPremium() && !me.isTeacher() && !window.serverConfig.picoCTF
-      return me.getCampaignAdsGroup() is 'leaderboard-ads'
-    false
 
   annotateLevels: (orderedLevels) ->
     return if @isClassroom()
@@ -1091,7 +1083,6 @@ module.exports = class CampaignView extends RootView
     aspectRatio = mapWidth / mapHeight
     pageWidth = @$el.width()
     pageHeight = @$el.height()
-    pageHeight -= adContainerHeight if adContainerHeight = $('.ad-container').outerHeight()
     widthRatio = pageWidth / mapWidth
     heightRatio = pageHeight / mapHeight
     # Make sure we can see the whole map, fading to background in one dimension.

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -263,12 +263,6 @@ module.exports = class PlayLevelView extends RootView
 
   isCourseMode: -> @courseID and @courseInstanceID
 
-  showAds: ->
-    return false # No ads for now.
-    if application.isProduction() && !me.isPremium() && !me.isTeacher() && !window.serverConfig.picoCTF && !@isCourseMode()
-      return me.getCampaignAdsGroup() is 'leaderboard-ads'
-    false
-
   # CocoView overridden methods ###############################################
 
   getRenderData: ->
@@ -508,7 +502,7 @@ module.exports = class PlayLevelView extends RootView
       @observing
       playerNames: @findPlayerNames()
       levelType: @level.get('type', true)
-      stayVisible: @showAds()
+      stayVisible: false
       @gameUIState
       @level # TODO: change from levelType to level
     }

--- a/static-mock.coffee
+++ b/static-mock.coffee
@@ -33,7 +33,6 @@ exports.me =
   hideFooter: -> false
   useGoogleAnalytics: -> true
   showChinaVideo: -> false
-  getHomePageTestGroup: -> undefined
   showForumLink: -> true
   showChinaResourceInfo: -> false
   hideDiplomatModal: -> false
@@ -43,6 +42,5 @@ exports.me =
 exports.view =
   forumLink: () -> 'http://discourse.codecombat.com/'
   isMobile: () -> false
-  showAds: () -> false
   isOldBrowser: () -> false
   isIPadBrowser: () -> false


### PR DESCRIPTION
We do want to include the "Request a Quote" action in the header, based on data; but we had only finished the test and picked the winning variant for Ozaria, forgot to do it for CodeCombat. Did that, and while I was at it, removed a bunch of old A/B testing code. Manually ran through SubscribeModal, CampaignView, PlayLevelView, and HomeView for a minute to make sure they didn't obviously break.