### PR TITLE
Add player count to AI League arena leaderboard

### DIFF
--- a/app/core/api/leaderboard.js
+++ b/app/core/api/leaderboard.js
@@ -15,6 +15,10 @@ export const getMyRank = (levelOriginal, sessionId, options) => {
   return fetchJson(`/db/level/${levelOriginal}/rankings/${sessionId}?${$.param(options)}`)
 }
 
+export const getLeaderboardPlayerCount = (levelOriginal, options) => {
+  return fetchJson(`/db/level/${levelOriginal}/rankings-count?${$.param(options)}`)
+}
+
 export const getCodePointsLeaderboard = (clanId, options) => {
   return fetchJson(`/db/clan/${clanId || '-'}/code-points?${$.param(options)}`)
 }

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -203,7 +203,9 @@ export default {
   computed: {
     ...mapGetters({
       globalRankings: 'seasonalLeague/globalRankings',
+      globalLeaderboardPlayerCount: 'seasonalLeague/globalLeaderboardPlayerCount',
       clanRankings: 'seasonalLeague/clanRankings',
+      clanLeaderboardPlayerCount: 'seasonalLeague/clanLeaderboardPlayerCount',
       codePointsRankings: 'seasonalLeague/codePointsRankings',
       myClans: 'clans/myClans',
       clanByIdOrSlug: 'clans/clanByIdOrSlug',
@@ -243,6 +245,10 @@ export default {
 
     selectedClanRankings () {
       return this.clanRankings(this.clanIdSelected)
+    },
+
+    selectedClanLeaderboardPlayerCount () {
+      return this.clanLeaderboardPlayerCount(this.clanIdSelected)
     },
 
     selectedClanCodePointsRankings () {
@@ -333,8 +339,8 @@ export default {
       <h1 v-if="currentSelectedClan"><span class="esports-aqua">{{ currentSelectedClanName }} </span><span class="esports-pink">stats</span></h1>
       <h1 v-else><span class="esports-aqua">Global </span><span class="esports-pink">stats</span></h1>
       <p>Use your coding skills and battle strategies to rise up the ranks!</p>
-      <leaderboard v-if="currentSelectedClan" :rankings="selectedClanRankings" :key="`${clanIdSelected}-score`" class="leaderboard-component" style="color: black;" />
-      <leaderboard v-else :rankings="globalRankings" class="leaderboard-component" />
+  <leaderboard v-if="currentSelectedClan" :rankings="selectedClanRankings" :playerCount="selectedClanLeaderboardPlayerCount" :key="`${clanIdSelected}-score`" class="leaderboard-component" style="color: black;" />
+      <leaderboard v-else :rankings="globalRankings" :playerCount="globalLeaderboardPlayerCount" class="leaderboard-component" />
       <leaderboard :rankings="selectedClanCodePointsRankings" :key="`${clanIdSelected}-codepoints`" scoreType="codePoints" class="leaderboard-component" />
     </div>
     <div class="row text-center section-space">

--- a/app/views/landing-pages/league/components/Leaderboard.vue
+++ b/app/views/landing-pages/league/components/Leaderboard.vue
@@ -13,6 +13,10 @@ export default {
     scoreType: {
       type: String,
       default: 'arena'
+    },
+    playerCount: {
+      type: Number,
+      default: 0
     }
   },
 
@@ -58,6 +62,10 @@ export default {
             span(v-else) Blazing Battle
             span &nbsp;
             span {{ $t('ladder.leaderboard') }}
+            span(v-if="playerCount > 1")
+              span  -&nbsp;
+              span {{ playerCount }}
+              span  players
 
         tr
           th(colspan=1)


### PR DESCRIPTION
Global:
<img width="868" alt="Screen Shot 2021-01-21 at 16 18 23" src="https://user-images.githubusercontent.com/99704/105428535-693a8700-5c04-11eb-923f-35e9cfd4621c.png">

Clan-specific:
<img width="927" alt="Screen Shot 2021-01-21 at 16 18 56" src="https://user-images.githubusercontent.com/99704/105428541-6b044a80-5c04-11eb-8327-c42b32309cb5.png">

Was just practicing Vue a little more. I wonder if I'm not missing something, though, since this is a pretty hefty amount of boilerplate to load a value from the server and display it in the template?