### PR TITLE
Esports link from home and student first campaign view

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -3147,3 +3147,5 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     general_news: "Get emails on the latest news and updates regarding our AI Leagues and tournaments."
     team: 'team'
     how_it_works1: 'Join a __team__'
+    seasonal_arena_name: 'Blazing Battle'
+    seasonal_arena_tooltip: 'Battle against your teammates and others as you use your best programming skills to earn points and rank up the AI League leaderboard before taking on the Championship arena at the end of the season.'

--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -408,7 +408,7 @@ $gameControlMargin: 30px
         &.complete.premium .level-status
           background-position: -180px 0
 
-        .start-level
+        .start-level, .start-esports
           min-width: 200px
           display: block
           margin: 10px auto 0 auto
@@ -934,13 +934,6 @@ $gameControlMargin: 30px
   .under-logo
     position: absolute
     top: calc(1% + 64px)
-    left: 1%
-    z-index: 1
-    width: 193px
-
-  #videos-button
-    position: absolute
-    top: calc(1% + 128px)
     left: 1%
     z-index: 1
     width: 193px

--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -16,11 +16,15 @@ if showGameDevAlert
       em.spr powered by
       img(src="/images/pages/base/logo.png", title="Powered by CodeCombat - Learn how to code by playing a game ", alt="Powered by CodeCombat")
 
-  if view.shouldShow('back-to-classroom')
-    a.btn.btn-illustrated.btn-success.btn-block.btn-lg.text-uppercase.under-logo(href='/play', data-i18n="play.back_to_classroom")
+  div.under-logo.button-container
+    if view.shouldShow('back-to-classroom')
+      a.btn.btn-illustrated.btn-success.btn-block.btn-lg.text-uppercase(href='/play', data-i18n="play.back_to_classroom")
 
-  if view.shouldShow('videos')
-    a.btn.btn-illustrated.btn-block.btn-lg.text-uppercase#videos-button(data-i18n="play_level.videos")
+    if view.shouldShow('videos')
+      a.btn.btn-illustrated.btn-block.btn-lg.text-uppercase#videos-button(data-i18n="play_level.videos")
+
+    if view.shouldShow('blazing-battle')
+      a.btn.btn-illustrated.btn-block.btn-lg.text-uppercase#esports-arena(class=`${(me.get('stats') || {}).codePoints > 30 ? 'btn-danger' : ''}`) Play Blazing Battle
 
   if serverConfig.codeNinjas
     a(href="https://code.ninja")
@@ -130,6 +134,16 @@ if showGameDevAlert
             else if level.unlocksHero
               img.treasure-chest(src="/images/pages/play/gold-chest.png")
         div(style="left: " + level.position.x + "%; bottom: " + level.position.y + "%",class="level-shadow" + (level.next ? " next" : "") + (level.locked ? " locked" : "") + " " + (levelStatusMap[level.slug] || ""))
+        if view.shouldShow('blazing-battle')
+          .level-info-container.rtl-allowed.blazing-battle-tooltip
+            //- TODO: don't hard code that the user has completed the level.
+            div(class="level-info rtl-allowed complete")
+              .level-status.rtl-allowed(dir="auto")
+              h3(dir="ltr") Blazing Battle
+              .level-description.rtl-allowed(dir="auto")
+                p Battle against your teammates and others as you use your best programming skills to earn points and rank up the AI League leaderboard before taking on the Championship arena at the end of the season.
+
+              a.btn.btn-success.btn.btn-lg.btn-illustrated.start-esports(data-i18n="common.play" href="/play/ladder/blazing-battle") Play
         .level-info-container.rtl-allowed(data-level-slug=level.slug, data-level-path=level.levelPath || 'level', data-level-name=level.name, data-level-original=level.original)
           - var playCount = levelPlayCountMap[level.slug]
           .progress.progress-striped.active.hide

--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -23,7 +23,7 @@ if showGameDevAlert
     if view.shouldShow('videos')
       a.btn.btn-illustrated.btn-block.btn-lg.text-uppercase#videos-button(data-i18n="play_level.videos")
 
-    if view.shouldShow('blazing-battle')
+    if view.shouldShow('league-arena')
       a.btn.btn-illustrated.btn-block.btn-lg.text-uppercase#esports-arena(class=`${(me.get('stats') || {}).codePoints > 30 ? 'btn-danger' : ''}`) Play Blazing Battle
 
   if serverConfig.codeNinjas
@@ -134,16 +134,16 @@ if showGameDevAlert
             else if level.unlocksHero
               img.treasure-chest(src="/images/pages/play/gold-chest.png")
         div(style="left: " + level.position.x + "%; bottom: " + level.position.y + "%",class="level-shadow" + (level.next ? " next" : "") + (level.locked ? " locked" : "") + " " + (levelStatusMap[level.slug] || ""))
-        if view.shouldShow('blazing-battle')
-          .level-info-container.rtl-allowed.blazing-battle-tooltip
+        if view.shouldShow('league-arena')
+          .level-info-container.rtl-allowed.league-arena-tooltip
             //- TODO: don't hard code that the user has completed the level.
             div(class="level-info rtl-allowed complete")
               .level-status.rtl-allowed(dir="auto")
-              h3(dir="ltr") Blazing Battle
+              h3(dir="ltr" data-i18n="league.seasonal_arena_name")
               .level-description.rtl-allowed(dir="auto")
-                p Battle against your teammates and others as you use your best programming skills to earn points and rank up the AI League leaderboard before taking on the Championship arena at the end of the season.
+                p(data-i18n="league.seasonal_arena_tooltip")
 
-              a.btn.btn-success.btn.btn-lg.btn-illustrated.start-esports(data-i18n="common.play" href="/play/ladder/blazing-battle") Play
+              a.btn.btn-success.btn.btn-lg.btn-illustrated.start-esports(data-i18n="common.play" href="/play/ladder/blazing-battle")
         .level-info-container.rtl-allowed(data-level-slug=level.slug, data-level-path=level.levelPath || 'level', data-level-name=level.name, data-level-original=level.original)
           - var playCount = levelPlayCountMap[level.slug]
           .progress.progress-striped.active.hide

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -112,6 +112,7 @@ module.exports = class CampaignView extends RootView
     'click [data-toggle="coco-modal"][data-target="core/AnonymousTeacherModal"]': 'openAnonymousTeacherModal'
     'click #videos-button': 'onClickVideosButton'
     'click #esports-arena': 'onClickEsportsButton'
+    'click a.start-esports': 'onClickEsportsLink'
 
   shortcuts:
     'shift+s': 'onShiftS'
@@ -376,8 +377,12 @@ module.exports = class CampaignView extends RootView
 
   onClickEsportsButton: (e) ->
     @$levelInfo?.hide()
-    @$levelInfo = @$el.find(".level-info-container.blazing-battle-tooltip").show()
+    window.tracker?.trackEvent 'Click LevelInfo AI League Button', { category: 'World Map', label: 'blazing-battle' }
+    @$levelInfo = @$el.find(".level-info-container.league-arena-tooltip").show()
     @adjustLevelInfoPosition e
+
+  onClickEsportsLink: ->
+    window.tracker?.trackEvent 'Click Play AI League Button', { category: 'World Map', label: 'blazing-battle' }
 
   getLevelPlayCounts: ->
     return unless me.isAdmin()
@@ -1473,7 +1478,7 @@ module.exports = class CampaignView extends RootView
     if what is 'amazon-campaign'
       return @campaign?.get('slug') is 'game-dev-hoc'
 
-    if what is 'blazing-battle'
+    if what is 'league-arena'
       return @campaign?.get('slug') in ['dungeon', 'intro']
 
     return true

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -111,6 +111,7 @@ module.exports = class CampaignView extends RootView
     'click [data-toggle="coco-modal"][data-target="core/CreateAccountModal"]': 'openCreateAccountModal'
     'click [data-toggle="coco-modal"][data-target="core/AnonymousTeacherModal"]': 'openAnonymousTeacherModal'
     'click #videos-button': 'onClickVideosButton'
+    'click #esports-arena': 'onClickEsportsButton'
 
   shortcuts:
     'shift+s': 'onShiftS'
@@ -372,6 +373,11 @@ module.exports = class CampaignView extends RootView
 
   onClickVideosButton: ->
     @openModalView(new CourseVideosModal({courseInstanceID: @courseInstanceID, courseID: @course.get('_id')}))
+
+  onClickEsportsButton: (e) ->
+    @$levelInfo?.hide()
+    @$levelInfo = @$el.find(".level-info-container.blazing-battle-tooltip").show()
+    @adjustLevelInfoPosition e
 
   getLevelPlayCounts: ->
     return unless me.isAdmin()
@@ -1466,5 +1472,8 @@ module.exports = class CampaignView extends RootView
 
     if what is 'amazon-campaign'
       return @campaign?.get('slug') is 'game-dev-hoc'
+
+    if what is 'blazing-battle'
+      return @campaign?.get('slug') in ['dungeon', 'intro']
 
     return true


### PR DESCRIPTION
# Context

We want home users and students with a certain amount of codepoints to be able to find the seasonal esports arena.
In order to do that we are adding a button that links directly to the esports arena from CS1 and Dungeon campaigns.

This button is initially brown and not very visible. When the user gets over some (not decided) threshold of codepoints, we make the button more visible and potentially even trigger an animation. In this PR the button changes to red for initial implementation.

First implementation has codepoints threshold set to 30 points. This is enough to ensure the user has played a couple practice levels.

# Testing

This can be tested by spinning up a local proxy: `npm run dev` and `npm run proxy` running at the same time.

First test:
Login as a home user.
Navigate to http://localhost:3000/play/dungeon and notice the Blazing Battles button in the top left.

Second test:
Login as a student and navigate to the cs1 campaign map. You may need a classroom set up for the student.
I used the test account: `andrew+student2@codecombat.com`
If spying on this account you can directly navigate to: http://localhost:3000/play/55b29efd1cd6abe8ce07db0d?course-instance=5bd0b86333f9ca0047e6a459

This is the CS1 campaign map. It should also have a blazing battle button.

Third test:
In both cases the button behaves once it is there. You should be able to click between the button and other levels on the map and the tooltip should toggle correctly.
Clicking "Play" on the blazing battle tooltip takes you to the blazing battle ladder.

**How to test analytics events?**

In your local environment update this variable to `true`:
https://github.com/codecombat/codecombat/blob/c963c22/app/core/Tracker.coffee#L7

This will make tracking events be logged in the developer console.

We expect to see two new events added:
 - Category: World Map, Action: Click LevelInfo AI League Button, Label: blazing-battle
 - Category: World Map, Action: Click Play AI League Button, Label: blazing-battle

# Risk

This is a first version and works well enough. Manual testing didn't find any bugs. Currently awaiting feedback for this initial implementation. Once finalized text can add it to i18n system.

# Screenshots and gifs

![dca6322ddd993f45a609debf4a09d1b4](https://user-images.githubusercontent.com/15080861/105922624-d9c01a00-5fef-11eb-84b6-e0cca9c8e5c1.gif)
![a90e451d6537a7105c5ca7ecacae3518](https://user-images.githubusercontent.com/15080861/105922627-da58b080-5fef-11eb-8f22-62eeeaa2179a.gif)

Example of button without enough codepoints.
![image](https://user-images.githubusercontent.com/15080861/105922645-e3498200-5fef-11eb-9e62-2c446e3d0536.png)

