### PR TITLE
Disable buying gems

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -938,6 +938,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     feature_level_access: "Access 300+ levels available"
     feature_heroes: "Unlock exclusive heroes and pets"
     feature_learn: "Learn to make games and websites"
+    feature_gems: "Receive __gems__ gems per month"
     month_price: "$__price__"
     first_month_price: "Only $__price__ for your first month!"
     lifetime: "Lifetime Access"

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -91,6 +91,8 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     teachers_love_codecombat_blurb3: "Say that CodeCombat helps them support students’ problem solving abilities"
     teachers_love_codecombat_subblurb: "In partnership with McREL International, a leader in research-based guidance and evaluations of educational technology."
     top_banner_blurb: "Parents, give your child the gift of coding and personalized instruction with our live teachers!"
+    top_banner_blurb_team_derbezt_link: "Join Team DerBezt in the CodeCombat AI League"
+    top_banner_blurb_team_derbezt_suffix: "to get the exclusive Armando Hoyos hero from Mexican superstar Eugenio Derbez!"
     try_the_game: "Try the game"
     classroom_edition: "Classroom Edition:"
     learn_to_code: "Learn to code:"

--- a/app/locale/es-419.coffee
+++ b/app/locale/es-419.coffee
@@ -92,6 +92,8 @@ module.exports = nativeDescription: "Español (América Latina)", englishDescrip
     teachers_love_codecombat_blurb3: "Dicen que CodeCombat los ayuda a mejorar las habilidades de resolución de problemas de sus estudiantes"
     teachers_love_codecombat_subblurb: "En asociación con McREL International, líder en orientación basada en investigación y evaluaciones de tecnología educativa."
 #    top_banner_blurb: "Parents, give your child the gift of coding and personalized instruction with our live teachers!"
+    top_banner_blurb_team_derbezt_link: "¡Únete al equipo DerBezt en CodeCombat AI League"
+    top_banner_blurb_team_derbezt_suffix: "para obtener el héroe exclusivo Armando Hoyos de la superestrella mexicano Eugenio Derbez!"
     try_the_game: "Prueba el juego"
     classroom_edition: "Versión para el aula:"
     learn_to_code: "Aprende a programar:"

--- a/app/locale/es-ES.coffee
+++ b/app/locale/es-ES.coffee
@@ -92,6 +92,8 @@ module.exports = nativeDescription: "español (ES)", englishDescription: "Spanis
 #    teachers_love_codecombat_blurb3: "Say that CodeCombat helps them support students’ problem solving abilities"
 #    teachers_love_codecombat_subblurb: "In partnership with McREL International, a leader in research-based guidance and evaluations of educational technology."
 #    top_banner_blurb: "Parents, give your child the gift of coding and personalized instruction with our live teachers!"
+    top_banner_blurb_team_derbezt_link: "¡Únete al equipo DerBezt en CodeCombat AI League"
+    top_banner_blurb_team_derbezt_suffix: "para obtener el héroe exclusivo Armando Hoyos de la superestrella mexicano Eugenio Derbez!"
 #    try_the_game: "Try the game"
     classroom_edition: "Edición para aulas:"
     learn_to_code: "Aprende a programar:"

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -565,7 +565,7 @@ module.exports = class User extends CocoModel
   # Feature Flags
   # Abstract raw settings away from specific UX changes
   allowStudentHeroPurchase: -> features?.classroomItems ? false and @isStudent()
-  canBuyGems: -> not (features?.chinaUx ? false)
+  canBuyGems: -> false  # Disabled direct buying of gems around 2021-03-16
   constrainHeroHealth: -> features?.classroomItems ? false and @isStudent()
   promptForClassroomSignup: -> not ((features?.chinaUx ? false) or (window.serverConfig?.codeNinjas ? false) or (features?.brainPop ? false))
   showAvatarOnStudentDashboard: -> not (features?.classroomItems ? false) and @isStudent()

--- a/app/styles/home-view.sass
+++ b/app/styles/home-view.sass
@@ -108,6 +108,18 @@
         color: #FFFFFF
         text-decoration: underline
 
+      .top-banner-img
+        position: absolute
+        height: 120px
+        left: -20px
+        transform: scaleX(-1)
+
+        @media (max-width: 768px)
+          display: none
+
+        @media (max-width: 1100px)
+          left: 0px
+
     #jumbotron-container-fluid
       background-image: url("/images/pages/home/jumbotron.png")
       background-size: cover

--- a/app/templates/core/subscribe-modal.jade
+++ b/app/templates/core/subscribe-modal.jade
@@ -43,6 +43,8 @@ mixin price(name, p)
                li(data-i18n="subscribe.feature_level_access")
                li(data-i18n="subscribe.feature_heroes")
                li(data-i18n="subscribe.feature_learn")
+               if view.basicProduct
+                 li(data-i18n="subscribe.feature_gems", data-i18n-options={gems: view.basicProduct.get('gems')})
 
          hr
 

--- a/app/templates/home-view.pug
+++ b/app/templates/home-view.pug
@@ -5,8 +5,12 @@ block content
     .row#top-banner
       .row
         .col-xs-12
-          span(data-i18n="new_home.top_banner_blurb")
-          a(href="/parents", data-i18n="new_home.learn_more", data-event-action="Click: Homepage Banner Parents Page")
+          //span(data-i18n="new_home.top_banner_blurb")
+          //a(href="/parents", data-i18n="new_home.learn_more", data-event-action="Click: Homepage Banner Parents Page")
+          a(href="/league/team-derbezt/" data-i18n="new_home.top_banner_blurb_team_derbezt_link")
+          span= ' '
+          span(data-i18n="new_home.top_banner_blurb_team_derbezt_suffix")
+          img.top-banner-img(src="/file/db/thang.type/6037ed81ad0ac000f5e9f0b5/armando-pose.png" alt="Armando Hoyos")
 
     .row#jumbotron-container-fluid
       .col-lg-6


### PR DESCRIPTION
Finally getting around to it. (Mentioned [on forum 2.5 years ago](https://discourse.codecombat.com/t/gem-purchases-will-be-turned-off-in-the-near-future/15697/2) and then forgot to actually turn them off.) Individually buying gems as an "in-app purchase" isn't really in line with our mission, plus kids would sometimes buy them without parental consent–no bueno!

Players can still get gems by playing the game, and extra gems still come with the premium subscriptions.