### PR TITLE
increase font size of esports-header

### DIFF
--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -258,7 +258,7 @@ export default {
     <section class="row esports-header" style="min-height: 600px;">
       <div class="col-sm-5">
         <clan-selector v-if="!isLoading && Array.isArray(myClans) && myClans.length > 0" :clans="myClans" @change="e => changeClanSelected(e)" :selected="clanIdSelected || clanIdOrSlug" style="margin-bottom: 40px;"/>
-        <h1 style="transform: rotate(-10deg);"><span class="esports-pink">Competitive </span><span class="esports-green">coding </span><span class="esports-aqua">has </span><span class="esports-purple">never </span><span class="esports-pink">been </span><span class="esports-aqua">so </span><span class="esports-green">epic</span></h1>
+        <h1 class="esports-h1"><span class="esports-pink">Competitive </span><span class="esports-green">coding </span><span class="esports-aqua">has </span><span class="esports-purple">never </span><span class="esports-pink">been </span><span class="esports-aqua">so </span><span class="esports-green">epic</span></h1>
       </div>
     </section>
 
@@ -582,6 +582,15 @@ export default {
     background: url(/images/pages/league/game_hero.png) no-repeat;
     background-size: contain;
     background-position: right center;
+  }
+
+  .esports-header .esports-h1 {
+    font-style: normal;
+    font-weight: bold;
+    font-size: 60px;
+    line-height: 80px;
+    text-transform: uppercase;
+    transform: rotate(-12deg);
   }
 
   // Most sections have a max width and are centered.


### PR DESCRIPTION
Changed font to 60px instead of 70px since that was taking letters out of frame. Copied design changes from Figma.

<img width="1731" alt="Screenshot 2020-12-16 at 12 36 24 PM" src="https://user-images.githubusercontent.com/6376157/102316108-585e7c00-3f9b-11eb-9d38-b9bb8a0fd3a8.png">
