### PR TITLE
Shift pet position

### DIFF
--- a/app/styles/play/menu/inventory-modal.sass
+++ b/app/styles/play/menu/inventory-modal.sass
@@ -644,7 +644,9 @@ $itemSlotGridHeight: 51px
         left: -16px
 
     &.pet
-      z-index: 20
+      z-index: 18
+      left: 15%
+      bottom: 5%
 
 body[lang='ja'], body[lang^='zh'], body[lang='ca'], body[lang^='es'], body[lang^='pt'], body[lang='ro'], body[lang='fi'], body[lang='sv'], body[lang='uk'], body[lang='vi'], body[lang='cz']
   #inventory-modal #unequipped .item button


### PR DESCRIPTION
Shifts pet positions so the pet does not appear to be right in front of the hero