### PR TITLE
move coco premium purchase to stripe checkout

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -34,6 +34,8 @@ module.exports = class CocoRouter extends Backbone.Router
     '': ->
       if window.serverConfig.picoCTF
         return @routeDirectly 'play/CampaignView', ['picoctf'], {}
+      if utils.getQueryVariable 'payment-homeSubscriptions'
+        return @routeDirectly 'HomeView'
       if utils.getQueryVariable 'hour_of_code'
         delete window.alreadyLoadedView
         return @navigate "/play?hour_of_code=true", {trigger: true, replace: true}

--- a/app/core/api/payment-group.js
+++ b/app/core/api/payment-group.js
@@ -2,6 +2,9 @@ const fetchJson = require('./fetch-json');
 
 const getPaymentGroup	= slug => fetchJson(`/db/payments/payment.groups/${slug}`);
 
+const getPaymentGroupFromProduct = productId => fetchJson(`/db/payments/payment.groups/products/${productId}`)
+
 module.exports = {
-	getPaymentGroup
+	getPaymentGroup,
+	getPaymentGroupFromProduct
 }

--- a/app/lib/paymentUtils.js
+++ b/app/lib/paymentUtils.js
@@ -1,0 +1,25 @@
+import { getPaymentGroupFromProduct } from '../core/api/payment-group'
+import { handleCheckoutSession } from '../views/payment/paymentPriceHelper'
+
+async function handleHomeSubscription(product) {
+  const productId = product.get('_id')
+  const paymentGroupResp = await getPaymentGroupFromProduct(productId)
+  const paymentGroup = paymentGroupResp.data
+  const homeSubDetails = {
+    productId
+  }
+  const options = {
+    stripePriceId: paymentGroup.priceInfo.id,
+    paymentGroupId: paymentGroup._id,
+    numberOfLicenses: 1,
+    email: me.get('email'),
+    userId: me.get('_id'),
+    totalAmount: paymentGroup.priceInfo.unit_amount,
+    homeSubDetails
+  }
+  return handleCheckoutSession(options)
+}
+
+module.exports = {
+  handleHomeSubscription
+}

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -3335,6 +3335,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     great_courses: 'Great Courses included for'
     studentLicense_successful: 'Congratulations! Your licenses will be ready to use in a min. Click on the Getting Started Guide in the Resource Hub to learn how to apply them to your students.'
     onlineClasses_successful: 'Congratulations! Your payment was successful. Our team will reach out to you with the next steps.'
+    homeSubscriptions_successful: 'Congratulations! Your payment was successful. Your premium access will be available in few minutes.'
     failed: 'Your payment failed, please try again'
     session_week_1: '1 session/week'
     session_week_2: '2 sessions/week'

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -299,7 +299,7 @@ _.extend UserSchema.properties,
 
   stripe: c.object {}, {
     customerID: { type: 'string' }
-    planID: { enum: ['basic', 'price_1Hja49KaReE7xLUdlPuATOvQ'], description: 'Determines if a user has or wants to subscribe. Matches subscription plan on stripe.' }
+    planID: { type: 'string', description: 'Determines if a user has or wants to subscribe. Matches subscription plan on stripe.' }
     subscriptionID: { type: 'string', description: 'Determines if a user is subscribed' }
     token: { type: 'string' }
     couponID: { type: 'string' }

--- a/app/views/HomeView.coffee
+++ b/app/views/HomeView.coffee
@@ -174,10 +174,10 @@ module.exports = class HomeView extends RootView
         type = 'error'
       noty({ text: title, type: type, timeout: 10000, killer: true })
       @renderedPaymentNoty = true
-    else if utils.getQueryVariable('payment-onlineClasses') in ['success', 'failed'] and not @renderedPaymentNoty
-      paymentResult = utils.getQueryVariable('payment-onlineClasses')
+    else if utils.getQueryVariable('payment-homeSubscriptions') in ['success', 'failed'] and not @renderedPaymentNoty
+      paymentResult = utils.getQueryVariable('payment-homeSubscriptions')
       if paymentResult is 'success'
-        title = $.i18n.t 'payments.onlineClasses_successful'
+        title = $.i18n.t 'payments.homeSubscriptions_successful'
         type = 'success'
       else
         title = $.i18n.t 'payments.failed'

--- a/app/views/core/SubscribeModal.coffee
+++ b/app/views/core/SubscribeModal.coffee
@@ -7,6 +7,7 @@ utils = require 'core/utils'
 CreateAccountModal = require 'views/core/CreateAccountModal'
 Products = require 'collections/Products'
 payPal = require('core/services/paypal')
+paymentUtils = require '../../lib/paymentUtils'
 
 module.exports = class SubscribeModal extends ModalView
   id: 'subscribe-modal'
@@ -157,6 +158,12 @@ module.exports = class SubscribeModal extends ModalView
     Starts a stripe subscription based on the product passed in.
   ###
   startStripeSubscription: (product) ->
+    paymentUtils.handleHomeSubscription(product)
+      .catch (err) =>
+        console.error 'homeSubscription handle failed by new stripe', err
+        @handleStripeSubscriptionByOldFormat(product)
+
+  handleStripeSubscriptionByOldFormat: (product) ->
     application.tracker?.trackEvent 'Started subscription purchase', { service: 'stripe' }
     options = @stripeOptions {
       description: if product.get('name') is 'basic_subscription_annual' then $.i18n.t('subscribe.stripe_yearly_description') else $.i18n.t('subscribe.stripe_description')

--- a/app/views/payment/PaymentStudentLicensePurchaseComponent.vue
+++ b/app/views/payment/PaymentStudentLicensePurchaseComponent.vue
@@ -52,7 +52,7 @@
 
 <script>
 import PaymentLicenseMinMaxTextComponent from "./PaymentLicenseMinMaxTextComponent";
-import {getDisplayCurrency, getDisplayUnitPrice, handleStudentLicenseCheckoutSession} from "./paymentPriceHelper";
+import {getDisplayCurrency, getDisplayUnitPrice, handleCheckoutSession} from "./paymentPriceHelper";
 import ModalGetLicenses from "../../components/common/ModalGetLicenses";
 export default {
   name: "PaymentStudentLicenseBuyNowComponent",
@@ -130,7 +130,7 @@ export default {
         userId: me.get('_id'),
         totalAmount: this.getPriceBasedOnAmount(this.numOfLicenses),
       }
-      const { errMsg } = await handleStudentLicenseCheckoutSession(options)
+      const { errMsg } = await handleCheckoutSession(options)
       this.errMsg = errMsg
     },
     onContactUs(e) {

--- a/app/views/payment/PaymentStudentLicensePurchaseView.vue
+++ b/app/views/payment/PaymentStudentLicensePurchaseView.vue
@@ -36,7 +36,7 @@
 </template>
 
 <script>
-import { handleStudentLicenseCheckoutSession } from './paymentPriceHelper'
+import { handleCheckoutSession } from './paymentPriceHelper'
 
 export default {
   name: "PaymentStudentLicensePurchaseView",
@@ -94,7 +94,7 @@ export default {
         userId: me.get('_id'),
         totalAmount: this.totalPrice
       }
-      const { errMsg } = await handleStudentLicenseCheckoutSession(sessionOptions)
+      const { errMsg } = await handleCheckoutSession(sessionOptions)
       this.errMsg = errMsg
     }
   },

--- a/app/views/payment/paymentPriceHelper.js
+++ b/app/views/payment/paymentPriceHelper.js
@@ -9,7 +9,7 @@ function getDisplayCurrency(currency) {
   return currency === 'usd' ? '$' : currency;
 }
 
-async function handleStudentLicenseCheckoutSession(options) {
+async function handleCheckoutSession(options) {
   const stripe = await getStripeLib()
   const sessionOptions = { ...options }
   try {
@@ -33,5 +33,5 @@ async function handleStudentLicenseCheckoutSession(options) {
 module.exports = {
   getDisplayUnitPrice,
   getDisplayCurrency,
-  handleStudentLicenseCheckoutSession,
+  handleCheckoutSession,
 };


### PR DESCRIPTION
there is a fallback to the old payment way if new stripe checkout fails

On click of Buy Now is Subscribe Modal, we redirect users to stripe checkout
