### PR TITLE
may fix the bug in game-dev wrong error message

### DIFF
--- a/app/lib/God.coffee
+++ b/app/lib/God.coffee
@@ -75,7 +75,7 @@ module.exports = class God extends CocoClass
     @lastFixedSeed = e.fixedSeed
     @lastFlagHistory = (flag for flag in e.flagHistory when flag.source isnt 'code')
     @lastDifficulty = e.difficulty
-    @createWorld e
+    _.delay (=>@createWorld e), 100 # delay this function to wait spells update
 
   createWorld: ({spells, preload, realTime, justBegin, keyValueDb, synchronous}) ->
     console.log "#{@nick}: Let there be light upon #{@level.name}! (preload: #{preload})"


### PR DESCRIPTION
i think in one of `tome:cast` we update the spells at the same time with `God.createWorld`, so the new world get the wrong(old) spells.

now try to delay 100ms(a time guessed by myself) to make it run well. while it maybe better to make a robust fix


PS: this pr is conflict with https://github.com/codecombat/codecombat/pull/6254, i think it is better to review that first.