### PR TITLE
Prevent drift from loading more than once

### DIFF
--- a/app/core/Tracker2/DriftTracker.js
+++ b/app/core/Tracker2/DriftTracker.js
@@ -70,11 +70,10 @@ export default class DriftTracker extends BaseTracker {
 
     window.drift.on('ready', async (api) => {
       this.driftApi = api
-
       this.initDriftOnLoad()
-      this.onInitializeSuccess()
-
       this.updateDriftConfiguration()
+
+      this.onInitializeSuccess()
 
       const retries = await getPageUnloadRetriesForNamespace('drift')
       for (const retry of retries) {
@@ -84,8 +83,9 @@ export default class DriftTracker extends BaseTracker {
   }
 
   initDriftOnLoad () {
-    // Hide by default
-    this.driftApi.widget.hide()
+    if (!this.isChatEnabled) {
+      this.driftApi.widget.hide()
+    }
 
     // Show when a message is received
     window.drift.on('message', (e) => {
@@ -114,9 +114,11 @@ export default class DriftTracker extends BaseTracker {
     return !this.onPlayPage && !this.store.getters['me/isStudent'] && !this.store.getters['me/isHomePlayer']  // && !this.disableAllTracking
   }
 
-  updateDriftConfiguration () {
+  async updateDriftConfiguration () {
+    await this.initializationComplete
+
     const chatEnabled = this.isChatEnabled
-    if (this.isInitialized !== false) {
+    if (!this.isInitialized) {
       // Drift failed to load, let's not try again.
       return
     } else if (chatEnabled && !this.driftApi) {


### PR DESCRIPTION
# Context

This pull request fixes some more subtle issues in Drift. Specifically it resolves the issue that turns up when you navigate to the following page: https://codecombat.com/students?_cc=SafeGateStone

Navigating to this page creates the following errors:
![image](https://user-images.githubusercontent.com/15080861/106832396-76b13180-6646-11eb-9ce3-5caf60084527.png)

![image](https://user-images.githubusercontent.com/15080861/106832463-93e60000-6646-11eb-8531-5cbbdedeb184.png)

Although this error appears the Drift widget still works.

# Why

Why this error occurs because of a race condition.
Because we call `updateDriftConfiguration` on route updating as well as when initializing drift. It is possible for `updateDriftConfiguration` to trigger a second load before the first one has completed.

# How to fix

Make `updateDriftConfigration` async and check to see if the `initializationComplete` promise is complete. Then check for Drift and potentially trigger an initialization.

# Testing

Spin this up locally. No other changes are needed.

Use `npm run dev` and `npm run proxy`.

Navigate as an anonymous user to localhost:3000/students?_cc=SafeGateStone
 - Drift should show up and no error should appear in the console.

Log in as a teacher. Drift should stay working unless you navigate to a play view.

Log in as a student - drift should dissapear.

# Risk

I manually tested, and this fix is relatively minor. Thus I think the risk is low (although there may still be more bugs).
