### PR TITLE
Updated rben-installer path to match actual

### DIFF
--- a/development/docker/Dockerfile
+++ b/development/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get install -y git curl libssl-dev libreadline-dev zlib1g-dev autoconf bison \
                        build-essential libyaml-dev libncurses5-dev \
                        libffi-dev libgdbm-dev && \
-    curl -sL https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-installer | bash -
+    curl -sL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-installer | bash -
 
 RUN rbenv install ${RUBY_VERSION} && \
     rbenv global ${RUBY_VERSION}


### PR DESCRIPTION
Current project on github doesn't have a "master" branch.  It appears this is now called main.

https://raw.githubusercontent.com/rbenv/rbenv-installer/main/bin/rbenv-installer