### PR TITLE
Responsiveness fix for esports ladder level page

### DIFF
--- a/app/templates/play/ladder/ladder.jade
+++ b/app/templates/play/ladder/ladder.jade
@@ -172,7 +172,7 @@ block content
           a(href="#winners", data-toggle="tab", data-i18n="ladder.winners") Winners
 
   //don't render when tournament is ended in order to control page height
-  div.tab-content(style=view.displayTabContent)
+  div.row.tab-content(style="padding: 0 15px 0 15px;")
     if view.level.isType('ladder')
       if view.winners
         .tab-pane.active.well#ladder

--- a/app/views/ladder/LadderView.coffee
+++ b/app/views/ladder/LadderView.coffee
@@ -73,8 +73,6 @@ module.exports = class LadderView extends RootView
     if tournamentStartDate = {'zero-sum': 1427472000000, 'ace-of-coders': 1442417400000, 'battle-of-red-cliffs': 1596295800000}[@levelID]
       @tournamentTimeElapsed = moment(new Date(tournamentStartDate)).fromNow()
 
-    @displayTabContent = 'display: block'
-
     @calcTimeOffset()
     @mandate = @supermodel.loadModel(new Mandate()).model
 


### PR DESCRIPTION
# Context

The default experience of [this page](https://codecombat.com/play/ladder/blazing-battle) looks really rough.

This is the page currently live in production (screenshot taken in Chrome):

![image](https://user-images.githubusercontent.com/15080861/104791675-6cd79500-5750-11eb-8ffe-0c61dc8eeab3.png)

Note that the background container doesn't respond to the length of the ladder and leaks into the footer!

In addition to this if the user extends the ladder it doesn't bring the background with it.

![9344227f77453ab202811fffea191187](https://user-images.githubusercontent.com/15080861/104791730-a7413200-5750-11eb-805c-811f8c9366f4.gif)


This change is extremely small, but fixes up the responsiveness of the ladder pages. See screenshot section for the fixed screenshot and gif.

# How was this fixed

Original page isn't using original bootstrap semantics properly.
Adding the `row` class correctly propagates the page height across the various ladder pages without changing the bootstrap tab semantics.

# Testing

This was tested across our various ladder pages.

Spin up a local development environment with `npm run dev` and `npm run proxy`.

Then navigate to the following links.

 - http://localhost:3000/play/ladder/blazing-battle
 - http://localhost:3000/play/ladder/ace-of-coders (Click through the various tabs. Ladder, My Matches, Winners, Simulate)


# Screenshots and Gifs of fix

![399e13ad681e9c236040649d60cac825](https://user-images.githubusercontent.com/15080861/104791818-e8d1dd00-5750-11eb-8dcd-5d77d0f05737.gif)

![image](https://user-images.githubusercontent.com/15080861/104791839-f8e9bc80-5750-11eb-9d00-c44fcf3e2479.png)


