### PR TITLE
🐛 Scroll position shouldn't be saved between vue router pages

### DIFF
--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -45,6 +45,18 @@ export default function getVueRouter () {
         }
       ]
     })
+
+    vueRouter.afterEach((to, from) => {
+      // Fixes issue of page not scrolling to top on navigation change
+      if (to.path !== from.path) {
+        // If the user has navigated within the router, try and reset the scroll position.
+        try {
+          window.scrollTo(0, 0)
+        } catch (e) {
+          // Can fail silently. Handling browser compatibility
+        }
+      }
+    })
   }
 
   return vueRouter

--- a/app/views/landing-pages/parents/PageParents.vue
+++ b/app/views/landing-pages/parents/PageParents.vue
@@ -611,10 +611,6 @@ export default {
   mounted () {
     window.drift.on('scheduling:meetingBooked', this.onDriftMeetingBooked)
 
-    console.log('>>>>>>>>>>>>>>>>>>>')
-    console.log(this.$router.currentRoute.query)
-    console.log('>>>>>>>>>>>>>>>>>>>')
-
     if (this.type === 'thank-you') {
       this.onClassBooked()
     }


### PR DESCRIPTION
# Issue

When navigating between different vue router pages the scroll isn't reset. This can lead to users looking at the bottom of a page when navigating.

# Repro steps and graphic

1. Navigate to codecombat.com/league
2. Scroll down, and then click "Parents" in the navigation
3. Notice that the page doesn't scroll back to top.

Gif recorded in Chrome.

![412c9bd5d60a12574d00c4cd71a4a4ae (1)](https://user-images.githubusercontent.com/15080861/102417027-c876fd00-3faf-11eb-8c04-9f77e9b49781.gif)

These are the same steps to test locally.
I also manually tested back and forward navigation.

# Fix

I initially explored using the [`scrollBehaviour`](https://router.vuejs.org/api/#scrollbehavior) method on the vueRouter constructor. However it doesn't work in `abstract` mode. We have set this mode because the vueRouter is controlled by the backbone router.

Thus I added the scroll behavior in a global `afterEach` hook. This ensures that if the user navigates to a different path the scroll responds.

This also works correctly when user is navigating back and forth through history.

After fix the behavior looks like so:
![41f68578228f7660318bf7a1b7cddb0d](https://user-images.githubusercontent.com/15080861/102417105-e93f5280-3faf-11eb-84e8-817018cc4f17.gif)


