### PR TITLE
🐛 Esports league page ladder and clan loading

### DIFF
--- a/app/core/store/modules/seasonalLeague.js
+++ b/app/core/store/modules/seasonalLeague.js
@@ -127,8 +127,14 @@ export default {
 
           if (state.myCodePointsRank && typeof state.myCodePointsRank.rank === 'number' && state.myCodePointsRank.rank <= 20) {
             // This patches in the correct name and id if you are in the top 20.
-            codePointsRankings.top[state.myCodePointsRank.rank - 1].creator = me.id
-            codePointsRankings.top[state.myCodePointsRank.rank - 1].creatorName = me.broadName()
+            const rankIdx = state.myCodePointsRank.rank - 1
+            const top = [...codePointsRankings.top]
+            top[rankIdx] = {
+              ...codePointsRankings.top[rankIdx],
+              creator: me.id,
+              creatorName: me.broadName()
+            }
+            return top
           }
 
           return codePointsRankings.top

--- a/app/core/store/modules/seasonalLeague.js
+++ b/app/core/store/modules/seasonalLeague.js
@@ -70,7 +70,11 @@ export default {
         splitRankings.push(...state.globalRankings.globalTop.slice(0, 10))
         splitRankings.push({ type: 'BLANK_ROW' })
         splitRankings.push(...state.globalRankings.playersAbove)
-        splitRankings.push(state.mySession)
+        // This hack is due to a race condition where the server returns the player
+        // in the 4 above or 4 below. Thus we prevent player seeing duplicate of their result.
+        if (![...state.globalRankings.playersAbove, ...state.globalRankings.playersBelow].some(ranking => ranking.creator === me.id)) {
+          splitRankings.push(state.mySession)
+        }
         splitRankings.push(...state.globalRankings.playersBelow)
         return splitRankings
       }

--- a/app/core/store/modules/seasonalLeague.js
+++ b/app/core/store/modules/seasonalLeague.js
@@ -46,6 +46,10 @@ export default {
       state.mySession = mySession
     },
 
+    clearMySession (state) {
+      state.mySession = {}
+    },
+
     setLeagueRanking (state, { leagueId, ranking }) {
       Vue.set(state.rankingsForLeague, leagueId, ranking)
     },
@@ -140,6 +144,7 @@ export default {
   actions: {
     async loadGlobalRequiredData ({ commit, dispatch }) {
       commit('setLoading', true)
+      commit('clearMySession')
       const awaitPromises = [dispatch('fetchGlobalLeaderboard')]
       const sessionsData = await fetchMySessions(currentSeasonalLevelOriginal)
 
@@ -193,6 +198,7 @@ export default {
         playersAbove: [],
         playersBelow: []
       }
+      commit('clearMySession')
 
       const topLeagueRankingPromise = getLeaderboard(currentSeasonalLevelOriginal, {
         order: -1,

--- a/app/views/landing-pages/league/PageLeague.vue
+++ b/app/views/landing-pages/league/PageLeague.vue
@@ -20,7 +20,6 @@
 
       created () {
         this.fetchRequiredInitialData({ optionalIdOrSlug: this.$route.params.idOrSlug })
-        this.loadGlobalRequiredData()
       },
 
       computed: {
@@ -31,7 +30,6 @@
 
       methods: {
         ...mapActions({
-          loadGlobalRequiredData: 'seasonalLeague/loadGlobalRequiredData',
           fetchRequiredInitialData: 'clans/fetchRequiredInitialData'
         })
       }

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -51,20 +51,27 @@ export default {
     }),
 
     changeClanSelected (e) {
+      let newSelectedClan = ''
       if (e.target.value === 'global') {
-        this.clanIdOrSlug = ''
+        newSelectedClan = ''
       } else {
-        this.clanIdOrSlug = e.target.value
+        newSelectedClan = e.target.value
       }
 
-      const leagueURL = this.clanIdSelected ? `league/${this.clanIdSelected}` : 'league'
+      const leagueURL = newSelectedClan ? `league/${newSelectedClan}` : 'league'
 
       application.router.navigate(leagueURL, { trigger: true })
     },
 
     async loadRequiredData () {
       if (this.clanIdOrSlug) {
-        await this.fetchClan({ idOrSlug: this.clanIdOrSlug })
+        try {
+          await this.fetchClan({ idOrSlug: this.clanIdOrSlug })
+        } catch (e) {
+          // Default to global page
+          application.router.navigate('league', { trigger: true })
+          return
+        }
 
         this.loadClanRequiredData({ leagueId: this.clanIdSelected })
         this.loadCodePointsRequiredData({ leagueId: this.clanIdSelected })

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -74,6 +74,7 @@ export default {
         this.loadClanRequiredData({ leagueId: this.clanIdSelected })
         this.loadCodePointsRequiredData({ leagueId: this.clanIdSelected })
       } else {
+        this.clanIdSelected = ''
         this.loadGlobalRequiredData()
         this.loadCodePointsRequiredData({ leagueId: '' })
       }


### PR DESCRIPTION
# What does this PR fix?

This PR fixes some esports page bugs.

1. Fixes race condition where two sessions appear next to one another
2. Clear vuex ranking sessions between pages in case the user isn't in that clan or leaderboard.
3. Also stops accidental global session load even when you aren't looking at global version of page.
4. Fixes navigation of clans when clicking on leaderboard or dropdown. As well as browser back and forward arrows.
5. Handle direct navigation to incorrect or malformed clan slug
6. Handle creation of clan without accidental chinese clan name.

# How to test

- Start a dev server connected to the proxy (or production) with `npm run dev` and `npm run proxy`.
- Spy on my account: andrew@codecombat.com
- Navigate to codecombat.com/league . It may take a couple refreshes but you may be able to repro the following screenshot
![image](https://user-images.githubusercontent.com/15080861/103598390-53fcf300-4eb7-11eb-9e2a-721d69470352.png)

- Navigate to https://codecombat.com/league/5febc4e0b0124ed69f57e07e
- Select a clan in the leaderboard.

![image](https://user-images.githubusercontent.com/15080861/103598413-65de9600-4eb7-11eb-8b52-cb40cae31604.png)

These issues shouldn't happen with these changes checked out via localhost:3000

# Risk

Low risk. Tested across global leaderboard, joined clan, and not joined clan.

# Screenshots

This screenshot shows what happens when your session state remains when inspecting a clan. We share a single variable in the store for your session between global and clan ranking. We need to ensure that we clear this and only load the data when it is required. Here my session appears in a clan because it is leaking from the global leaderboard.

![Screen Shot 2021-01-04 at 4 50 12 PM](https://user-images.githubusercontent.com/15080861/103594993-26ac4700-4eaf-11eb-888e-381e8f06c340.png)


Clicking on clans now works (last clan doesn't load in time for the gif):

![fab37952a355c0d5d7d0bbe4e45319b8](https://user-images.githubusercontent.com/15080861/103715792-58d4ac00-4f76-11eb-977b-71529b276f5a.gif)


Pressing the back button is correctly handled:

![180c0fef1cbbe3111455abcf052f5de2](https://user-images.githubusercontent.com/15080861/103715865-84579680-4f76-11eb-91db-33863a7eea27.gif)

Typing in a clan slug or id that doesn't exist is now handled by defaulting to global leaderboard:
![45f6400c032967d5e5349dbdf689c83b](https://user-images.githubusercontent.com/15080861/103715974-cb458c00-4f76-11eb-8f97-a38b3f177e08.gif)



