### PR TITLE
Apply coupons to local price on /parents pricing grid

### DIFF
--- a/app/core/store/modules/products.js
+++ b/app/core/store/modules/products.js
@@ -83,7 +83,13 @@ export default {
       }
 
       const coupon = _.find(getters.basicAnnualSubscriptionForCurrentUser.coupons, { code: getters.activeCouponID })
-      if (coupon && typeof coupon.amount === 'number') {
+
+      if (!coupon) {
+        return 99
+      }
+
+      const amount = parseInt(coupon.amount, 10)
+      if (!isNaN(amount)) {
         return (coupon.amount / 100).toFixed(2)
       }
 

--- a/app/core/store/modules/products.js
+++ b/app/core/store/modules/products.js
@@ -1,4 +1,6 @@
 import Products from 'app/collections/Products'
+import _ from 'lodash'
+const utils = require('core/utils')
 
 /**
  * This module acts as a simple proxy to the Products collection.  Ideally we'd move the products
@@ -26,10 +28,15 @@ export default {
   },
 
   actions: {
-    loadProducts ({ commit }) {
+    loadProducts ({ commit, getters }) {
       commit('toggleLoadingProducts')
 
-      const productsRequest = new Products().fetch()
+      const data = {}
+      if (getters.activeCouponID) {
+        data.coupon = getters.activeCouponID
+      }
+
+      const productsRequest = new Products().fetch({ data })
       productsRequest.done(products => commit('addProducts', { products }))
       productsRequest.fail(() => noty({ text: 'Failed to load product pricing', type: 'error' }))
       productsRequest.always(() => commit('toggleLoadingProducts'))
@@ -37,6 +44,15 @@ export default {
   },
 
   getters: {
+    activeCouponID () {
+      const couponID = utils.getQueryVariable('coupon') || me.get('country')
+      if (couponID === 'brazil') {
+        // Edge case due to misconfigured brazil coupon in stripe that is immutable
+        return 'brazil-annual'
+      }
+      return couponID
+    },
+
     basicSubscriptionForCurrentUser (state) {
       if (!Array.isArray(state.products) || state.products.length === 0) {
         return undefined
@@ -57,6 +73,21 @@ export default {
       productsCollection.add(state.products)
 
       return productsCollection.getBasicAnnualSubscriptionForUser(window.me).toJSON()
+    },
+
+    // Returns price of basic annual subscription modified by coupon
+    basicAnnualSubscriptionPrice (_state, getters) {
+      if (!getters.basicAnnualSubscriptionForCurrentUser || !getters.activeCouponID) {
+        // Default price of product. Can safely show while loading.
+        return 99
+      }
+
+      const coupon = _.find(getters.basicAnnualSubscriptionForCurrentUser.coupons, { code: getters.activeCouponID })
+      if (coupon !== null) {
+        return (coupon.amount / 100).toFixed(2)
+      }
+
+      return 99
     },
 
     lifetimeSubscriptionForCurrentUser (state) {

--- a/app/core/store/modules/products.js
+++ b/app/core/store/modules/products.js
@@ -83,7 +83,7 @@ export default {
       }
 
       const coupon = _.find(getters.basicAnnualSubscriptionForCurrentUser.coupons, { code: getters.activeCouponID })
-      if (coupon !== null) {
+      if (coupon && typeof coupon.amount === 'number') {
         return (coupon.amount / 100).toFixed(2)
       }
 

--- a/app/views/landing-pages/parents/PageParents.vue
+++ b/app/views/landing-pages/parents/PageParents.vue
@@ -228,7 +228,7 @@
         <!-- End First Row -->
         <!-- Second Row -->
         <div class="grid-item">Subscription plan</div>
-        <div class="grid-item">$99 per year per student</div>
+        <div class="grid-item">${{ basicAnnualSubscriptionPrice }} per year per student</div>
         <div class="grid-item">$159 per month per student</div>
         <div class="grid-item">$219 per month per student</div>
         <div class="grid-item">$399 per month per student</div>
@@ -589,6 +589,7 @@ import ModalTimetapConfirmation from './ModalTimetapConfirmation'
 import ButtonScheduleFreeClass from './ButtonScheduleFreeClass'
 import IconGem from './IconGem'
 import ButtonArrow from './ButtonArrow'
+import { mapGetters } from 'vuex'
 
 const DRIFT_LIVE_CLASSES_DEFAULT_INTERACTION_ID = 214809
 const DRIFT_LIVE_CLASSES_DIRECT_CHAT_INTERACTION_ID = 222065
@@ -745,6 +746,10 @@ export default {
   },
 
   computed: {
+    ...mapGetters('products', [
+      'basicAnnualSubscriptionPrice'
+    ]),
+
     isUs: function () {
       return window.me.get('country') === 'united-states'
     }


### PR DESCRIPTION
# Context

Our pricing grid on the parents page doesn't adjust to local prices.
This is jarring when the stripe payment adjusts to a different price.

This PR moves the coupon logic into the vuex store making is possible to fetch the dynamic price on the parents page.

## How to reproduce the visual bug

Navigate to: https://codecombat.com/parents?coupon=brazil

Notice on the pricing grid the student pricing per year is $99, which is the American pricing.
![Screen Shot 2021-03-12 at 2 33 05 PM](https://user-images.githubusercontent.com/15080861/111005590-f619db00-833f-11eb-977a-0424fe06d372.png)

It should instead be $39.60

## How to test fix

Spin up local dev and proxy: `npm run dev & npm run proxy`.

Navigate to localhost:3000/parents?coupon=brazil

The local pricing has been applied correctly:
![Screen Shot 2021-03-12 at 2 35 43 PM](https://user-images.githubusercontent.com/15080861/111005783-4d1fb000-8340-11eb-9af3-f500034f852c.png)

Other cases that can be checked are:
 - no coupon: falls back to $99
 - invalid coupon: falls back to $99
 

# Risk

This is a small change only improving the UI experience. The payment system isn't touched and thus I expect this is strictly better than the wrong price being shown.