### PR TITLE
Initial school clan UI search system

### DIFF
--- a/app/core/api/clans.js
+++ b/app/core/api/clans.js
@@ -14,4 +14,4 @@ export const leaveClan = clanId => fetchJson(`/db/clan/${clanId}/leave`, {
   method: 'PUT'
 })
 
-export const getChildClanDetails = idOrSlug => fetchJson(`/db/clan/${idOrSlug}/children`)
+export const getChildClanDetails = idOrSlug => fetchJson(`/db/clan/${idOrSlug}/subclans`)

--- a/app/core/api/clans.js
+++ b/app/core/api/clans.js
@@ -13,3 +13,5 @@ export const joinClan = clanId => fetchJson(`/db/clan/${clanId}/join`, {
 export const leaveClan = clanId => fetchJson(`/db/clan/${clanId}/leave`, {
   method: 'PUT'
 })
+
+export const getChildClanDetails = idOrSlug => fetchJson(`/db/clan/${idOrSlug}/children`)

--- a/app/core/store/modules/clans.js
+++ b/app/core/store/modules/clans.js
@@ -1,10 +1,12 @@
-import { getPublicClans, getMyClans, getClan } from '../../api/clans'
+import { getPublicClans, getMyClans, getClan, getChildClanDetails } from '../../api/clans'
 
 export default {
   namespaced: true,
   state: {
     // key is clan id, with clan data stored as object literal.
     clans: {},
+    // key is the clan id that initiated the request. Response array is memoized.
+    childClanDetails: {},
     loading: false
   },
 
@@ -21,6 +23,12 @@ export default {
       return idOrSlug => {
         return state.clans[idOrSlug] || Object.values(state.clans).find(({ slug }) => slug === idOrSlug)
       }
+    },
+
+    childClanDetails (state) {
+      return id => {
+        return state.childClanDetails[id] || []
+      }
     }
   },
 
@@ -33,6 +41,10 @@ export default {
       }
 
       Vue.set(state.clans, clan._id, clan)
+    },
+
+    setClanDetails (state, { clanId, childClans }) {
+      Vue.set(state.childClanDetails, clanId, childClans)
     },
 
     setLoading (state, loading) {
@@ -74,6 +86,12 @@ export default {
       for (const clan of clans) {
         commit('setClan', clan)
       }
+    },
+
+    async fetchChildClanDetails ({ commit }, { id }) {
+      const childClans = await getChildClanDetails(id)
+      console.log(childClans)
+      commit('setClanDetails', { clanId: id, childClans })
     }
   }
 }

--- a/app/core/store/modules/clans.js
+++ b/app/core/store/modules/clans.js
@@ -90,7 +90,6 @@ export default {
 
     async fetchChildClanDetails ({ commit }, { id }) {
       const childClans = await getChildClanDetails(id)
-      console.log(childClans)
       commit('setClanDetails', { clanId: id, childClans })
     }
   }

--- a/app/core/utils.coffee
+++ b/app/core/utils.coffee
@@ -213,6 +213,14 @@ courseIDs =
   COMPUTER_SCIENCE_5: '569ed916efa72b0ced971447'
   COMPUTER_SCIENCE_6: '5817d673e85d1220db624ca4'
 
+CSCourseIDs = [
+  courseIDs.INTRODUCTION_TO_COMPUTER_SCIENCE
+  courseIDs.COMPUTER_SCIENCE_2
+  courseIDs.COMPUTER_SCIENCE_3
+  courseIDs.COMPUTER_SCIENCE_4
+  courseIDs.COMPUTER_SCIENCE_5
+  courseIDs.COMPUTER_SCIENCE_6
+]
 orderedCourseIDs = [
   courseIDs.INTRODUCTION_TO_COMPUTER_SCIENCE
   courseIDs.GAME_DEVELOPMENT_1
@@ -883,6 +891,7 @@ module.exports = {
   countryCodeToFlagEmoji
   courseAcronyms
   courseIDs
+  CSCourseIDs
   createLevelNumberMap
   extractPlayerCodeTag
   filterMarkdownCodeLanguages

--- a/app/lib/surface/SegmentedSprite.coffee
+++ b/app/lib/surface/SegmentedSprite.coffee
@@ -124,6 +124,7 @@ module.exports = class SegmentedSprite extends createjs.Container
 
   buildMovieClip: (animationName, mode, startPosition, loops) ->
     key = JSON.stringify([@spriteSheetPrefix].concat(arguments))
+    @spriteSheet.mcPool ?= {}
     @spriteSheet.mcPool[key] ?= []
     for mc in @spriteSheet.mcPool[key]
       if not mc.inUse

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1943,11 +1943,11 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     student_state: "How is"
     student_state_2: "doing?"
     student_good: "is doing well in"
-    student_good_detail: "This student is keeping pace with the class."
+    student_good_detail: "This student is keeping pace with the class's average level completion times." # {change}
     student_warn: "might need some help in"
-    student_warn_detail: "This student might need some help with new concepts that have been introduced in this course."
+    student_warn_detail: "This student's average level completion times suggest they might need some help with new concepts that have been introduced in this course." # {change}
     student_great: "is doing great in"
-    student_great_detail: "This student might be a good candidate to help other students working through this course."
+    student_great_detail: "This student might be a good candidate to help other students working through this course, based on average level completion times." # {change}
     full_license: "Full License"
     starter_license: "Starter License"
     customized_license: "Customized License"

--- a/app/templates/courses/teacher-class-view.jade
+++ b/app/templates/courses/teacher-class-view.jade
@@ -363,7 +363,7 @@ mixin bulkAssignControls
       span :
     select.bulk-course-select.form-control
       each course in _.rest(view.latestReleasedCourses)
-        if classroom.language != 'cpp' || (course.id === view.utils.courseIDs.INTRODUCTION_TO_COMPUTER_SCIENCE || course.id === view.utils.courseIDs.COMPUTER_SCIENCE_2 || course.id === view.utils.courseIDs.COMPUTER_SCIENCE_3)
+        if classroom.language !== 'cpp' || (view.utils.CSCourseIDs.indexOf(course.id) !== -1) 
           option(value=course.id selected=(course===state.get('selectedCourse')))
             = i18n(course.attributes, 'name')
             if !view.availableCourseMap[course.id]

--- a/app/templates/courses/teacher-courses-view.jade
+++ b/app/templates/courses/teacher-courses-view.jade
@@ -50,7 +50,7 @@ block content
                         | Python
                       option(value="javascript")
                         | JavaScript
-                      if view.enableCpp && (course.id === view.utils.courseIDs.INTRODUCTION_TO_COMPUTER_SCIENCE || course.id === view.utils.courseIDs.COMPUTER_SCIENCE_2 || course.id === view.utils.courseIDs.COMPUTER_SCIENCE_3)
+                      if view.enableCpp && (view.utils.CSCourseIDs.indexOf(course.id) !== -1)
                         option(value="cpp")
                           | C++
               .form-group
@@ -120,7 +120,7 @@ mixin course-info(course)
           |  &mdash; Python
         a.guide-btn.btn.btn-primary(disabled=disableButtons href=("/teachers/course-solution/" + course.id + "/javascript") data-course-id=course.id data-course-name=course.get('name') data-event-action="Classes Guides Guide JavaScript" class=(me.isTeacher() || me.isAdmin() ? '': 'disabled'))
           span JavaScript
-        if view.enableCpp && (course.id === view.utils.courseIDs.INTRODUCTION_TO_COMPUTER_SCIENCE || course.id === view.utils.courseIDs.COMPUTER_SCIENCE_2 || course.id === view.utils.courseIDs.COMPUTER_SCIENCE_3)
+        if view.enableCpp && (view.utils.CSCourseIDs.indexOf(course.id) !== -1)
           a.guide-btn.btn.btn-primary(disabled=disableButtons href=("/teachers/course-solution/" + course.id + "/cpp") data-course-id=course.id data-course-name=course.get('name') data-event-action="Classes Guides Guide C++" class=(me.isTeacher() || me.isAdmin() ? '': 'disabled'))
             span C++
 

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -5,6 +5,7 @@ import ClanSelector from './components/ClanSelector.vue'
 import LeagueSignupModal from './components/LeagueSignupModal'
 import ClanCreationModal from './components/ClanCreationModal'
 import ChildClanDetailDropdown from './components/ChildClanDetailDropdown'
+import SectionFirstCTA from './components/SectionFirstCTA'
 
 import { joinClan, leaveClan } from '../../../core/api/clans'
 
@@ -14,7 +15,8 @@ export default {
     ClanSelector,
     LeagueSignupModal,
     ClanCreationModal,
-    ChildClanDetailDropdown
+    ChildClanDetailDropdown,
+    SectionFirstCTA
   },
 
   data: () => ({
@@ -79,6 +81,9 @@ export default {
 
         if (['school-network', 'school-subnetwork'].includes(this.currentSelectedClan?.kind)) {
           this.fetchChildClanDetails({ id: this.currentSelectedClan._id })
+            .catch(() => {
+              console.error('Failed to retrieve child clans.')
+            })
         }
 
         this.loadClanRequiredData({ leagueId: this.clanIdSelected })
@@ -227,6 +232,10 @@ export default {
       return this.clanByIdOrSlug(this.clanIdOrSlug) || null
     },
 
+    isGlobalPage () {
+      return this.clanIdSelected === ''
+    },
+
     currentSelectedClanChildDetails () {
       const selectedId = this.clanIdSelected
       if (selectedId === '') {
@@ -323,21 +332,7 @@ export default {
       </div>
     </section>
 
-    <div class="graphic text-code-section">
-      <img class="img-responsive" src="/images/pages/league/text_code.svg" width="501" height="147" />
-    </div>
-    <div class="row flex-row text-center">
-      <p
-        class="subheader2"
-        style="max-width: 800px;"
-      >{{ $t('league.summary') }}</p>
-    </div>
-    <div v-if="!doneRegistering && !isClanCreator()" class="row flex-row text-center xs-m-0">
-      <a class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">{{ $t('league.join_now') }}</a>
-    </div>
-    <div class="graphic text-2021-section section-space">
-      <img class="img-responsive" src="/images/pages/league/text_2021.svg" width="501" height="147" />
-    </div>
+    <SectionFirstCTA v-if="isGlobalPage" :doneRegistering="doneRegistering" :isClanCreator="isClanCreator" :onHandleJoinCTA="onHandleJoinCTA" />
 
     <div v-if="clanIdSelected !== ''" id="clan-invite" class="row flex-row text-center" style="margin-top: -25px; z-index: 0;">
       <div class="col-sm-5">
@@ -379,6 +374,8 @@ export default {
         <a v-else href="/play" class="btn btn-large btn-primary btn-moon play-btn-cta">Earn CodePoints by completing levels</a>
       </div>
     </div>
+
+    <SectionFirstCTA v-if="!isGlobalPage" :doneRegistering="doneRegistering" :isClanCreator="isClanCreator" :onHandleJoinCTA="onHandleJoinCTA" />
 
     <section class="row flex-row free-to-get-start" :class="clanIdSelected === '' ? 'free-to-get-start-bg':''">
       <div class="col-sm-10">
@@ -629,7 +626,7 @@ export default {
     color: #f7d047;
   }
 
-  /deep/ .esports-aqua {
+  ::v-deep .esports-aqua {
     color: #30efd3;
   }
 
@@ -683,7 +680,7 @@ export default {
     margin: 25px 0;
   }
 
-  .row.flex-row {
+  ::v-deep .row.flex-row {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -772,7 +769,7 @@ export default {
     font-size: 72px;
   }
 
-  .subheader2 {
+  ::v-deep .subheader2 {
     font-size: 29px;
     line-height: 40px;
   }
@@ -798,25 +795,16 @@ export default {
     color: #000;
   }
 
-  .text-2021-section {
-    width: 100%;
-    overflow-x: hidden;
-    display: flex;
-    justify-content: flex-end;
-  }
-
   .text-are-you-an-educator {
     justify-content: flex-start;
     margin-top: 100px;
   }
-  .text-code-section {
-    width: 100%;
-    overflow-x: hidden;
-  }
+
   .esports-flyer-optimized-section {
     margin-bottom: 100px;
   }
-  .btn-primary.btn-moon {
+
+  ::v-deep .btn-primary.btn-moon {
     background-color: #d1b147;
     border-radius: 4px;
     color: #232323;
@@ -834,7 +822,7 @@ export default {
     }
   }
 
-  .section-space {
+  ::v-deep .section-space {
     margin-bottom: 110px;
   }
   .w-100 {
@@ -848,16 +836,16 @@ export default {
   }
 
   @media screen and (min-width: 768px) {
-    .btn-primary.btn-moon, .play-btn-cta {
+    ::v-deep .btn-primary.btn-moon, .play-btn-cta {
       padding: 20px 100px;
     }
-    .section-space {
+    ::v-deep .section-space {
       margin-bottom: 200px;
     }
   }
 
   @media screen and (max-width: 767px) {
-    .row.flex-row {
+    ::v-deep .row.flex-row {
       display: table;
     }
 
@@ -865,7 +853,7 @@ export default {
       padding: 0px;
     }
 
-    .btn-primary.btn-moon {
+    ::v-deep .btn-primary.btn-moon {
       font-size: 14px;
       padding: 8px 24px;
     }
@@ -896,24 +884,19 @@ export default {
       border-color: #000;
       padding: 0px;
     }
-    .text-2021-section {
-      margin-bottom: auto;
-      padding: 0 10px;
-    }
+
     .text-are-you-an-educator {
       margin-top: auto;
       text-align: center;
     }
-    .text-code-section {
-      padding: 0 10px;
-    }
+
     .esports-flyer-optimized-section {
       margin-bottom: 0px;
     }
     .xs-centered {
       text-align: center;
     }
-    .xs-m-0 {
+    ::v-deep .xs-m-0 {
       margin: 0px;
     }
     .xs-mt-0 {

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -346,7 +346,6 @@ export default {
       <div class="col-sm-7">
         <h1><span class="esports-aqua">{{ currentSelectedClanName }}</span></h1>
         <h3 style="margin-bottom: 40px;">{{ currentSelectedClanDescription }}</h3>
-        <ChildClanDetailDropdown v-if="currentSelectedClanChildDetails.length > 0" :childClans="currentSelectedClanChildDetails"/>
         <p style="margin-bottom: 14px;">Invite players to this team by sending them this link:</p>
         <input readonly style="margin-bottom: 40px;" :value="clanInviteLink()" /><br />
         <a v-if="isAnonymous()" class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">{{ $t('league.join_now') }}</a>
@@ -357,8 +356,17 @@ export default {
     </div>
 
     <div class="row text-center">
-      <h1 v-if="currentSelectedClan"><span class="esports-aqua">{{ currentSelectedClanName }} </span><span class="esports-pink">stats</span></h1>
-      <h1 v-else><span class="esports-aqua">Global </span><span class="esports-pink">stats</span></h1>
+      <div class="team-banner-container">
+        <div class="flex-spacer" />
+        <h1 v-if="currentSelectedClan"><span class="esports-aqua">{{ currentSelectedClanName }} </span><span class="esports-pink">stats</span></h1>
+        <h1 v-else><span class="esports-aqua">Global </span><span class="esports-pink">stats</span></h1>
+        <ChildClanDetailDropdown
+           v-if="currentSelectedClanChildDetails.length > 0"
+          :label="`Search ${currentSelectedClanName} teams`"
+          :childClans="currentSelectedClanChildDetails"
+        />
+        <div v-else class="flex-spacer" />
+      </div>
       <p>Use your coding skills and battle strategies to rise up the ranks!</p>
       <div class="col-lg-6 section-space">
         <leaderboard v-if="currentSelectedClan" :rankings="selectedClanRankings" :playerCount="selectedClanLeaderboardPlayerCount" :key="`${clanIdSelected}-score`" class="leaderboard-component" style="color: black;" />
@@ -834,6 +842,16 @@ export default {
   }
   .w-100 {
     width: 100%;
+  }
+
+  .team-banner-container {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+
+    & > * {
+      flex: 1;
+    }
   }
 
   @media screen and (min-width: 768px) {

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -4,6 +4,8 @@ import Leaderboard from './components/Leaderboard'
 import ClanSelector from './components/ClanSelector.vue'
 import LeagueSignupModal from './components/LeagueSignupModal'
 import ClanCreationModal from './components/ClanCreationModal'
+import ChildClanDetailDropdown from './components/ChildClanDetailDropdown'
+
 import { joinClan, leaveClan } from '../../../core/api/clans'
 
 export default {
@@ -11,7 +13,8 @@ export default {
     Leaderboard,
     ClanSelector,
     LeagueSignupModal,
-    ClanCreationModal
+    ClanCreationModal,
+    ChildClanDetailDropdown
   },
 
   data: () => ({
@@ -48,6 +51,7 @@ export default {
       loadGlobalRequiredData: 'seasonalLeague/loadGlobalRequiredData',
       loadCodePointsRequiredData: 'seasonalLeague/loadCodePointsRequiredData',
       fetchClan: 'clans/fetchClan',
+      fetchChildClanDetails: 'clans/fetchChildClanDetails'
     }),
 
     changeClanSelected (e) {
@@ -71,6 +75,10 @@ export default {
           // Default to global page
           application.router.navigate('league', { trigger: true })
           return
+        }
+
+        if (this.currentSelectedClan?.kind === 'school-network') {
+          this.fetchChildClanDetails({ id: this.currentSelectedClan._id })
         }
 
         this.loadClanRequiredData({ leagueId: this.clanIdSelected })
@@ -208,6 +216,7 @@ export default {
       clanLeaderboardPlayerCount: 'seasonalLeague/clanLeaderboardPlayerCount',
       codePointsRankings: 'seasonalLeague/codePointsRankings',
       myClans: 'clans/myClans',
+      childClanDetails: 'clans/childClanDetails',
       clanByIdOrSlug: 'clans/clanByIdOrSlug',
       isLoading: 'clans/isLoading',
       isStudent: 'me/isStudent',
@@ -216,6 +225,15 @@ export default {
 
     currentSelectedClan () {
       return this.clanByIdOrSlug(this.clanIdOrSlug) || null
+    },
+
+    currentSelectedClanChildDetails () {
+      const selectedId = this.clanIdSelected
+      if (selectedId === '') {
+        return []
+      }
+      const result = this.childClanDetails(selectedId)
+      return result
     },
 
     clanIdSelected () {
@@ -328,8 +346,9 @@ export default {
       <div class="col-sm-7">
         <h1><span class="esports-aqua">{{ currentSelectedClanName }}</span></h1>
         <h3 style="margin-bottom: 40px;">{{ currentSelectedClanDescription }}</h3>
-        <p>Invite players to this team by sending them this link:</p>
-        <input readonly :value="clanInviteLink()" /><br />
+        <ChildClanDetailDropdown v-if="currentSelectedClanChildDetails.length > 0" :childClans="currentSelectedClanChildDetails"/>
+        <p style="margin-bottom: 14px;">Invite players to this team by sending them this link:</p>
+        <input readonly style="margin-bottom: 40px;" :value="clanInviteLink()" /><br />
         <a v-if="isAnonymous()" class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">{{ $t('league.join_now') }}</a>
         <a v-else-if="isClanCreator()" class="btn btn-large btn-primary btn-moon" @click="openClanCreation">Edit Team</a>
         <a v-else-if="inSelectedClan()" class="btn btn-large btn-primary btn-moon" :disabled="joinOrLeaveClanLoading" @click="leaveClan">Leave Team</a>

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -77,7 +77,7 @@ export default {
           return
         }
 
-        if (this.currentSelectedClan?.kind === 'school-network') {
+        if (['school-network', 'school-subnetwork'].includes(this.currentSelectedClan?.kind)) {
           this.fetchChildClanDetails({ id: this.currentSelectedClan._id })
         }
 

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -356,17 +356,14 @@ export default {
     </div>
 
     <div class="row text-center">
-      <div class="team-banner-container">
-        <div class="flex-spacer" />
-        <h1 v-if="currentSelectedClan"><span class="esports-aqua">{{ currentSelectedClanName }} </span><span class="esports-pink">stats</span></h1>
-        <h1 v-else><span class="esports-aqua">Global </span><span class="esports-pink">stats</span></h1>
-        <ChildClanDetailDropdown
-           v-if="currentSelectedClanChildDetails.length > 0"
-          :label="`Search ${currentSelectedClanName} teams`"
-          :childClans="currentSelectedClanChildDetails"
-        />
-        <div v-else class="flex-spacer" />
-      </div>
+      <h1 v-if="currentSelectedClan"><span class="esports-aqua">{{ currentSelectedClanName }} </span><span class="esports-pink">stats</span></h1>
+      <h1 v-else><span class="esports-aqua">Global </span><span class="esports-pink">stats</span></h1>
+      <ChildClanDetailDropdown
+        v-if="currentSelectedClanChildDetails.length > 0"
+        :label="`Search ${currentSelectedClanName} teams`"
+        :childClans="currentSelectedClanChildDetails"
+        class="clan-search"
+      />
       <p>Use your coding skills and battle strategies to rise up the ranks!</p>
       <div class="col-lg-6 section-space">
         <leaderboard v-if="currentSelectedClan" :rankings="selectedClanRankings" :playerCount="selectedClanLeaderboardPlayerCount" :key="`${clanIdSelected}-score`" class="leaderboard-component" style="color: black;" />
@@ -844,14 +841,10 @@ export default {
     width: 100%;
   }
 
-  .team-banner-container {
-    display: flex;
-    justify-content: space-around;
-    align-items: center;
-
-    & > * {
-      flex: 1;
-    }
+  .clan-search {
+    margin: 12px auto;
+    width: 90%;
+    max-width: 510px;
   }
 
   @media screen and (min-width: 768px) {

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -346,8 +346,8 @@ export default {
       <div class="col-sm-7">
         <h1><span class="esports-aqua">{{ currentSelectedClanName }}</span></h1>
         <h3 style="margin-bottom: 40px;">{{ currentSelectedClanDescription }}</h3>
-        <p style="margin-bottom: 14px;">Invite players to this team by sending them this link:</p>
-        <input readonly style="margin-bottom: 40px;" :value="clanInviteLink()" /><br />
+        <p>Invite players to this team by sending them this link:</p>
+        <input readonly :value="clanInviteLink()" /><br />
         <a v-if="isAnonymous()" class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">{{ $t('league.join_now') }}</a>
         <a v-else-if="isClanCreator()" class="btn btn-large btn-primary btn-moon" @click="openClanCreation">Edit Team</a>
         <a v-else-if="inSelectedClan()" class="btn btn-large btn-primary btn-moon" :disabled="joinOrLeaveClanLoading" @click="leaveClan">Leave Team</a>

--- a/app/views/landing-pages/league/components/ChildClanDetailDropdown.vue
+++ b/app/views/landing-pages/league/components/ChildClanDetailDropdown.vue
@@ -8,6 +8,12 @@ export default {
       required: false,
       default: () => ([])
     },
+
+    label: {
+      type: String,
+      required: false,
+      default: 'Search teams'
+    }
   },
 
   data: () => ({
@@ -18,21 +24,14 @@ export default {
 
   watch: {
     childClans (newVal) {
-      if (!this.flexsearch) {
-        this.flexsearch = new FlexSearch()
-      }
-
-      this.flexsearch.destroy().init({
-        tokenize: 'full',
-        depth: 3,
-        doc: {
-          id: '_id',
-          field: 'displayName'
-        }
-      })
-
+      this.createNewFlexSearch()
       this.flexsearch.add(newVal)
     }
+  },
+
+  created () {
+    this.createNewFlexSearch()
+    this.flexsearch.add(this.childClans)
   },
 
   computed: {
@@ -59,6 +58,30 @@ export default {
       setTimeout(() => {
         this.suggestions = []
       }, 150)
+    },
+
+    getClanKindDisplay (clan) {
+      if (clan.kind === 'school') {
+        return 'School:'
+      } else if (clan.kind === 'school-subnetwork') {
+        return 'SubNetwork:'
+      }
+      return ''
+    },
+
+    createNewFlexSearch () {
+      if (!this.flexsearch) {
+        this.flexsearch = new FlexSearch()
+      }
+
+      this.flexsearch.destroy().init({
+        tokenize: 'full',
+        depth: 3,
+        doc: {
+          id: '_id',
+          field: 'displayName'
+        }
+      })
     }
   }
 }
@@ -66,8 +89,7 @@ export default {
 
 <template>
   <div class="form-group child-clan-search">
-    <p class="control-label">Search School teams:</p>
-    <input class="form-control" v-model="inputVal" name="child-clan-search" autocomplete="off" placeholder="School Name" @focus="handleFocusInput" @blur="handleBlurInput"/>
+    <input class="form-control" v-model="inputVal" name="child-clan-search" autocomplete="off" :placeholder="label || 'Search School teams'" @focus="handleFocusInput" @blur="handleBlurInput"/>
     <div class="suggestion-wrapper">
       <div class="list-group">
         <div
@@ -75,7 +97,7 @@ export default {
           :key="child._id"
           class="list-group-item"
         >
-          <div><a :href="`/league/${child._id}`">{{child.displayName}}</a></div>
+          <div><a :href="`/league/${child._id}`">{{`${getClanKindDisplay(child)} ${child.displayName}`}}</a></div>
           <div>{{child.memberCount}}</div>
         </div>
       </div>
@@ -86,7 +108,7 @@ export default {
 
 <style lang="scss" scoped>
 .child-clan-search {
-  margin-bottom: 30px;
+  margin: 0;
 }
 
 .form-control {
@@ -118,5 +140,6 @@ export default {
   width: 100%;
   max-height: 40vh;
   overflow-y: scroll;
+  z-index: 10;
 }
 </style>

--- a/app/views/landing-pages/league/components/ChildClanDetailDropdown.vue
+++ b/app/views/landing-pages/league/components/ChildClanDetailDropdown.vue
@@ -65,6 +65,11 @@ export default {
       this.suggestions = this.childClans
     },
 
+    clearInput () {
+      this.suggestions = []
+      this.inputVal = ""
+    },
+
     handleBlurInput () {
       // Needs to take some time in case the user has clicked a suggestion in the dropdown.
       setTimeout(() => {
@@ -103,7 +108,12 @@ export default {
         </svg>
       </span>
       <input class="form-control" v-model="inputVal" name="child-clan-search" autocomplete="off" :placeholder="label || 'Search School teams'" @focus="handleFocusInput" @blur="handleBlurInput"/>
-      <span class="input-group-addon">
+      <div v-if="this.inputVal !== ''" class="input-group-btn input-group-addon" style="cursor: pointer;" @click="clearInput">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x" viewBox="0 0 16 16">
+          <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
+        </svg>
+      </div>
+      <span v-else class="input-group-addon">
         {{`${childClans.length} teams`}}
       </span>
     </div>
@@ -120,7 +130,7 @@ export default {
           class="list-group-item school-subnetwork"
           @click="() => navigateToTeamLeaguePage(child.slug)"
         >
-          <div><span>{{ child.displayName }}</span></div>
+          <div class="name-style"><span>{{ child.displayName }}</span></div>
           <div class="member-counts">
             <span>{{child.memberCount}}</span>
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-people" viewBox="0 0 16 16">
@@ -140,7 +150,7 @@ export default {
           class="list-group-item school"
           @click="() => navigateToTeamLeaguePage(child.slug)"
         >
-          <div><span>{{ child.displayName }}</span></div>
+          <div class="name-style"><span>{{ child.displayName }}</span></div>
           <div class="member-counts">
             <span>{{child.memberCount}}</span>
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-people" viewBox="0 0 16 16">
@@ -229,6 +239,14 @@ export default {
   svg {
     margin-left: 12px;
   }
+}
+
+.name-style {
+  flex: 2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: left;
 }
 
 .list-group {

--- a/app/views/landing-pages/league/components/ChildClanDetailDropdown.vue
+++ b/app/views/landing-pages/league/components/ChildClanDetailDropdown.vue
@@ -1,0 +1,122 @@
+<script>
+const FlexSearch = require('flexsearch')
+
+export default {
+  props: {
+    childClans: {
+      type: Array,
+      required: false,
+      default: () => ([])
+    },
+  },
+
+  data: () => ({
+    inputVal: "",
+    flexsearch: null,
+    suggestions: []
+  }),
+
+  watch: {
+    childClans (newVal) {
+      if (!this.flexsearch) {
+        this.flexsearch = new FlexSearch()
+      }
+
+      this.flexsearch.destroy().init({
+        tokenize: 'full',
+        depth: 3,
+        doc: {
+          id: '_id',
+          field: 'displayName'
+        }
+      })
+
+      this.flexsearch.add(newVal)
+    }
+  },
+
+  computed: {
+    filteredSuggestions () {
+      if (this.flexsearch === null) {
+        return this.suggestions
+      }
+
+      if (this.inputVal === '') {
+        return this.suggestions
+      }
+
+      return this.flexsearch.search({ query: this.inputVal, suggest: true })
+    }
+  },
+
+  methods: {
+    handleFocusInput() {
+      this.suggestions = this.childClans
+    },
+
+    handleBlurInput () {
+      // Needs to take some time in case the user has clicked a suggestion in the dropdown.
+      setTimeout(() => {
+        this.suggestions = []
+      }, 150)
+    }
+  }
+}
+</script>
+
+<template>
+  <div class="form-group child-clan-search">
+    <p class="control-label">Search School teams:</p>
+    <input class="form-control" v-model="inputVal" name="child-clan-search" autocomplete="off" placeholder="School Name" @focus="handleFocusInput" @blur="handleBlurInput"/>
+    <div class="suggestion-wrapper">
+      <div class="list-group">
+        <div
+          v-for="child in filteredSuggestions"
+          :key="child._id"
+          class="list-group-item"
+        >
+          <div><a :href="`/league/${child._id}`">{{child.displayName}}</a></div>
+          <div>{{child.memberCount}}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+
+<style lang="scss" scoped>
+.child-clan-search {
+  margin-bottom: 30px;
+}
+
+.form-control {
+  color: black;
+}
+
+.control-label {
+  color: white;
+}
+
+.suggestion-wrapper {
+  color: black;
+  position: relative;
+}
+
+.list-group-item {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+
+  &:hover {
+    background-color: #dedede;
+  }
+}
+
+.list-group {
+  position: absolute;
+  width: 100%;
+  max-height: 40vh;
+  overflow-y: scroll;
+}
+</style>

--- a/app/views/landing-pages/league/components/ChildClanDetailDropdown.vue
+++ b/app/views/landing-pages/league/components/ChildClanDetailDropdown.vue
@@ -43,8 +43,8 @@ export default {
       if (this.inputVal === '') {
         return this.suggestions
       }
-
-      return this.flexsearch.search({ query: this.inputVal, suggest: true })
+      // Sometimes flexsearch returns duplicates breaking unique key invariant in UI.
+      return _.unique(this.flexsearch.search({ query: this.inputVal, suggest: true }) || [], '_id')
     },
 
     subNetworkSuggestions () {

--- a/app/views/landing-pages/league/components/ChildClanDetailDropdown.vue
+++ b/app/views/landing-pages/league/components/ChildClanDetailDropdown.vue
@@ -45,6 +45,18 @@ export default {
       }
 
       return this.flexsearch.search({ query: this.inputVal, suggest: true })
+    },
+
+    subNetworkSuggestions () {
+      const subNetworks = this.filteredSuggestions.filter(({kind}) => kind === 'school-subnetwork')
+      subNetworks.sort(({memberCount: a}, {memberCount: b}) => b - a)
+      return subNetworks
+    },
+
+    schoolSuggestions () {
+      const schoolSuggestions = this.filteredSuggestions.filter(({kind}) => kind === "school")
+      schoolSuggestions.sort(({memberCount: a}, {memberCount: b}) => b - a)
+      return schoolSuggestions
     }
   },
 
@@ -60,13 +72,8 @@ export default {
       }, 150)
     },
 
-    getClanKindDisplay (clan) {
-      if (clan.kind === 'school') {
-        return 'School:'
-      } else if (clan.kind === 'school-subnetwork') {
-        return 'SubNetwork:'
-      }
-      return ''
+    navigateToTeamLeaguePage (clanSlug) {
+      application.router.navigate(`/league/${clanSlug}`, { trigger: true })
     },
 
     createNewFlexSearch () {
@@ -89,16 +96,57 @@ export default {
 
 <template>
   <div class="form-group child-clan-search">
-    <input class="form-control" v-model="inputVal" name="child-clan-search" autocomplete="off" :placeholder="label || 'Search School teams'" @focus="handleFocusInput" @blur="handleBlurInput"/>
+    <div class="input-group">
+      <span class="input-group-addon">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-search" viewBox="0 0 16 16">
+          <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
+        </svg>
+      </span>
+      <input class="form-control" v-model="inputVal" name="child-clan-search" autocomplete="off" :placeholder="label || 'Search School teams'" @focus="handleFocusInput" @blur="handleBlurInput"/>
+      <span class="input-group-addon">
+        {{`${childClans.length} teams`}}
+      </span>
+    </div>
+
     <div class="suggestion-wrapper">
       <div class="list-group">
+        <div v-if="subNetworkSuggestions.length > 0"
+          class="list-group-heading school-subnetwork">
+          <p>Subnetwork Teams</p>
+        </div>
         <div
-          v-for="child in filteredSuggestions"
+          v-for="child in subNetworkSuggestions"
           :key="child._id"
-          class="list-group-item"
+          class="list-group-item school-subnetwork"
+          @click="() => navigateToTeamLeaguePage(child.slug)"
         >
-          <div><a :href="`/league/${child._id}`">{{`${getClanKindDisplay(child)} ${child.displayName}`}}</a></div>
-          <div>{{child.memberCount}}</div>
+          <div><span>{{ child.displayName }}</span></div>
+          <div class="member-counts">
+            <span>{{child.memberCount}}</span>
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-people" viewBox="0 0 16 16">
+              <path d="M15 14s1 0 1-1-1-4-5-4-5 3-5 4 1 1 1 1h8zm-7.978-1A.261.261 0 0 1 7 12.996c.001-.264.167-1.03.76-1.72C8.312 10.629 9.282 10 11 10c1.717 0 2.687.63 3.24 1.276.593.69.758 1.457.76 1.72l-.008.002a.274.274 0 0 1-.014.002H7.022zM11 7a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm3-2a3 3 0 1 1-6 0 3 3 0 0 1 6 0zM6.936 9.28a5.88 5.88 0 0 0-1.23-.247A7.35 7.35 0 0 0 5 9c-4 0-5 3-5 4 0 .667.333 1 1 1h4.216A2.238 2.238 0 0 1 5 13c0-1.01.377-2.042 1.09-2.904.243-.294.526-.569.846-.816zM4.92 10A5.493 5.493 0 0 0 4 13H1c0-.26.164-1.03.76-1.724.545-.636 1.492-1.256 3.16-1.275zM1.5 5.5a3 3 0 1 1 6 0 3 3 0 0 1-6 0zm3-2a2 2 0 1 0 0 4 2 2 0 0 0 0-4z"/>
+            </svg>
+          </div>
+          
+        </div>
+        <div
+          v-if="schoolSuggestions.length > 0"
+          class="list-group-heading school">
+          <p>School Teams</p>
+        </div>
+        <div
+          v-for="child in schoolSuggestions"
+          :key="child._id"
+          class="list-group-item school"
+          @click="() => navigateToTeamLeaguePage(child.slug)"
+        >
+          <div><span>{{ child.displayName }}</span></div>
+          <div class="member-counts">
+            <span>{{child.memberCount}}</span>
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-people" viewBox="0 0 16 16">
+                <path d="M15 14s1 0 1-1-1-4-5-4-5 3-5 4 1 1 1 1h8zm-7.978-1A.261.261 0 0 1 7 12.996c.001-.264.167-1.03.76-1.72C8.312 10.629 9.282 10 11 10c1.717 0 2.687.63 3.24 1.276.593.69.758 1.457.76 1.72l-.008.002a.274.274 0 0 1-.014.002H7.022zM11 7a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm3-2a3 3 0 1 1-6 0 3 3 0 0 1 6 0zM6.936 9.28a5.88 5.88 0 0 0-1.23-.247A7.35 7.35 0 0 0 5 9c-4 0-5 3-5 4 0 .667.333 1 1 1h4.216A2.238 2.238 0 0 1 5 13c0-1.01.377-2.042 1.09-2.904.243-.294.526-.569.846-.816zM4.92 10A5.493 5.493 0 0 0 4 13H1c0-.26.164-1.03.76-1.724.545-.636 1.492-1.256 3.16-1.275zM1.5 5.5a3 3 0 1 1 6 0 3 3 0 0 1-6 0zm3-2a2 2 0 1 0 0 4 2 2 0 0 0 0-4z"/>
+              </svg>
+          </div>
         </div>
       </div>
     </div>
@@ -124,21 +172,69 @@ export default {
   position: relative;
 }
 
+.list-group-heading, .list-group-item {
+  height: 34px;
+  background-color: white;
+}
+
+.list-group-heading {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding-left: 20px;
+  background-color: #eee;
+  cursor: default;
+
+  p {
+    margin: 0;
+  }
+
+  &.school-subnetwork {
+    border-left: 12px solid #1D8F7E;
+  }
+
+  &.school {
+    border-left: 12px solid #8F205D;
+  }
+}
+
 .list-group-item {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
 
+  cursor: pointer;
+
+  &.school-subnetwork {
+    border-left: 12px solid #30efd3;
+    padding-left: 52px;
+  }
+
+  &.school {
+    border-left: 12px solid #ff39a6;
+    padding-left: 52px;
+  }
+
   &:hover {
     background-color: #dedede;
+  }
+}
+
+.member-counts {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+
+  svg {
+    margin-left: 12px;
   }
 }
 
 .list-group {
   position: absolute;
   width: 100%;
-  max-height: 40vh;
+  max-height: 70vh;
   overflow-y: scroll;
   z-index: 10;
 }

--- a/app/views/landing-pages/league/components/SectionFirstCTA.vue
+++ b/app/views/landing-pages/league/components/SectionFirstCTA.vue
@@ -1,0 +1,79 @@
+<script>
+export default {
+  props: {
+    doneRegistering: {
+      type: Boolean,
+      required: true
+    },
+    isClanCreator: {
+      required: true
+    },
+    onHandleJoinCTA: {
+      required: true
+    }
+  }
+}
+</script>
+
+<template>
+  <div class="section-first-cta">
+    <div class="text-code-section">
+      <img class="img-responsive" src="/images/pages/league/text_code.svg" width="501" height="147" />
+    </div>
+    <div class="row flex-row text-center">
+      <p
+        class="subheader2"
+        style="max-width: 800px;"
+      >{{ $t('league.summary') }}</p>
+    </div>
+    <div v-if="!doneRegistering && !isClanCreator()" class="row flex-row text-center xs-m-0">
+      <a class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">{{ $t('league.join_now') }}</a>
+    </div>
+    <div class="text-2021-section section-space">
+      <img class="img-responsive" src="/images/pages/league/text_2021.svg" width="501" height="147" />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+p {
+  color: white;
+}
+
+.text-code-section {
+  width: 100%;
+  overflow-x: hidden;
+  padding: 0 10px;
+}
+
+.text-2021-section {
+  width: 100%;
+  overflow-x: hidden;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.section-first-cta > div {
+  max-width: 1820px;
+  width:100%;
+  padding: 0 70px;
+  position: relative;
+  z-index: 1;
+  margin: 25px 0;
+}
+
+@media screen and (max-width: 767px) {
+  .text-code-section {
+    padding: 0 10px;
+  }
+
+  .text-2021-section {
+    margin-bottom: auto;
+    padding: 0 10px;
+  }
+
+  .section-first-cta > div {
+    padding: 0px;
+  }
+}
+</style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3211,6 +3211,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
       "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -4609,6 +4610,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -4862,7 +4864,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
       "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "buffer-shims": {
       "version": "1.0.0",
@@ -7253,6 +7256,7 @@
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -8410,6 +8414,11 @@
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
     },
+    "flexsearch": {
+      "version": "0.6.32",
+      "resolved": "https://registry.npmjs.org/flexsearch/-/flexsearch-0.6.32.tgz",
+      "integrity": "sha512-EF1BWkhwoeLtbIlDbY/vDSLBen/E5l/f1Vg7iX5CDymQCamcx1vhlc3tIZxIDplPjgi0jhG37c67idFbjg+v+Q=="
+    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -8673,7 +8682,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8694,12 +8704,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8714,17 +8726,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8841,7 +8856,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8853,6 +8869,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8867,6 +8884,7 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8874,12 +8892,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8898,6 +8918,7 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8978,7 +8999,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8990,6 +9012,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9075,7 +9098,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9111,6 +9135,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9130,6 +9155,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9173,12 +9199,14 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "optional": true
         }
       }
     },
@@ -9929,7 +9957,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "hoist-non-react-statics": {
       "version": "3.3.0",
@@ -10093,6 +10122,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "4",
         "debug": "3.1.0"
@@ -10103,6 +10133,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -10124,6 +10155,7 @@
       "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
       "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
       "dev": true,
+      "optional": true,
       "requires": {
         "httpreq": ">=0.4.22",
         "underscore": "~1.7.0"
@@ -10133,7 +10165,8 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
           "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10141,7 +10174,8 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz",
       "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "https-browserify": {
       "version": "1.0.0",
@@ -10153,6 +10187,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "^4.1.0",
         "debug": "^3.1.0"
@@ -10163,6 +10198,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -10171,7 +10207,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10819,7 +10856,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -11698,13 +11736,15 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
       "integrity": "sha1-YjUag5VjrF/1vSbxL2Dpgwu3UeY=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "libmime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/libmime/-/libmime-3.0.0.tgz",
       "integrity": "sha1-UaGp50SOy9Ms2lRCFnW7IbwJPaY=",
       "dev": true,
+      "optional": true,
       "requires": {
         "iconv-lite": "0.4.15",
         "libbase64": "0.1.0",
@@ -11715,7 +11755,8 @@
           "version": "0.4.15",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
           "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11723,7 +11764,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
       "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "livereload-js": {
       "version": "2.4.0",
@@ -13606,13 +13648,15 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz",
       "integrity": "sha1-ecSQihwPXzdbc/6IjamCj23JY6Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nodemailer-shared": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz",
       "integrity": "sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "nodemailer-fetch": "1.6.0"
       }
@@ -13645,7 +13689,8 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz",
       "integrity": "sha1-WG24EB2zDLRDjrVGc3pBqtDPE9U=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nodemon": {
       "version": "1.6.1",
@@ -14646,7 +14691,8 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pify": {
       "version": "3.0.0",
@@ -17751,13 +17797,15 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
       "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "smtp-connection": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz",
       "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME=",
       "dev": true,
+      "optional": true,
       "requires": {
         "httpntlm": "1.6.1",
         "nodemailer-shared": "1.1.0"
@@ -17979,6 +18027,7 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
       "integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "ip": "^1.1.5",
         "smart-buffer": "4.0.2"
@@ -17989,6 +18038,7 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
       "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "~4.2.1",
         "socks": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "extract-text-webpack-plugin": "^3.0.1",
     "fastclick": "~1.0.3",
     "file-saver": "1.3.3",
+    "flexsearch": "^0.6.32",
     "geoip-lite": "^1.1.6",
     "graceful-fs": "~2.0.1",
     "gridfs-stream": "~1.1.1",


### PR DESCRIPTION
# Context

We want it to be easier for parent umbrella clans to filter and search for any of their children.

This PR includes an initial component that can be fed a list of teams, and creates a fuzzy search input for exploring these teams. The teams can also display other data such as member counts.

The use case is that `school-network` and `school-subnetwork` type teams will be able to see the teams that make them up. It's also sorted by size.
![9acc0a662823fb081891caaec2051057](https://user-images.githubusercontent.com/15080861/107691155-f13e0a80-6c5f-11eb-9997-67ce5c4cbe60.gif)

# How

Server portion has been merged but not deployed.
The server returns a list of teams with membership counts.

On the frontend we use a fuzzy search library to search, filter and sort the results to display to the user.
This is all encapsulated in a single search component.

Clicking any of the clans will link to their page.

# Testing

Awaiting server portion to ship before testing is easier locally.
Otherwise you can mock some data here: https://github.com/codecombat/codecombat/blob/29f1279/app/core/store/modules/clans.js#L91

Hard coding and returning something like this will work:
```
const childClans = [
        {
          _id: '1',
          kind: 'school',
          displayName: 'Mock Data School of life!',
          memberCount: 42
        },
        {
          _id: '4',
          kind: 'school-subnetwork',
          displayName: 'SUPER TEAM',
          memberCount: 412
        }
]
```

Then to trigger the UI spin up a proxy dev environment, and navigate to any network or subnetwork team.
Example: `localhost:3000/league/academica`

Above the ladder you should see the search bar as per screenshot.

I manually tested:
 - On small screen
 - On medium and large screen
 - Using touch controls

User type of logging in doesn't matter as all users can use this component on this page.

# Risk

Low. Very additive PR.

# Screenshot

Responsiveness screenshot. Note the truncating names:
![image](https://user-images.githubusercontent.com/15080861/107691630-86d99a00-6c60-11eb-9843-bc65e22450ba.png)
