### PR TITLE
Fix esports routing and clan CTA

### DIFF
--- a/app/views/landing-pages/league/PageLeague.vue
+++ b/app/views/landing-pages/league/PageLeague.vue
@@ -3,7 +3,8 @@
 
 <template>
     <div id="page-league">
-      <router-view></router-view>
+      <!-- Key ensures any change of url re-renders component -->
+      <router-view :key="$route.fullPath"></router-view>
     </div>
 </template>
 

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -190,6 +190,13 @@ export default {
     isClanCreator () {
       return (this.currentSelectedClan || {}).ownerID === me.id
     },
+
+    clanInviteLink () {
+      if (this.currentSelectedClan !== null) {
+        return `${window.location.origin}/league/${this.currentSelectedClan.slug}`
+      }
+      return `${window.location.origin}/league/${this.clanIdOrSlug}`
+    },
   },
 
   computed: {
@@ -201,13 +208,6 @@ export default {
       clanByIdOrSlug: 'clans/clanByIdOrSlug',
       isLoading: 'clans/isLoading'
     }),
-
-    clanInviteLink () {
-      if (this.currentSelectedClan !== null) {
-        return `${window.location.origin}/league/${this.currentSelectedClan.slug}`
-      }
-      return `${window.location.origin}/league/${this.clanIdOrSlug}`
-    },
 
     currentSelectedClan () {
       return this.clanByIdOrSlug(this.clanIdSelected) || null
@@ -304,7 +304,7 @@ export default {
         <h1><span class="esports-aqua">{{ currentSelectedClanName }}</span></h1>
         <h3 style="margin-bottom: 40px;">{{ currentSelectedClanDescription }}</h3>
         <p>Invite players to this clan by sending them this link:</p>
-        <input readonly :value="clanInviteLink" /><br />
+        <input readonly :value="clanInviteLink()" /><br />
         <a v-if="isAnonymous()" class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">Join Now</a>
         <a v-else-if="isClanCreator()" class="btn btn-large btn-primary btn-moon" @click="openClanCreation">Edit Clan</a>
         <a v-else-if="inSelectedClan()" class="btn btn-large btn-primary btn-moon" :disabled="joinOrLeaveClanLoading" @click="leaveClan">Leave Clan</a>

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -177,7 +177,19 @@ export default {
 
     isAnonymous () {
       return me.isAnonymous()
-    }
+    },
+
+    inSelectedClan () {
+      if (!this.currentSelectedClan) {
+        return false
+      }
+
+      return (me.get('clans') || []).indexOf(this.currentSelectedClan._id) !== -1
+    },
+
+    isClanCreator () {
+      return (this.currentSelectedClan || {}).ownerID === me.id
+    },
   },
 
   computed: {
@@ -209,19 +221,8 @@ export default {
       return (this.currentSelectedClan || {}).description || ''
     },
 
-    inSelectedClan () {
-      if (!this.currentSelectedClan) {
-        return false
-      }
-      return (this.currentSelectedClan.members || []).indexOf(me.id) !== -1
-    },
-
-    isClanCreator () {
-      return (this.currentSelectedClan || {}).ownerID === me.id
-    },
-
     myCreatedClan () {
-      return this.isClanCreator ? this.currentSelectedClan : null
+      return this.isClanCreator() ? this.currentSelectedClan : null
     },
 
     selectedClanRankings () {
@@ -288,7 +289,7 @@ export default {
         style="max-width: 800px; margin-bottom: 50px;"
       >The CodeCombat AI League is uniquely both a competitive AI battle simulator and game engine for learning real Python and JavaScript code.</p>
     </div>
-    <div v-if="!doneRegistering && !isClanCreator" class="row flex-row text-center">
+    <div v-if="!doneRegistering && !isClanCreator()" class="row flex-row text-center">
       <a class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">Join Now</a>
     </div>
     <div class="graphic" style="width: 100%; overflow-x: hidden; display: flex; justify-content: flex-end; margin-bottom: 120px;">
@@ -305,8 +306,8 @@ export default {
         <p>Invite players to this clan by sending them this link:</p>
         <input readonly :value="clanInviteLink" /><br />
         <a v-if="isAnonymous()" class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">Join Now</a>
-        <a v-else-if="isClanCreator" class="btn btn-large btn-primary btn-moon" @click="openClanCreation">Edit Clan</a>
-        <a v-else-if="inSelectedClan" class="btn btn-large btn-primary btn-moon" :disabled="joinOrLeaveClanLoading" @click="leaveClan">Leave Clan</a>
+        <a v-else-if="isClanCreator()" class="btn btn-large btn-primary btn-moon" @click="openClanCreation">Edit Clan</a>
+        <a v-else-if="inSelectedClan()" class="btn btn-large btn-primary btn-moon" :disabled="joinOrLeaveClanLoading" @click="leaveClan">Leave Clan</a>
         <a v-else class="btn btn-large btn-primary btn-moon" :disabled="joinOrLeaveClanLoading" @click="joinClan">Join Clan</a>
       </div>
     </div>
@@ -349,7 +350,7 @@ export default {
         <p style="margin-bottom: 30px;">
           Put all the skills you’ve learned to the test! Compete against students and players from across the world in this exciting culmination to the season.
         </p>
-        <a v-if="!doneRegistering && !isClanCreator" style="margin-bottom: 30px;" class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">Join Now</a>
+        <a v-if="!doneRegistering && !isClanCreator()" style="margin-bottom: 30px;" class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">Join Now</a>
       </div>
       <div class="col-sm-5">
         <img class="img-responsive" src="/images/pages/league/text_coming_april_2021.svg" loading="lazy">
@@ -407,7 +408,7 @@ export default {
       </div>
     </div>
 
-    <div v-if="!doneRegistering && !isClanCreator" class="row flex-row text-center">
+    <div v-if="!doneRegistering && !isClanCreator()" class="row flex-row text-center">
       <a class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">Join Now</a>
     </div>
 
@@ -498,7 +499,7 @@ export default {
     </div>
 
     <div class="row flex-row text-center" style="margin-bottom: 300px;">
-      <a v-if="isClanCreator" class="btn btn-large btn-primary btn-moon" @click="openClanCreation">Edit Clan</a>
+      <a v-if="isClanCreator()" class="btn btn-large btn-primary btn-moon" @click="openClanCreation">Edit Clan</a>
       <a v-else-if="!currentSelectedClan && canCreateClan()" class="btn btn-large btn-primary btn-moon" @click="openClanCreation">Start a Clan</a>
       <a v-else-if="!doneRegistering" class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">Join Now</a>
     </div>

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -65,9 +65,8 @@ export default {
       this.findIdOfParam()
 
       const leagueURL = this.clanIdSelected ? `league/${this.clanIdSelected}` : 'league'
-      application.router.navigate(leagueURL)
-      // { trigger: true } does not work here due to Vue routing weirdness, so we change URL and reload:
-      location.reload()
+
+      application.router.navigate(leagueURL, { trigger: true })
     },
 
     findIdOfParam () {
@@ -316,9 +315,9 @@ export default {
       <h1 v-if="currentSelectedClan"><span class="esports-aqua">{{ currentSelectedClanName }} </span><span class="esports-pink">stats</span></h1>
       <h1 v-else><span class="esports-aqua">Global </span><span class="esports-pink">stats</span></h1>
       <p>Use your coding skills and battle strategies to rise up the ranks!</p>
-      <leaderboard v-if="currentSelectedClan" :rankings="selectedClanRankings" :key="clanIdSelected" style="color: black;" />
+      <leaderboard v-if="currentSelectedClan" :rankings="selectedClanRankings" :key="`${clanIdSelected}-score`" style="color: black;" />
       <leaderboard v-else :rankings="globalRankings" style="color: black;" />
-      <leaderboard :rankings="selectedClanCodePointsRankings" :key="clanIdSelected" scoreType="codePoints" style="color: black;" />
+      <leaderboard :rankings="selectedClanCodePointsRankings" :key="`${clanIdSelected}-codepoints`" scoreType="codePoints" style="color: black;" />
     </div>
     <div class="row text-center" style="margin-bottom: 50px;">
       <!-- TODO: this CTA should be in the left column with the arena leaderboard, and there should be a separate CTA to play levels and earn CodePoints in the right column -->


### PR DESCRIPTION
# Issue

The routing to the page was passing through a parent component. When the route changed the exact same components were being used and Vue was more than happy to keep them the same.

To force vue to change the page on a url change (even if it is the same component), we can use a key. Here I've opted to use a full URL key which will re-render page when any url changes happen.


# Testing

Tested manually by navigating to the /league page and testing clicking on the clan dropdown as well as the clans in the leaderboard.

Tested clan from perspective of anonymous, logged in, in clan, and owner of clan.

# Screenshots


![13c10950527d8f0b68cea57031b97487](https://user-images.githubusercontent.com/15080861/102376176-31428300-3f78-11eb-8878-70abd2cbafa8.gif)
