### PR TITLE
Zendesk widget offset improvements

### DIFF
--- a/app/core/application.coffee
+++ b/app/core/application.coffee
@@ -81,6 +81,12 @@ Application = {
             zE('webWidget', 'open')
         )
         zE('webWidget:on', 'close', -> zE('webWidget', 'hide'))
+        zE('webWidget', 'updateSettings', {
+          webWidget: {
+            offset: { horizontal: '100px', vertical: '20px' }
+          }
+        })
+
 
       zendeskElement.src = 'https://static.zdassets.com/ekr/snippet.js?key=ed461a46-91a6-430a-a09c-73c364e02ffe'
       script = document.getElementsByTagName('script')[0]


### PR DESCRIPTION
### Context

We are improving Drift widget handling, but there are still edge cases where both Zendesk and Drift can be active at the same time. This change lets them "co-exist" side by side happily 😀 

### How to test

- Check out `matias/zendesk-widget-offset`
- Start up local dev environment and go to the homepage
- Open the browser console and write `zE('webWidget', 'open') ; zE('webWidget', 'show')`
- Notice the Zendesk widget appearing side-by-side instead of overlapping

### Before

<img width="470" alt="zendesk before" src="https://user-images.githubusercontent.com/1154150/106226272-c72d2700-6221-11eb-8dd4-07de05c25f67.png">

### After

<img width="666" alt="zendesk after" src="https://user-images.githubusercontent.com/1154150/106226294-cf856200-6221-11eb-836b-626df030693f.png">
