### PR TITLE
Move marketing section when looking at an esports team page

### DIFF
--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -614,7 +614,7 @@ export default {
     font-size: 70px;
   }
 
-  ::v-deep p, h4 {
+  p, h4 {
     color: white;
   }
 

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -5,6 +5,7 @@ import ClanSelector from './components/ClanSelector.vue'
 import LeagueSignupModal from './components/LeagueSignupModal'
 import ClanCreationModal from './components/ClanCreationModal'
 import ChildClanDetailDropdown from './components/ChildClanDetailDropdown'
+import SectionFirstCTA from './components/SectionFirstCTA'
 
 import { joinClan, leaveClan } from '../../../core/api/clans'
 
@@ -14,7 +15,8 @@ export default {
     ClanSelector,
     LeagueSignupModal,
     ClanCreationModal,
-    ChildClanDetailDropdown
+    ChildClanDetailDropdown,
+    SectionFirstCTA
   },
 
   data: () => ({
@@ -79,6 +81,9 @@ export default {
 
         if (['school-network', 'school-subnetwork'].includes(this.currentSelectedClan?.kind)) {
           this.fetchChildClanDetails({ id: this.currentSelectedClan._id })
+            .catch(() => {
+              console.error('Failed to retrieve child clans.')
+            })
         }
 
         this.loadClanRequiredData({ leagueId: this.clanIdSelected })
@@ -227,6 +232,10 @@ export default {
       return this.clanByIdOrSlug(this.clanIdOrSlug) || null
     },
 
+    isGlobalPage () {
+      return this.clanIdSelected === ''
+    },
+
     currentSelectedClanChildDetails () {
       const selectedId = this.clanIdSelected
       if (selectedId === '') {
@@ -323,21 +332,7 @@ export default {
       </div>
     </section>
 
-    <div class="graphic text-code-section">
-      <img class="img-responsive" src="/images/pages/league/text_code.svg" width="501" height="147" />
-    </div>
-    <div class="row flex-row text-center">
-      <p
-        class="subheader2"
-        style="max-width: 800px;"
-      >{{ $t('league.summary') }}</p>
-    </div>
-    <div v-if="!doneRegistering && !isClanCreator()" class="row flex-row text-center xs-m-0">
-      <a class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">{{ $t('league.join_now') }}</a>
-    </div>
-    <div class="graphic text-2021-section section-space">
-      <img class="img-responsive" src="/images/pages/league/text_2021.svg" width="501" height="147" />
-    </div>
+    <SectionFirstCTA v-if="isGlobalPage" :doneRegistering="doneRegistering" :isClanCreator="isClanCreator" :onHandleJoinCTA="onHandleJoinCTA" />
 
     <div v-if="clanIdSelected !== ''" id="clan-invite" class="row flex-row text-center" style="margin-top: -25px; z-index: 0;">
       <div class="col-sm-5">
@@ -379,6 +374,8 @@ export default {
         <a v-else href="/play" class="btn btn-large btn-primary btn-moon play-btn-cta">Earn CodePoints by completing levels</a>
       </div>
     </div>
+
+    <SectionFirstCTA v-if="!isGlobalPage" :doneRegistering="doneRegistering" :isClanCreator="isClanCreator" :onHandleJoinCTA="onHandleJoinCTA" />
 
     <section class="row flex-row free-to-get-start" :class="clanIdSelected === '' ? 'free-to-get-start-bg':''">
       <div class="col-sm-10">
@@ -617,7 +614,7 @@ export default {
     font-size: 70px;
   }
 
-  p, h4 {
+  ::v-deep p, h4 {
     color: white;
   }
 
@@ -629,7 +626,7 @@ export default {
     color: #f7d047;
   }
 
-  /deep/ .esports-aqua {
+  ::v-deep .esports-aqua {
     color: #30efd3;
   }
 
@@ -683,7 +680,7 @@ export default {
     margin: 25px 0;
   }
 
-  .row.flex-row {
+  ::v-deep .row.flex-row {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -772,7 +769,7 @@ export default {
     font-size: 72px;
   }
 
-  .subheader2 {
+  ::v-deep .subheader2 {
     font-size: 29px;
     line-height: 40px;
   }
@@ -798,25 +795,16 @@ export default {
     color: #000;
   }
 
-  .text-2021-section {
-    width: 100%;
-    overflow-x: hidden;
-    display: flex;
-    justify-content: flex-end;
-  }
-
   .text-are-you-an-educator {
     justify-content: flex-start;
     margin-top: 100px;
   }
-  .text-code-section {
-    width: 100%;
-    overflow-x: hidden;
-  }
+
   .esports-flyer-optimized-section {
     margin-bottom: 100px;
   }
-  .btn-primary.btn-moon {
+
+  ::v-deep .btn-primary.btn-moon {
     background-color: #d1b147;
     border-radius: 4px;
     color: #232323;
@@ -834,7 +822,7 @@ export default {
     }
   }
 
-  .section-space {
+  ::v-deep .section-space {
     margin-bottom: 110px;
   }
   .w-100 {
@@ -848,16 +836,16 @@ export default {
   }
 
   @media screen and (min-width: 768px) {
-    .btn-primary.btn-moon, .play-btn-cta {
+    ::v-deep .btn-primary.btn-moon, .play-btn-cta {
       padding: 20px 100px;
     }
-    .section-space {
+    ::v-deep .section-space {
       margin-bottom: 200px;
     }
   }
 
   @media screen and (max-width: 767px) {
-    .row.flex-row {
+    ::v-deep .row.flex-row {
       display: table;
     }
 
@@ -865,7 +853,7 @@ export default {
       padding: 0px;
     }
 
-    .btn-primary.btn-moon {
+    ::v-deep .btn-primary.btn-moon {
       font-size: 14px;
       padding: 8px 24px;
     }
@@ -896,24 +884,19 @@ export default {
       border-color: #000;
       padding: 0px;
     }
-    .text-2021-section {
-      margin-bottom: auto;
-      padding: 0 10px;
-    }
+
     .text-are-you-an-educator {
       margin-top: auto;
       text-align: center;
     }
-    .text-code-section {
-      padding: 0 10px;
-    }
+
     .esports-flyer-optimized-section {
       margin-bottom: 0px;
     }
     .xs-centered {
       text-align: center;
     }
-    .xs-m-0 {
+    ::v-deep .xs-m-0 {
       margin: 0px;
     }
     .xs-mt-0 {

--- a/app/views/landing-pages/league/components/SectionFirstCTA.vue
+++ b/app/views/landing-pages/league/components/SectionFirstCTA.vue
@@ -1,0 +1,76 @@
+<script>
+export default {
+  props: {
+    doneRegistering: {
+      type: Boolean,
+      required: true
+    },
+    isClanCreator: {
+      required: true
+    },
+    onHandleJoinCTA: {
+      required: true
+    }
+  }
+}
+</script>
+
+<template>
+  <div class="section-first-cta">
+    <div class="text-code-section">
+      <img class="img-responsive" src="/images/pages/league/text_code.svg" width="501" height="147" />
+    </div>
+    <div class="row flex-row text-center">
+      <p
+        class="subheader2"
+        style="max-width: 800px;"
+      >{{ $t('league.summary') }}</p>
+    </div>
+    <div v-if="!doneRegistering && !isClanCreator()" class="row flex-row text-center xs-m-0">
+      <a class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">{{ $t('league.join_now') }}</a>
+    </div>
+    <div class="text-2021-section section-space">
+      <img class="img-responsive" src="/images/pages/league/text_2021.svg" width="501" height="147" />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+
+.text-code-section {
+  width: 100%;
+  overflow-x: hidden;
+  padding: 0 10px;
+}
+
+.text-2021-section {
+  width: 100%;
+  overflow-x: hidden;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.section-first-cta > div {
+  max-width: 1820px;
+  width:100%;
+  padding: 0 70px;
+  position: relative;
+  z-index: 1;
+  margin: 25px 0;
+}
+
+@media screen and (max-width: 767px) {
+  .text-code-section {
+    padding: 0 10px;
+  }
+
+  .text-2021-section {
+    margin-bottom: auto;
+    padding: 0 10px;
+  }
+
+  .section-first-cta > div {
+    padding: 0px;
+  }
+}
+</style>

--- a/app/views/landing-pages/league/components/SectionFirstCTA.vue
+++ b/app/views/landing-pages/league/components/SectionFirstCTA.vue
@@ -36,6 +36,9 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+p {
+  color: white;
+}
 
 .text-code-section {
   width: 100%;


### PR DESCRIPTION
# Context

When we are looking at esports teams it's frustrating scrolling down as there is a large block of marketing before the team details.

This is a first step in moving a marketing section beneath the team.
Because we will be shortly adding customization so that teams can feel unique, we want them to also sit more prominently on the page.

# Changes

Moved this marketing section to sit beneath team when on a custom team page:
![image](https://user-images.githubusercontent.com/15080861/107701921-69133180-6c6e-11eb-8a94-e4cb47e4946f.png)

Required CSS modifications so that the scoped CSS can modify the nested children.

# Testing

This can be tested on local proxy. Use `npm run dev` and `npm run proxy` to spin up a local environment.

As any user type the global league page should appear unchanged. localhost:3000/league should have the marketing section as the second section on the page.

I.e. (awkward screenshot showing the bottom of the header of the page and the start of the first marketing section).
![image](https://user-images.githubusercontent.com/15080861/107702174-b5f70800-6c6e-11eb-94ff-ddcbc84ecbb4.png)

However when you look at a team page such as: http://localhost:3000/league/codecombat

The marketing section moves beneath the leaderboards.

![e02103e437c967dc41d5122999f3c847](https://user-images.githubusercontent.com/15080861/107702340-f5bdef80-6c6e-11eb-9e89-ef3edf3dd0e3.gif)

I also tested that responsiveness continues to work as before.


# Risk

Biggest risk is some of the ::v-deep styles have interfered with other component styles. I don't believe there is any risk from logic.

I had found a bug where the deep text color change disrupted the modal. After fix it works:
![Screen Shot 2021-02-11 at 1 46 41 PM](https://user-images.githubusercontent.com/15080861/107702923-ce1b5700-6c6f-11eb-868f-8e86da9e55b7.png)

