### PR TITLE
Add known clan metadata schema properties

### DIFF
--- a/app/schemas/models/clan.schema.coffee
+++ b/app/schemas/models/clan.schema.coffee
@@ -63,6 +63,7 @@ _.extend ClanSchema.properties,
     subnetworkClanId: c.stringID( title: 'Sub-Network Clan' )
     districtId: c.int( title: 'District Id', description: 'The unique district that the school is part of.' )
     ncesId: c.float( title: 'NCES', description: 'The unique school NCES id. Should be a unique integer.')
+    cleverSchoolId: c.shortString( title: 'Clever Unique School Id' )
   })
   # Set only for auto clans (yet), to display instead of Clan.name
   displayName: { type: 'string' }

--- a/app/schemas/models/clan.schema.coffee
+++ b/app/schemas/models/clan.schema.coffee
@@ -58,6 +58,11 @@ _.extend ClanSchema.properties,
     title: 'Metadata',
     description: 'Contains properties that help find autoclans'
     additionalProperties: true
+  }, {
+    networkClanId: c.stringID( title: 'Network Clan' )
+    subnetworkClanId: c.stringID( title: 'Sub-Network Clan' )
+    districtId: c.int( title: 'District Id', description: 'The unique district that the school is part of.' )
+    ncesId: c.float( title: 'NCES', description: 'The unique school NCES id. Should be a unique integer.')
   })
   # Set only for auto clans (yet), to display instead of Clan.name
   displayName: { type: 'string' }


### PR DESCRIPTION
# Context

Autoclan metadata was made very flexible for speed of implementation.
Now these properties are in use they can be verified explicitly.

# Risk

Low, makes it much more explicit what might be found on the clan metadata property.