### PR TITLE
reduce app.js bundle size

### DIFF
--- a/app/templates/vue-base/base-empty.pug
+++ b/app/templates/vue-base/base-empty.pug
@@ -1,0 +1,1 @@
+extends ../base-empty.pug

--- a/app/templates/vue-base/base-flat.jade
+++ b/app/templates/vue-base/base-flat.jade
@@ -1,0 +1,1 @@
+extends ../base-flat.jade

--- a/app/views/core/VueComponentView.js
+++ b/app/views/core/VueComponentView.js
@@ -13,7 +13,7 @@ module.exports = class VueComponentView extends RootView {
     const baseTemplate = options.baseTemplate || 'base-flat'  //base template, by default using base-flat
     this.id = 'vue-component-view'
     try {
-      this.template = require('templates/'+ baseTemplate)
+      this.template = require('templates/vue-base/'+ baseTemplate)
     }
     catch (err) {
       console.error("Error in importing the base template.", err)

--- a/compile-static-templates.coffee
+++ b/compile-static-templates.coffee
@@ -126,10 +126,10 @@ WebpackStaticStuff.prototype.apply = (compiler) ->
   # Watch the static template files for changes
   compiler.plugin 'after-emit', (compilation, callback) =>
     files = fs.readdirSync(path.resolve('./app/templates/static'))
-    compilationFileDependencies = new Set(compilation.fileDependencies)
+    compilationFileDependencies = compilation.fileDependencies
     _.forEach(files, (filename) =>
       absoluteFilePath = path.join(path.resolve('./app/templates/static/'), filename)
       unless compilationFileDependencies.has(absoluteFilePath)
-        compilation.fileDependencies.push(absoluteFilePath)
+        compilation.fileDependencies.add(absoluteFilePath)
     )
     callback()


### PR DESCRIPTION
- separate vue-base templates to a folder so that all templates are not included in app.js

reduces the size from 1MB to 700kB