### PR TITLE
Custom esports images for teams

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -83,6 +83,7 @@ module.exports = class CocoRouter extends Backbone.Router
     'admin/skipped-contacts': go('admin/SkippedContactsView')
     'admin/outcomes-report-result': go('admin/OutcomeReportResultView')
     'admin/outcomes-report': go('admin/OutcomesReportView')
+    'admin/clan/:clanID': go('core/SingletonAppVueComponentView')
 
     'apcsp(/*subpath)': go('teachers/DynamicAPCSPView')
 

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -38,6 +38,11 @@ export default function getVueRouter () {
             { path: 'teacher/:teacherId/classroom/:classroomId/:studentId', component: () => import(/* webpackChunkName: "teachers" */ 'app/views/teachers/classes/TeacherStudentView.vue') }
           ]
         },
+        {
+          path: '/admin/clan/:clanId',
+          component: () => import(/* webpackChunkName: "admin" */ 'app/views/admin/PageClanEdit'),
+          props: (route) => ({clanId: route.params.clanId})
+        },
         // Warning: In production debugging of third party iframe!
         {
           path: '/temporary-debug-timetap',

--- a/app/schemas/models/clan.schema.coffee
+++ b/app/schemas/models/clan.schema.coffee
@@ -42,7 +42,7 @@ _.extend ClanSchema.properties,
   description: {type: 'string'}
   # Empty for auto clans
   members: c.array {title: 'Members'}, c.objectId()
-  # Set to Nick's user (512ef4805a67a8c507000001) for auto clans
+  # Optional property
   ownerID: c.objectId()
   # Set to 'public' for auto clans
   type: {type: 'string', 'enum': ['public', 'private'], description: 'Controls clan general visibility.'}
@@ -59,8 +59,8 @@ _.extend ClanSchema.properties,
     description: 'Contains properties that help find autoclans'
     additionalProperties: true
   })
-  # Set only for auto clans (yet), to display instead of Clan.name
-  displayName: { type: 'string' }
+  displayName: { type: 'string', description: 'overwrites visual visual name of clan - used as name is tied to the slug' }
+  esportsImage: { type: 'string', format: 'image-file', title: 'Esports Image', description: 'Image to show for this team on league page.' }
 
 c.extendBasicProperties ClanSchema, 'Clan'
 

--- a/app/views/admin/PageClanEdit.vue
+++ b/app/views/admin/PageClanEdit.vue
@@ -75,7 +75,7 @@ export default {
         <li>censoring a name or description on a team</li>
         <li>changing or adding an owner user to a team</li>
         <li>adding a custom image for a team</li>
-        <li>editting any other data of a team</li>
+        <li>editing any other data of a team</li>
       </ul>
 
       <p><a :href="`/league/${clan.slug}`">Esports page</a></p>

--- a/app/views/admin/PageClanEdit.vue
+++ b/app/views/admin/PageClanEdit.vue
@@ -4,7 +4,6 @@ import CocoCollection from 'app/collections/CocoCollection'
 import Clan from 'app/models/Clan'
 
 const api = require('core/api')
-require('core/services/filepicker')()
 require('lib/setupTreema')
 
 export default {

--- a/app/views/admin/PageClanEdit.vue
+++ b/app/views/admin/PageClanEdit.vue
@@ -1,0 +1,95 @@
+<script>
+import { getClan } from 'core/api/clans'
+import CocoCollection from 'app/collections/CocoCollection'
+import Clan from 'app/models/Clan'
+
+const api = require('core/api')
+require('core/services/filepicker')()
+require('lib/setupTreema')
+
+export default {
+  props: {
+    clanId: {
+      type: String,
+      required: true
+    }
+  },
+
+  data: () => ({
+    clan: null,
+    treema: null
+  }),
+
+  async mounted () {
+      if (!me.isAdmin()) {
+        alert('You must be logged in as an admin to use this page.')
+        return application.router.navigate('/', { trigger: true })
+      }
+      this.clan = await getClan(this.clanId)
+    
+      const data = $.extend(true, {}, this.clan)
+      const el = $(`<div></div>`)
+      const files = new CocoCollection(await api.files.getDirectory({ path: `clan/${this.clan._id}` }), { model: Clan })
+
+      const treema = this.treema = TreemaNode.make(el,
+      {
+        data: data,
+        schema: Clan.schema,
+        // Automatically uploads the file to /file/clan/<clanId>/<fileName>
+        // You can view files at /admin/files
+        // clan _id ensures we don't overwrite another clans image.
+        filePath: `clan/${this.clan._id}`,
+        files
+      })
+      treema.build()
+      $(this.$refs.treemaEditor).append(el)
+    },
+
+    methods: {
+      /**
+       * Pushes changes from treema to the cinematic model.
+       */
+      async saveChanges () {
+        this.clan = _.cloneDeep(this.treema.data)
+        const clan = new Clan(this.clan)
+        clan.validate()
+        console.log({ clan })
+        if (confirm("Are you sure you want to save these changes?")) {
+          await clan.save()
+          noty({text: "Clan save successful", layout: 'topCenter', type: 'success'})
+        }
+      },
+    }
+}
+</script>
+
+<template>
+  <div>
+    <h1>Internal Admin Team/Clan edit tool</h1>
+    <div v-if="clan !== null">
+      <p>This internal tool lets admin and internal accounts customize teams.
+        For engineers - 'team' refers to a 'clan' in the code and database.
+        Use the tool for:
+      </p>
+      <ul>
+        <li>censoring a name or description on a team</li>
+        <li>changing or adding an owner user to a team</li>
+        <li>adding a custom image for a team</li>
+        <li>editting any other data of a team</li>
+      </ul>
+
+      <p><a :href="`/league/${clan.slug}`">Esports page</a></p>
+      <p><a :href="`/clan/${clan.slug}`">Legacy clan page</a></p>
+
+      <div
+            v-once
+            id="treema-editor"
+            ref="treemaEditor"
+      ></div>
+      <button @click="saveChanges">Save Changes</button>
+    </div>
+    <div v-else>
+      Loading...
+    </div>
+  </div>
+</template>

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -268,6 +268,21 @@ export default {
       return description
     },
 
+    currentSelectedClanEsportsImage () {
+      const image = this.currentSelectedClan?.esportsImage
+      if (image) {
+        return `/file/${image}`
+      }
+      return `/images/pages/league/graphic_1.png`
+    },
+
+    customEsportsImageClass () {
+      return {
+        'img-responsive': true,
+        'unset-flip': typeof this.currentSelectedClan?.esportsImage === 'string'
+      }
+    },
+
     myCreatedClan () {
       return this.isClanCreator() ? this.currentSelectedClan : null
     },
@@ -336,7 +351,7 @@ export default {
 
     <div v-if="clanIdSelected !== ''" id="clan-invite" class="row flex-row text-center" style="margin-top: -25px; z-index: 0;">
       <div class="col-sm-5">
-        <img class="img-responsive" src="/images/pages/league/graphic_1.png">
+        <img :class="customEsportsImageClass" :src="currentSelectedClanEsportsImage">
       </div>
       <div class="col-sm-7">
         <h1><span class="esports-aqua">{{ currentSelectedClanName }}</span></h1>
@@ -691,6 +706,10 @@ export default {
     text-align: left;
     img {
       transform: scaleX(-1);
+    }
+
+    img.unset-flip {
+      transform: unset;
     }
 
     p {

--- a/app/views/landing-pages/league/components/ClanSelector.vue
+++ b/app/views/landing-pages/league/components/ClanSelector.vue
@@ -12,6 +12,12 @@ export default {
       required: false,
       default: ''
     }
+  },
+
+  computed: {
+    clanSanitized () {
+      return this.clans.filter(v => v !== undefined)
+    }
   }
 }
 </script>
@@ -21,7 +27,7 @@ export default {
     <label for="clans">My Teams:</label>
     <select id="clans" name="clans" @change="e => $emit('change', e)">
       <option value="global" :selected="selected===''">--</option>
-      <option  v-for="clan in clans" :key="clan._id" :value="clan._id" :selected="selected===clan._id">
+      <option  v-for="clan in clanSanitized" :key="clan._id" :value="clan._id" :selected="selected===clan._id">
         {{ clan.displayName || clan.name }}
       </option>
     </select>

--- a/app/views/landing-pages/league/components/ClanSelector.vue
+++ b/app/views/landing-pages/league/components/ClanSelector.vue
@@ -27,7 +27,7 @@ export default {
     <label for="clans">My Teams:</label>
     <select id="clans" name="clans" @change="e => $emit('change', e)">
       <option value="global" :selected="selected===''">--</option>
-      <option  v-for="clan in clanSanitized" :key="clan._id" :value="clan._id" :selected="selected===clan._id">
+      <option  v-for="clan in clansSanitized" :key="clan._id" :value="clan._id" :selected="selected===clan._id">
         {{ clan.displayName || clan.name }}
       </option>
     </select>

--- a/app/views/landing-pages/league/components/ClanSelector.vue
+++ b/app/views/landing-pages/league/components/ClanSelector.vue
@@ -15,7 +15,7 @@ export default {
   },
 
   computed: {
-    clanSanitized () {
+    clansSanitized () {
       return this.clans.filter(v => v !== undefined)
     }
   }


### PR DESCRIPTION
# Context

For certain esports teams we want to be able to add custom images. This PR adds an internal admin Clan edit page for editing clans and uploading custom images.

New internal admin tool at route: `/admin/clan/:clanID`

The new `esportsImage` property uploads into our static file system and replaces the static image on the teams league page.

These gifs provide more context.

Uploading a new image:
![dbe2e0f84c586da159e1bc81252b2c86](https://user-images.githubusercontent.com/15080861/108292175-6cb02800-7148-11eb-908b-159a40fbeba2.gif)

Saving the uploaded image:
![9077b3102c5010d6f89c24c38c049bae](https://user-images.githubusercontent.com/15080861/108292194-789bea00-7148-11eb-8b66-80837b533822.gif)

The final result: 
![image](https://user-images.githubusercontent.com/15080861/108292217-80f42500-7148-11eb-851f-3645be914ddc.png)

Vs the default static image:
![image](https://user-images.githubusercontent.com/15080861/108292241-91a49b00-7148-11eb-80a4-89e47d0587f9.png)

# Testing

As this PR includes mostly UI additions, it was manually tested against a local mongo instance.
To successfully reproduce the gif animations above, the server portion needs to be running locally - this allows admin users to edit the esportsImage and clan in the put request.


# Risk

Low risk as most of the logic is internal tooling that doesn't need to be perfect. Few changes to user facing code.
The team/clan admin UI is secured server side.