### PR TITLE
Level Forking should reset all tasks

### DIFF
--- a/app/views/editor/ForkModal.coffee
+++ b/app/views/editor/ForkModal.coffee
@@ -32,6 +32,8 @@ module.exports = class ForkModal extends ModalView
     newModel.unset 'i18nCoverage'
     newModel.set 'commitMessage', "Forked from #{@model.get('name')}"
     newModel.set 'name', @$el.find('#fork-model-name').val()
+    newModel.set 'tasks', newModel.get('tasks').map (task)=>
+      {name: task.name, complete:false}
     if @model.schema().properties.permissions
       newModel.set 'permissions', [access: 'owner', target: me.id]
     newPathPrefix = "editor/#{@editorPath}/"


### PR DESCRIPTION
### Brief description of the bug
When you fork a level all task statuses are copied.

### Modifications
Set the `complete` property of each task to `false` before creating the forked level.

### Test
1) Create a new level and mark some of its task completed.
2) Fork a new level from it.
3) None of the new level's tasks should be completed.