### PR TITLE
Academica team - student call to actions

### DIFF
--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -550,7 +550,7 @@ module.exports = class User extends CocoModel
   age: -> utils.yearsSinceMonth me.get('birthday')
 
   isInAcademicaClan: ->
-    return @get('clans')?.indexOf('5ff88bcdfe17d7bb1c7d2d00') isnt -1
+    return Array.isArray(@get('clans')) and @get('clans')?.indexOf('5ff88bcdfe17d7bb1c7d2d00') isnt -1
 
   # Feature Flags
   # Abstract raw settings away from specific UX changes

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -549,6 +549,9 @@ module.exports = class User extends CocoModel
 
   age: -> utils.yearsSinceMonth me.get('birthday')
 
+  isInAcademicaClan: ->
+    return @get('clans')?.indexOf('5ff88bcdfe17d7bb1c7d2d00') isnt -1
+
   # Feature Flags
   # Abstract raw settings away from specific UX changes
   allowStudentHeroPurchase: -> features?.classroomItems ? false and @isStudent()

--- a/app/templates/courses/courses-view.jade
+++ b/app/templates/courses/courses-view.jade
@@ -142,6 +142,13 @@ block content
                       +course-instance-body(courseInstance, classroom)
                       .clearfix
 
+            if me.isInAcademicaClan()
+              #announcement
+                h5 You can still learn and play without a classroom!
+                ul
+                  li Compete in the Blazing Battles esports arena by <a href='/play/ladder/blazing-battle'>clicking here</a>.
+                  li Play the free Hour of Code campaign <a href='/play/hoc-2018'>here</a>.
+
             h3.text-uppercase(data-i18n="courses.join_class")
             hr
 


### PR DESCRIPTION
# Context

Currently our Academica partners need their student user's to be able to engage without a teacher or classroom.

This is a low risk and informative PR to add specific information for these students to access free content without a teacher or school intervening.

Next week we will be handling this more systemically for all students, thus keeping this low cost and easy to remove later.

# How to test

The user flow for a Clever student is as follows:

- They log in through Clever.
- Get dropped in the student dashboard.
- See this announcement if they are Academica student and engage.

There is no easy way to test the Clever sign up flow, but you can emulate being a student in the Academica team.
For all other students they will not see the announcement.

You can test by spying on various students and navigating to:
localhost:3000/students

# Screenshots

New user flows for Academica team

![07caacb4b043888c353cfab60f0f5548](https://user-images.githubusercontent.com/15080861/104784238-bb7b3400-573c-11eb-99e1-a6c45da32cda.gif)

![bd357839cdacc9ddc11d2fe50ebe28b5](https://user-images.githubusercontent.com/15080861/104784242-bd44f780-573c-11eb-941d-9f995dedbc30.gif)




