### PR TITLE
fix and optimize rectangle calculations

### DIFF
--- a/app/lib/world/rectangle.coffee
+++ b/app/lib/world/rectangle.coffee
@@ -32,11 +32,12 @@ class Rectangle
 
   lineSegments: ->
     vertices = @vertices()
-    lineSegment0 = new LineSegment vertices[0], vertices[1]
-    lineSegment1 = new LineSegment vertices[1], vertices[2]
-    lineSegment2 = new LineSegment vertices[2], vertices[3]
-    lineSegment3 = new LineSegment vertices[3], vertices[0]
-    [lineSegment0, lineSegment1, lineSegment2, lineSegment3]
+    [
+      new LineSegment vertices[0], vertices[1]
+      new LineSegment vertices[1], vertices[2]
+      new LineSegment vertices[2], vertices[3]
+      new LineSegment vertices[3], vertices[0]
+    ]
 
   touchesRect: (other) ->
     # Whether this rect shares part of any edge with other rect, for non-rotated, non-overlapping rectangles.
@@ -60,45 +61,108 @@ class Rectangle
     false
 
   axisAlignedBoundingBox: (rounded=true) ->
-    box = @copy()
-    return box unless @rotation
-    box.rotation = 0
-    [left, top] = [9001, 9001]
-    for vertex in @vertices()
-      [left, top] = [Math.min(left, vertex.x), Math.min(top, vertex.y)]
+    # Generates 1 rotated point and directly calculates the min and max
+
+    cos = Math.cos(@rotation)
+    sin = Math.sin(@rotation)
+    rot = @rotation % (2 * Math.PI)
+
+    Ax = @x - (@width / 2 * cos - @height / 2 * sin)
+    Ay = @y - (@width / 2 * sin + @height / 2 * cos)
+
+    xmin = ymin = 0
+    if rot > Math.PI
+      if rot < 3 * Math.PI / 2
+        xmin = Ax + @width  * cos
+        ymin = Ay + @height * cos + @width * sin
+      else
+        xmin = Ax
+        ymin = Ay + @width * sin
+    else
+      if rot > Math.PI / 2
+        xmin = Ax + @width  * cos - @height * sin
+        ymin = Ay + @height * cos
+      else
+        xmin = Ax - @height * sin
+        ymin = Ay
+
     if rounded
-      [left, top] = [Math.round(left), Math.round(top)]
-    [box.width, box.height] = [2 * (@x - left), 2 * (@y - top)]
-    box
+      xmin = Math.round(xmin)
+      ymin = Math.round(ymin)
+
+    new Rectangle @x, @y, 2 * (@x - xmin), 2 * (@y - ymin), 0
 
   distanceToPoint: (p) ->
     # Get p in rect's coordinate space, then operate in one quadrant.
-    p = Vector.subtract(p, @getPos()).rotate(-@rotation)
-    dx = Math.max(Math.abs(p.x) - @width / 2, 0)
-    dy = Math.max(Math.abs(p.y) - @height / 2, 0)
+
+    cos = Math.cos(@rotation)
+    sin = Math.sin(@rotation)
+    px = (p.x - @x) * cos - (p.y - @y) * sin
+    py = (p.x - @x) * sin + (p.y - @y) * cos
+
+    dx = Math.max(Math.abs(px) - @width / 2, 0)
+    dy = Math.max(Math.abs(py) - @height / 2, 0)
     Math.sqrt dx * dx + dy * dy
 
   distanceSquaredToPoint: (p) ->
-    # Doesn't handle rotation; just supposed to be faster than distanceToPoint.
-    p = Vector.subtract(p, @getPos())
-    dx = Math.max(Math.abs(p.x) - @width / 2, 0)
-    dy = Math.max(Math.abs(p.y) - @height / 2, 0)
+    # Doesn't handle rotation and is significantly faster than distanceToPoint.
+    dx = Math.max(Math.abs(p.x - @x) - @width / 2, 0)
+    dy = Math.max(Math.abs(p.y - @y) - @height / 2, 0)
     dx * dx + dy * dy
 
   distanceToRectangle: (other) ->
     Math.sqrt @distanceSquaredToRectangle other
 
-  distanceSquaredToRectangle: (other) ->
-    return 0 if @intersectsRectangle other
-    [firstVertices, secondVertices] = [@vertices(), other.vertices()]
-    [firstEdges, secondEdges] = [@lineSegments(), other.lineSegments()]
-    ans = Infinity
-    for i in [0 ... 4]
-      for j in [0 ... firstEdges.length]
-        ans = Math.min ans, firstEdges[j].distanceSquaredToPoint(secondVertices[i])
-      for j in [0 ... secondEdges.length]
-        ans = Math.min ans, secondEdges[j].distanceSquaredToPoint(firstVertices[i])
-    ans
+  distanceSquaredToRectangle: (rect) ->
+    return 0 if @intersectsRectangle rect
+
+    distanceSquaredSegmentPoint = (a, b, point) ->
+      # Assuming a != b
+
+      t = ((point.x - a.x) * (b.x - a.x) + (point.y - a.y) * (b.y - a.y)) / a.distanceSquared(b)
+      return point.distanceSquared a if t <= 0
+      return point.distanceSquared b if t >= 1
+
+      dx = point.x - (a.x + t * (b.x - a.x))
+      dy = point.y - (a.y + t * (b.y - a.y))
+      return dx * dx + dy * dy
+
+
+    # Find the indices of the point on each rect furthest from the center of the other rect
+    # Then, find the minimum distSq of every pair of vertices from one rect and sides from another
+    #   excluding all points and sides that are/include the furthest points decided above (12 pairs)
+
+    verts1 = @vertices()
+    verts2 = rect.vertices()
+
+    # Index of furthest vertex in verts1
+    d0 = Math.pow(verts1[0].x - rect.x, 2) + Math.pow(verts1[0].y - rect.y, 2)
+    d1 = Math.pow(verts1[1].x - rect.x, 2) + Math.pow(verts1[1].y - rect.y, 2)
+    d2 = Math.pow(verts1[2].x - rect.x, 2) + Math.pow(verts1[2].y - rect.y, 2)
+    idx1 = if d0 < d1 then (if d1 < d2 then 2 else 1) else (if d1 < d2 then 3 else 0)
+
+    # Index of furthest vertex in verts2
+    d0 = Math.pow(verts2[0].x - @x, 2) + Math.pow(verts2[0].y - @y, 2)
+    d1 = Math.pow(verts2[1].x - @x, 2) + Math.pow(verts2[1].y - @y, 2)
+    d2 = Math.pow(verts2[2].x - @x, 2) + Math.pow(verts2[2].y - @y, 2)
+    idx2 = if d0 < d1 then (if d1 < d2 then 2 else 1) else (if d1 < d2 then 3 else 0)
+
+    minDist = Infinity
+
+    for i in [1..2] # 2 segments per rectangle
+      a1 = verts1[(idx1 + i    ) % 4]
+      a2 = verts1[(idx1 + i + 1) % 4]
+      b1 = verts2[(idx2 + i    ) % 4]
+      b2 = verts2[(idx2 + i + 1) % 4]
+
+      for j in [1..3] # 3 points per rectangle
+        minDist = Math.min(
+          minDist,
+          distanceSquaredSegmentPoint(a1, a2, verts2[(idx2 + j) % 4])
+          distanceSquaredSegmentPoint(b1, b2, verts1[(idx1 + j) % 4])
+        )
+
+    minDist
 
   distanceToEllipse: (ellipse) ->
     Math.sqrt @distanceSquaredToEllipse ellipse
@@ -119,34 +183,85 @@ class Rectangle
       @x - @width / 2 < p.x < @x + @width / 2 and @y - @height / 2 < p.y < @y + @height / 2
 
   intersectsLineSegment: (p1, p2) ->
-    [px1, py1, px2, py2] = [p1.x, p1.y, p2.x, p2.y]
-    m1 = (py1 - py2) / (px1 - px2)
-    b1 = py1 - (m1 * px1)
-    vertices = @vertices()
-    lineSegments = [[vertices[0], vertices[1]], [vertices[1], vertices[2]], [vertices[2], vertices[3]], [vertices[3], vertices[0]]]
-    for lineSegment in lineSegments
-      [px1, py1, px2, py2] = [p1.x, p1.y, p2.x, p2.y]
-      m2 = (py1 - py2) / (px1 - px2)
-      b2 = py1 - (m * px1)
-      if m1 isnt m2
-        m = m1 - m2
-        b = b2 - b1
-        x = b / m
-        [littleX, bigX] = if px1 < px2 then [px1, px2] else [px2, px1]
-        if x >= littleX and x <= bigX
-          y = (m1 * x) + b1
-          [littleY, bigY] = if py1 < py2 then [py1, py2] else [py2, py1]
-          if littleY <= solution and bigY >= solution
-            return true
-    false
+    # Optimized @intersectsRectangle(rect)
+    # where rect = Rectangle((p1.x + p2.x) / 2, (p1.y + p2.y) / 2, 0, dist(p1, p2), atan2(p2.x - p1.x, p2.y - p1.y))
+    # essentially considers the line segment a zero-width rectangle
 
-  intersectsRectangle: (rectangle) ->
-    return true if @containsPoint rectangle.getPos()
-    for thisLineSegment in @lineSegments()
-      for thatLineSegment in rectangle.lineSegments()
-        if thisLineSegment.intersectsLineSegment(thatLineSegment)
-          return true
-    false
+    Tx = (p1.x + p2.x) / 2 - @x
+    Ty = (p1.y + p2.y) / 2 - @y
+
+    Acos = Math.cos(@rotation)
+    Asin = Math.sin(@rotation)
+    Axx = -Acos
+    Axy =  Asin
+    Ayx =  Asin
+    Ayy =  Acos
+
+    # B rotation = atan2(p2.x - p1.x, p2.y - p1.y)
+    # when r = sqrt(x*x + y*y)
+    #   cos(atan2(y, x)) == x / r
+    #   sin(atan2(y, x)) == y / r
+
+    dx = p2.x - p1.x
+    dy = p2.y - p1.y
+    r = dx * dx + dy * dy
+
+    Bcos = dy / r
+    Bsin = dx / r
+    Bxx = -Bcos
+    Bxy =  Bsin
+    Byx =  Bsin
+    Byy =  Bcos
+
+    Aw = @width  / 2
+    Ah = @height / 2
+    Bh = r / 2
+
+    not (
+      Math.abs(Tx * Axx + Ty * Axy) > Aw + Math.abs((Byx * Bh) * Axx + (Byy * Bh) * Axy) or
+      Math.abs(Tx * Ayx + Ty * Ayy) > Ah + Math.abs((Byx * Bh) * Ayx + (Byy * Bh) * Ayy) or
+      Math.abs(Tx * Bxx + Ty * Bxy) > Math.abs((Axx * Aw) * Bxx + (Axy * Aw) * Bxy) + Math.abs((Ayx * Ah) * Bxx + (Ayy * Ah) * Bxy) or
+      Math.abs(Tx * Byx + Ty * Byy) > Math.abs((Axx * Aw) * Byx + (Axy * Aw) * Byy) + Math.abs((Ayx * Ah) * Byx + (Ayy * Ah) * Byy) + Bh
+    )
+
+  intersectsRectangle: (rect) ->
+    # "intersects" includes the case when one rectangle is entirely inside another
+
+    # Rectangle-specific form of SAT
+    # https://www.jkh.me/files/tutorials/Separating%20Axis%20Theorem%20for%20Oriented%20Bounding%20Boxes.pdf
+
+    Tx = rect.x - @x
+    Ty = rect.y - @y
+
+    # Ax = [-1, 0].rotate -@rotation
+    # Ay = [ 0, 1].rotate -@rotation
+    Acos = Math.cos(@rotation)
+    Asin = Math.sin(@rotation)
+    Axx = -Acos
+    Axy =  Asin
+    Ayx =  Asin
+    Ayy =  Acos
+
+    # Bx = [-1, 0].rotate -rect.rotation
+    # By = [ 0, 1].rotate -rect.rotation
+    Bcos = Math.cos(rect.rotation)
+    Bsin = Math.sin(rect.rotation)
+    Bxx = -Bcos
+    Bxy =  Bsin
+    Byx =  Bsin
+    Byy =  Bcos
+
+    Aw = @width  / 2
+    Ah = @height / 2
+    Bw = rect.width  / 2
+    Bh = rect.height / 2
+
+    not (
+      Math.abs(Tx * Axx + Ty * Axy) > Aw + Math.abs((Bxx * Bw) * Axx + (Bxy * Bw) * Axy) + Math.abs((Byx * Bh) * Axx + (Byy * Bh) * Axy) or
+      Math.abs(Tx * Ayx + Ty * Ayy) > Ah + Math.abs((Bxx * Bw) * Ayx + (Bxy * Bw) * Ayy) + Math.abs((Byx * Bh) * Ayx + (Byy * Bh) * Ayy) or
+      Math.abs(Tx * Bxx + Ty * Bxy) > Math.abs((Axx * Aw) * Bxx + (Axy * Aw) * Bxy) + Math.abs((Ayx * Ah) * Bxx + (Ayy * Ah) * Bxy) + Bw or
+      Math.abs(Tx * Byx + Ty * Byy) > Math.abs((Axx * Aw) * Byx + (Axy * Aw) * Byy) + Math.abs((Ayx * Ah) * Byx + (Ayy * Ah) * Byy) + Bh
+    )
 
   intersectsEllipse: (ellipse) ->
     return true if @containsPoint ellipse.getPos()
@@ -193,5 +308,49 @@ class Rectangle
 
   serializeForAether: -> @serialize()
   @deserializeFromAether: (o) -> @deserialize o
+
+  @fromVertices: (vertices) ->
+    # Create a rectangle from a list of vertices. Inverse of @vertices()
+    [a, b, c, d] = vertices
+
+    p1 = new Vector (a.x + d.x) / 2, (a.y + d.y) / 2
+    p2 = new Vector (b.x + c.x) / 2, (b.y + c.y) / 2
+
+    new Rectangle(
+      (p1.x + p2.x) / 2,
+      (p1.y + p2.y) / 2,
+      p1.distance(a) * 2,
+      p1.distance(p2),
+      Math.atan2(p2.x - p1.x, p2.y - p1.y)
+    )
+
+  @equals: (a, b) ->
+    # Tests if two rectangles' x, y, width, heigth, and rotation are exactly equal
+    a.x == b.x and a.y == b.y and a.width == b.width and a.height == b.height and a.rotation == b.rotation
+
+  @equalsByVertices: (a, b) ->
+    # Tests if a.vertices() and b.vertices() are exactly equal (same order, same x and y values)
+    v1 = a.vertices()
+    v2 = b.vertices()
+    v1.every((v, i) -> v.x == v2[i].x && v.y == v2[i].y)
+
+  @approxEquals: (a, b, epsilon=1e-13) ->
+    # Tests if the difference between two rectangles' x, y, width, heigth, and rotation are all within epsilon
+    Math.abs(a.x        - b.x       ) < epsilon and
+    Math.abs(a.y        - b.y       ) < epsilon and
+    Math.abs(a.width    - b.width   ) < epsilon and
+    Math.abs(a.height   - b.height  ) < epsilon and
+    Math.abs(a.rotation - b.rotation) < epsilon
+
+  @approxEqualsByVertices: (a, b, epsilon=1e-13) ->
+    # Tests if every vertex in a.vertices() and b.vertices() are within epsilon x-wise and y-wise
+    # Requires vertices to be in the same order
+    v1 = a.vertices()
+    v2 = b.vertices()
+
+    v1.every((v, i) ->
+      Math.abs(v.x - v2[i].x) < epsilon and
+      Math.abs(v.y - v2[i].y) < epsilon
+    )
 
 module.exports = Rectangle

--- a/test/app/lib/world/rectangle.spec.coffee
+++ b/test/app/lib/world/rectangle.spec.coffee
@@ -3,14 +3,28 @@ describe 'Rectangle', ->
   Vector = require 'lib/world/vector'
   Ellipse = require 'lib/world/ellipse'
 
+  it 'creates a rectangle from vertices', ->
+    rects = [
+      new Rectangle 0, 0, 10, 10, 0
+      new Rectangle 0, 0, 10, 10, 2
+      new Rectangle 20, 10, 1, 100, 3.2
+    ]
+
+    for rect in rects
+      expect(Rectangle.approxEqualsByVertices rect, Rectangle.fromVertices(rect.vertices())).toBe true
+
   it 'contains its own center', ->
-    rect = new Rectangle 0, 0, 10, 10
+    rect = new Rectangle 0, 0, 10, 10, 0
     expect(rect.containsPoint(new Vector 0, 0)).toBe true
 
   it 'contains a point when rotated', ->
     rect = new Rectangle 0, -20, 40, 40, 3 * Math.PI / 4
     p = new Vector 0, 2
     expect(rect.containsPoint(p, true)).toBe true
+
+    # https://www.desmos.com/calculator/po8ifjklfs
+    rect = Rectangle.fromVertices [new Vector(13.516, -25.286), new Vector(-1.728, 6.305), new Vector(77.682, 44.622), new Vector(92.926, 13.031)]
+    expect(rect.containsPoint new Vector(8.650, 0.499)).toBe true
 
   it 'correctly calculates distance to a faraway point', ->
     rect = new Rectangle 100, 50, 20, 40
@@ -37,9 +51,7 @@ describe 'Rectangle', ->
 
   it 'correctly calculates distance to contained point', ->
     rect = new Rectangle -100, -200, 1, 100
-    rect2 = rect.copy()
     p = new Vector -100.25, -160
-    p2 = p.copy()
     expect(rect.distanceToPoint(p)).toBe 0
     rect.rotation = 0.00000001 * Math.PI
     expect(rect.distanceToPoint(p)).toBe 0
@@ -50,6 +62,11 @@ describe 'Rectangle', ->
     expect(new Rectangle(0, 0, 3, 3, 0).distanceToRectangle(new Rectangle(0, 0, 2.5, 2.5, Math.PI / 4))).toBe 0
     expect(new Rectangle(0, 0, 4, 4, 0).distanceToRectangle(new Rectangle(4, 2, 2, 2, 0))).toBe 1
     expect(new Rectangle(0, 0, 4, 4, 0).distanceToRectangle(new Rectangle(4, 2, 2, 2, Math.PI / 4))).toBeCloseTo 2 - Math.SQRT2
+
+    # https://www.desmos.com/calculator/po8ifjklfs
+    rect1 = Rectangle.fromVertices [new Vector(89.936, 100.355), new Vector(105.842, 88.077), new Vector(54.581, 21.670), new Vector(38.675, 33.948)]
+    rect2 = Rectangle.fromVertices [new Vector(116.029, 61.108), new Vector(87.422, 9.247), new Vector(68.955, 19.433), new Vector(97.563, 71.294)]
+    expect(rect1.distanceToRectangle rect2).toBeCloseTo 3.701777957811988
 
   it 'has predictable vertices', ->
     rect = new Rectangle 50, 50, 100, 100
@@ -100,9 +117,28 @@ describe 'Rectangle', ->
     expect(rect.intersectsShape new Rectangle(3, 1, 2, 2, Math.PI / 4)).toBe true
     expect(rect.intersectsShape new Rectangle(1, 2, 2 * Math.SQRT2, 2 * Math.SQRT2, Math.PI / 4)).toBe true
 
+    # https://www.desmos.com/calculator/po8ifjklfs
+    rect1 = Rectangle.fromVertices [new Vector(89.936, 100.355), new Vector(105.842, 88.077), new Vector(54.581, 21.670), new Vector(38.675, 33.948)]
+    rect2 = Rectangle.fromVertices [new Vector(116.029, 61.108), new Vector(87.422, 9.247), new Vector(68.955, 19.433), new Vector(97.563, 71.294)]
+    expect(rect1.intersectsShape rect2).toBe false
+
   it 'calculates ellipse intersections properly', ->
     rect = new Rectangle 1, 1, 2, 2, 0
     expect(rect.intersectsShape new Ellipse(1, 1, Math.SQRT1_2, Math.SQRT1_2, Math.PI / 4)).toBe true
     expect(rect.intersectsShape new Ellipse(4, 1, 2, 2, 0)).toBe false
     expect(rect.intersectsShape new Ellipse(3, 4, 2, 2, 0)).toBe false
     expect(rect.intersectsShape new Ellipse(1, 4, 2 * Math.SQRT1_2, 2 * Math.SQRT1_2, Math.PI / 4)).toBe false
+
+  it 'calculates line segment intersections properly', ->
+    rect = new Rectangle 1, 1, 2, 2, 0
+    expect(rect.intersectsLineSegment new Vector(2.1, -1), new Vector(2.1, 3)).toBe false
+
+    # https://www.desmos.com/calculator/po8ifjklfs
+    rect1 = Rectangle.fromVertices [new Vector(-26.780, -25.019), new Vector(-32.317, 71.140), new Vector(39.084, 75.251), new Vector(44.621, -20.907)]
+    rect2 = Rectangle.fromVertices [new Vector(13.516, -25.286), new Vector(-1.728, 6.305), new Vector(77.682, 44.622), new Vector(92.926, 13.031)]
+
+    p1 = new Vector 8.650, 0.499
+    p2 = new Vector 0.284, 8.543
+
+    expect(rect1.intersectsLineSegment p1, p2).toBe true
+    expect(rect2.intersectsLineSegment p1, p2).toBe true


### PR DESCRIPTION
This PR rewrites parts of the Rectangle class for correctness and speed. It also adds 5 utility static methods to `Rectangle`, of which only some are used during testing. The relevant cases that the old methods failed have been added to the test suite.

Some brief benchmarking suggests significant performance improvement: ~10x in `intersectsRectangles`, ~5x in `distanceSquaredRect` and `boundingBox`, and optimizations in other methods. `intersectsLineSegment` is ~4x faster and no longer always returns false.

Performance comes from using new algorithms and reducing the creation of temporary Vectors, especially in smaller methods like `distanceToPoint`.

Note: `add` and `subtract` reference an undefined attribute `@pos`, are they used anywhere?