### PR TITLE
Clan/Team search admin tool

### DIFF
--- a/app/views/admin/InputClanSearch.vue
+++ b/app/views/admin/InputClanSearch.vue
@@ -1,0 +1,43 @@
+<script>
+export default {
+  data: (() => ({
+    searchString: '',
+    autoComplete: []
+  })),
+
+  methods: {
+    debounceInput: _.debounce(async function (e) {
+      const fuzzyString = e.target.value
+      if (fuzzyString === '') {
+        this.autoComplete = []
+        return
+      }
+      const res = await fetch(`/db/clan?project=slug,name,displayName&term=${fuzzyString}&limit=10`)
+      const json = await res.json()
+      if (res.status !== 200) {
+        noty({
+          text: json.message,
+          layout: 'topCenter',
+          type: 'error',
+          timeout: 5000
+        })
+        return
+      }
+
+      this.autoComplete = json
+    }, 500)
+  }
+}
+</script>
+
+<template>
+  <div class="form-group">
+    <label>Clan/Team search</label>
+    <input @input="debounceInput" id="clan-search" class="form-control" v-model="searchString"/>
+    <ul>
+      <li v-for="{ slug, name, displayName } in autoComplete" :key="slug">
+        <a :href="`/league/${slug}`">{{ displayName || name }}</a>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/app/views/admin/PageClanSearch.vue
+++ b/app/views/admin/PageClanSearch.vue
@@ -1,118 +1,24 @@
 <script>
-import { getClanBySchool, getClanByDistrict } from 'core/api/clans'
-const algolia = require('core/services/algolia')
+import InputClanSearch from './InputClanSearch'
 
 export default {
-  data:() => ({
-    foundClans: []
-  }),
+  components: {
+    InputClanSearch
+  },
+
   mounted() {
     if (!me.isAdmin()) {
       alert('You must be logged in as an admin to use this page.')
       return application.router.navigate('/', { trigger: true })
     }
-    $(this.$refs.organizationControl).algolia_autocomplete({ hint: false }, [{
-      source: function (query, callback) {
-        algolia.schoolsIndex.search(query, { hitsPerPage: 5, aroundLatLngViaIP: false }).then((answer) =>
-          callback(answer.hits)
-        , function () {
-          return callback([])
-        })
-      },
-      displayKey: 'name',
-      templates: {
-        suggestion: function (suggestion) {
-          const hr = suggestion._highlightResult
-          return `<div class='school'> ${hr.name.value} </div>` +
-            `<div class='district'>${hr.district.value}, ` +
-              `<span>${hr.city?.value}, ${hr.state.value}</span></div>`
-        }
-      },
-    }]).on('autocomplete:selected', async (event, suggestion, dataset) => {
-      const districtId = suggestion.district_id
-      const schoolId = suggestion.id
-
-      try {
-        const school = await getClanBySchool(schoolId)
-        this.foundClans = [...this.foundClans, school]
-      } catch (e) {
-        noty({
-          text: e.message,
-          layout: 'topCenter',
-          type: 'error',
-          timeout: 5000,
-          killer: false
-        })
-      }
-
-      try {
-        const district = await getClanByDistrict(districtId)
-        this.foundClans = [...this.foundClans, district]
-      } catch (e) {
-        noty({
-          text: e.message,
-          layout: 'topCenter',
-          type: 'error',
-          timeout: 5000,
-          killer: false
-        })
-      }
-    });
-
-  $(this.$refs.districtControl).algolia_autocomplete({ hint: false }, [{
-    source: function (query, callback) {
-      algolia.schoolsIndex.search(query, { hitsPerPage: 5, aroundLatLngViaIP: false }).then((answer) =>
-        callback(answer.hits)
-      , function () {
-        return callback([])
-      })
-    },
-    displayKey: 'district',
-    templates: {
-      suggestion: function (suggestion) {
-        const hr = suggestion._highlightResult
-        return `<div class='district'>${hr.district.value}, ` +
-        `<span>${hr.city?.value}, ${hr.state.value}</span></div>`
-      }
-    }
-  }]).on('autocomplete:selected', async (event, suggestion, dataset) => {
-    console.log(suggestion)
-    const districtId = suggestion.district_id
-
-    try {
-      const district = await getClanByDistrict(districtId)
-      this.foundClans = [...this.foundClans, district]
-    } catch (e) {
-      noty({
-        text: e.message,
-        layout: 'topCenter',
-        type: 'error',
-        timeout: 5000,
-        killer: false
-      })
-    }
-    })
   }
 }
 </script>
 
 <template>
   <div class="form-group">
-    <label>School search</label>
-    <input id="organization-control" class="form-control" ref="organizationControl"/>
-    <label>District search</label>
-    <input id="district-control" class="form-control" ref="districtControl"/>
-
-    <div>
-      <h2>List of found clans/teams</h2>
-      <ul>
-        <li
-          v-for="child in foundClans"
-          :key="child._id">
-          <span>{{child.displayName || child.name}} - </span><span>{{child.id}}</span><a :href="`/league/${child.slug}`">Esports Page</a>
-          </li>
-      </ul>
-    </div>
+    <p>Search for clans and teams by name</p>
+    <InputClanSearch />
   </div>
 </template>
 


### PR DESCRIPTION
# Context

We want to allow everyone to be able to more easily find their teams for esports.
This PR adds a test admin UI for searching all the clans and teams.
I've also removes a legacy attempt at searching for clans using ncesId.

This PR depends on a private server PR: https://github.com/codecombat/codecombat-server/pull/256

The server includes the new route and clan text index.

# Testing

In order to test you currently need to use the server PR which will apply the text index to your local database.

Then navigate to http://localhost:3000/admin/clan
Here you can search for clans in your local db.

# Risks

Risks are listed in server Pr.
Once this has been code reviewed, and tested internally we can add a component onto the league page.


# Screenshots
![720c692e09e7321f69b11b09a0e9bce9](https://user-images.githubusercontent.com/15080861/112706142-80456180-8e5f-11eb-90cc-b447382856cf.gif)
