### PR TITLE
Handle unloaded Drift when identifying

### DIFF
--- a/app/core/Tracker2/DriftTracker.js
+++ b/app/core/Tracker2/DriftTracker.js
@@ -163,13 +163,15 @@ export default class DriftTracker extends BaseTracker {
     }, {})
 
     retryOnPageUnload('drift', 'identify', [ traits ], () => {
-      window.drift.identify(
-        _id.toString(),
-        {
-          ...filteredMeAttributes,
-          ...traits
+      if (window.drift) {
+        window.drift.identify(
+          _id.toString(),
+          {
+            ...filteredMeAttributes,
+            ...traits
+          }
+          )
         }
-      )
     })
   }
 

--- a/app/core/Tracker2/DriftTracker.js
+++ b/app/core/Tracker2/DriftTracker.js
@@ -72,8 +72,7 @@ export default class DriftTracker extends BaseTracker {
       this.driftApi = api
 
       this.initDriftOnLoad()
-      if (!this.initializationComplete)
-        this.onInitializeSuccess()
+      this.onInitializeSuccess()
 
       this.updateDriftConfiguration()
 
@@ -145,6 +144,9 @@ export default class DriftTracker extends BaseTracker {
     }
 
     await this.initializationComplete
+    if (!window.drift) {
+      return;
+    }
 
     const { me } = this.store.state
 
@@ -163,15 +165,13 @@ export default class DriftTracker extends BaseTracker {
     }, {})
 
     retryOnPageUnload('drift', 'identify', [ traits ], () => {
-      if (window.drift) {
-        window.drift.identify(
-          _id.toString(),
-          {
-            ...filteredMeAttributes,
-            ...traits
-          }
-          )
+      window.drift.identify(
+        _id.toString(),
+        {
+          ...filteredMeAttributes,
+          ...traits
         }
+      )
     })
   }
 


### PR DESCRIPTION
# Context

We don't want to try and identify users when drift isn't loaded.
In the past we have had drift constantly loaded, but now load drift for only certain conditions.

# How to reproduce bug and test change

This issue comes up in production but not in local development environment. This occurs because we turn tracking off in local development so we don't add our own internal data to analytics.
Thus we need to do a bit of setup to locally reproduce the bug.

First to find the source of the bug I noticed it was during the `identify` call.
![image](https://user-images.githubusercontent.com/15080861/106673540-9a04af80-6566-11eb-8047-7df75574e67b.png)

This lead me to Tracker.coffee that is the controller for all tracking.
Here there is a method `shouldTrackExternalEvents` that will block tracking when on local development.
https://github.com/codecombat/codecombat/blob/107748d/app/core/Tracker.coffee#L120

I set an early `return true`.

I also needed to add `localhost` temporarily to the `DEFAULT_TRACKING_DOMAINS` in the vuex tracker.
https://github.com/codecombat/codecombat/blob/107748d/app/core/store/modules/tracker.js#L1

With these changes I was able to reproduce the bug locally.
Steps to reproduce:

1. Make code changes mentioned above.
2. Spin up `npm run dev` and `npm run proxy` for local development.
3. Sign into a non-teacher account. The error should appear in the console.
4. You should also be able to sign into a teacher and see the absence of the error.


# Result

With this change, teachers will correctly get identified (as Drift loads for them), whilst other non teacher accounts will no longer have the crash.

We also are seeing a lack of other events being sent. I have a hypothesis that this crash unwinds the `identify` stack causing the other trackers not to work. We can confirm this after deploy.

# Risk

Low