### PR TITLE
🐛 Hide broken campaign view esports link

### DIFF
--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -1466,7 +1466,8 @@ module.exports = class CampaignView extends RootView
       return @campaign?.get('slug') is 'game-dev-hoc'
 
     if what is 'league-arena'
-      return not me.isAnonymous()
+      # Note: Currently the tooltips don't work in the campaignView overworld.
+      return not me.isAnonymous() and @campaign?.get('slug')
 
     return true
 


### PR DESCRIPTION
# Context

Fixes an error currently in production when accessing esports arenas through codecombat.com/play route.

### Why

The error occurs as the tooltips are not initiated on this page.
Thus clicking the button fails to open a tooltip.

![image](https://user-images.githubusercontent.com/15080861/113778116-dd9fa500-96e0-11eb-97d5-f4b3ee98355c.png)


### How

It's currently fine to fix by turning off the esports arena links from the campaign overworld.
They are still accessible from within the various campaigns.

There will also be future work to add a global button to the bottom right that links to esports arenas.

### Test

Simple change and can be easily verified with `npm run dev` and `npm run proxy`.
Navigate to localhost:3000/play and note the buttons are missing. (See screenshot).

![Screen Shot 2021-04-06 at 2 02 25 PM](https://user-images.githubusercontent.com/15080861/113778023-bc3eb900-96e0-11eb-97c2-95bb32a4558e.png)

On a campaign the buttons are visible. I.e. game-dev
![Screen Shot 2021-04-06 at 2 02 59 PM](https://user-images.githubusercontent.com/15080861/113778084-d1b3e300-96e0-11eb-8dbb-9ca7733859d4.png)
