### PR TITLE
Add autoclan metadata and clean up kind

### DIFF
--- a/app/schemas/models/clan.schema.coffee
+++ b/app/schemas/models/clan.schema.coffee
@@ -51,7 +51,7 @@ _.extend ClanSchema.properties,
   # Set only for auto clans, to the origins of the programmatic creation
   kind: {
     type: 'string',
-    enum: ['classroom', 'teacher', 'school', 'school-network', 'school-subnetwork', 'school-district', 'administrative-region', 'country'],
+    enum: ['classroom', 'teacher', 'school', 'school-subnetwork', 'school-network', 'school-district', 'administrative-region', 'country'],
     description: 'Signals an autoclan that may use different logic to look up membership'
   }
   metadata: c.object({

--- a/app/schemas/models/clan.schema.coffee
+++ b/app/schemas/models/clan.schema.coffee
@@ -49,7 +49,16 @@ _.extend ClanSchema.properties,
   # Set to 'basic' for auto clans
   dashboardType: {type: 'string', 'enum': ['basic', 'premium']}
   # Set only for auto clans, to the origins of the programmatic creation
-  kind: { type: 'string', 'enum': ['classroom', 'teacher', 'school', 'district', 'state', 'country'], description: 'Signals an autoclan that may use different logic to look up membership'}
+  kind: {
+    type: 'string',
+    enum: ['classroom', 'teacher', 'school', 'school-network', 'school-subnetwork', 'school-district', 'administrative-region', 'country'],
+    description: 'Signals an autoclan that may use different logic to look up membership'
+  }
+  metadata: c.object({
+    title: 'Metadata',
+    description: 'Contains properties that help find autoclans'
+    additionalProperties: true
+  })
   # Set only for auto clans (yet), to display instead of Clan.name
   displayName: { type: 'string' }
 


### PR DESCRIPTION
# Context

This is required to create a bucket property to store information letting us locate required autoclans efficiently.
Haven't specified the properties explicitly as they are subject to change and I don't want to break any clans that have any of these properties.

In the future will use these properties to more efficiently query for autoclans. I.e. clan.metadata.ncesId will have link to the school ncesId.

Also cleaned up terminology of the various kinds that we want to have.
Will be merging and deploying this today for Academica work.

# Risk

Risk is low for changed enum properties as they aren't in use yet (only classroom and teacher are used).

The metadata property allows for any properties while we iterate on the data required.
