### PR TITLE
display myranks in leaderboard

### DIFF
--- a/app/views/ladder/MyMatchesTabView.coffee
+++ b/app/views/ladder/MyMatchesTabView.coffee
@@ -17,11 +17,11 @@ module.exports = class MyMatchesTabView extends CocoView
   initialize: (options, @level, @sessions) ->
     @nameMap = {}
     @previouslyRankingTeams = {}
-    @matchesLimit = 92
+    @matchesLimit = 95
     @refreshMatches 20
 
   onLoadMoreMatches: ->
-    @matchesLimit ?= 92
+    @matchesLimit ?= 95
     @matchesLimit += 100
     @refreshMatches(10)
 

--- a/app/views/ladder/components/Leaderboard.vue
+++ b/app/views/ladder/components/Leaderboard.vue
@@ -239,14 +239,12 @@
         }
       },
       classForRow (row) {
-        if (row.creator === me.id) {
+        if (row[1] === this.myRank) {
           return 'my-row'
         }
-
         if (window.location.pathname === '/league' && row.fullName) {
           return 'student-row'
         }
-
         return ''
       },
       onClickUserRow (rank) {
@@ -301,6 +299,14 @@
             td(colspan=3) ...
           template(v-else)
             td(v-for="item, index in row" :key="'' + rank + index" :colspan="tableTitles[index].col" :style="computeStyle(item, index)" :class="computeClass(tableTitles[index].slug, item)" :title="computeTitle(tableTitles[index].slug, item)" v-html="index != 0 ? computeBody(tableTitles[index].slug, item): ''" @click="onClickUserRow(rank)")
+            td.spectate-cell.iconic-cell(@click="onClickSpectateCell(rank)")
+              .glyphicon(:class="{'glyphicon-eye-open': selectedRow.indexOf(rank) != -1}")
+
+        tr(v-for="row, rank in playerRankings" :key="'player-'+rank" :class="classForRow(row)")
+          template(v-if="row.type==='BLANK_ROW'")
+            td(colspan=3) ...
+          template(v-else)
+            td(v-for="item, index in row" :key="'player-' + rank + index" :colspan="tableTitles[index].col" :style="computeStyle(item, index)" :class="computeClass(tableTitles[index].slug, item)" :title="computeTitle(tableTitles[index].slug, item)" v-html="index != 0 ? computeBody(tableTitles[index].slug, item): ''" @click="onClickUserRow(rank)")
             td.spectate-cell.iconic-cell(@click="onClickSpectateCell(rank)")
               .glyphicon(:class="{'glyphicon-eye-open': selectedRow.indexOf(rank) != -1}")
 


### PR DESCRIPTION
make a better leaderboard to see where player himself is,  here are 3 different situation example:
just in the current leaderboard, do nothing except highlight himself
![when_i_in_ranking](https://user-images.githubusercontent.com/11417632/131610015-3b88dc17-9d54-42f1-bc05-a6389f0feaf7.png)
while at the edge case we expand the leaderboard to contains himself and below 4 players
![when_i_at_edge_ranking](https://user-images.githubusercontent.com/11417632/131610020-d7ad51d1-b129-4217-988c-078479256931.png)
while out of leaderboard adding a `...` line and display 4 above and 4 below
![when_I_out_of_ranking](https://user-images.githubusercontent.com/11417632/131610022-edee2e96-c0c7-49ef-b256-d57c68797387.png)
