### PR TITLE
Fix capstone performance by removing backbone mediator event validation

### DIFF
--- a/app/core/application.coffee
+++ b/app/core/application.coffee
@@ -48,7 +48,6 @@ console.debug ?= console.log  # Needed for IE10 and earlier
 Application = {
   initialize: ->
     Router = require('core/Router')
-    @isProduction = -> document.location.href.search('https?://localhost') is -1
     Vue.config.devtools = not @isProduction()
 
     # propagate changes from global 'me' User to 'me' vuex module
@@ -135,6 +134,8 @@ Application = {
     useBrainPop: -> api.admin.setFeatureMode('brain-pop').then(-> document.location.reload())
     clear: -> api.admin.clearFeatureMode().then(-> document.location.reload())
   }
+
+  isProduction: -> document.location.href.search('https?://localhost') is -1
 
   loadedStaticPage: window.alreadyLoadedView?
 

--- a/app/core/initialize.coffee
+++ b/app/core/initialize.coffee
@@ -91,7 +91,7 @@ handleNormalUrls = ->
 setUpBackboneMediator = ->
   Backbone.Mediator.addDefSchemas schemas for definition, schemas of definitionSchemas
   Backbone.Mediator.addChannelSchemas schemas for channel, schemas of channelSchemas
-  Backbone.Mediator.setValidationEnabled document.location.href.search(/codecombat.com/) is -1
+  Backbone.Mediator.setValidationEnabled(not app.isProduction())
   if false  # Debug which events are being fired
     originalPublish = Backbone.Mediator.publish
     Backbone.Mediator.publish = ->

--- a/app/core/initialize.coffee
+++ b/app/core/initialize.coffee
@@ -54,7 +54,7 @@ init = ->
   path = document.location.pathname
   app.testing = _.string.startsWith path, '/test'
   app.demoing = _.string.startsWith path, '/demo'
-  setUpBackboneMediator()
+  setUpBackboneMediator(app)
   app.initialize()
   loadOfflineFonts() unless app.isProduction()
   Backbone.history.start({ pushState: true })
@@ -88,7 +88,7 @@ handleNormalUrls = ->
 
     return false
 
-setUpBackboneMediator = ->
+setUpBackboneMediator = (app) ->
   Backbone.Mediator.addDefSchemas schemas for definition, schemas of definitionSchemas
   Backbone.Mediator.addChannelSchemas schemas for channel, schemas of channelSchemas
   Backbone.Mediator.setValidationEnabled(not app.isProduction())


### PR DESCRIPTION
# Context

Context is written up in the private Ozaria PR: https://github.com/codecombat/ozaria/pull/653

In short event validation can add another 200% of time to every frame.
Currently we hard coded whether event validation was turned on so that codecombat.com has a great experience but any other production domains have a slower experience (although playable).

This general fix should provide smoother framerates on low end hardware such as chromebooks in environments such as our domain in china.

cc/ @smallst 