### PR TITLE
Add custom hero details for Team DerBezt

### DIFF
--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -721,7 +721,7 @@ export default {
     height: 20vw;
     min-height: 100px;
     max-height: 350px;
-    transform: scaleX(-1);
+    transform: scaleX(1);
   }
 
   @media screen and (max-width: 1000px) {

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -369,8 +369,10 @@ export default {
         <img :class="customEsportsImageClass" :src="currentSelectedClanEsportsImage">
       </div>
       <div class="col-sm-7">
+        <img v-if="currentSelectedClanName === 'Team DerBezt'" class="custom-esports-image-2" alt="" src="/file/db/thang.type/6037ed81ad0ac000f5e9f0b5/armando-pose.png">
         <h1><span class="esports-aqua">{{ currentSelectedClanName }}</span></h1>
         <h3 style="margin-bottom: 40px;">{{ currentSelectedClanDescription }}</h3>
+        <p v-if="currentSelectedClanName === 'Team DerBezt'">Learn coding and win prizes sponsored by superstar Mexican actor, comedian, and filmmaker Eugenio Derbez.</p>
         <p>{{showJoinTeamBtn ? 'Invite players to this team by sending them this link:': 'Share this team leaderboard with its public link:'}}</p>
         <input readonly :value="clanInviteLink()" /><br />
         <a v-if="isAnonymous()" class="btn btn-large btn-primary btn-moon" @click="onHandleJoinCTA">{{ $t('league.join_now') }}</a>
@@ -708,9 +710,23 @@ export default {
   @media screen and (max-width: 767px) {
     .esports-header .ai-league-logo {
       position: relative;
-      top: 170px;
+      top: 120px;
       left: calc(50% - 10vw);
       width: 20vw;
+    }
+  }
+
+  .custom-esports-image-2 {
+    float: right;
+    height: 20vw;
+    min-height: 100px;
+    max-height: 350px;
+    transform: scaleX(-1);
+  }
+
+  @media screen and (max-width: 1000px) {
+    .custom-esports-image-2 {
+      display: none
     }
   }
 

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -716,20 +716,6 @@ export default {
     }
   }
 
-  .custom-esports-image-2 {
-    float: right;
-    height: 20vw;
-    min-height: 100px;
-    max-height: 350px;
-    transform: scaleX(1);
-  }
-
-  @media screen and (max-width: 1000px) {
-    .custom-esports-image-2 {
-      display: none
-    }
-  }
-
   // Most sections have a max width and are centered.
   section, & > div {
     max-width: 1820px;
@@ -764,6 +750,20 @@ export default {
     input {
       width: 100%;
       margin-bottom: 26px;
+    }
+
+    .custom-esports-image-2 {
+      float: right;
+      height: 20vw;
+      min-height: 100px;
+      max-height: 350px;
+      transform: scaleX(1);
+    }
+
+    @media screen and (max-width: 1000px) {
+      .custom-esports-image-2 {
+        display: none
+      }
     }
   }
 


### PR DESCRIPTION
This is not a very good design, and I just hide the guy when it's too small, but likely better than nothing, as I want to show off the hero and Eugenio's bio.

<img width="1505" alt="Screen Shot 2021-03-14 at 16 04 56" src="https://user-images.githubusercontent.com/99704/111087469-10d68600-84df-11eb-8aba-74f2db8f314d.png">

I also move AI League logo up a bit on mobile, as it was overlaying right on top of Eugenio's head.