### PR TITLE
Replace "Regeneration" with "Regen" to fix overlapping text

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1023,7 +1023,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     attack: "Damage"  # Can also translate as "Attack"
     health: "Health"
     speed: "Speed"
-    regeneration: "Regeneration"
+    regeneration: "Regen"
     range: "Range"  # As in "attack or visual range"
     blocks: "Blocks"  # As in "this shield blocks this much damage"
     backstab: "Backstab"  # As in "this dagger does this much backstab damage"


### PR DESCRIPTION
Right now the text for Regeneration covers the number stats, as seen below:
<img width="372" alt="Screen Shot 2020-10-27 at 4 56 17 PM" src="https://user-images.githubusercontent.com/29741391/97272508-659d9b00-1875-11eb-8f30-3e91a8d74ad0.png">
However, replacing that with just "Regen" fixes the problem of overlapping text, as seen here:
<img width="366" alt="Screen Shot 2020-10-27 at 4 56 36 PM" src="https://user-images.githubusercontent.com/29741391/97272590-7a7a2e80-1875-11eb-9d0f-cfe689e2b976.png">

This PR will fix the issue of overlapping text 👍 