### PR TITLE
Griffin responsiveness to Parent Page and jumbotron overflow-x

### DIFF
--- a/app/views/landing-pages/parents/PageParents.vue
+++ b/app/views/landing-pages/parents/PageParents.vue
@@ -938,6 +938,7 @@ export default {
   margin-bottom: 5px;
 }
 
+
 .pricing-grid-container > .grid-item {
   display: flex;
   align-items: center;
@@ -1019,6 +1020,11 @@ export default {
 }
 
 @media screen and (max-width: 700px) {
+  .pricing-grid-container {
+    grid-template-columns: 40% 15% 15% 15% 15%;
+    font-size: small;
+  }
+
   .container-pricing-table {
     padding: 0;
     font-style: smaller;

--- a/app/views/landing-pages/parents/PageParentsJumbotron.vue
+++ b/app/views/landing-pages/parents/PageParentsJumbotron.vue
@@ -104,6 +104,7 @@ export default {
   @media (max-width: 1000px) {
     .top-jumbotron {
       /* Moves images out of the way of the heading to keep it legible */
+      background-size: 443px, 260px, 90px, 260px, 250px;
       background-position: bottom -74% left -5%,
         top 50px left 30px,
         top 35px right 280px,
@@ -113,9 +114,10 @@ export default {
 
     .animated-griffin {
       position: absolute;
-      top: -6%;
-      right: -10%;
+      top: -1%;
+      right: -11%;
       overflow: hidden;
+      max-width: 50%;
     }
   }
 

--- a/app/views/landing-pages/parents/PageParentsJumbotron.vue
+++ b/app/views/landing-pages/parents/PageParentsJumbotron.vue
@@ -46,6 +46,7 @@ export default {
     min-height: 580px;
 
     padding-top: 155px;
+    overflow-x: hidden;
 
     background-color: unset;
 
@@ -80,17 +81,6 @@ export default {
       250px;
   }
 
-  @media (max-width: 1000px) {
-    .top-jumbotron {
-      /* Moves images out of the way of the heading to keep it legible */
-      background-position: bottom -74% left -5%,
-        top 50px left 30px,
-        top 35px right 280px,
-        top 360px right 300px,
-        bottom 52px right 475px;
-    }
-  }
-
   .pixelated {
     font-family: "lores12ot-bold";
     color: #0E4C60;
@@ -109,6 +99,24 @@ export default {
     position: absolute;
     top: 30%;
     right: 6%;
+  }
+
+  @media (max-width: 1000px) {
+    .top-jumbotron {
+      /* Moves images out of the way of the heading to keep it legible */
+      background-position: bottom -74% left -5%,
+        top 50px left 30px,
+        top 35px right 280px,
+        top 360px right 300px,
+        bottom 52px right 475px;
+    }
+
+    .animated-griffin {
+      position: absolute;
+      top: -6%;
+      right: -10%;
+      overflow: hidden;
+    }
   }
 
 </style>


### PR DESCRIPTION
Tweaks the griffin image to move out of the way of the heading.
Also added overflow-x to prevent the bit of space creating a horizontal scroll to appear in the page.

Note that localhost doesn't have the font in production (in screenshot).


I also tried to quickly animate the clouds but found that animating separate background-positions doesn't work. Next time will overlay some divs behind the jumbotron with a cloud in each div, and translate those divs instead of one background-position.

Tested in chrome and Firefox. The gif was from firefox:

![0c38aff7d6b8f9fd695a0f178518e7c5](https://user-images.githubusercontent.com/15080861/100688602-99b62100-3337-11eb-90ee-1c5f5aebe4c3.gif)


## Before this PR:

Example of image:

![759be9f145cf3cc6ad8bd204a1a08166](https://user-images.githubusercontent.com/15080861/100688697-ca965600-3337-11eb-9306-1fdde9d24bfd.gif)

Example of tiny space to the right.
![52a9983c094e71d9c534500fd2a5e2f8](https://user-images.githubusercontent.com/15080861/100688889-324ca100-3338-11eb-99b3-01d60985a70d.gif)
