### PR TITLE
Example: Unified nav update to base.jade pages

### DIFF
--- a/app/styles/common/site-chrome.sass
+++ b/app/styles/common/site-chrome.sass
@@ -15,7 +15,7 @@
   margin: 0 auto
 
   @media screen and ( max-height: 800px )
-    padding-top: 50px
+    padding-top: 70px
 
   //- Nav
   

--- a/app/templates/base.jade
+++ b/app/templates/base.jade
@@ -1,5 +1,7 @@
 block header
-  #site-nav
+  //- Add 'legacy' class to support some old hacky workarounds for adding site-chrome
+  //- without breaking new pages.
+  #main-nav.legacy
     block site_nav
       a(href="/")
         img#nav-logo(src="/images/pages/base/logo.png", title="CodeCombat - Learn how to code by playing a game", alt="CodeCombat")

--- a/app/views/core/RootView.coffee
+++ b/app/views/core/RootView.coffee
@@ -139,7 +139,7 @@ module.exports = class RootView extends CocoView
     @initializeNavigation()
 
   afterRender: ->
-    if @$el.find('#site-nav').length # hack...
+    if @$el.find('#main-nav.legacy').length # hack...
       @$el.addClass('site-chrome')
       if @showBackground
         @$el.addClass('show-background')


### PR DESCRIPTION
## Context

Shows how we might be able to attach the new unified nav across the pages that use the `base.jade` template.

We apply some classes programmatically so `.legacy` class is used to keep that hack working, without impacting newer pages.

This PR makes no attempt to clean up the previous nav bar in base.jade. However I would recommend deleting the styles and markup for the previous nav if we want to move ahead with this.

Some local page examples:

![Screen Shot 2021-04-20 at 5 27 35 PM](https://user-images.githubusercontent.com/15080861/115479747-ed99a780-a1fd-11eb-9ca1-a842ac5219d4.png)

![Screen Shot 2021-04-20 at 5 29 58 PM](https://user-images.githubusercontent.com/15080861/115479794-0d30d000-a1fe-11eb-9fd8-7b9247c791dc.png)
