### PR TITLE
Don't show irrelevant UI elements to partners on teacher dashboard.

### DIFF
--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -590,14 +590,16 @@ module.exports = class User extends CocoModel
   useSocialSignOn: -> not ((features?.chinaUx ? false) or (features?.china ? false))
   isTarena: -> features?.Tarena ? false
   useTarenaLogo: -> @isTarena()
-  hideTopRightNav: -> @isTarena()
-  hideFooter: -> @isTarena()
+  hideTopRightNav: -> @isTarena() or @isILK()
+  hideFooter: -> @isTarena() or @isILK()
+  hideOtherProductCTAs: -> @isTarena() or @isILK()
   useGoogleClassroom: -> not (features?.chinaUx ? false) and me.get('gplusID')?   # if signed in using google SSO
   useGoogleAnalytics: -> not ((features?.china ? false) or (features?.chinaInfra ? false))
   # features.china is set globally for our China server
   showChinaVideo: -> (features?.china ? false) or (features?.chinaInfra ? false)
   canAccessCampaignFreelyFromChina: (campaignID) -> campaignID == "55b29efd1cd6abe8ce07db0d" # teacher can only access CS1 freely in China
   isCreatedByTarena: -> @get('clientCreator') == "5c80a2a0d78b69002448f545"   #ClientID of Tarena2 on koudashijie.com
+  isILK: -> @get('clientCreator') is '6082ec9996895d00a9b96e90'
   showForumLink: -> not (features?.china ? false)
   showChinaResourceInfo: -> features?.china ? false
   useChinaHomeView: -> features?.china ? false

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -90,6 +90,16 @@ _.extend UserSchema.properties,
     }
   }
   clientCreator: c.objectId({description: 'Client which created this user'})
+  clientPermissions:
+    description: 'More APIClients with permissions on this user, apart from clientCreator.'
+    type: 'array'
+    items:
+      type: 'object'
+      additionalProperties: false
+      properties:
+        client: {type: c.objectId({description: 'APIClient with permissions on this user'})}
+        access: {type: 'string', 'enum': ['read', 'grant', 'write', 'owner']}  # 'grant' permissions allow APIClients to grant licenses to a user
+    format: 'hidden'
 
   wizardColor1: c.pct({title: 'Wizard Clothes Color'})  # No longer used
   volume: c.pct({title: 'Volume'})

--- a/app/templates/base-flat.jade
+++ b/app/templates/base-flat.jade
@@ -39,8 +39,8 @@
         p If this is showing, you dun goofed
 
   block footer
-    if !me.hideFooter()
-      #footer.small
+    #footer.small
+      if !me.hideFooter()
         .container
           .row
             if me.showChinaResourceInfo()
@@ -157,15 +157,15 @@
                         a(href="https://www.facebook.com/codecombat", target="_blank")
                           img(src="/images/pages/base/facebook_logo_btn.png", width="40")
 
-      #final-footer(dir="ltr")
-        img(src="/images/pages/base/logo.png" alt="CodeCombat")
-        .float-right
-          if me.showChinaResourceInfo()
-            - var {COCO_CHINA_CONST} = require('core/constants')
-            span.contact= "商务合作："+COCO_CHINA_CONST.CONTACT_EMAIL
-            span.contact= "业务咨询："+COCO_CHINA_CONST.CONTACT_PHONE
-          span(data-i18n="nav.copyright_prefix")
-          span= ' ©2021 CodeCombat Inc. '
-          span.spl(data-i18n="nav.copyright_suffix")
-          a.small(href="/legal") Terms of Service
-          a.small(href="/privacy") Privacy
+        #final-footer(dir="ltr")
+          img(src="/images/pages/base/logo.png" alt="CodeCombat")
+          .float-right
+            if me.showChinaResourceInfo()
+              - var {COCO_CHINA_CONST} = require('core/constants')
+              span.contact= "商务合作："+COCO_CHINA_CONST.CONTACT_EMAIL
+              span.contact= "业务咨询："+COCO_CHINA_CONST.CONTACT_PHONE
+            span(data-i18n="nav.copyright_prefix")
+            span= ' ©2021 CodeCombat Inc. '
+            span.spl(data-i18n="nav.copyright_suffix")
+            a.small(href="/legal") Terms of Service
+            a.small(href="/privacy") Privacy

--- a/app/templates/courses/teacher-classes-view.jade
+++ b/app/templates/courses/teacher-classes-view.jade
@@ -57,7 +57,8 @@ block content
             else if view.howManyOfficeHours == 'some' && limited
               a.see-all-office-hours.btn.btn-primary.btn-small.pull-right(data-i18n="general.more") More
 
-    .banner-webinar
+    if !me.hideOtherProductCTAs()
+      .banner-webinar
 
     .container
       +teacher-quests
@@ -93,9 +94,9 @@ block content
 
 
     +createClassButton
-    .container.try-ozaria
-      a(data-i18n="teacher.try_ozaria_footer")
-
+    if !me.hideOtherProductCTAs()
+      .container.try-ozaria
+        a(data-i18n="teacher.try_ozaria_footer")
 
   - var archivedClassrooms = view.classrooms.where({archived: true});
   if _.size(archivedClassrooms)

--- a/app/views/courses/TeacherClassesView.coffee
+++ b/app/views/courses/TeacherClassesView.coffee
@@ -238,12 +238,12 @@ module.exports = class TeacherClassesView extends RootView
     @calculateQuestCompletion()
 
     showOzariaEncouragementModal = window.localStorage.getItem('showOzariaEncouragementModal')
-    if showOzariaEncouragementModal
+    if showOzariaEncouragementModal and not me.hideOtherProductCTAs()
       window.localStorage.removeItem('showOzariaEncouragementModal')
 
     if showOzariaEncouragementModal
       @openOzariaEncouragementModal()
-    else if me.isTeacher() and not @classrooms.length
+    else if me.isTeacher() and not @classrooms.length and not me.isSchoolAdmin()
       @openNewClassroomModal()
 
     super()


### PR DESCRIPTION
Also, add schema update for extra APIClient permissions (for example, to be able to grant licenses to users).

Not the prettiest when hiding some of these elements, but perhaps an ok start.

Before, for teacher who would have dashboard iframed into another site:
<img width="1555" alt="Screen Shot 2021-06-13 at 17 13 08" src="https://user-images.githubusercontent.com/99704/121826089-d493fc80-cc6a-11eb-8347-55f2b2592cba.png">

After:
<img width="1555" alt="Screen Shot 2021-06-13 at 17 13 32" src="https://user-images.githubusercontent.com/99704/121826096-dbbb0a80-cc6a-11eb-875d-0c1314d3ea4b.png">
