### PR TITLE
Fix four above/below logic in league ladder

### DIFF
--- a/app/core/store/modules/seasonalLeague.js
+++ b/app/core/store/modules/seasonalLeague.js
@@ -216,7 +216,7 @@ export default {
           teamSession.rank = parseInt(myRank, 10)
           leagueRankingInfo.playersAbove = playersAbove
           leagueRankingInfo.playersBelow = playersBelow
-          debugger
+
           commit('setMySession', teamSession)
         }
       }

--- a/app/core/store/modules/seasonalLeague.js
+++ b/app/core/store/modules/seasonalLeague.js
@@ -85,11 +85,11 @@ export default {
         const leagueRankings = state.rankingsForLeague[leagueId]
         if (state.mySession && state.mySession.rank > 20) {
           const splitRankings = []
-          splitRankings.push(...state.leagueRankings.top.slice(0, 10))
+          splitRankings.push(...leagueRankings.top.slice(0, 10))
           splitRankings.push({ type: 'BLANK_ROW' })
-          splitRankings.push(...state.leagueRankings.playersAbove)
+          splitRankings.push(...leagueRankings.playersAbove)
           splitRankings.push(state.mySession)
-          splitRankings.push(...state.leagueRankings.playersBelow)
+          splitRankings.push(...leagueRankings.playersBelow)
           return splitRankings
         }
         return leagueRankings.top
@@ -104,11 +104,11 @@ export default {
         const codePointsRankings = state.codePointsRankingsForLeague[leagueId]
         if (state.mySession && state.mySession.rank > 20) {
           const splitRankings = []
-          splitRankings.push(...state.codePointsRankings.top.slice(0, 10))
+          splitRankings.push(...codePointsRankings.top.slice(0, 10))
           splitRankings.push({ type: 'BLANK_ROW' })
-          splitRankings.push(...state.codePointsRankings.playersAbove)
+          splitRankings.push(...codePointsRankings.playersAbove)
           splitRankings.push(state.mySession)
-          splitRankings.push(...state.codePointsRankings.playersBelow)
+          splitRankings.push(...codePointsRankings.playersBelow)
           return splitRankings
         }
         return codePointsRankings.top
@@ -216,7 +216,7 @@ export default {
           teamSession.rank = parseInt(myRank, 10)
           leagueRankingInfo.playersAbove = playersAbove
           leagueRankingInfo.playersBelow = playersBelow
-
+          debugger
           commit('setMySession', teamSession)
         }
       }


### PR DESCRIPTION
## Issue

Ladder doesn't show 4 above and 4 below if logged in user isn't in the top 20 of the ladder. There is also the following error in the console: `app.js:82 TypeError: Cannot read property 'top' of undefined`


## How it was fixed

The error is due to accidentally referencing vuex `state` rather than the in scope variable.
Fixed for both ladders by using the correct variable 🤦 .

## How to test

Check out local proxy. Navigate to /league page.

Test on internal user with issue: andrew+student912@codecombat.com
Can also check leaderboard still works anonymously.

## Screenshot of fix

![image](https://user-images.githubusercontent.com/15080861/103252733-df640a80-4932-11eb-942d-f557a67df074.png)
