### PR TITLE
Hero Section: decrease size of header text

### DIFF
--- a/app/styles/style-flat.sass
+++ b/app/styles/style-flat.sass
@@ -180,6 +180,8 @@ body[lang='ru'], body[lang='uk'], body[lang='bg'], body[lang^='mk'], body[lang='
       color: black
       margin: 30px 70px 0
       border-color: $navy
+      @media (max-width: 767px)
+        margin: 10px 10px 0
 
       .icon-bar
         background-color: $navy

--- a/app/views/landing-pages/parents/PageParentsJumbotron.vue
+++ b/app/views/landing-pages/parents/PageParentsJumbotron.vue
@@ -21,8 +21,8 @@ export default {
          alt="flying griffin"/>
     <div class="row">
       <div class="col-lg-12">
-        <h1 class="pixelated">Live Online Coding Classes</h1>
-        <h1 class="pixelated">Your Child Will Love</h1>
+        <h1 class="pixelated parents-header-text">Live Online Coding Classes</h1>
+        <h1 class="pixelated parents-header-text">Your Child Will Love</h1>
       </div>
     </div>
 
@@ -102,10 +102,13 @@ export default {
   }
 
   @media (max-width: 1000px) {
+    .top-jumbotron h1 + h1 {
+      margin-bottom: 38px;
+    }
     .top-jumbotron {
       /* Moves images out of the way of the heading to keep it legible */
       background-size: 443px, 260px, 90px, 260px, 250px;
-      background-position: bottom -74% left -5%,
+      background-position: bottom -65% left -5%,
         top 50px left 30px,
         top 35px right 280px,
         top 360px right 300px,
@@ -118,6 +121,31 @@ export default {
       right: -11%;
       overflow: hidden;
       max-width: 50%;
+    }
+  }
+
+  @media (max-width: 767px) {
+    .parents-header-text {
+      font-size: 40px;
+    }
+  }
+
+  @media (max-width: 320px) {
+    .parents-header-text {
+      font-size: 36px;
+      line-height: 48px;
+    }
+    .top-jumbotron h1 + h1 {
+      margin-bottom: 20px;
+    }
+    .top-jumbotron {
+      /* Moves images out of the way of the heading to keep it legible */
+      background-size: 443px, 260px, 90px, 260px, 250px;
+      background-position: bottom -40% left -5%,
+        top 50px left 30px,
+        top 35px right 280px,
+        top 360px right 300px,
+        bottom 52px right 475px;
     }
   }
 


### PR DESCRIPTION
- Decrease the text-size so that it fits on 3 rows
- The CTA can be moved up so that it doesn't cover the boy's face
- Boy's image can be moved up so that we see more of it above the fold

Desktop/Laptop
![Live-coding-classes-from-CodeCombat-20](https://user-images.githubusercontent.com/75598717/102490064-5a583600-4094-11eb-8760-cbf7e26280ac.png)

iPhone5/SE
![Live-coding-classes-from-CodeCombat-18](https://user-images.githubusercontent.com/75598717/102490085-5e845380-4094-11eb-8bf3-5aed9548b4fa.png)

iPhoneX
![Live-coding-classes-from-CodeCombat-19](https://user-images.githubusercontent.com/75598717/102490080-5debbd00-4094-11eb-886b-6f37003179df.png)

Galaxy S5
![Live-coding-classes-from-CodeCombat-17](https://user-images.githubusercontent.com/75598717/102490090-5fb58080-4094-11eb-932c-8d1360cdbd4f.png)
