### PR TITLE
Clan to Team esports page renaming

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -3194,3 +3194,5 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     student_register_3: "Provide the information below to be eligible for prizes."
     teacher_register_1: "Sign up to access your class league profile page and get your class started."
     general_news: "Get emails on the latest news and updates regarding our AI Leagues and tournaments."
+    team: 'team'
+    how_it_works1: 'Join a __team__'

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -3190,7 +3190,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
 
   league:
     student_register_1: "Become the next AI Champion!"
-    student_register_2: "Sign up, create your own clan, or join other clans to start competing."
+    student_register_2: "Sign up, create your own team, or join other teams to start competing." # {change}
     student_register_3: "Provide the information below to be eligible for prizes."
     teacher_register_1: "Sign up to access your class league profile page and get your class started."
     general_news: "Get emails on the latest news and updates regarding our AI Leagues and tournaments."

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -309,7 +309,7 @@ export default {
       <div class="col-sm-7">
         <h1><span class="esports-aqua">{{ currentSelectedClanName }}</span></h1>
         <h3 style="margin-bottom: 40px;">{{ currentSelectedClanDescription }}</h3>
-        <p>Invite players to this clan by sending them this link:</p>
+        <p>Invite players to this team by sending them this link:</p>
         <input readonly :value="clanInviteLink()" /><br />
         <a v-if="isAnonymous()" class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">Join Now</a>
         <a v-else-if="isClanCreator()" class="btn btn-large btn-primary btn-moon" @click="openClanCreation">Edit Clan</a>
@@ -337,7 +337,7 @@ export default {
         <ul style="list-style-type: none; padding: 0;">
           <li><span class="bullet-point" style="background-color: #bcff16;"/>Access competitive multiplayer arenas, leaderboard, and global coding championships</li>
           <li><span class="bullet-point" style="background-color: #30EFD3;"/>Earn points for completing practice levels and competing in head-to-head matches</li>
-          <li><span class="bullet-point" style="background-color: #FF39A6;"/>Join competitive coding clans with friends, family, or classmates</li>
+          <li><span class="bullet-point" style="background-color: #FF39A6;"/>Join competitive coding teams with friends, family, or classmates</li>
           <li><span class="bullet-point" style="background-color: #9B83FF;"/>Showcase your coding skills and take home great prizes</li>
         </ul>
         <div class="xs-centered">
@@ -372,7 +372,7 @@ export default {
     </div>
     <div class="row flex-row">
       <div class="col-sm-1"><img src="/images/pages/league/text_1.svg" class="img-responsive" loading="lazy"></div>
-      <div class="col-sm-11"><p class="subheader2 mb-0">Join a <span class="esports-aqua">clan</span></p></div>
+      <div class="col-sm-11"><p class="subheader2 mb-0" v-html="$t('league.how_it_works1', { team: `<span class='esports-aqua'>${this.$t('league.team')}</span>` })"></p></div>
     </div>
 
     <div class="row flex-row">
@@ -585,7 +585,7 @@ export default {
     color: #f7d047;
   }
 
-  .esports-aqua {
+  /deep/ .esports-aqua {
     color: #30efd3;
   }
 

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -521,7 +521,7 @@ export default {
 
     <div class="row flex-row text-center section-space">
       <a v-if="isClanCreator()" class="btn btn-large btn-primary btn-moon" @click="openClanCreation">Edit Clan</a>
-      <a v-else-if="!currentSelectedClan && canCreateClan()" class="btn btn-large btn-primary btn-moon" @click="openClanCreation">Start a Clan</a>
+      <a v-else-if="!currentSelectedClan && canCreateClan()" class="btn btn-large btn-primary btn-moon" @click="openClanCreation">Start a Team</a>
       <a v-else-if="!doneRegistering" class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">Join Now</a>
     </div>
 

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -223,7 +223,18 @@ export default {
     },
 
     currentSelectedClanDescription () {
-      return (this.currentSelectedClan || {}).description || ''
+      const description = (this.currentSelectedClan || {}).description || ''
+      if (!description) {
+        return ''
+      }
+
+      // Hack - In the future we should autopopulate autoclan descriptions better server side.
+      //        Or alternatively populate client side with i18n enabled.
+      if (this.currentSelectedClan.kind) {
+        return description.replace('Clan', 'Team')
+      }
+
+      return description
     },
 
     myCreatedClan () {

--- a/app/views/landing-pages/league/components/ClanCreationModal.vue
+++ b/app/views/landing-pages/league/components/ClanCreationModal.vue
@@ -30,9 +30,9 @@
     computed: {
       modalTitle() {
         if (this.clan === null) {
-          return 'Create clan'
+          return 'Create team'
         } else {
-          return 'Edit clan'
+          return 'Edit team'
         }
       }
     },
@@ -40,10 +40,10 @@
     methods: {
       async submit () {
         if (!this.isPublic && !me.isPremium()) {
-          noty({ type: 'error', text: 'Must be a subscriber to create private clans', timeout: 3000 })
+          noty({ type: 'error', text: 'Must be a subscriber to create private teams', timeout: 3000 })
           return
         } else if (this.name.length < 2) {
-          noty({ type: 'error', text: 'Must have at least 2 letters for the clan name', timeout: 3000 })
+          noty({ type: 'error', text: 'Must have at least 2 letters for the team name', timeout: 3000 })
           return
         }
 
@@ -67,7 +67,7 @@
           application.router.navigate(`/league/${savedClan._id}`, { trigger: true })
         } catch (e) {
           if (e.errorName === 'Conflict' || e.code === 409) {
-            noty({ type: 'error', text: 'Clan name already exists', timeout: 3000 })
+            noty({ type: 'error', text: 'Team name already exists', timeout: 3000 })
             return
           } else {
             throw e
@@ -89,7 +89,7 @@
           this.$emit('close')
         } catch (e) {
           if (e.errorName === 'Conflict' || e.code === 409) {
-            noty({ type: 'error', text: 'Clan name already exists', timeout: 3000 })
+            noty({ type: 'error', text: 'Team name already exists', timeout: 3000 })
             return
           } else {
             throw e
@@ -105,7 +105,7 @@
   <modal @close="$emit('close')" :title="modalTitle" id="clan-creation-modal">
     <div class="container">
       <div>
-        <label for="input-name">Clan name:</label>
+        <label for="input-name">Team name:</label>
         <input id="input-name" type="text" v-model="name" />
       </div>
 

--- a/app/views/landing-pages/league/components/Leaderboard.vue
+++ b/app/views/landing-pages/league/components/Leaderboard.vue
@@ -64,7 +64,7 @@ export default {
           th(colspan=1) {{ $t('general.rank') }}
           th {{ $t('general.score') }}
           th.name-col-cell {{ $t('general.name') }}
-          th(colspan=4) {{ $t('clans.clan') }}
+          th(colspan=4 style="text-transform: capitalize;") {{ $t('league.team') }}
           th(colspan=1) {{ $t('ladder.age') }}
           th(colspan=1) 🏴‍☠️
 


### PR DESCRIPTION
# Context

We're using a legacy & internal name on the esports page leading to confusion for customers.

This change replaces the usage of the word `clan` to the word `team` on the /league page.

Translation effort is out of scope of this PR. This PR is more of an initial quick fix. I've added some small i18n improvements where it makes sense but the page remains mostly hard coded in English for now.

# How

 - Change static text from `clan` to `team` across page and Clan/Team update modal.
 - Replace `Clan` with `Team` in autoclan descriptions that are automatically generated. Quick hack as we want to better handle this server side.

# Risk

Minimal risk as text changes.


# How to test

Navigate to localhost:3000/league and note the lack of clan verbiage on the page.

Clicking on an autoclan will no longer have `Clan for` description used.

# Screenshots

Example of autoclan description changed:

![image](https://user-images.githubusercontent.com/15080861/104367622-f0368380-54cf-11eb-8372-7d53c458c436.png)


Team heading on leaderboard:

![image](https://user-images.githubusercontent.com/15080861/104367773-21af4f00-54d0-11eb-88ba-f4070b2b197a.png)


Some text

![image](https://user-images.githubusercontent.com/15080861/104367836-30960180-54d0-11eb-892a-7fe69e43f28d.png)
