### PR TITLE
Only load Zendesk when we are about to open it, not on page load

### DIFF
--- a/app/core/application.coffee
+++ b/app/core/application.coffee
@@ -63,35 +63,6 @@ Application = {
     store.commit('me/updateUser', me.attributes)
     store.commit('updateFeatures', features)
 
-    # Load zendesk here instead of in layout.static.pug in order to make it properly global
-    if !me.showChinaResourceInfo()
-      zendeskElement = document.createElement('script')
-      zendeskElement.id ="ze-snippet"
-      zendeskElement.type = 'text/javascript'
-      zendeskElement.async = true
-      zendeskElement.onerror = (event) -> console.error('Zendesk failed to initialize: ', event)
-      zendeskElement.onload = ->
-        # zE is the global variable created by the script. We never want the floating button to show, so we:
-        # 1: Hide it right away
-        # 2: Bind showing it to opening it
-        # 3: Bind closing it to hiding it
-        zE('webWidget', 'hide')
-        zE('webWidget:on', 'userEvent', (event) ->
-          if event.action == 'Contact Form Shown'
-            zE('webWidget', 'open')
-        )
-        zE('webWidget:on', 'close', -> zE('webWidget', 'hide'))
-        zE('webWidget', 'updateSettings', {
-          webWidget: {
-            offset: { horizontal: '100px', vertical: '20px' }
-          }
-        })
-
-
-      zendeskElement.src = 'https://static.zdassets.com/ekr/snippet.js?key=ed461a46-91a6-430a-a09c-73c364e02ffe'
-      script = document.getElementsByTagName('script')[0]
-      script.parentNode.insertBefore(zendeskElement, script)
-
     if me.showChinaRemindToast()
       setInterval ( -> noty {
         text: '你已经练习了一个小时了，建议休息一会儿哦'

--- a/app/core/services/zendesk.coffee
+++ b/app/core/services/zendesk.coffee
@@ -1,0 +1,53 @@
+loadZendesk = _.once () ->
+  return new Promise (accept, reject) ->
+    onLoad = ->
+      # zE is the global variable created by the script. We never want the floating button to show, so we:
+      # 1: Hide it right away
+      # 2: Bind showing it to opening it
+      # 3: Bind closing it to hiding it
+      zE('webWidget', 'hide')
+      zE('webWidget:on', 'userEvent', (event) ->
+        if event.action == 'Contact Form Shown'
+          zE('webWidget', 'open')
+      )
+      zE('webWidget:on', 'close', -> zE('webWidget', 'hide'))
+      zE('webWidget', 'updateSettings', {
+        webWidget: {
+          offset: { horizontal: '100px', vertical: '20px' }
+        }
+      })
+      accept()
+
+    onError = (e) ->
+      console.error 'Zendesk failed to initialize:', e
+      reject()
+
+    zendeskElement = document.createElement('script')
+    zendeskElement.id ="ze-snippet"
+    zendeskElement.type = 'text/javascript'
+    zendeskElement.async = true
+    zendeskElement.onerror = onError
+    zendeskElement.onload = onLoad
+    zendeskElement.src = 'https://static.zdassets.com/ekr/snippet.js?key=ed461a46-91a6-430a-a09c-73c364e02ffe'
+    script = document.getElementsByTagName('script')[0]
+    script.parentNode.insertBefore(zendeskElement, script)
+
+openZendesk = ->
+  try
+    if !me.isAnonymous()
+      zE('webWidget', 'prefill', {
+        email: {
+          value: me.get('email')
+        }
+      })
+    zE('webWidget', 'open')
+    zE('webWidget', 'show')
+  catch e
+    console.error('Error trying to open Zendesk widget: ', e)
+    return false
+  return true
+
+module.exports = {
+  loadZendesk
+  openZendesk
+}

--- a/app/views/core/CocoView.coffee
+++ b/app/views/core/CocoView.coffee
@@ -7,6 +7,7 @@ require('app/styles/core/loading-error.sass')
 auth = require 'core/auth'
 ViewVisibleTimer = require 'core/ViewVisibleTimer'
 storage = require 'core/storage'
+zendesk = require 'core/services/zendesk'
 
 visibleModal = null
 waitingModal = null
@@ -260,23 +261,14 @@ module.exports = class CocoView extends Backbone.View
       DirectContactModal = require('app/views/core/DirectContactModal').default
       @openModalView(new DirectContactModal())
 
-    if me.isTeacher(true) and window?.tracker?.drift?.openChat
+    if (me.isTeacher(true) and window?.tracker?.drift?.openChat) or me.showChinaResourceInfo()
       openDirectContactModal()
     else
-      try
-        if !me.isAnonymous()
-          zE('webWidget', 'prefill', {
-            email: {
-              value: me.get('email')
-            }
-          })
-        zE('webWidget', 'open')
-        zE('webWidget', 'show')
-      catch e
-        console.error('Error trying to open Zendesk widget: ', e)
-        # There's an unlikely case where both Drift and Zendesk are unavailable, or Zendesk exists but fails.
-        # Since the modal communicates errors better, and shows the direct support email, we still open it.
-        openDirectContactModal()
+      # There's an unlikely case where both Drift and Zendesk are unavailable, or Zendesk exists but fails.
+      # Since the modal communicates errors better, and shows the direct support email, we still open it.
+      zendesk.loadZendesk()
+        .then(-> if not zendesk.openZendesk() then openDirectContactModal())
+        .catch(-> openDirectContactModal())
 
   onClickLoadingErrorLoginButton: (e) ->
     e.stopPropagation() # Backbone subviews and superviews will handle this call repeatedly otherwise


### PR DESCRIPTION
The Zendesk email widget would be very rarely needed, but it was being loaded at all times. I moved it to load when you start to use it.

Not sure if this is the best pattern for lazy loading a service like this; modeled it after some code I saw in `app/core/services/paypal.coffee`.