### PR TITLE
Fix confusing student enrollment characters in teacher dashboard

### DIFF
--- a/app/templates/courses/enrollments-view.jade
+++ b/app/templates/courses/enrollments-view.jade
@@ -164,5 +164,5 @@ mixin addCredits
         span.glyphicon.glyphicon-question-sign
       p.m-y-2.unique-students
         each year in Object.keys(uniqueStudentsPerYear).sort().reverse()
-          | #{year}: #{uniqueStudentsPerYear[year].size} #{$.i18n.t('courses.students').toLowerCase()}
+          | !{year}: #{uniqueStudentsPerYear[year].size} #{$.i18n.t('courses.students').toLowerCase()}
           br


### PR DESCRIPTION
# Context

Issue found while checking teacher dashboard for context on purchasing licenses.

Very small risk. Escaping interpolation like this does open up the possibility of a vulnerability, however we aren't inserting user generated content.

Before fix:

![Screen Shot 2021-04-01 at 5 34 38 PM](https://user-images.githubusercontent.com/15080861/113367460-e96e1e80-9310-11eb-8e14-10369c51f472.png)


After fix:
![Screen Shot 2021-04-01 at 5 33 46 PM](https://user-images.githubusercontent.com/15080861/113367338-9300e000-9310-11eb-8c11-05097fee8ae1.png)
