### PR TITLE
Remove redundant noun 'język' for Polish language

### DIFF
--- a/app/locale/locale.coffee
+++ b/app/locale/locale.coffee
@@ -56,7 +56,7 @@ module.exports =
   'nb': { nativeDescription: 'Norsk Bokmål', englishDescription: 'Norwegian (Bokmål)' }
   'nn': { nativeDescription: 'Norsk Nynorsk', englishDescription: 'Norwegian (Nynorsk)' }
   'uz': { nativeDescription: "O'zbekcha", englishDescription: 'Uzbek' }
-  'pl': { nativeDescription: 'język polski', englishDescription: 'Polish' }
+  'pl': { nativeDescription: 'Polski', englishDescription: 'Polish' }
   'ro': { nativeDescription: 'limba română', englishDescription: 'Romanian' }
   'sr': { nativeDescription: 'српски', englishDescription: 'Serbian' }
   'sk': { nativeDescription: 'slovenčina', englishDescription: 'Slovak' }

--- a/app/views/contribute/DiplomatView.coffee
+++ b/app/views/contribute/DiplomatView.coffee
@@ -61,7 +61,7 @@ module.exports = class DiplomatView extends ContributeClassView
     ar: ['5y', 'ahmed80dz']             # العربية, Arabic
     'pt-BR': ['Bia41', 'Gutenberg Barros', 'Kieizroe', 'Matthew Burt', 'brunoporto', 'cassiocardoso', 'jklemm', 'Arkhad']        # português do Brasil, Portuguese (Brazil)
     'pt-PT': ['Imperadeiro98', 'Matthew Burt', 'ProgramadorLucas', 'ReiDuKuduro', 'batista', 'gutierri']        # Português (Portugal), Portuguese (Portugal)
-    pl: ['Anon', 'Kacper Ciepielewski', 'TigroTigro', 'kvasnyk', 'CatSkald']             # język polski, Polish
+    pl: ['Anon', 'Kacper Ciepielewski', 'TigroTigro', 'kvasnyk', 'CatSkald']             # Polski, Polish
     it: ['flauta', 'Atomk', 'Lionhear7']              # italiano, Italian
     tr: ['Nazım Gediz Aydındoğmuş', 'cobaimelan', 'gediz', 'ilisyus', 'wakeup']             # Türkçe, Turkish
     nl: []        # Nederlands, Dutch


### PR DESCRIPTION
The `język` means `language`
It is redundant to display the `język polski` in the list of languages.
It is correct yet clear to display just `Polski`
It is also easier to search for the language as it respects the lexicographical order of languages names.

-----

By the way, in English all the [language names in the list should be capitalised](https://www.grammarly.com/blog/capitalization-countries-nationalities-languages/). I think it is safe bet to capitalise them in i10n forms too. It would make the UI/UX friendlier - clean display, nicely sorted list.