### PR TITLE
Handle missing mcPool gracefully in spriteSheet buildMovieClip (#6195)

### DIFF
--- a/app/lib/surface/SegmentedSprite.coffee
+++ b/app/lib/surface/SegmentedSprite.coffee
@@ -124,6 +124,7 @@ module.exports = class SegmentedSprite extends createjs.Container
 
   buildMovieClip: (animationName, mode, startPosition, loops) ->
     key = JSON.stringify([@spriteSheetPrefix].concat(arguments))
+    @spriteSheet.mcPool ?= {}
     @spriteSheet.mcPool[key] ?= []
     for mc in @spriteSheet.mcPool[key]
       if not mc.inUse


### PR DESCRIPTION
#6195 describes an issue where game play freezes when playing a Game Development level game.
This is a simple, safe change that does not fix the root cause, but that enables the game to continue when the problem occurs.