### PR TITLE
Remove monthly subscription option from parents page

### DIFF
--- a/app/templates/core/subscribe-modal.jade
+++ b/app/templates/core/subscribe-modal.jade
@@ -48,7 +48,7 @@ mixin price(name, p)
 
          if view.lifetimeProduct
            .short-row.row
-             if view.basicProduct
+             if view.basicProduct && !view.hideMonthlySub
                .col-xs-5.option-col.col-xs-offset-1
                .option-col(class='.col-xs-5')
                  .option-header.best-deal(data-i18n="subscribe.best_deal")
@@ -57,7 +57,7 @@ mixin price(name, p)
                  .option-header.best-deal(data-i18n="subscribe.best_deal")
          .row
            - var secondRowClass = '.col-xs-5'
-           if view.basicProduct
+           if view.basicProduct && !view.hideMonthlySub
              .col-xs-5.option-col.col-xs-offset-1
                +price("subscribe.month_price", view.basicProduct)
                .option-header.price-subtext.text-center(data-i18n="subscribe.stripe_description")

--- a/app/views/core/SubscribeModal.coffee
+++ b/app/views/core/SubscribeModal.coffee
@@ -27,6 +27,7 @@ module.exports = class SubscribeModal extends ModalView
     #  document.location.href = 'http://codecombat.net.br/'
 
     super(options)
+    @hideMonthlySub = options?.hideMonthlySub or null
     @state = 'standby'
     @couponID = utils.getQueryVariable('coupon')
     @subModalContinue = options.subModalContinue

--- a/app/views/landing-pages/parents/PageParentsSectionPremium.vue
+++ b/app/views/landing-pages/parents/PageParentsSectionPremium.vue
@@ -33,13 +33,7 @@
                 </div>
 
                 <div class="row premium-pricing">
-                    <div class="col-lg-3 col-lg-offset-3" :style="{ visibility: (productsLoading) ? 'hidden': 'visible' }">
-                        <h5>${{ basicSubAmount }}{{ $t('parents_landing_2.per_month') }}</h5>
-                        <h6>{{ $t('parents_landing_2.monthly_sub') }}</h6>
-
-                        <button @click="subscribeBasic">{{ $t('parents_landing_2.buy_now') }}</button>
-                    </div>
-                    <div class="col-lg-3" :style="{ visibility: (productsLoading) ? 'hidden': 'visible' }">
+                    <div class="col-lg-6 col-lg-offset-3" :style="{ visibility: (productsLoading) ? 'hidden': 'visible' }">
                         <h5>${{ lifetimeSubAmount }}</h5>
                         <h6>{{ $t('parents_landing_2.lifetime_access') }}</h6>
 
@@ -165,22 +159,6 @@
        * be used.  Once it is ready to be used we manually trigger the proper subscribe flow
        * by grabbing a reference to the SubscribeModal instance and calling the method that
        * is normally called by the onclick listener.
-       */
-      subscribeBasic () {
-        if (!this.checkSubscribeAndShowError()) {
-          return
-        }
-
-        this.$refs.subscribeModal.$once('shown', () => {
-          const modal = this.$refs.subscribeModal.$data.modalViewInstance
-          modal.onClickPurchaseButton()
-        })
-
-        this.openPremiumSubscribeModal()
-      },
-
-      /**
-       * See subscribeBasic comments
        */
       subscribeLifetime () {
         if (!this.checkSubscribeAndShowError()) {

--- a/app/views/landing-pages/parents/PageParentsSectionPremium.vue
+++ b/app/views/landing-pages/parents/PageParentsSectionPremium.vue
@@ -62,6 +62,7 @@
                 ref="subscribeModal"
                 :modal-view="SubscribeModal"
                 :open="subscribeModalOpen"
+                :modal-options="{ hideMonthlySub: true }"
                 @close="subscribeModalClosed"
         />
     </div>


### PR DESCRIPTION
This is a small step to our new individual pricing model and online classes payment structure.

Here is the subscription modal by default.
![image](https://user-images.githubusercontent.com/15080861/96793799-e3633180-13b1-11eb-8205-c5ec19639c39.png)

Gif below shows the modal through parent page flow. This should reduce confusion by only showing what the user clicked.
![9ad8afb1a4fef4d2a8f4cf46ef89b11a](https://user-images.githubusercontent.com/15080861/96793957-2c1aea80-13b2-11eb-844e-fc780825c4fd.gif)

Removed monthly option from the parent page.

