### PR TITLE
Input team/clan search UI and UX

### DIFF
--- a/app/views/admin/InputClanSearch.vue
+++ b/app/views/admin/InputClanSearch.vue
@@ -2,8 +2,16 @@
 export default {
   data: (() => ({
     searchString: '',
-    autoComplete: []
+    autoComplete: [],
+    lostFocusBuffer: []
   })),
+
+  props: {
+    maxWidth: {
+      type: Number,
+      default: 0
+    }
+  },
 
   methods: {
     debounceInput: _.debounce(async function (e) {
@@ -25,19 +33,101 @@ export default {
       }
 
       this.autoComplete = json
-    }, 500)
+      this.lostFocusBuffer = json
+    }, 500),
+
+    navigateToTeamLeaguePage (clanSlug) {
+      application.router.navigate(`/league/${clanSlug}`, { trigger: true })
+    },
+
+    handleFocusInput() {
+      this.autoComplete = this.lostFocusBuffer
+    },
+
+    clearInput () {
+      this.autoComplete = []
+      this.lostFocusBuffer = []
+      this.searchString = ""
+    },
+
+    handleBlurInput () {
+      setTimeout(() => {
+        this.lostFocusBuffer = this.autoComplete
+        this.autoComplete = []
+      }, 150)
+    }
   }
 }
 </script>
 
 <template>
-  <div class="form-group">
-    <label>Clan/Team search</label>
-    <input @input="debounceInput" id="clan-search" class="form-control" v-model="searchString"/>
-    <ul>
-      <li v-for="{ slug, name, displayName } in autoComplete" :key="slug">
-        <a :href="`/league/${slug}`">{{ displayName || name }}</a>
-      </li>
-    </ul>
+  <div class="form-group input-clan-search" :style="maxWidth ? `max-width: ${maxWidth}px;` : null">
+    <div class="input-group">
+      <span class="input-group-addon">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-search" viewBox="0 0 16 16">
+          <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
+        </svg>
+      </span>
+      <input @input="debounceInput" id="clan-search" class="form-control" v-model="searchString" autocomplete="off" :placeholder="'Search teams'" @blur="handleBlurInput" @focus="handleFocusInput"/>
+      <div v-if="this.searchString !== ''" class="input-group-btn input-group-addon" style="cursor: pointer;" @click="clearInput">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x" viewBox="0 0 16 16">
+          <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
+        </svg>
+      </div>
+    </div>
+    <div class="suggestion-wrapper">
+      <div class="list-group">
+        <div v-for="{ slug, name, displayName } in autoComplete" :key="slug" class="list-group-item" @click="() => navigateToTeamLeaguePage(slug)" :title="displayName || name">
+          <p>{{ displayName || name }}</p>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
+
+
+<style lang="scss" scoped>
+.input-clan-search {
+  margin: 0;
+}
+
+.form-control {
+  color: black;
+}
+
+.suggestion-wrapper {
+  color: black;
+  position: relative;
+}
+
+.list-group-item {
+  height: 34px;
+  background-color: white;
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  align-items: center;
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: #dedede;
+  }
+
+  p {
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.list-group {
+  position: absolute;
+  width: 100%;
+  max-height: 70vh;
+  overflow-y: auto;
+  z-index: 10;
+  padding: 0;
+}
+</style>

--- a/app/views/admin/PageClanSearch.vue
+++ b/app/views/admin/PageClanSearch.vue
@@ -16,54 +16,8 @@ export default {
 </script>
 
 <template>
-  <div class="form-group">
+  <div>
     <p>Search for clans and teams by name</p>
     <InputClanSearch />
   </div>
 </template>
-
-
-<style lang="sass">
-.algolia-autocomplete 
-    width: 100%
-
-    .aa-input
-      width: 100%
-
-    .aa-hint
-      color: #999
-      width: 100%
-
-    .aa-dropdown-menu 
-      background-color: #fff
-      border: 1px solid #999
-      border-top: none
-      width: 100%
-
-      .aa-suggestion 
-        cursor: pointer
-        padding: 5px 4px
-        border-top: 1px solid #ccc
-
-        .school
-          font-family: Open Sans
-          font-size: 14px
-          line-height: 20px
-          font-weight: bold
-
-        .district
-          font-family: Open Sans
-          font-size: 14px
-          line-height: 20px
-
-          span
-            white-space: nowrap
-
-
-      .aa-suggestion.aa-cursor 
-        background-color: #B2D7FF
-
-      em
-        font-weight: bold
-        font-style: normal
-</style>

--- a/app/views/admin/PageClanSearch.vue
+++ b/app/views/admin/PageClanSearch.vue
@@ -1,5 +1,5 @@
 <script>
-import InputClanSearch from './InputClanSearch'
+import InputClanSearch from 'app/views/landing-pages/league/components/InputClanSearch'
 
 export default {
   components: {

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -6,6 +6,7 @@ import LeagueSignupModal from './components/LeagueSignupModal'
 import ClanCreationModal from './components/ClanCreationModal'
 import ChildClanDetailDropdown from './components/ChildClanDetailDropdown'
 import SectionFirstCTA from './components/SectionFirstCTA'
+import InputClanSearch from './components/InputClanSearch'
 
 import { joinClan, leaveClan } from '../../../core/api/clans'
 
@@ -16,7 +17,8 @@ export default {
     LeagueSignupModal,
     ClanCreationModal,
     ChildClanDetailDropdown,
-    SectionFirstCTA
+    SectionFirstCTA,
+    InputClanSearch
   },
 
   data: () => ({
@@ -412,6 +414,7 @@ export default {
         :childClans="currentSelectedClanChildDetails"
         class="clan-search"
       />
+      <InputClanSearch v-if="isGlobalPage" max-width="510" style="margin: 10px auto"/>
       <p class="subheader2">{{ $t('league.ladder_subheader') }}</p>
       <div class="col-lg-6 section-space">
         <leaderboard v-if="currentSelectedClan" :rankings="selectedClanRankings" :playerCount="selectedClanLeaderboardPlayerCount" :key="`${clanIdSelected}-score`" :clanId="clanIdSelected" class="leaderboard-component" style="color: black;" />

--- a/app/views/landing-pages/league/components/InputClanSearch.vue
+++ b/app/views/landing-pages/league/components/InputClanSearch.vue
@@ -88,7 +88,7 @@ export default {
 
 <style lang="scss" scoped>
 .input-clan-search {
-  margin: 0;
+  margin: 0 auto;
 }
 
 .form-control {


### PR DESCRIPTION
# Context

This is the user facing component of the fuzzy clan search.
Intention is for anyone to be able to find the team they are looking for.
Whether it is a school, district, custom team or anything in between.

This team search component has been placed on the global league page (codecombat.com/league) between the global stats and the rankings. This is consistent with where the subclan search appears when you are viewing a network or subnetwork team.

### How

The server endpoint is done. This is a very similar Vue component to the `ChildClanDetailDropdown`, but simplified as any clan can be retrieved.

### UI / UX demo

![2a914f0f2c5f594463bd2053ea1325dd](https://user-images.githubusercontent.com/15080861/112905899-1cf64200-90a0-11eb-8f12-baed6357ec85.gif)

In the context of the global league page:

![543b2bd31853b584092f1a72093a1405](https://user-images.githubusercontent.com/15080861/112907073-1072e900-90a2-11eb-8d64-338498e0d388.gif)

## Testing

The manual component can be tested by using a local database with your local clans collection filled.
Run the server on master branch and this branch as the client.
You cannot test with proxy yet as the server hasn't shipped.

Then navigate to localhost:3000/league and use the input component.
It should allow fuzzy searching of the clan collection in your local database.

## Risks

The UI/UX risk is relatively low. This is a much lower risk PR than the server endpoint.
We can measure performance on staging environment.
