### PR TITLE
Fixed extra space in parent page for mobile devices

### DIFF
--- a/app/styles/style-flat.sass
+++ b/app/styles/style-flat.sass
@@ -181,7 +181,7 @@ body[lang='ru'], body[lang='uk'], body[lang='bg'], body[lang^='mk'], body[lang='
       margin: 30px 70px 0
       border-color: $navy
       @media (max-width: 767px)
-        margin: 10px 10px 0
+        margin: 15px 10px 0
 
       .icon-bar
         background-color: $navy

--- a/app/views/landing-pages/parents/PageParents.vue
+++ b/app/views/landing-pages/parents/PageParents.vue
@@ -182,7 +182,7 @@
     </div>
 
     <!-- Added some custom inline styles specific to this graphic -->
-    <div class="container-graphic-spacer pet-following-yellow-dotted">
+    <div class="pet-following-yellow-dotted">
       <div class="container">
         <div class="row">
           <div class="col-xs-12">
@@ -351,11 +351,11 @@
       </div>
     </div>
 
-    <div class="container-graphic-spacer">
+    <div class="hero-for-student-outcomes">
       <div class="container">
         <div class="row">
           <div class="col-lg-12">
-            <img class="img-responsive" src="/images/pages/parents/graphic_06.svg" style="margin: 0 auto; transform: translate(-47%, 0);" loading="lazy"/>
+            <img class="img-responsive" src="/images/pages/parents/graphic_06.svg" loading="lazy"/>
           </div>
         </div>
       </div>
@@ -1048,6 +1048,7 @@ export default {
 
 .container-pricing-table {
   padding: 0 70px;
+  margin-top: 20px;
   margin-bottom: 48px;
 
   /* Added some clouds to the pricing table */
@@ -1321,8 +1322,17 @@ export default {
 }
 
 .pet-following-yellow-dotted img{
-  margin: 0px 30% 0px auto;
-  transform: rotate(-15deg);
+  margin: 0px 25% 0px auto;
+}
+
+.hero-for-student-outcomes {
+  min-height: 270px;
+  pointer-events: none;
+  overflow-x: hidden;
+}
+
+.hero-for-student-outcomes img {
+  margin-left: 25%;
 }
 
 @media screen and (max-width: 768px) {
@@ -1344,15 +1354,22 @@ export default {
   .pet-following-yellow-dotted {
     margin-bottom: 0px;
     overflow-x: hidden;
+    min-height: auto;
   }
   .pet-following-yellow-dotted img{
-    margin: 0px 0px 0px auto;
-    transform: rotate(-30deg);
-    width: 75%;
+    margin-right: 10%;
+    width: 50%;
   }
-  div.pricing-grid-container {
+  .pricing-grid-container {
     padding: 0 5px;
-    margin-top: 20px;
+  }
+  .hero-for-student-outcomes {
+    margin-bottom: 50px;
+    min-height: auto;
+  }
+  .hero-for-student-outcomes img {
+    width: 50%;
+    margin-left: 10%;
   }
 }
 

--- a/app/views/landing-pages/parents/PageParents.vue
+++ b/app/views/landing-pages/parents/PageParents.vue
@@ -66,7 +66,7 @@
       </div>
     </div>
 
-    <div class="container-graphic-spacer">
+    <div class="container-graphic-spacer sm-min-height-auto">
     </div>
 
     <div class="container">
@@ -182,9 +182,7 @@
     </div>
 
     <!-- Added some custom inline styles specific to this graphic -->
-    <div class="container-graphic-spacer"
-         style="margin-bottom: -35px; overflow-x: hidden;"
-    >
+    <div class="container-graphic-spacer pet-following-yellow-dotted">
       <div class="container">
         <div class="row">
           <div class="col-xs-12">
@@ -192,7 +190,6 @@
                 class="img-responsive"
                 src="/images/pages/parents/graphic_04.svg"
                 alt="CodeCombat pet following yellow dotted path"
-                style="transform: translate(40%, -35px);"
                 loading="lazy"
             />
           </div>
@@ -987,6 +984,7 @@ export default {
   text-align: center;
 
   margin-bottom: 5px;
+  margin-top: 20px;
 }
 
 
@@ -1320,6 +1318,11 @@ export default {
   font-weight: 700;
 }
 
+.pet-following-yellow-dotted img{
+  margin: 0px 30% 0px auto;
+  transform: rotate(-15deg);
+}
+
 @media screen and (max-width: 768px) {
   .xs-pb-50 {
     padding-bottom: 50px;
@@ -1332,6 +1335,23 @@ export default {
   }
   .outcome-to-concepts {
     min-height: 200px;
+  }
+  .sm-min-height-auto {
+    min-height: auto;
+  }
+  .pet-following-yellow-dotted {
+    margin-bottom: 0px; overflow-x: hidden;
+  }
+  .pet-following-yellow-dotted img{
+    margin: 0px 0px 0px auto;
+    transform: rotate(-30deg);
+    width: 75%;
+  }
+  .pricing-grid-container {
+    padding: 0 5px;
+  }
+  div.pricing-grid-container {
+    margin-top: 20px;
   }
 }
 

--- a/app/views/landing-pages/parents/PageParents.vue
+++ b/app/views/landing-pages/parents/PageParents.vue
@@ -1340,17 +1340,16 @@ export default {
     min-height: auto;
   }
   .pet-following-yellow-dotted {
-    margin-bottom: 0px; overflow-x: hidden;
+    margin-bottom: 0px;
+    overflow-x: hidden;
   }
   .pet-following-yellow-dotted img{
     margin: 0px 0px 0px auto;
     transform: rotate(-30deg);
     width: 75%;
   }
-  .pricing-grid-container {
-    padding: 0 5px;
-  }
   div.pricing-grid-container {
+    padding: 0 5px;
     margin-top: 20px;
   }
 }

--- a/app/views/landing-pages/parents/PageParents.vue
+++ b/app/views/landing-pages/parents/PageParents.vue
@@ -511,7 +511,7 @@
     <div class="container-background-faq">
       <div class="container">
         <div class="row">
-          <div class="col-lg-12 text-center">
+          <div class="col-lg-12 text-center container-background-header">
             <h1 class="pixelated">FAQs</h1>
           </div>
         </div>
@@ -1123,7 +1123,7 @@ export default {
 }
 
 #student-outcome-carousel .row {
-  padding: 60px;
+  padding: 0px 60px;
 }
 
 .carousel-row {
@@ -1267,8 +1267,10 @@ export default {
   margin: 32px 0 0;
 }
 
-.container-background-faq h1 {
-  transform: translateY(-64px);
+.container-background-header {
+  position: absolute;
+  transform: translateY(-60px);
+  width: calc(100% - 30px);
 }
 
 /* These create the broken top border which FAQ sits between */


### PR DESCRIPTION
Fixed extra space in parent page for mobile device and add padding for course offering table.
1. Remove extra space from `Remove Learning` Section
![Live-coding-classes-from-CodeCombat-26](https://user-images.githubusercontent.com/75598717/102894586-59a31380-4489-11eb-8a3e-8ccec6aa0638.png)

2. Display `Pet following yellow dotted path` image which was not displaying before and causes extra space for "Course Offering" Section, Also rotate (-15 degree) this image to point `Course Offering` for mobile devices.
![Live-coding-classes-from-CodeCombat-27](https://user-images.githubusercontent.com/75598717/102895004-f49bed80-4489-11eb-829e-8f4c030b320d.png)

3. Added padding for `Course Offering` table.
![Live-coding-classes-from-CodeCombat-28](https://user-images.githubusercontent.com/75598717/102895036-05e4fa00-448a-11eb-93c8-a324bb14913d.png)
 
