### PR TITLE
Academica third party esports bug fixes

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -179,6 +179,7 @@ module.exports = class CocoRouter extends Backbone.Router
     'impact': () ->
       @routeDirectly('PageImpact', [], { vueRoute: true, baseTemplate: 'base-flat' })
 
+    'league/academica': redirect('/league/autoclan-school-network-academica') # Redirect for Academica.
     'league(/*subpath)': go('core/SingletonAppVueComponentView')
 
     'legal': go('LegalView')

--- a/app/core/store/modules/clans.js
+++ b/app/core/store/modules/clans.js
@@ -26,6 +26,12 @@ export default {
 
   mutations: {
     setClan (state, clan) {
+      // We do not want to overwrite a clan with a version of the clan with less fields.
+      // This can result in a clan losing a displayName and showing the slug as a result.
+      if (state.clans[clan._id] && Object.keys(state.clans[clan._id]).length > Object.keys(clan).length) {
+        return
+      }
+
       Vue.set(state.clans, clan._id, clan)
     },
 

--- a/app/views/landing-pages/league/PageLeague.vue
+++ b/app/views/landing-pages/league/PageLeague.vue
@@ -14,7 +14,7 @@
     export default {
       metaInfo () {
         return {
-          title: 'Competitive AI coding eSports from CodeCombat',
+          title: 'Competitive AI coding esports from CodeCombat',
           meta: [
             { name: 'viewport', content: 'width=device-width, initial-scale=1' }
           ]

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -464,7 +464,7 @@ export default {
           <div class="row flex-row" style="justify-content: flex-start;">
             <div class="col-sm-5">
               <p style="margin-bottom: 70px;">
-                Unlike other eSports platforms serving schools, we own the structure top to bottom, which means we’re not tied to any game developer or have issues with licensing. That also means we can make custom modifications in-game for your school or organization.
+                Unlike other esports platforms serving schools, we own the structure top to bottom, which means we’re not tied to any game developer or have issues with licensing. That also means we can make custom modifications in-game for your school or organization.
               </p>
             </div>
             <div class="col-sm-7">
@@ -552,7 +552,7 @@ export default {
     <div class="row esports-flyer-optimized-section">
       <div class="col-sm-8">
         <h1 style="margin-bottom: 50px;"><span class="esports-aqua">Bring </span><span class="esports-pink">competitive coding </span><span class="esports-aqua">to your </span><span class="esports-purple">school</span></h1>
-        <p style="margin-bottom: 50px;">Share our AI League flyer with educators, administrators, parents, eSports coaches or others that may be interested.</p>
+        <p style="margin-bottom: 50px;">Share our AI League flyer with educators, administrators, parents, esports coaches or others that may be interested.</p>
         <div class="xs-centered">
           <a style="margin-bottom: 50px;" class="btn btn-large btn-primary btn-moon" href="https://s3.amazonaws.com/files.codecombat.com/docs/esports_flyer.pdf" target="_blank" rel="noopener noreferrer">Download Flyer</a>
         </div>

--- a/app/views/landing-pages/league/components/ClanSelector.vue
+++ b/app/views/landing-pages/league/components/ClanSelector.vue
@@ -18,7 +18,7 @@ export default {
 
 <template>
   <div>
-    <label for="clans">My Clans:</label>
+    <label for="clans">My Teams:</label>
     <select id="clans" name="clans" @change="e => $emit('change', e)">
       <option value="global" :selected="selected===''">--</option>
       <option  v-for="clan in clans" :key="clan._id" :value="clan._id" :selected="selected===clan._id">


### PR DESCRIPTION
# Description

Fixes some small issues with the esports league page making the experience more enjoyable.

 - Changes eSports text to esports.
 - Ensures we don't accidentally set a clan in the vuex store with fewer fields than previously loaded.
 - Fixes an additional Clan -> Team terminology change.
 - A third party redirect for academica. Adds redirect for the url `/league/academica`.

# Testing

Tested manually via local development with both a user in teams and looking at the global page.

These changes can be manually by spinning up local development via `npm run dev` and `npm run proxy`.

Navigating to `localhost:3000/league/academica` leads you to the school network team page.

The page should look like so:
![image](https://user-images.githubusercontent.com/15080861/104651134-142ecc00-566c-11eb-9519-a539fff2b580.png)

Prior to this PR the page looks like this:
![image](https://user-images.githubusercontent.com/15080861/104651162-1db83400-566c-11eb-9f6a-78fba136abb9.png)

Note the incorrect team name.

# Risk

Risk is low as these changes are small copy fixes.
