### PR TITLE
TimeTap page to debug iframe in private browsing

### DIFF
--- a/app/components/timetap/TimeTapDebugPage.vue
+++ b/app/components/timetap/TimeTapDebugPage.vue
@@ -1,0 +1,4 @@
+<template>
+  <!-- Temporary debug page for TimeTap -->
+  <iframe src='https://www.timetap.com/ttcs/app/home/codecombat#/' frameborder='0' width='100%' height='500'></iframe>
+</template>

--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -212,6 +212,9 @@ module.exports = class CocoRouter extends Backbone.Router
     'parents': go('core/SingletonAppVueComponentView')
     'live-classes': go('core/SingletonAppVueComponentView')
 
+    # Warning: In production debugging of third party iframe!
+    'temporary-debug-timetap': go('core/SingletonAppVueComponentView')
+
     'paypal/subscribe-callback': go('play/CampaignView')
     'paypal/cancel-callback': go('account/SubscriptionView')
 

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -28,6 +28,11 @@ export default function getVueRouter () {
             { path: 'teacher/:teacherId/classroom/:classroomId', component: () => import(/* webpackChunkName: "teachers" */ 'app/views/courses/TeacherClassView.vue') },
             { path: 'teacher/:teacherId/classroom/:classroomId/:studentId', component: () => import(/* webpackChunkName: "teachers" */ 'app/views/teachers/classes/TeacherStudentView.vue') }
           ]
+        },
+        // Warning: In production debugging of third party iframe!
+        {
+          path: '/temporary-debug-timetap',
+          component: () => import(/* webpackChunkName: "thirdPartyDebugging" */ 'app/components/timetap/TimeTapDebugPage')
         }
       ]
     })


### PR DESCRIPTION
Following instructions to help TimeTap debug the iframe in private browsing.

Looks like this:

![image](https://user-images.githubusercontent.com/15080861/97637039-31ea7e80-19f7-11eb-9784-5b3f46e46e31.png)
