### PR TITLE
Load esper.js later for better performance

### DIFF
--- a/app/lib/loadAetherLanguage.coffee
+++ b/app/lib/loadAetherLanguage.coffee
@@ -7,6 +7,17 @@ loadScript = (url, cb) ->
     script.addEventListener('load', cb, false)
   document.head.appendChild(script)
 
+loadEsper = -> new Promise (accept, reject) ->
+  if window.esper
+    return accept()
+  try
+    eval("'use strict'; let test = WeakMap && (class Test { *gen(a=7) { yield yield * () => true ; } });")
+    #console.log("Modern javascript detected, aw yeah!");
+    loadScript("/javascripts/esper.modern.js", accept)
+  catch e
+    #console.log("Legacy javascript detected, falling back...", e.message);
+    loadScript("/javascripts/esper.js", accept)
+
 ###
   Loads the language plugin for a chosen language.
   Should be called after esper is loaded.
@@ -14,19 +25,24 @@ loadScript = (url, cb) ->
   Ensures that modern plugins are loaded on modern browsers.
 ###
 loadAetherLanguage = (language) -> new Promise (accept, reject) ->
-  # Javascript is build into esper.
-  if language in ['javascript']
-    return accept()
+  loadEsper().then ->
 
-  if language in ['python', 'coffeescript', 'lua', 'java', 'cpp']
-    try
-      eval("'use strict'; let test = WeakMap && (class Test { *gen(a=7) { yield yield * () => true ; } });")
-      console.log("Modern plugin chosen for: '#{language}'")
-      loadScript(window.javascriptsPath + "app/vendor/aether-#{language}.modern.js", accept)
-    catch e
-      console.log("Falling back on legacy language plugin for: '#{language}'")
-      loadScript(window.javascriptsPath + "app/vendor/aether-#{language}.js", accept)
-  else
-    reject(new Error("Can't load language '#{language}'"))
+    # Javascript is built into Esper.
+    if language in ['javascript']
+      return accept()
+
+    if language in ['python', 'coffeescript', 'lua', 'java', 'cpp']
+      try
+        eval("'use strict'; let test = WeakMap && (class Test { *gen(a=7) { yield yield * () => true ; } });")
+        #console.log("Modern plugin chosen for: '#{language}'")
+        #loadScript(window.javascriptsPath + "app/vendor/aether-#{language}.modern.js", accept)
+        # Workers don't know how to load from window.javascriptsPath, which would offer better cache invalidation, but no point in double load on non-hash-cached version
+        loadScript("/javascripts/app/vendor/aether-#{language}.modern.js", accept)
+      catch e
+        #console.log("Falling back on legacy language plugin for: '#{language}'")
+        #loadScript(window.javascriptsPath + "app/vendor/aether-#{language}.js", accept)
+        loadScript("/javascripts/app/vendor/aether-#{language}.js", accept)
+    else
+      reject(new Error("Can't load language '#{language}'"))
 
 module.exports = loadAetherLanguage

--- a/app/vendor.js
+++ b/app/vendor.js
@@ -71,22 +71,6 @@ if (!String.prototype.includes) {
   })
 })([Element.prototype, CharacterData.prototype, DocumentType.prototype])
 
-function loadScript (url) {
-  var script = document.createElement('script');
-  script.src = url;
-  document.head.appendChild(script);
-}
-try {
-  //Detect very modern javascript support.
-  (0,eval("'use strict'; let test = WeakMap && (class Test { *gen(a=7) { yield yield * () => true ; } });"));
-  console.log("Modern javascript detected, aw yeah!");
-  loadScript(window.javascriptsPath + 'esper.modern.js')
-
-} catch (e) {
-  console.log("Legacy javascript detected, falling back...", e.message);
-  loadScript(window.javascriptsPath + 'esper.js');
-}
-
 // All the rest of Vendor...
 require('vendor/scripts/css.js')
 require('vendor/scripts/flying-focus.js')


### PR DESCRIPTION
We noticed that esper.js was loading on the homepage, when it's not needed until you are playing/editing a level, simulating, verifying, etc. in game. I moved it from a vendor.js include to the same way we load its plugins, so that any time we needed to load an esper plugin, we first load esper itself.

I also load esper.js and its language plugins consistently from the non-hashed JS path, because the web workers don't currently know how to use the hashed version, and so they would be doing a separate load anyway. Probably fine because it changes so infrequently, but if we wanted, we could move web worker JS loads to use the hashed JS path as well by passing that to the web workers as future work.