### PR TITLE
Admin school and district team search

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -83,7 +83,7 @@ module.exports = class CocoRouter extends Backbone.Router
     'admin/skipped-contacts': go('admin/SkippedContactsView')
     'admin/outcomes-report-result': go('admin/OutcomeReportResultView')
     'admin/outcomes-report': go('admin/OutcomesReportView')
-    'admin/clan/:clanID': go('core/SingletonAppVueComponentView')
+    'admin/clan(/:clanID)': go('core/SingletonAppVueComponentView')
 
     'apcsp(/*subpath)': go('teachers/DynamicAPCSPView')
 

--- a/app/core/api/clans.js
+++ b/app/core/api/clans.js
@@ -5,6 +5,8 @@ export const getPublicClans = () => fetchJson(`/db/clan/-/public`)
 export const getMyClans = () => fetchJson(`/db/user/${me.id}/clans`)
 
 export const getClan = idOrSlug => fetchJson(`/db/clan/${idOrSlug}`)
+export const getClanBySchool = ncesId => fetchJson(`/db/clan/school/${ncesId}`)
+export const getClanByDistrict = ncesId => fetchJson(`/db/clan/district/${ncesId}`)
 
 export const joinClan = clanId => fetchJson(`/db/clan/${clanId}/join`, {
   method: 'PUT'

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -39,9 +39,12 @@ export default function getVueRouter () {
           ]
         },
         {
+          path: '/admin/clan',
+          component: () => import(/* webpackChunkName: "admin" */ 'app/views/admin/PageClanSearch'),
+        },
+        {
           path: '/admin/clan/:clanId',
           component: () => import(/* webpackChunkName: "admin" */ 'app/views/admin/PageClanEdit'),
-          props: (route) => ({clanId: route.params.clanId})
         },
         // Warning: In production debugging of third party iframe!
         {

--- a/app/views/admin/PageClanEdit.vue
+++ b/app/views/admin/PageClanEdit.vue
@@ -1,19 +1,11 @@
 <script>
-import { getClan } from 'core/api/clans'
 import CocoCollection from 'app/collections/CocoCollection'
+import { getClan } from 'core/api/clans'
 import Clan from 'app/models/Clan'
-
 const api = require('core/api')
 require('lib/setupTreema')
 
 export default {
-  props: {
-    clanId: {
-      type: String,
-      required: true
-    }
-  },
-
   data: () => ({
     clan: null,
     treema: null
@@ -24,7 +16,7 @@ export default {
         alert('You must be logged in as an admin to use this page.')
         return application.router.navigate('/', { trigger: true })
       }
-      this.clan = await getClan(this.clanId)
+      this.clan = await getClan(this.$route.params.clanId)
     
       const data = $.extend(true, {}, this.clan)
       const el = $(`<div></div>`)
@@ -65,6 +57,8 @@ export default {
 <template>
   <div>
     <h1>Internal Admin Team/Clan edit tool</h1>
+
+    <p>Search for school and district <a href="/admin/clan">clans here.</a></p>
     <div v-if="clan !== null">
       <p>This internal tool lets admin and internal accounts customize teams.
         For engineers - 'team' refers to a 'clan' in the code and database.
@@ -79,6 +73,11 @@ export default {
 
       <p><a :href="`/league/${clan.slug}`">Esports page</a></p>
       <p><a :href="`/clan/${clan.slug}`">Legacy clan page</a></p>
+
+      <h2>Clan Stats</h2>
+      <ul>
+        <li>{{(clan.members || []).length}} members</li>
+      </ul>
 
       <div
             v-once

--- a/app/views/admin/PageClanSearch.vue
+++ b/app/views/admin/PageClanSearch.vue
@@ -1,10 +1,10 @@
 <script>
-import { getClan, getClanBySchool, getClanByDistrict } from 'core/api/clans'
+import { getClanBySchool, getClanByDistrict } from 'core/api/clans'
 import Clan from 'app/models/Clan'
 const algolia = require('core/services/algolia')
 
 export default {
-  data: (() => {
+  data:() => ({
     foundClans: []
   }),
   mounted() {

--- a/app/views/admin/PageClanSearch.vue
+++ b/app/views/admin/PageClanSearch.vue
@@ -1,0 +1,122 @@
+<script>
+import { getClan, getClanBySchool, getClanByDistrict } from 'core/api/clans'
+import Clan from 'app/models/Clan'
+const algolia = require('core/services/algolia')
+
+export default {
+  data: (() => {
+    foundClans: []
+  }),
+  mounted() {
+      $(this.$refs.organizationControl).algolia_autocomplete({ hint: false }, [{
+        source: function (query, callback) {
+          algolia.schoolsIndex.search(query, { hitsPerPage: 5, aroundLatLngViaIP: false }).then((answer) =>
+            callback(answer.hits)
+          , function () {
+            return callback([])
+          })
+        },
+        displayKey: 'name',
+        templates: {
+          suggestion: function (suggestion) {
+            const hr = suggestion._highlightResult
+            return `<div class='school'> ${hr.name.value} </div>` +
+              `<div class='district'>${hr.district.value}, ` +
+                `<span>${hr.city?.value}, ${hr.state.value}</span></div>`
+          }
+        },
+      }]).on('autocomplete:selected', async (event, suggestion, dataset) => {
+        console.log(suggestion)
+        const districtId = suggestion.district_id
+        const schoolId = suggestion.id
+
+        try {
+          const school = await getClanBySchool(schoolId)
+          this.foundClans = [...this.foundClans, school]
+        } catch (e) {}
+
+        try {
+          const district = await getClanByDistrict(districtId)
+          this.foundClans = [...this.foundClans, district]
+        } catch (e) {}
+      })
+    // TODO
+    // $("#district-control").algolia_autocomplete({hint: false}, [
+    //   source: (query, callback) ->
+    //     algolia.schoolsIndex.search(query, { hitsPerPage: 5, aroundLatLngViaIP: false }).then (answer) ->
+    //       callback answer.hits
+    //     , ->
+    //       callback []
+    //   displayKey: 'district',
+    //   templates:
+    //     suggestion: (suggestion) ->
+    //       hr = suggestion._highlightResult
+    //       "<div class='district'>#{hr.district.value}, " +
+    //         "<span>#{hr.city?.value}, #{hr.state.value}</span></div>"
+    // ]).on 'autocomplete:selected', (event, suggestion, dataset) =>
+    //   @$('input[name="organization"]').val '' # TODO: does not persist on tabbing: back to school, back to district
+    //   @$('input[name="city"]').val suggestion.city
+    //   @$('input[name="state"]').val suggestion.state
+    //   @$('select[name="state"]').val suggestion.state
+    //   @$('select[name="country"]').val 'United States'
+    //   @state.set({showUsaStateDropdown: true})
+    //   @state.set({stateValue: suggestion.state})
+    //   for key in DISTRICT_NCES_KEYS
+    //     @$('input[name="nces_' + key + '"]').val suggestion[key]
+    //   @onChangeForm()
+  }
+}
+</script>
+
+<template>
+  <div class="form-group">
+    <label>School search</label>
+    <input id="organization-control" class="form-control" ref="organizationControl"/>
+  </div>
+</template>
+
+
+<style lang="sass">
+.algolia-autocomplete 
+    width: 100%
+
+    .aa-input
+      width: 100%
+
+    .aa-hint
+      color: #999
+      width: 100%
+
+    .aa-dropdown-menu 
+      background-color: #fff
+      border: 1px solid #999
+      border-top: none
+      width: 100%
+
+      .aa-suggestion 
+        cursor: pointer
+        padding: 5px 4px
+        border-top: 1px solid #ccc
+
+        .school
+          font-family: Open Sans
+          font-size: 14px
+          line-height: 20px
+          font-weight: bold
+
+        .district
+          font-family: Open Sans
+          font-size: 14px
+          line-height: 20px
+
+          span
+            white-space: nowrap
+
+
+      .aa-suggestion.aa-cursor 
+        background-color: #B2D7FF
+
+      em
+        font-weight: bold
+        font-style: normal
+</style>

--- a/app/views/admin/PageClanSearch.vue
+++ b/app/views/admin/PageClanSearch.vue
@@ -1,6 +1,5 @@
 <script>
 import { getClanBySchool, getClanByDistrict } from 'core/api/clans'
-import Clan from 'app/models/Clan'
 const algolia = require('core/services/algolia')
 
 export default {
@@ -8,62 +7,91 @@ export default {
     foundClans: []
   }),
   mounted() {
-      $(this.$refs.organizationControl).algolia_autocomplete({ hint: false }, [{
-        source: function (query, callback) {
-          algolia.schoolsIndex.search(query, { hitsPerPage: 5, aroundLatLngViaIP: false }).then((answer) =>
-            callback(answer.hits)
-          , function () {
-            return callback([])
-          })
-        },
-        displayKey: 'name',
-        templates: {
-          suggestion: function (suggestion) {
-            const hr = suggestion._highlightResult
-            return `<div class='school'> ${hr.name.value} </div>` +
-              `<div class='district'>${hr.district.value}, ` +
-                `<span>${hr.city?.value}, ${hr.state.value}</span></div>`
-          }
-        },
-      }]).on('autocomplete:selected', async (event, suggestion, dataset) => {
-        console.log(suggestion)
-        const districtId = suggestion.district_id
-        const schoolId = suggestion.id
+    if (!me.isAdmin()) {
+      alert('You must be logged in as an admin to use this page.')
+      return application.router.navigate('/', { trigger: true })
+    }
+    $(this.$refs.organizationControl).algolia_autocomplete({ hint: false }, [{
+      source: function (query, callback) {
+        algolia.schoolsIndex.search(query, { hitsPerPage: 5, aroundLatLngViaIP: false }).then((answer) =>
+          callback(answer.hits)
+        , function () {
+          return callback([])
+        })
+      },
+      displayKey: 'name',
+      templates: {
+        suggestion: function (suggestion) {
+          const hr = suggestion._highlightResult
+          return `<div class='school'> ${hr.name.value} </div>` +
+            `<div class='district'>${hr.district.value}, ` +
+              `<span>${hr.city?.value}, ${hr.state.value}</span></div>`
+        }
+      },
+    }]).on('autocomplete:selected', async (event, suggestion, dataset) => {
+      const districtId = suggestion.district_id
+      const schoolId = suggestion.id
 
-        try {
-          const school = await getClanBySchool(schoolId)
-          this.foundClans = [...this.foundClans, school]
-        } catch (e) {}
+      try {
+        const school = await getClanBySchool(schoolId)
+        this.foundClans = [...this.foundClans, school]
+      } catch (e) {
+        noty({
+          text: e.message,
+          layout: 'topCenter',
+          type: 'error',
+          timeout: 5000,
+          killer: false
+        })
+      }
 
-        try {
-          const district = await getClanByDistrict(districtId)
-          this.foundClans = [...this.foundClans, district]
-        } catch (e) {}
+      try {
+        const district = await getClanByDistrict(districtId)
+        this.foundClans = [...this.foundClans, district]
+      } catch (e) {
+        noty({
+          text: e.message,
+          layout: 'topCenter',
+          type: 'error',
+          timeout: 5000,
+          killer: false
+        })
+      }
+    });
+
+  $(this.$refs.districtControl).algolia_autocomplete({ hint: false }, [{
+    source: function (query, callback) {
+      algolia.schoolsIndex.search(query, { hitsPerPage: 5, aroundLatLngViaIP: false }).then((answer) =>
+        callback(answer.hits)
+      , function () {
+        return callback([])
       })
-    // TODO
-    // $("#district-control").algolia_autocomplete({hint: false}, [
-    //   source: (query, callback) ->
-    //     algolia.schoolsIndex.search(query, { hitsPerPage: 5, aroundLatLngViaIP: false }).then (answer) ->
-    //       callback answer.hits
-    //     , ->
-    //       callback []
-    //   displayKey: 'district',
-    //   templates:
-    //     suggestion: (suggestion) ->
-    //       hr = suggestion._highlightResult
-    //       "<div class='district'>#{hr.district.value}, " +
-    //         "<span>#{hr.city?.value}, #{hr.state.value}</span></div>"
-    // ]).on 'autocomplete:selected', (event, suggestion, dataset) =>
-    //   @$('input[name="organization"]').val '' # TODO: does not persist on tabbing: back to school, back to district
-    //   @$('input[name="city"]').val suggestion.city
-    //   @$('input[name="state"]').val suggestion.state
-    //   @$('select[name="state"]').val suggestion.state
-    //   @$('select[name="country"]').val 'United States'
-    //   @state.set({showUsaStateDropdown: true})
-    //   @state.set({stateValue: suggestion.state})
-    //   for key in DISTRICT_NCES_KEYS
-    //     @$('input[name="nces_' + key + '"]').val suggestion[key]
-    //   @onChangeForm()
+    },
+    displayKey: 'district',
+    templates: {
+      suggestion: function (suggestion) {
+        const hr = suggestion._highlightResult
+        return `<div class='district'>${hr.district.value}, ` +
+        `<span>${hr.city?.value}, ${hr.state.value}</span></div>`
+      }
+    }
+  }]).on('autocomplete:selected', async (event, suggestion, dataset) => {
+    console.log(suggestion)
+    const districtId = suggestion.district_id
+
+    try {
+      const district = await getClanByDistrict(districtId)
+      this.foundClans = [...this.foundClans, district]
+    } catch (e) {
+      noty({
+        text: e.message,
+        layout: 'topCenter',
+        type: 'error',
+        timeout: 5000,
+        killer: false
+      })
+    }
+    })
   }
 }
 </script>
@@ -72,6 +100,19 @@ export default {
   <div class="form-group">
     <label>School search</label>
     <input id="organization-control" class="form-control" ref="organizationControl"/>
+    <label>District search</label>
+    <input id="district-control" class="form-control" ref="districtControl"/>
+
+    <div>
+      <h2>List of found clans/teams</h2>
+      <ul>
+        <li
+          v-for="child in foundClans"
+          :key="child._id">
+          <span>{{child.displayName || child.name}} - </span><span>{{child.id}}</span><a :href="`/league/${child.slug}`">Esports Page</a>
+          </li>
+      </ul>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
# Context

This is paired with a server change -- thus doesn't work on proxy yet.
Adds a new admin only route (checked client & server side) that allows for searching of clans by school and district.

New route: /admin/clan

When the user clicks on a school or district in the algolia dropdown, we try and fetch any related clans and append them on a list beneath. (Really simple and naive working behavior).

Here is a demo of it working with a mock clan. Hence the errors as my local db is missing schools and districts.
Clan that is appended is always "Doral Academy" -- hard coded.

![5491344374f0e3cacf95f30c5c731d45](https://user-images.githubusercontent.com/15080861/111396944-5e88f500-867d-11eb-867e-717e3c8a56e6.gif)


# Risk

The risk is low because this is internal facing only.
Also why it looks so bad on the first pass.