### PR TITLE
Esports navigation header

### DIFF
--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -45,18 +45,6 @@ export default function getVueRouter () {
         }
       ]
     })
-
-    vueRouter.afterEach((to, from) => {
-      // Fixes issue of page not scrolling to top on navigation change
-      if (to.path !== from.path) {
-        // If the user has navigated within the router, try and reset the scroll position.
-        try {
-          window.scrollTo(0, 0)
-        } catch (e) {
-          // Can fail silently. Handling browser compatibility
-        }
-      }
-    })
   }
 
   return vueRouter

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -209,6 +209,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     resource_hub: "Resource Hub"
     apcsp: "AP CS Principles"
     parent: "Parents"
+    esports: "Esports"
     browser_recommendation: "For the best experience we recommend using the latest version of Chrome. Download the browser here!"
 
   modal:

--- a/app/templates/base-flat.jade
+++ b/app/templates/base-flat.jade
@@ -61,14 +61,11 @@ mixin accountLinks
                         a.text-p(data-i18n="nav.blog", href="https://blog.koudashijie.com")
                       li
                         a.text-p(data-event-action="Header Request Quote CTA", data-i18n="new_home.request_quote", href="/contact-cn")
-                    else if me.isAnonymous()
-                      li.request-class-list
-                        a.text-p(data-event-action="Header Request Quote CTA", data-i18n="new_home.request_quote", href="/teachers/quote")
                     li
-                      if document.location.href.search('/about') >= 0
-                        a.text-p.text-teal(href="/about", data-i18n="nav.about")
+                      if document.location.href.search('/league') >= 0
+                        a.text-p.text-teal(href="/league", data-i18n="nav.esports")
                       else
-                        a.text-p(href="/about", data-i18n="nav.about")
+                        a.text-p(href="/league", data-i18n="nav.esports")
                     li
                       if document.location.href.search('/parents') >= 0
                         a.text-p.text-teal(href="/parents", data-i18n="nav.parent")

--- a/app/views/core/SingletonAppVueComponentView.js
+++ b/app/views/core/SingletonAppVueComponentView.js
@@ -18,6 +18,20 @@ export default class SingletonAppVueComponentView extends VueComponentView {
   buildVueComponent () {
     this.router = cocoVueRouter()
 
+    this.router.afterEach((to, from) => {
+      // Fixes issue of page not scrolling to top on navigation change
+      if (to.path !== from.path) {
+        // If the user has navigated within the router, try and reset the scroll position.
+        try {
+          // Required so that jade recompiles with new variables.
+          this.render()
+          window.scrollTo(0, 0)
+        } catch (e) {
+          // Can fail silently. Handling browser compatibility
+        }
+      }
+    })
+
     return new Vue({
       el: this.$el.find('#site-content-area')[0],
 


### PR DESCRIPTION
# Feature

Updates the global navigation bar to remove "Request a Quote" and "About". Instead adds "Esports" with link to /league.

There was also a bug where switching between vue router pages didn't re-render the backing Backbone.js view. This can be fixed by triggering a render after any vue navigation.

# Testing

1. Spin up local proxy (`npm run proxy` with `npm run dev`) and navigate to localhost:3000
2. Note nav bar changes

Clicking between the two correctly highlights them.

## Screenshots

### Clicking between two vue routes in navigation

![0e1fd6d1640f4aa996e0391e922c1132](https://user-images.githubusercontent.com/15080861/103320525-8657ad80-49ea-11eb-9517-cb56b4aaaf74.gif)


# Risks

Vue component instance gets inserted into new backbone view after render. Risk of vue router bug can break website. However I think in this case manual checking confirms it as working without the surface area being very high.