### PR TITLE
🐛 Remove duplication of AI session from league clan page

### DIFF
--- a/app/core/store/modules/seasonalLeague.js
+++ b/app/core/store/modules/seasonalLeague.js
@@ -176,7 +176,7 @@ export default {
         team: 'humans',
         'leagues.leagueID': leagueId
       }).then(ranking => {
-        leagueRankingInfo.top = ranking
+        leagueRankingInfo.top = _.uniq(ranking, true, session => session._id)
       })
 
       const sessionsData = await fetchMySessions(currentSeasonalLevelOriginal)

--- a/app/core/store/modules/seasonalLeague.js
+++ b/app/core/store/modules/seasonalLeague.js
@@ -176,6 +176,7 @@ export default {
         team: 'humans',
         'leagues.leagueID': leagueId
       }).then(ranking => {
+        // Temporarily only choose unique sessions as duplicate AI sessions are returned.
         leagueRankingInfo.top = _.uniq(ranking, true, session => session._id)
       })
 


### PR DESCRIPTION
# Issue

Currently if you navigate to /league page and select a clan there are duplicate AI sessions shown.

See screenshot below after navigating to https://codecombat.com/league/stem-spartans

![image](https://user-images.githubusercontent.com/15080861/102407113-6d89d980-3fa0-11eb-9811-0128d044ee67.png)

# Fix

A more robust fix tackles this on the server side. However temporarily for agility this can be solved on the client.

![image](https://user-images.githubusercontent.com/15080861/102407210-94481000-3fa0-11eb-8c47-f577a48e2ff8.png)
