### PR TITLE
Update web dev iframes to not use blocked methods of cross-domain communication

### DIFF
--- a/app/assets/javascripts/web-dev-listener.js
+++ b/app/assets/javascripts/web-dev-listener.js
@@ -4,13 +4,15 @@ var lastSource = null;
 var lastOrigin = null;
 window.onerror = function(message, url, line, column, error){
   console.log("User script error on line " + line + ", column " + column + ": ", error);
-  lastSource.postMessage({
-    type: 'error',
-    message: message,
-    url: url,
-    line: line || 0,
-    column: column || 0,
-  }, lastOrigin);
+  if (lastSource) {
+    lastSource.postMessage({
+      type: 'error',
+      message: message,
+      url: url,
+      line: line || 0,
+      column: column || 0,
+    }, lastOrigin);
+  }
 }
 window.addEventListener('message', receiveMessage, false);
 

--- a/app/assets/web-dev-iframe.html
+++ b/app/assets/web-dev-iframe.html
@@ -21,7 +21,7 @@
       const styleEl = document.createElement('style')
       styleEl.type = "text/css"
       let styleText = '';
-      if (parent.features && parent.features.chinaUx) {
+      if (new URLSearchParams(window.location.search).get('chinaUx')) {
         styleText = `@import 'https://fonts.loli.net/css?family=Holtwood+One+SC';`
       } else {
         styleText = `@import 'https://fonts.googleapis.com/css?family=Holtwood+One+SC';`

--- a/app/assets/web-dev-iframe.html
+++ b/app/assets/web-dev-iframe.html
@@ -21,7 +21,7 @@
       const styleEl = document.createElement('style')
       styleEl.type = "text/css"
       let styleText = '';
-      if (new URLSearchParams(window.location.search).get('chinaUx')) {
+      if (new URLSearchParams(window.location.search).get('chinaUx') === 'true') {
         styleText = `@import 'https://fonts.loli.net/css?family=Holtwood+One+SC';`
       } else {
         styleText = `@import 'https://fonts.googleapis.com/css?family=Holtwood+One+SC';`

--- a/app/templates/play/level/web-surface-view.jade
+++ b/app/templates/play/level/web-surface-view.jade
@@ -1,1 +1,1 @@
-iframe(src="//" + fullUnsafeContentHostname + "/web-dev-iframe.html")
+iframe(src="//" + fullUnsafeContentHostname + "/web-dev-iframe.html?chinaUx=" + Boolean(features.chinaUx))


### PR DESCRIPTION
I think going from child to parent directly used to work, but no longer does, but it's pretty easy to pass that one piece of info we need to the iframe on creation via a URL parameter.

Also not calling `postMessage` to log an error if we haven't received a message yet (since it wouldn't know where to send it). Guessing that only happens on startup and those aren't the kind of errors we are trying to communicate.