### PR TITLE
Don't load Drift unless/until it's needed.

### DIFF
--- a/app/core/Tracker2/DriftTracker.js
+++ b/app/core/Tracker2/DriftTracker.js
@@ -117,7 +117,10 @@ export default class DriftTracker extends BaseTracker {
 
   updateDriftConfiguration () {
     const chatEnabled = this.isChatEnabled
-    if (chatEnabled && !this.driftApi && this.isInitialized !== false) {
+    if (this.isInitialized !== false) {
+      // Drift failed to load, let's not try again.
+      return
+    } else if (chatEnabled && !this.driftApi) {
       return this.initializeDrift()
     } else if (!chatEnabled && !this.driftApi) {
       return

--- a/app/core/Tracker2/DriftTracker.js
+++ b/app/core/Tracker2/DriftTracker.js
@@ -46,14 +46,11 @@ export default class DriftTracker extends BaseTracker {
   }
 
   async _initializeTracker () {
-    loadDrift()
-
-    window.drift.on('ready', (api) => {
-      this.driftApi = api
-
-      this.initDriftOnLoad()
+    if (this.isChatEnabled) {
+      await this.initializeDrift()
+    } else {
       this.onInitializeSuccess()
-    })
+    }
 
     this.store.watch(
       (state) => state.route,
@@ -66,21 +63,25 @@ export default class DriftTracker extends BaseTracker {
     )
 
     this.watchForDisableAllTrackingChanges(this.store)
+  }
 
-    const isChina = (window.features || {}).china
-    if (isChina) {
-      this.enabled = false
-    }
-    else {
-      this.enabled = true
-    }
-    await this.initializationComplete
-    this.updateDriftConfiguration()
+  async initializeDrift () {
+    loadDrift()
 
-    const retries = await getPageUnloadRetriesForNamespace('drift')
-    for (const retry of retries) {
-      this[retry.identifier](...retry.args)
-    }
+    window.drift.on('ready', async (api) => {
+      this.driftApi = api
+
+      this.initDriftOnLoad()
+      if (!this.initializationComplete)
+        this.onInitializeSuccess()
+
+      this.updateDriftConfiguration()
+
+      const retries = await getPageUnloadRetriesForNamespace('drift')
+      for (const retry of retries) {
+        this[retry.identifier](...retry.args)
+      }
+    })
   }
 
   initDriftOnLoad () {
@@ -111,11 +112,14 @@ export default class DriftTracker extends BaseTracker {
   }
 
   get isChatEnabled () {
-    return !this.onPlayPage && !this.store.getters['me/isStudent']
+    return !this.onPlayPage && !this.store.getters['me/isStudent'] && !this.store.getters['me/isHomePlayer']  // && !this.disableAllTracking
   }
 
   updateDriftConfiguration () {
     const chatEnabled = this.isChatEnabled
+    if (chatEnabled && !this.driftApi && this.isInitialized !== false) {
+      return this.initializeDrift()
+    }
 
     window.drift.config({
       enableWelcomeMessage: chatEnabled,
@@ -131,7 +135,7 @@ export default class DriftTracker extends BaseTracker {
   }
 
   async identify (traits = {}) {
-    if (this.disableAllTracking || !this.enabled) {
+    if (this.disableAllTracking) {
       return
     }
 
@@ -165,7 +169,7 @@ export default class DriftTracker extends BaseTracker {
   }
 
   async trackPageView (includeIntegrations = []) {
-    if (this.disableAllTracking || !this.enabled) {
+    if (this.disableAllTracking) {
       return
     }
 
@@ -176,7 +180,7 @@ export default class DriftTracker extends BaseTracker {
   }
 
   async trackEvent (action, properties = {}) {
-    if (this.disableAllTracking || !this.enabled) {
+    if (this.disableAllTracking) {
       return
     }
 

--- a/app/core/Tracker2/DriftTracker.js
+++ b/app/core/Tracker2/DriftTracker.js
@@ -119,6 +119,8 @@ export default class DriftTracker extends BaseTracker {
     const chatEnabled = this.isChatEnabled
     if (chatEnabled && !this.driftApi && this.isInitialized !== false) {
       return this.initializeDrift()
+    } else if (!chatEnabled && !this.driftApi) {
+      return
     }
 
     window.drift.config({

--- a/app/core/Tracker2/index.js
+++ b/app/core/Tracker2/index.js
@@ -39,9 +39,6 @@ export default class Tracker2 extends BaseTracker {
 
     this.trackers = [
       this.legacyTracker,
-      // this.googleAnalyticsTracker,
-      this.segmentTracker,
-      this.fullStoryTracker,
     ]
 
     const isGlobal = !(window.features || {}).china
@@ -49,7 +46,10 @@ export default class Tracker2 extends BaseTracker {
       // add trackers we don't want china to enable here.
       this.trackers = [
         ...this.trackers,
+        this.segmentTracker,
+        // this.googleAnalyticsTracker,
         this.driftTracker,
+        this.fullStoryTracker,
         this.googleOptimizeTracker,
         this.facebookPixelTracker
       ]

--- a/app/core/store/modules/me.js
+++ b/app/core/store/modules/me.js
@@ -29,6 +29,10 @@ export default {
       return (state || {}).role === 'parent'
     },
 
+    isHomePlayer (state) {
+      return !(state || {}).role && state.anonymous === false
+    },
+
     forumLink (state) {
       let link = 'http://discourse.codecombat.com/'
       const lang = (state.preferredLanguage || 'en-US').split('-')[0]

--- a/app/views/landing-pages/parents/PageParents.vue
+++ b/app/views/landing-pages/parents/PageParents.vue
@@ -636,7 +636,9 @@ export default {
   },
 
   mounted () {
-    window.drift.on('scheduling:meetingBooked', this.onDriftMeetingBooked)
+    if (window.drift) {
+      window.drift.on('scheduling:meetingBooked', this.onDriftMeetingBooked)
+    }
 
     if (this.type === 'thank-you') {
       this.onClassBooked()
@@ -644,7 +646,9 @@ export default {
   },
 
   beforeDestroy () {
-    window.drift.off('scheduling:meetingBooked', this.onDriftMeetingBooked)
+    if (window.drift) {
+      window.drift.off('scheduling:meetingBooked', this.onDriftMeetingBooked)
+    }
   },
 
   methods: {
@@ -696,6 +700,11 @@ export default {
     async onCtaClicked (e) {
       if (e && e.preventDefault) {
         e.preventDefault()
+      }
+
+      if (!window.drift && (this.type === 'parents' || this.type === 'sales' || this.type == 'chat')) {
+        console.log('No Drift, resetting to self-serve')
+        this.type = 'self-serve'
       }
 
       this.trackCtaClicked()


### PR DESCRIPTION
Also, update logic to not show Drift for logged-in home players.

Also, remove extraneous `this.enabled = false` guards against Drift loading in China, since the Drift tracker is already not initialized when in China.

There are also a couple services that I don't think we use in China that I moved to the global-server-only list.

I'm not very familiar with this code, especially the async loading parts, so could use eyes on it. Wanted to get something out soon to help sales team not get buried in irrelevant chat messages. I tested locally being logged into nothing, home account, teacher account, and on/not on /play pages, and moving between those.