### PR TITLE
Redirect classroom user away from clan pages

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -105,8 +105,8 @@ module.exports = class CocoRouter extends Backbone.Router
 
     'cla': go('CLAView')
 
-    'clans': go('clans/ClansView', { redirectStudents: true, redirectTeachers: true })
-    'clans/:clanID': go('clans/ClanDetailsView', { redirectStudents: true, redirectTeachers: true })
+    'clans': go('clans/ClansView', { redirectStudents: true })
+    'clans/:clanID': go('clans/ClanDetailsView', { redirectStudents: true })
 
     'community': go('CommunityView')
 

--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -105,8 +105,8 @@ module.exports = class CocoRouter extends Backbone.Router
 
     'cla': go('CLAView')
 
-    'clans': go('clans/ClansView')
-    'clans/:clanID': go('clans/ClanDetailsView')
+    'clans': go('clans/ClansView', { redirectStudents: true, redirectTeachers: true })
+    'clans/:clanID': go('clans/ClanDetailsView', { redirectStudents: true, redirectTeachers: true })
 
     'community': go('CommunityView')
 


### PR DESCRIPTION
# Context

Redirect students away from the clan page routes.
This limits student interaction to teams to /league routes.

## Risk

Minimal risk. Tested manually and can be checked on our staging environment.
