### PR TITLE
/parents route changed to use self-signup by default

### DIFF
--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -12,7 +12,7 @@ export default function getVueRouter () {
         {
           path: '/parents',
           component: () => import(/* webpackChunkName: "ParentsView" */ 'app/views/landing-pages/parents/PageParents'),
-          props: { type: 'parents', showPremium: true }
+          props: (route) => ({ showPremium: true, type: route.query.type })
         },
         {
           path: '/live-classes',


### PR DESCRIPTION
Changing default behavior of the parents from Drift to self-signup.

Route has been made the same as /live-classes route and has type overrides based on query params.

i.e.
`?type=parents` will revert original behavior
`?type=call` will show direct sales number.

Tested manually.