### PR TITLE
Fix CodePoints ladder if not in top 20

### DIFF
--- a/app/core/store/modules/seasonalLeague.js
+++ b/app/core/store/modules/seasonalLeague.js
@@ -105,7 +105,7 @@ export default {
 
         // TODO - Clean up this hack check. The returned codePointsRank is not
         // guaranteed to return a rank. Thus we "guess" if the user is in the top by
-        // comparing returned totalScores.
+        // comparing totalScores.
         if ((state.myCodePointsRank && state.myCodePointsRank.rank > 20) ||
           ((codePointsRankings.top && !codePointsRankings.top.includes(({ totalScore }) => me.get('stats').codePoints === totalScore)))) {
           const splitRankings = []
@@ -253,9 +253,7 @@ export default {
           getCodePointsRankForUser(leagueId, me.id, { scoreOffset: me.get('stats').codePoints })
         ])
 
-        // Returned by server when rank is unknown.
         let rank = parseInt(myRank, 10)
-
         for (const abovePlayer of playersAbove) {
           rank -= 1
           abovePlayer.rank = rank
@@ -267,6 +265,7 @@ export default {
           belowPlayer.rank = rank
         }
 
+        // Required by the leaderboard to correctly show your user and highlight the row
         const myPlayerRow = {
           creatorName: me.broadName(),
           rank: parseInt(myRank, 10),
@@ -278,7 +277,7 @@ export default {
         codePointsRankingInfo.playersBelow = playersBelow
 
         // This edge case happens when we don't know the rank of the user.
-        // In this case we want to wipe all rankings so we aren't guessing.
+        // In this case we want to wipe all rankings so we aren't guessing random ranks.
         if (myRank === 'unknown') {
           codePointsRankingInfo.playersAbove = playersAbove.map(session => { session.rank = ' '; return session })
           codePointsRankingInfo.playersBelow = playersBelow.map(session => { session.rank = ' '; return session })

--- a/app/core/store/modules/seasonalLeague.js
+++ b/app/core/store/modules/seasonalLeague.js
@@ -103,11 +103,7 @@ export default {
         }
         const codePointsRankings = state.codePointsRankingsForLeague[leagueId]
 
-        // TODO - Clean up this hack check. The returned codePointsRank is not
-        // guaranteed to return a rank. Thus we "guess" if the user is in the top by
-        // comparing totalScores.
-        if ((state.myCodePointsRank && state.myCodePointsRank.rank > 20) ||
-          ((codePointsRankings.top && !codePointsRankings.top.includes(({ totalScore }) => me.get('stats').codePoints === totalScore)))) {
+        if (state.myCodePointsRank && state.myCodePointsRank.rank > 20) {
           const splitRankings = []
           splitRankings.push(...codePointsRankings.top.slice(0, 10))
           splitRankings.push({ type: 'BLANK_ROW' })
@@ -116,6 +112,11 @@ export default {
           splitRankings.push(...codePointsRankings.playersBelow)
           return splitRankings
         }
+
+        if (state.myCodePointsRank && state.myCodePointsRank.rank <= 20) {
+          codePointsRankings.top[state.myCodePointsRank.rank - 1].creator = me.id
+        }
+
         return codePointsRankings.top
       }
     }


### PR DESCRIPTION
## Issue

Currently it's possible for your codepoints rank to be unknown, leading you to not appear in the codepoints leaderboard.

There are also variables referencing the league ladder causing league values to appear in the codepoints ladder.


## Edge case

Because the only usable information from the ranking endpoint is the codePoints totalScore, I am using a guess to see if the user is in the top 20. If the user is tied for 20th the heuristic may fail to guess correctly. However it works in most cases which currently aren't working.

Future work is to return some kind of identifier from the rankings endpoint or fix the ranking.


## Screenshot of fix

![image](https://user-images.githubusercontent.com/15080861/103318670-04fd1c80-49e4-11eb-85b1-748ed54ce952.png)


In production it looks like this (hasn't detected my user correctly):
![image](https://user-images.githubusercontent.com/15080861/103318764-4e4d6c00-49e4-11eb-80c3-934e1944568e.png)
