### PR TITLE
Remove top banner and fix parent page overflowing

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -90,7 +90,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     teachers_love_codecombat_blurb2: "Would recommend CodeCombat to other computer science teachers"
     teachers_love_codecombat_blurb3: "Say that CodeCombat helps them support students’ problem solving abilities"
     teachers_love_codecombat_subblurb: "In partnership with McREL International, a leader in research-based guidance and evaluations of educational technology."
-    top_banner_blurb: "Parents, book your child's first live online coding class for free!"
+    top_banner_blurb: "Parents, give your child the gift of coding and personalized instruction this holiday season!" # {change}
     try_the_game: "Try the game"
     classroom_edition: "Classroom Edition:"
     learn_to_code: "Learn to code:"

--- a/app/views/landing-pages/parents/PageParents.vue
+++ b/app/views/landing-pages/parents/PageParents.vue
@@ -155,7 +155,7 @@
 
     <!-- Added some custom inline styles specific to this graphic -->
     <div class="container-graphic-spacer"
-         style="margin-bottom: -35px"
+         style="margin-bottom: -35px; overflow-x: hidden;"
     >
       <div class="container">
         <div class="row">


### PR DESCRIPTION
# Context

This is a very small fix that addresses two tasks.

 1. Updating the top marketing banner on the CodeCombat homepage
 2. Fixing an image overflow problem on /parents page when viewed on mobiles or small width screens.

# Testing

To test run local proxy and manually check the home page and /parents page.

I manually tested on Chrome and Firefox.

# Risk

Very low. Small and simple changes.

# Screenshots

## Top banner change

![image](https://user-images.githubusercontent.com/15080861/101535573-b5c84c80-394d-11eb-86be-9a50bc6fd6cb.png)

## Parent page width fix

After overflow fix:

![41f07f895f63089ffe6b042dfd5bafcb](https://user-images.githubusercontent.com/15080861/101535886-1eafc480-394e-11eb-8143-4d49488e76ee.gif)

before

![4b70a1ac606d1d0144f9cdac06d9e73a](https://user-images.githubusercontent.com/15080861/101535975-3a1acf80-394e-11eb-8844-100560226b31.gif)
