### PR TITLE
Remove background graphic from parent video

### DIFF
--- a/app/views/landing-pages/parents/PageParents.vue
+++ b/app/views/landing-pages/parents/PageParents.vue
@@ -768,10 +768,7 @@ export default {
 
 .video-container {
   margin-top: 50px;
-  padding: 45px;
 
-  background: url(/images/pages/parents/video_backer.png) no-repeat center;
-  background-size: contain;
 }
 
 .invest-heading {


### PR DESCRIPTION
Small fix removing the background graphic from the parents page video.

![image](https://user-images.githubusercontent.com/15080861/102930853-1d07f580-4452-11eb-925e-0100bdff6e60.png)


Tested manually in local development environment.