### PR TITLE
Fix automatic application of coupons

### DIFF
--- a/app/views/core/SubscribeModal.coffee
+++ b/app/views/core/SubscribeModal.coffee
@@ -40,6 +40,13 @@ module.exports = class SubscribeModal extends ModalView
     else
       @products = new Products()
       data = {}
+
+      # Attempt to get the coupon associated with the user's country.
+      # If coupon doesn't exist nothing is returned.
+      @couponID ?= me?.get('country')
+      if @couponID is 'brazil'
+        @couponID = 'brazil-annual'
+
       if @couponID
         data.coupon = @couponID
       @supermodel.trackRequest @products.fetch {data}

--- a/app/views/core/SubscribeModal.coffee
+++ b/app/views/core/SubscribeModal.coffee
@@ -45,6 +45,7 @@ module.exports = class SubscribeModal extends ModalView
       # If coupon doesn't exist nothing is returned.
       @couponID ?= me?.get('country')
       if @couponID is 'brazil'
+        # Edge case due to misconfigured brazil coupon in stripe that is immutable
         @couponID = 'brazil-annual'
 
       if @couponID


### PR DESCRIPTION
# Context

We have country specific pricing for our monthly subscription and our annual subscription.
Unfortunately the country specific pricing wasn't being applied to the annual subscription automatically leading to confusing pricing suggestions as shown beneath.

Currently what modal looks like if in a discounted region:
![image](https://user-images.githubusercontent.com/15080861/99003756-6e3bd580-24f3-11eb-8d15-cb97b74bc9fa.png)


This fix ensures that the country coupon is applied. I added an edge case for brazil due to issue with the prior brazil coupon not correctly discounting.

Gif shows fixed behavior when doing a manual test. Because this is additive and still allows manual coupon adding this is a very low risk change.

![b41b326f227653ad67fb00402fa35b8a](https://user-images.githubusercontent.com/15080861/99004182-9297b200-24f3-11eb-9680-1ba8b47ffb7e.gif)
