### PR TITLE
Make content locking more obvious

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1670,7 +1670,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     certificate_btn_print: "Print"
     certificate_btn_toggle: "Toggle"
     ask_next_course: "Want to play more? Ask your teacher for access to the next course."
-    set_start_locked_level: "Assign up to level"
+    set_start_locked_level: "Lock levels starting at"
     no_level_limit: "--"
 
   project_gallery:

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1670,8 +1670,8 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     certificate_btn_print: "Print"
     certificate_btn_toggle: "Toggle"
     ask_next_course: "Want to play more? Ask your teacher for access to the next course."
-    set_start_locked_level: "Lock levels starting at"
-    no_level_limit: "--"
+    set_start_locked_level: "Lock levels starting at" # {change}
+    no_level_limit: "-- (no levels locked)" # {change}
 
   project_gallery:
     no_projects_published: "Be the first to publish a project in this course!"

--- a/app/styles/courses/teacher-class-view.sass
+++ b/app/styles/courses/teacher-class-view.sass
@@ -371,6 +371,14 @@
       .dot-label-inner
         color: $gray-light
 
+  .progress-dot.locked:not(.practice)
+    opacity: 0.5
+    background-image: url("/images/pages/game-menu/lock-processed.png")
+    background-size: 34px
+    background-position: center
+    background-repeat: no-repeat
+    text-shadow: 0 1px 0 black, 0 -1px 0 black, 1px 0 0 black, -1px 0 0 black
+
   // Code copying buttons
 
   .class-code-blurb

--- a/app/styles/courses/teacher-class-view.sass
+++ b/app/styles/courses/teacher-class-view.sass
@@ -232,6 +232,15 @@
 
   #course-progress-tab, #student-projects-tab
 
+    .course-progress-select-wrapper
+      label
+        min-width: 195px
+        display: inline-block
+        font-weight: normal
+
+      select
+        min-width: 306px
+
     .course-overview-row
       margin-top: 50px
       border: thin solid gray
@@ -372,12 +381,15 @@
         color: $gray-light
 
   .progress-dot.locked:not(.practice)
-    opacity: 0.5
+    opacity: 0.75
     background-image: url("/images/pages/game-menu/lock-processed.png")
     background-size: 34px
     background-position: center
     background-repeat: no-repeat
-    text-shadow: 0 1px 0 black, 0 -1px 0 black, 1px 0 0 black, -1px 0 0 black
+    text-shadow: 0 1px 0 white, 0 -1px 0 white, 1px 0 0 white, -1px 0 0 white
+
+    .dot-label-inner
+      color: black
 
   // Code copying buttons
 

--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -199,11 +199,14 @@ mixin courseOverview(course)
       span(data-i18n='teacher.course_overview')
     .course-overview-progress
       if state.get('progressData')
+        - var lockedFromHere = false;
+        - var courseInstance = view.getSelectedCourseInstance();
         each level, index in levels
           - if (level.get('assessment')) continue;
+          - if (courseInstance && level.get('slug') === courseInstance.get('startLockedLevel')) lockedFromHere = true;
           - var progress = state.get('progressData').get({ classroom: view.classroom, course: course, level: level })
           - var levelNumber = view.classroom.getLevelNumber(level.get('original'), index + 1)
-          +allStudentsLevelProgressDot(progress, level, levelNumber)
+          +allStudentsLevelProgressDot(progress, level, levelNumber, lockedFromHere)
 
 mixin studentLevelsRow(student)
   .student-levels-row.alternating-background
@@ -216,13 +219,16 @@ mixin studentLevelsRow(student)
         - var levels = view.classroom.getLevels({courseID: course.id}).models
         - var courseFinished = false;
         if state.get('progressData')
+          - var lockedFromHere = false;
+          - var courseInstance = view.getSelectedCourseInstance();
           each level, index in levels
             - if (level.get('assessment')) continue;
+            - if (courseInstance && level.get('slug') === courseInstance.get('startLockedLevel')) lockedFromHere = true;
             - var progress = state.get('progressData').get({ classroom: view.classroom, course: course, level: level, user: student })
             - var levelNumber = view.classroom.getLevelNumber(level.get('original'), index + 1)
             - if (!level.get('practice'))
               - courseFinished = progress.completed;
-            +studentLevelProgressDot(progress, level, levelNumber, student)
+            +studentLevelProgressDot(progress, level, levelNumber, student, lockedFromHere)
       div
         if courseFinished
           a.certificate-link.open-certificate-btn(target='_blank', href='/certificates/' + student.id + '?class=' + view.classroom.id + '&course=' + course.id + '&course-instance=' + state.get('selectedCourseInstance').id, data-event-action="Teachers Click Certificates - Progress tab")
@@ -246,10 +252,10 @@ mixin studentCourseProgressDot(progress, levelsTotal, label, student, course, co
     .progress-dot.has-tooltip(class=dotClass, data-html='true', data-title=view.singleStudentCourseProgressDotTemplate(progress))
       +progressDotLabel(label)
 
-mixin allStudentsLevelProgressDot(progress, level, levelNumber)
+mixin allStudentsLevelProgressDot(progress, level, levelNumber, locked=false)
   - dotClass = progress.completed ? 'forest' : (progress.started ? 'gold' : '');
   - levelName = i18n(level.attributes, 'name')
-  - context = _.merge(progress, { levelName: levelName, levelNumber: levelNumber, numStudents: view.students.length, practice: level.get('practice') })
+  - context = _.merge(progress, { levelName: levelName, levelNumber: levelNumber, numStudents: view.students.length, practice: level.get('practice'), locked: locked })
   - link = null;
   - labelText = levelNumber;
   - var courseInstance = state.get('selectedCourseInstance');
@@ -269,6 +275,8 @@ mixin allStudentsLevelProgressDot(progress, level, levelNumber)
     if !(progress.completed || progress.started)
       - labelText = ''
       - dotClass += ' practice'
+  if locked && !progress.completed
+    - dotClass += ' locked'
 
   if link
     if state.get('readOnly')
@@ -280,11 +288,11 @@ mixin allStudentsLevelProgressDot(progress, level, levelNumber)
       +progressDotLabel(labelText)
 
 
-mixin studentLevelProgressDot(progress, level, levelNumber, student)
+mixin studentLevelProgressDot(progress, level, levelNumber, student, locked=false)
   //- TODO: Refactor with TeacherClassesView jade
   - dotClass = progress.completed ? 'forest' : (progress.started ? 'gold' : '');
   - levelName = i18n(level.attributes, 'name')
-  - context = _.merge(progress, { levelName: levelName, levelNumber: levelNumber, moment: moment, practice: level.get('practice'), isProject: level.isProject(), assessment: level.get('assessment'), primaryConcept: _.first(level.get('primaryConcepts')), topScore: topScore, translate: translate })
+  - context = _.merge(progress, { levelName: levelName, levelNumber: levelNumber, moment: moment, practice: level.get('practice'), isProject: level.isProject(), assessment: level.get('assessment'), primaryConcept: _.first(level.get('primaryConcepts')), topScore: topScore, translate: translate, locked: locked })
   - var link = null;
   if dotClass
     //- TODO: these anchor links do not navigate to the anchor in destination page
@@ -307,7 +315,8 @@ mixin studentLevelProgressDot(progress, level, levelNumber, student)
     if !(progress.completed || progress.started)
       - labelText = ''
       - dotClass += ' practice'
-
+  if locked && !(progress.completed || progress.started)
+    - dotClass += ' locked'
 
   if link
     if state.get('readOnly')

--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -107,15 +107,34 @@ mixin studentRow(student)
 mixin courseProgressTab
   #course-progress-tab.m-t-3
     if view.courses
-      .text-center
-        span(data-i18n='teacher.select_course')
-        span.spr :
-        select.course-select
+      .course-progress-select-wrapper
+        label(for="course-select")
+          span(data-i18n='teacher.select_course')
+          span.spr :
+        select.course-select#course-select
           each course in view.latestReleasedCourses
             option(value=course.id selected=(course===state.get('selectedCourse')))
               = i18n(course.attributes, 'name')
               if !view.availableCourseMap[course.id]
                 = " " + translate('teacher.paren_new')
+
+    - var course = state.get('selectedCourse');
+    - var courseInstance = view.getSelectedCourseInstance()
+    if courseInstance && course && view.campaignLevelNumberMap[course.get('campaignID')]
+      .course-progress-select-wrapper(data-course-id=course.id)
+        label(for="locked-level-select")
+          span(data-i18n="courses.set_start_locked_level")
+          span.spr :
+        select#locked-level-select
+          option(data-i18n="courses.no_level_limit" value='none')
+          - var levels = view.classroom.getLevels({courseID: course.id}).models
+          each level, levelIndex in levels
+            unless level.get('assessment') || level.get('practice')
+              option(value=level.get('slug') selected=(level.get('slug') === courseInstance.get('startLockedLevel')))
+                span #{view.campaignLevelNumberMap[course.get('campaignID')][level.get('original')]}.
+                  = " "
+                span
+                  = i18n(level.attributes, 'name').replace('Course: ', '')
 
     h4.m-b-2.m-t-3(data-i18n="teacher.progress_color_key")
     #progress-color-key-row.row.m-b-3
@@ -139,22 +158,7 @@ mixin courseProgressTab
         .key-text
           span.small(data-i18n="teacher.level_not_started")
         .clearfix
-    - var course = state.get('selectedCourse');
-    - var courseInstance = view.getSelectedCourseInstance()
-    if courseInstance && course && view.campaignLevelNumberMap[course.get('campaignID')]
-      .text-center(data-course-id=course.id)
-        span(data-i18n="courses.set_start_locked_level")
-        span.spr :
-        select.locked-level-select
-          option(data-i18n="courses.no_level_limit" value='none')
-          - var levels = view.classroom.getLevels({courseID: course.id}).models
-          each level, levelIndex in levels
-            unless level.get('assessment') || level.get('practice')
-              option(value=level.get('slug') selected=(level.get('slug') === courseInstance.get('startLockedLevel')))
-                span #{view.campaignLevelNumberMap[course.get('campaignID')][level.get('original')]}.
-                  = " "
-                span
-                  = i18n(level.attributes, 'name').replace('Course: ', '')
+
     // TODO: Refactor this to use Vue components like in the assessments tab
     if course && view.availableCourseMap[course.id] && courseInstance && courseInstance.get('members').length > 0
       .render-on-course-sync

--- a/app/templates/teachers/hovers/progress-dot-all-students-single-level.jade
+++ b/app/templates/teachers/hovers/progress-dot-all-students-single-level.jade
@@ -21,3 +21,9 @@ else
     span.spr . 
     span= levelName
   span.small-details.nowrap(data-i18n='teacher.no_progress')
+
+if locked
+  .small-details.nowrap
+    span  (
+    span(data-i18n='play.locked')
+    span )

--- a/app/templates/teachers/hovers/progress-dot-single-student-level.jade
+++ b/app/templates/teachers/hovers/progress-dot-single-student-level.jade
@@ -87,3 +87,8 @@ else
     .small-details.nowrap(data-i18n='teacher.not_required')
   else
     .small-details.nowrap(data-i18n='teacher.no_progress')
+    if locked
+      .small-details.nowrap
+        span  (
+        span(data-i18n='play.locked')
+        span )

--- a/app/views/courses/TeacherClassView.coffee
+++ b/app/views/courses/TeacherClassView.coffee
@@ -62,7 +62,7 @@ module.exports = class TeacherClassView extends RootView
     'change .course-select, .bulk-course-select': 'onChangeCourseSelect'
     'click a.student-level-progress-dot': 'onClickStudentProgressDot'
     'click .sync-google-classroom-btn': 'onClickSyncGoogleClassroom'
-    'change .locked-level-select': 'onChangeLockedLevelSelect'
+    'change #locked-level-select': 'onChangeLockedLevelSelect'
     'click .student-details-row': 'trackClickEvent'
     'click .open-certificate-btn': 'trackClickEvent'
 


### PR DESCRIPTION
![2020-11-25 15 15 37](https://user-images.githubusercontent.com/99704/100291111-b6b2b480-2f31-11eb-91b0-a76f1b70fd0a.gif)

This was so confusing for teachers, so I:
- Renamed from "Assign up to level" to "Lock levels start at"
- Put lock images and faded the level dots for locked levels
- Added "(Locked)" to hover labels

(In the .gif I didn't have "(Locked)" on not-started levels, but I fixed that.)

I tested it as shown in the .gif but didn't test otherwise.