### PR TITLE
Update Academica cta to route to codePoints first

### DIFF
--- a/app/templates/courses/courses-view.jade
+++ b/app/templates/courses/courses-view.jade
@@ -146,8 +146,9 @@ block content
               #announcement
                 h5 You can still learn and play without a classroom!
                 ul
-                  li Compete in the Blazing Battles esports arena by <a href='/play/ladder/blazing-battle'>clicking here</a>.
-                  li Play the free Hour of Code campaign <a href='/play/hoc-2018'>here</a>.
+                  li
+                    b Start by playing the free Hour of Code campaign by <a href='/play/hoc-2018'>clicking here</a>.
+                  li Then compete in the Blazing Battles esports arena <a href='/play/ladder/blazing-battle'>here</a>.
             
             if (!me.isInAcademicaClan() && ((me.get('stats') || {}).codePoints || 0) > 30)
               #esports-announcement.flex-container


### PR DESCRIPTION
# Context

Very small change and very low risk.

Swaps order of codePoints link and arena link so that users are more likely to interact with the codepoints link.
Otherwise users are interacting with arena before getting our more gentle ramp up levels.

![image](https://user-images.githubusercontent.com/15080861/106538460-18067f00-64b1-11eb-98f2-c7a1e02eb03d.png)
