### PR TITLE
Add additional subscription plan requests

### DIFF
--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -277,7 +277,7 @@ _.extend UserSchema.properties,
 
   stripe: c.object {}, {
     customerID: { type: 'string' }
-    planID: { enum: ['basic', 'price_1HjXyXKaReE7xLUdLUN0RZgo', 'price_1Hja49KaReE7xLUdlPuATOvQ'], description: 'Determines if a user has or wants to subscribe' }
+    planID: { enum: ['basic', 'price_1Hja49KaReE7xLUdlPuATOvQ'], description: 'Determines if a user has or wants to subscribe. Matches subscription plan on stripe.' }
     subscriptionID: { type: 'string', description: 'Determines if a user is subscribed' }
     token: { type: 'string' }
     couponID: { type: 'string' }

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -3,6 +3,16 @@ c = require './../schemas'
 
 emailSubscriptions = ['announcement', 'tester', 'level_creator', 'developer', 'article_editor', 'translator', 'support', 'notification']
 
+###
+SCHEMA WARNING
+
+Any changes made to this schema need to be shared on the Ozaria user schema.
+Both products share the same database collection and currently duplicating
+changes is how we can avoid validation errors as the user traverses between
+the two products.
+###
+
+
 UserSchema = c.object
   title: 'User'
   default:
@@ -267,7 +277,7 @@ _.extend UserSchema.properties,
 
   stripe: c.object {}, {
     customerID: { type: 'string' }
-    planID: { enum: ['basic'], description: 'Determines if a user has or wants to subscribe' }
+    planID: { enum: ['basic', 'price_1HjXyXKaReE7xLUdLUN0RZgo', 'price_1Hja49KaReE7xLUdlPuATOvQ'], description: 'Determines if a user has or wants to subscribe' }
     subscriptionID: { type: 'string', description: 'Determines if a user is subscribed' }
     token: { type: 'string' }
     couponID: { type: 'string' }


### PR DESCRIPTION
Unblocks the client from requesting different subscription plans.

These plans are then verified on the server where the verification is done.
We are unable to make these subscription plans nicer as they match the stripe id which is immutable.