### PR TITLE
replace starter licenses with student and homeschool licenses

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -3333,6 +3333,8 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     year_1: 'Yearly'
     most_popular: 'Most Popular'
     best_value: 'Best Value'
+    purchase_licenses: 'Purchase Licenses easily to get full access to CodeCombat and Ozaria'
+    homeschooling: 'Homeschooling Licenses'
 
     recurring:
       month_1: 'Recurring billing every month'

--- a/app/templates/courses/enrollments-view.jade
+++ b/app/templates/courses/enrollments-view.jade
@@ -39,7 +39,7 @@ block content
             | Please convert your account to ensure you retain access to your classrooms.
           a.btn.btn-primary.btn-lg(href="/teachers/update-account") Upgrade to teacher account
 
-    if view.state.get('shouldUpsell')
+    if view.state.get('shouldUpsell') || view.state.get('shouldUpsellParent')
       .bg-forest
         .container(dir="auto")
           .row
@@ -47,12 +47,19 @@ block content
               b
                 span.text-uppercase(data-i18n="special_offer.special_offer")
                 =': '
-                span(data-i18n="special_offer.student_starter_license")
+                if view.state.get('shouldUpsellParent')
+                  span(data-i18n="payments.homeschooling")
+                else
+                  span(data-i18n="payments.student_licenses")
               .small-details
-                i(data-i18n="special_offer.purchase_starter_licenses_to_grant", data-i18n-options=JSON.stringify(view.i18nData()))
+                i(data-i18n="payments.purchase_licenses")
             .col-xs-3
-              a.btn.btn-lg.btn-forest-alt.m-t-2.m-b-2(href="/teachers/starter-licenses")
-                b(data-i18n="general.learn_more")
+              if view.state.get('shouldUpsellParent')
+                a.btn.btn-lg.btn-forest-alt.m-t-2.m-b-2(href="/payments/homeschool-coco", target="_blank")
+                  b(data-i18n="general.learn_more")
+              else
+                a.btn.btn-lg.btn-forest-alt.m-t-2.m-b-2(href="/payments/student-licenses-small-classroom-coco", target="_blank")
+                  b(data-i18n="general.learn_more")
 
     .container.m-t-5(dir="auto")
       h3(data-i18n='teacher.enrollments')

--- a/app/templates/teachers/teachers-contact-modal.jade
+++ b/app/templates/teachers/teachers-contact-modal.jade
@@ -28,6 +28,10 @@ block modal-body-content
       label.control-label(for="form-licensesNeeded" data-i18n="teachers.licenses_needed")
       +formErrors(errors.licensesNeeded)
       input.form-control(id="form-licensesNeeded", name="licensesNeeded", type="number", value=values.licensesNeeded || 0, tabindex=1, disabled=sending || sent)
+      if view.state.get('showParentsUpsell')
+        p You can purchase licenses directly #[a(href="/payments/homeschool-coco" target='_blank') here]
+      else if view.state.get('showUpsell')
+        p You can purchase licenses directly #[a(href="/payments/student-licenses-small-classroom-coco" target='_blank') here]
 
     .form-group(class=errors.message ? 'has-error' : '')
       label.control-label(for="form-message" data-i18n="general.message")

--- a/app/views/courses/EnrollmentsView.coffee
+++ b/app/views/courses/EnrollmentsView.coffee
@@ -189,7 +189,13 @@ module.exports = class EnrollmentsView extends RootView
       not me.get('administratedTeachers')?.length
     )
 
-    @state.set({ shouldUpsell })
+    shouldUpsellParent = (
+      me.get('role') is 'parent' and
+      me.get('country') not in ['australia', 'taiwan', 'hong-kong', 'netherlands', 'indonesia', 'singapore', 'malaysia'] and
+      !skipUpsellDueToExistingLicenses
+    )
+
+    @state.set({ shouldUpsell, shouldUpsellParent })
 
     if shouldUpsell and not @upsellTracked
       @upsellTracked = true

--- a/app/views/courses/EnrollmentsView.coffee
+++ b/app/views/courses/EnrollmentsView.coffee
@@ -197,7 +197,7 @@ module.exports = class EnrollmentsView extends RootView
 
     @state.set({ shouldUpsell, shouldUpsellParent })
 
-    if shouldUpsell and not @upsellTracked
+    if (shouldUpsell or shouldUpsellParent) and not @upsellTracked
       @upsellTracked = true
       application.tracker?.trackEvent 'Starter License Upsell: Banner Viewed', {price: @state.get('centsPerStudent'), seats: @state.get('quantityToBuy')}
 
@@ -246,7 +246,10 @@ module.exports = class EnrollmentsView extends RootView
       }
     })
     window.tracker?.trackEvent 'Classes Licenses Contact Us', category: 'Teachers', ['Mixpanel']
-    modal = new TeachersContactModal()
+    modal = new TeachersContactModal({
+      shouldUpsell: @state.get('shouldUpsell'),
+      shouldUpsellParent: @state.get('shouldUpsellParent')
+    })
     @openModalView(modal)
     modal.on 'submit', =>
       @enrollmentRequestSent = true


### PR DESCRIPTION
## Student license banner for teachers with 1-10 students
<img width="1138" alt="Screenshot 2021-07-29 at 3 59 06 PM" src="https://user-images.githubusercontent.com/6376157/127477128-1cf7d900-585d-4adb-acf6-8561bca1b300.png">
---------

## Home school banner for parents
<img width="1196" alt="Screenshot 2021-07-29 at 3 58 59 PM" src="https://user-images.githubusercontent.com/6376157/127477263-78f5c963-58b3-48bd-8092-ae9baedb9382.png">
--------

## In contact modal if they are parents or teacher with 1-10 students selected
<img width="581" alt="Screenshot 2021-07-29 at 4 48 54 PM" src="https://user-images.githubusercontent.com/6376157/127483407-71dc3752-645a-41d6-aa65-df98c1a37ddd.png">

