### PR TITLE
Hide teacher and classroom esport team join button

### DIFF
--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -371,7 +371,7 @@ export default {
       <div class="col-sm-7">
         <h1><span class="esports-aqua">{{ currentSelectedClanName }}</span></h1>
         <h3 style="margin-bottom: 40px;">{{ currentSelectedClanDescription }}</h3>
-        <p>Invite players to this team by sending them this link:</p>
+        <p>{{showJoinTeamBtn ? 'Invite players to this team by sending them this link:': 'Share this team leaderboard with its public link:'}}</p>
         <input readonly :value="clanInviteLink()" /><br />
         <a v-if="isAnonymous()" class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">{{ $t('league.join_now') }}</a>
         <a v-else-if="isClanCreator()" class="btn btn-large btn-primary btn-moon" @click="openClanCreation">Edit Team</a>

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -304,6 +304,15 @@ export default {
       return this.codePointsRankings(this.clanIdSelected)
     },
 
+    showJoinTeamBtn () {
+      if (!this.currentSelectedClan) {
+        return false
+      }
+      // We don't want to show this button if the team is a classroom or teacher.
+      // Those students are populated automatically.
+      return ['teacher', 'classroom'].indexOf(this.currentSelectedClan?.kind) === -1
+    },
+
     // NOTE: `me` and the specific `window.me` are both unavailable in this template for some reason? Hacky...
     firstName () { return me.get('firstName') },
 
@@ -367,7 +376,7 @@ export default {
         <a v-if="isAnonymous()" class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">{{ $t('league.join_now') }}</a>
         <a v-else-if="isClanCreator()" class="btn btn-large btn-primary btn-moon" @click="openClanCreation">Edit Team</a>
         <a v-else-if="inSelectedClan()" class="btn btn-large btn-primary btn-moon" :disabled="joinOrLeaveClanLoading" @click="leaveClan">Leave Team</a>
-        <a v-else class="btn btn-large btn-primary btn-moon" :disabled="joinOrLeaveClanLoading" @click="joinClan">Join Team</a>
+        <a v-else v-show="showJoinTeamBtn" class="btn btn-large btn-primary btn-moon" :disabled="joinOrLeaveClanLoading" @click="joinClan">Join Team</a>
       </div>
     </div>
 


### PR DESCRIPTION
# Context

Classroom and Teacher teams are populated automatically and don't need a manual button.
This also stops users accidentally or intentionally joining other classes.

## Summary of changes

 - Hide the "Join Team" button based on the 'kind' on the team.

# How to test

Checkout these changes with `npm run dev` and `npm run proxy`.
Navigate to http://localhost:3000/league and navigate different teams.

This gif navigates using Academica team, and drills down into a teacher and classroom. Note the lack of "Join Team" button.
![34d62b05ed9500e101c2cb19a73f6fb6](https://user-images.githubusercontent.com/15080861/109888483-6e91e500-7c38-11eb-89a8-adafcc75e63c.gif)

Updated text when button is not showing:
![Screen Shot 2021-03-03 at 4 11 45 PM](https://user-images.githubusercontent.com/15080861/109889942-317b2200-7c3b-11eb-8df6-4a5839d476d5.png)

# Risk

Risk is low, and this is intentionally a quick UI focussed fix.
Next steps may be to modify behavior of the joinClan api endpoint.