### PR TITLE
Added padding between 'How it Works' and 'Season Arenas' sections

### DIFF
--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -370,7 +370,7 @@ export default {
       <div class="col-sm-11"><p>Complete the training levels and compete in the <span class="esports-aqua">Season Arena</span></p></div>
     </div>
 
-    <div class="row flex-row">
+    <div class="row flex-row pb-200">
       <div class="col-sm-1"><img src="/images/pages/league/text_3.svg" class="img-responsive" loading="lazy"></div>
       <div class="col-sm-11"><p>Compete in the culminating <span class="esports-aqua">Global Final Arena</span> and push your coding skills to the test</p></div>
     </div>
@@ -714,6 +714,10 @@ export default {
       margin: 0 auto;
       max-height: 600px;
     }
+  }
+
+  .pb-200{
+    padding-bottom: 200px;
   }
 }
 </style>

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -716,7 +716,7 @@ export default {
     }
   }
 
-  .pb-200{
+  .pb-200 {
     padding-bottom: 200px;
   }
 }


### PR DESCRIPTION
Padding between "How it Works" and "Season Arenas" sections.

![Competitive-AI-coding-eSports-from-CodeCombat-2](https://user-images.githubusercontent.com/75598717/102356452-3aad0900-3fd3-11eb-9067-775b2ff617b5.png)
