### PR TITLE
🐛Fix spritesheet builder memory leak

### DIFF
--- a/app/lib/surface/LayerAdapter.coffee
+++ b/app/lib/surface/LayerAdapter.coffee
@@ -290,10 +290,21 @@ module.exports = LayerAdapter = class LayerAdapter extends CocoClass
   onBuildSpriteSheetComplete: (e, builder) ->
     return if @initializing or @destroyed
     @asyncBuilder = null
+    builder?.removeAllEventListeners()
+
+    if @spriteSheet
+      # This is required for old canvas to be garbage collected.
+      for image, i in @spriteSheet._images
+        image.width = 0
+        image.height = 0
+        @spriteSheet._images[i] = null
 
     @spriteSheet = builder.spriteSheet
+    builder = null
     @spriteSheet.resolutionFactor = @resolutionFactor
     oldLayer = @container
+    oldLayer?.removeAllEventListeners()
+
     @container = new createjs.Container(@spriteSheet)
     for lank in @lanks
       console.log 'zombie sprite found on layer', @name if lank.destroyed

--- a/app/lib/surface/SegmentedSprite.coffee
+++ b/app/lib/surface/SegmentedSprite.coffee
@@ -20,6 +20,8 @@ module.exports = class SegmentedSprite extends createjs.Container
   destroy: ->
     @handleTick = undefined
     @baseMovieClip.inUse = false if @baseMovieClip
+    delete @spriteSheet.mcPool
+    delete @spriteSheet
     @removeAllEventListeners()
 
   # CreateJS.Sprite-like interface

--- a/app/lib/surface/SingularSprite.coffee
+++ b/app/lib/surface/SingularSprite.coffee
@@ -12,6 +12,7 @@ module.exports = class SingularSprite extends createjs.Sprite
     super(@spriteSheet)
 
   destroy: ->
+    delete @spriteSheet
     @removeAllEventListeners()
 
   gotoAndPlay: (actionName) -> @goto(actionName, false)


### PR DESCRIPTION
# Context

Our game view or renderer dynamically builds spritesheets of all the entities or thangs that are in a level.
This is an optimization to pass the graphics card a single large image with all the required sprites to animate and play the level.
However if a new sprite is drawn midway through play it must be added to the spritesheet. The new spritesheet has the new art, and the old own persists in memory until either a browser refresh or page crash.
This means that over a period of play, if there is dynamic rendering, we get a memory leak.

For the last two years we've solved this memory leak by refreshing the page between every level. This has blocked many other optimizations of resources we don't want to be constantly fetching.

This PR was done specifically for the Blazing Battle arena but will benefit the whole platform. If no issues are found we can roll it into Ozaria as well. This PR should enable old sprite sheets to be garbage collected preventing the leak from crashing the browser.

This is difficult to test, and I've specifically used Safari for the measurements as Safari lets you visually see all in memory canvases via their developer tools.
**note: Looking at the canvas in the inspector will prevent them from being garbage collected as well.**


# How to test

We can test by using the Safari Graphics debugger.

To see canvas memory leak.

1. Navigate to codecombat.com/play/level/blazing-battle?team=humans
2. Add the following code.

```
# Build towers to outlast your opponent!
hero.buildTower("firewall", 3)
hero.buildTower("catapult", 6)
# Build more towers.
```

3. Press play and wait till game finishes.
4. Open Safari graphics debugger and manually count number of 16mb spritesheets.

^ Do the same locally on `npm run dev & npm run proxy`.

Results:

Currently in production: **44**, 16mb canvas elements.

With this PR: **3**, 16mb canvas elements.

## Other tests

Levels I have measured SpriteSheet memory impact:

To test in production use url: `codecombat.com/play/level/:slug`
Test this PR: `localhost:3000/play/level/:slug`

| Level Slug | Level Type | Production memory after one play (mbs) | Fixed memory after one play (mb) |
| ----------|-------------|---------|-------------|
|master-of-names| practice | 16 | 8 |
| time-to-live | game dev | 32 | 8 |
| blazing-battle | ladder | 704 | 48 |
|persistence-pays| game dev | 40 | 8 |
|ace-of-coders | ladder | 34 | 34 |


Might this also improve internal level editor memory?

# Risks

Could lead to issues as it does modify old spritesheets as we replace them with new ones.
Have tested across practice levels, game dev, web dev, and ladder.

# Screenshots

Use the Safari graphics debugger to visualize.
On codecombat.com/play/blazing-battle the following user code:
```
# Build towers to outlast your opponent!
hero.buildTower("firewall", 3)
hero.buildTower("catapult", 6)
# Build more towers.
```
Will lead to many 16mb canvases quickly running the user into a browser crash.


https://user-images.githubusercontent.com/15080861/106069784-017ab500-60b8-11eb-9cc2-bf3426441d23.mp4

With these changes after running game 3 times with three different towers:

https://user-images.githubusercontent.com/15080861/106071154-b0b88b80-60ba-11eb-8e23-3a75631a8703.mp4

There still seems to be some kind of leak but there are more canvases with width and height of 0. They appear to then dissapear.

