### PR TITLE
Solve level editor content overwriting problem

### DIFF
--- a/app/models/Level.coffee
+++ b/app/models/Level.coffee
@@ -340,4 +340,10 @@ module.exports = class Level extends CocoModel
 
   isAssessment: -> @get('assessment')?
 
+  checkRemoteChanges: ->
+    fetch(this.url()).then (response) =>
+      response.json().then (remoteAttributes) =>
+        hasChanges = @_revertAttributes and not _.isEqual remoteAttributes, @_revertAttributes
+        @trigger 'remote-changes-checked', {hasChanges: hasChanges}
+
 _.assign(Level, LevelLib)

--- a/app/templates/editor/modal/save-version-modal.jade
+++ b/app/templates/editor/modal/save-version-modal.jade
@@ -5,6 +5,8 @@ block modal-header-content
     h3(data-i18n="common.submit_patch") Submit Patch
   else
     h3(data-i18n="versions.save_version_title") Save New Version
+  if view.showChangesWarning
+    .alert.alert-danger(data-i18n="versions.remote_changes_alert") Warning! Remote changes will be lost!
 
 block modal-body-content
   if view.hasChanges

--- a/app/views/editor/level/modals/SaveLevelModal.coffee
+++ b/app/views/editor/level/modals/SaveLevelModal.coffee
@@ -24,6 +24,8 @@ module.exports = class SaveLevelModal extends SaveVersionModal
     @level = options.level
     @buildTime = options.buildTime
     @commitMessage = options.commitMessage ? ""
+    @listenToOnce @level, 'remote-changes-checked', @onRemoteChangesChecked
+    @level.checkRemoteChanges()
 
   getRenderData: (context={}) ->
     context = super(context)
@@ -34,7 +36,12 @@ module.exports = class SaveLevelModal extends SaveVersionModal
     context.commitMessage = @commitMessage
     @hasChanges = (context.levelNeedsSave or context.modifiedComponents.length or context.modifiedSystems.length)
     @lastContext = context
+    context.showChangesWarning = @showChangesWarning
     context
+
+  onRemoteChangesChecked: (data) ->
+    @showChangesWarning = data.hasChanges
+    this.render();
 
   afterRender: ->
     super(false)


### PR DESCRIPTION
Warning message added to "Save Level" modal if remote changes have been made, and server version is newer than the to-be-saved version. 
![Level_Editor___CodeCombat](https://user-images.githubusercontent.com/11805970/129488840-a6076027-0237-4da9-8835-76867392a4c5.png)
