### PR TITLE
add ace-diff to coco

### DIFF
--- a/app/styles/common/ace-diff.sass
+++ b/app/styles/common/ace-diff.sass
@@ -1,15 +1,18 @@
 $connectorBackground: #d8f2ff
+$connectorBackgroundRight: #d8f2ff
 $connectorBorder: #a2d7f2
 $gutterBackground: #efefef
 $copyArrowsColor: #000
 $mergeRightColor: #c98100
 $mergeLeftColor: #004ea0
+$charDiffBackground: rgba(0, 92, 175, 0.4)
+$charDiffBackgroundRight: rgba(0, 92, 175, 0.4)
 
 .acediff
   &__wrap
     display: flex
     flex-direction: row
-    position: absolute
+    position: relative
 
     // these 3 lines are to prevents an unsightly scrolling bounce affect on Safari
     height: 100%
@@ -27,7 +30,6 @@ $mergeLeftColor: #004ea0
       background-color: $gutterBackground
 
   &__left, &__right
-    height: 100%
     flex: 1
 
   // The line that's rendered in ACE editor under diffed lines
@@ -42,6 +44,22 @@ $mergeLeftColor: #004ea0
       border-top: 1px solid $connectorBorder
       border-bottom: 0px
       position: absolute
+    &.right
+      background-color: $connectorBackgroundRight
+
+  &__diffChar
+    background-color: $charDiffBackground
+    border-top: 1px solid $connectorBorder
+    border-bottom: 1px solid $connectorBorder
+    position: absolute
+    z-index: 5
+    &.targetOnly
+      height: 0px !important
+      border-top: 1px solid $connectorBorder
+      border-bottom: 0px
+      position: absolute
+    &.right
+      background-color: $charDiffBackgroundRight
 
   // SVG connector
   &__connector

--- a/app/styles/common/ace-diff.sass
+++ b/app/styles/common/ace-diff.sass
@@ -1,0 +1,73 @@
+$connectorBackground: #d8f2ff
+$connectorBorder: #a2d7f2
+$gutterBackground: #efefef
+$copyArrowsColor: #000
+$mergeRightColor: #c98100
+$mergeLeftColor: #004ea0
+
+.acediff
+  &__wrap
+    display: flex
+    flex-direction: row
+    position: absolute
+
+    // these 3 lines are to prevents an unsightly scrolling bounce affect on Safari
+    height: 100%
+    width: 100%
+    overflow: auto
+
+  &__gutter
+    flex: 0 0 60px
+    border-left: 1px solid darken($gutterBackground, 20)
+    border-right: 1px solid darken($gutterBackground, 20)
+    background-color: $gutterBackground
+    overflow: hidden
+
+    svg
+      background-color: $gutterBackground
+
+  &__left, &__right
+    height: 100%
+    flex: 1
+
+  // The line that's rendered in ACE editor under diffed lines
+  &__diffLine
+    background-color: $connectorBackground
+    border-top: 1px solid $connectorBorder
+    border-bottom: 1px solid $connectorBorder
+    position: absolute
+    z-index: 4
+    &.targetOnly
+      height: 0px !important
+      border-top: 1px solid $connectorBorder
+      border-bottom: 0px
+      position: absolute
+
+  // SVG connector
+  &__connector
+    fill: $connectorBackground
+    stroke: $connectorBorder
+
+  // Arrows for merging diffs
+  &__copy--right,
+  &__copy--left
+    position: relative
+
+    div
+      color: $copyArrowsColor
+      text-shadow: 1px 1px rgba(invert($copyArrowsColor), .7)
+      position: absolute
+      margin: 2px 3px
+      cursor: pointer
+
+  &__copy--right div:hover
+    color: $mergeLeftColor
+
+  &__copy--left
+    float: right
+
+    div
+      right: 0px
+
+      &:hover
+        color: $mergeRightColor

--- a/app/templates/teachers/teacher-student-view.jade
+++ b/app/templates/teachers/teacher-student-view.jade
@@ -331,6 +331,7 @@ mixin breadcrumbs
               td(colspan=2)
                 div(role='tabpanel')
                   .tab-content
+                    div(class="ace-diff-"+level.get('original'), style="position: relative; height: 200px")
                     //- For project level, there is no correct solution, just show the student's code
                     if level.isProject() && solutions.length === 0
                       - var target = level.get('original');
@@ -350,7 +351,7 @@ mixin breadcrumbs
                                     code(class=langClass)= code.plan
                             td.project-blurb
                               i.small(data-i18n="teacher.solution_project_blurb")
-                    each solution, index in solutions
+                    each solution, index in []
                       - var target = level.get('original') + index;
                       div.tab-pane(id=target, class=(index === 0 ? 'active' : ''), role=tabpanel, aria-labelledby="#{target}-tab")
                         table.side-by-side

--- a/app/templates/teachers/teacher-student-view.jade
+++ b/app/templates/teachers/teacher-student-view.jade
@@ -331,8 +331,8 @@ mixin breadcrumbs
               td(colspan=2)
                 div(role='tabpanel')
                   .tab-content
-                    div(class="ace-diff-"+level.get('original'), style="position: relative; height: 200px")
-                    //- For project level, there is no correct solution, just show the student's code
+                    div(class="ace-diff-"+level.get('original'), style="position: relative")
+                    //- For  project level, there is no correct solution, just show the student's code
                     if level.isProject() && solutions.length === 0
                       - var target = level.get('original');
                       div.tab-pane(id=target, class='active', role=tabpanel, aria-labelledby="#{target}-tab")

--- a/app/templates/teachers/teacher-student-view.jade
+++ b/app/templates/teachers/teacher-student-view.jade
@@ -306,27 +306,45 @@ mixin breadcrumbs
                     span(data-i18n="play_level.level")
                     span )
             - var solutions = view.levelSolutionsMap[level.get('original')] || [];
-            if solutions.length > 1
+            if solutions.length > 1 || level.isLadder()
               tr
                 td
+                  if level.isLadder()
+                    - var studentCodeMap = view.levelStudentCodeMap[level.get('original')] || []
+                    div(role='tabpanel')
+                      ul.nav.nav-tabs(role='tablist')
+                        each code, index in studentCodeMap
+                          li.nav-item(class=(index === 0 ? 'active' : ''))
+                            - var target = level.get('original') + '+' + code.team;
+                            a.nav-link(id="#{target}-tab", class=(index === 0 ? 'active' : ''), href="##{target}", role="tab", data-toggle="tab", aria-controls=target, aria-selected=(index === 0), data-level-slug=level.get('slug'), data-solution-index=index, data-team=code.team)
+                              if index === 0
+                                strong.text-center(data-i18n="ladder.#{code.team}")
+                              else
+                                .text-center
+                                  span(data-i18n="ladder.#{code.team}")
+                          if index == 0
+                            .tab-spacer
+                          else
+                            .tab-filler
                 td
-                  div(role='tabpanel')
-                    ul.nav.nav-tabs(role='tablist')
-                      each solution, index in solutions
-                        li.nav-item(class=(index === 0 ? 'active' : ''))
-                          - var target = level.get('original') + index;
-                          a.nav-link(id="#{target}-tab", class=(index === 0 ? 'active' : ''), href="##{target}", role="tab", data-toggle="tab", aria-controls=target, aria-selected=(index === 0), data-level-slug=level.get('slug'), data-solution-index=index)
-                            if index === 0
-                              strong.text-center(data-i18n="teacher.complete_solution")
-                            else
-                              .text-center
-                                span(data-i18n="teacher.partial_solution")
-                                =" "
-                                span= index
-                        if index < solutions.length - 1
-                          .tab-spacer
-                        else
-                          .tab-filler
+                  if solutions.length > 1
+                    div(role='tabpanel')
+                      ul.nav.nav-tabs(role='tablist')
+                        each solution, index in solutions
+                          li.nav-item(class=(index === 0 ? 'active' : ''))
+                            - var target = level.get('original') + index;
+                            a.nav-link(id="#{target}-tab", class=(index === 0 ? 'active' : ''), href="##{target}", role="tab", data-toggle="tab", aria-controls=target, aria-selected=(index === 0), data-level-slug=level.get('slug'), data-solution-index=index)
+                              if index === 0
+                                strong.text-center(data-i18n="teacher.complete_solution")
+                              else
+                                .text-center
+                                  span(data-i18n="teacher.partial_solution")
+                                  =" "
+                                  span= index
+                          if index < solutions.length - 1
+                            .tab-spacer
+                          else
+                            .tab-filler
             tr
               td(colspan=2)
                 div(role='tabpanel')

--- a/app/templates/teachers/teacher-student-view.jade
+++ b/app/templates/teachers/teacher-student-view.jade
@@ -322,7 +322,7 @@ mixin breadcrumbs
                               else
                                 .text-center
                                   span(data-i18n="ladder.#{code.team}")
-                          if index == 0
+                          if index < studentCodeMap.length - 1
                             .tab-spacer
                           else
                             .tab-filler

--- a/app/templates/teachers/teacher-student-view.jade
+++ b/app/templates/teachers/teacher-student-view.jade
@@ -331,7 +331,6 @@ mixin breadcrumbs
               td(colspan=2)
                 div(role='tabpanel')
                   .tab-content
-                    div(class="ace-diff-"+level.get('original'), style="position: relative")
                     //- For  project level, there is no correct solution, just show the student's code
                     if level.isProject() && solutions.length === 0
                       - var target = level.get('original');
@@ -351,36 +350,7 @@ mixin breadcrumbs
                                     code(class=langClass)= code.plan
                             td.project-blurb
                               i.small(data-i18n="teacher.solution_project_blurb")
-                    each solution, index in []
-                      - var target = level.get('original') + index;
-                      div.tab-pane(id=target, class=(index === 0 ? 'active' : ''), role=tabpanel, aria-labelledby="#{target}-tab")
-                        table.side-by-side
-                          tr
-                            td
-                            td
-                              .small!= marked(solution.description || '')
-                          tr
-                            td
-                              - var levelStudentCodes = view.levelStudentCodeMap[level.get('original')]
-                              unless levelStudentCodes.length
-                                i.small(data-i18n="teacher.no_code_yet")
-                              each code in levelStudentCodes
-                                if level.isLadder()
-                                  i.small(data-i18n="ladder."+code.team)
-                                if view.levelProgressMap[level.get('original')] === 'complete'
-                                  pre
-                                    code(class=langClass)= code.plan
-                                else
-                                  pre.incomplete-code
-                                    code(class=langClass)= code.plan
-                            td
-                              if solutions.length === 1
-                                pre
-                                  code(class=langClass)= solution.source
-                              else if solutions.length > 0
-                                  pre
-                                    code(class=langClass)= solution.source
-                              else
-                                i.small(data-i18n="common.coming_soon")
+                    div(class="ace-diff-"+level.get('original'), style="position: relative")
+
         if !courseStarted
           p(data-i18n="teacher.course_not_started")

--- a/app/views/teachers/TeacherStudentView.coffee
+++ b/app/views/teachers/TeacherStudentView.coffee
@@ -13,6 +13,8 @@ CourseInstances = require 'collections/CourseInstances'
 require 'd3/d3.js'
 utils = require 'core/utils'
 aceUtils = require 'core/aceUtils'
+AceDiff = require 'ace-diff'
+require('app/styles/common/ace-diff.sass')
 fullPageTemplate = require 'templates/teachers/teacher-student-view-full'
 viewTemplate = require 'templates/teachers/teacher-student-view'
 
@@ -123,9 +125,32 @@ module.exports = class TeacherStudentView extends RootView
     @$el.find('pre:has(code[class*="lang-"])').each ->
       codeElem = $(@).first().children().first()
       lang = mode for mode of aceUtils.aceEditModes when codeElem?.hasClass('lang-' + mode)
-      aceEditor = aceUtils.initializeACE(@, lang or classLang)
-      aceEditor.renderer.setShowGutter true
-      aceEditors.push aceEditor
+      # aceEditor = aceUtils.initializeACE(@, lang or classLang)
+      # aceEditor.renderer.setShowGutter true
+      # aceEditors.push aceEditor
+
+    view = @
+    @$el.find('div[class*="ace-diff-"]').each ->
+      cls = $(@).attr('class')
+      levelOriginal = cls.split('-')[2]
+      solutions = view.levelSolutionsMap[levelOriginal]
+      studentCode = view.levelStudentCodeMap[levelOriginal]
+      differ = new AceDiff({
+        # ace: window.ace
+        element: '.' + cls
+        mode: 'ace/mode/' +classLang
+        theme: 'ace/theme/textmate'
+        left: {
+          content: studentCode[0].plan
+          editable: false
+          copyLinkEnabled: false
+        }
+        right: {
+          content: solutions[0].source
+          editable: false
+          copyLinkEnabled: false
+        }
+      })
 
   updateSolutions: ->
     return unless @classroom?.loaded and @sessions?.loaded and @levels?.loaded

--- a/app/views/teachers/TeacherStudentView.coffee
+++ b/app/views/teachers/TeacherStudentView.coffee
@@ -32,11 +32,19 @@ module.exports = class TeacherStudentView extends RootView
   
   onClickSolutionTab: (e) ->
     link = $(e.target).closest('a')
-    levelOriginal = link.attr('id').split('-')[0].slice(0, -1)
     levelSlug = link.data('level-slug')
+    idTarget = link.attr('id').split('-')[0]
     solutionIndex = link.data('solution-index')
-    solutions = @levelSolutionsMap[levelOriginal]
-    @aceDiffs?[levelOriginal].editors.right.ace.setValue(solutions[solutionIndex].source, -1)
+    if /\+/.test(idTarget)
+      classLang = @classroom.get('aceConfig')?.language or 'python'
+      levelOriginal = idTarget.split('+')[0]
+      codes = @levelStudentCodeMap[levelOriginal]
+      code = @levels.fingerprint(codes[solutionIndex].plan, classLang)
+      @aceDiffs?[levelOriginal].editors.left.ace.setValue(code, -1)
+    else
+      levelOriginal = link.attr('id').split('-')[0].slice(0, -1)
+      solutions = @levelSolutionsMap[levelOriginal]
+      @aceDiffs?[levelOriginal].editors.right.ace.setValue(solutions[solutionIndex].source, -1)
     tracker.trackEvent('Click Teacher Student Solution Tab', {levelSlug, solutionIndex})
 
   initialize: (options, classroomID, @studentID) ->
@@ -128,9 +136,6 @@ module.exports = class TeacherStudentView extends RootView
     @$el.find('pre:has(code[class*="lang-"])').each ->
       codeElem = $(@).first().children().first()
       lang = mode for mode of aceUtils.aceEditModes when codeElem?.hasClass('lang-' + mode)
-      # aceEditor = aceUtils.initializeACE(@, lang or classLang)
-      # aceEditor.renderer.setShowGutter true
-      # aceEditors.push aceEditor
 
     view = @
     @aceDiffs = {}
@@ -144,12 +149,12 @@ module.exports = class TeacherStudentView extends RootView
         mode: 'ace/mode/' +classLang
         theme: 'ace/theme/textmate'
         left: {
-          content: view.levels.fingerprint(studentCode[0].plan, classLang)
+          content: view.levels.fingerprint(studentCode?[0]?.plan ? '', classLang)
           editable: false
           copyLinkEnabled: false
         }
         right: {
-          content: solutions[0].source
+          content: solutions?[0]?.source ? ''
           editable: false
           copyLinkEnabled: false
         }

--- a/app/views/teachers/TeacherStudentView.coffee
+++ b/app/views/teachers/TeacherStudentView.coffee
@@ -35,11 +35,13 @@ module.exports = class TeacherStudentView extends RootView
     levelSlug = link.data('level-slug')
     idTarget = link.attr('id').split('-')[0]
     solutionIndex = link.data('solution-index')
+    lang = @classroom.get('aceConfig').language ? 'python'
+    if [utils.courseIDs.WEB_DEVELOPMENT_1, utils.courseIDs.WEB_DEVELOPMENT_2].indexOf(@selectedCourseId) != -1
+      lang = 'html'
     if /\+/.test(idTarget)
-      classLang = @classroom.get('aceConfig')?.language or 'python'
       levelOriginal = idTarget.split('+')[0]
       codes = @levelStudentCodeMap[levelOriginal]
-      code = @levels.fingerprint(codes[solutionIndex].plan, classLang)
+      code = @levels.fingerprint(codes[solutionIndex].plan, lang)
       @aceDiffs?[levelOriginal].editors.left.ace.setValue(code, -1)
     else
       levelOriginal = link.attr('id').split('-')[0].slice(0, -1)
@@ -144,12 +146,15 @@ module.exports = class TeacherStudentView extends RootView
       levelOriginal = cls.split('-')[2]
       solutions = view.levelSolutionsMap[levelOriginal]
       studentCode = view.levelStudentCodeMap[levelOriginal]
+      lang = classLang
+      if [utils.courseIDs.WEB_DEVELOPMENT_1, utils.courseIDs.WEB_DEVELOPMENT_2].indexOf(view.selectedCourseId) != -1
+        lang = 'html'
       view.aceDiffs[levelOriginal] = new AceDiff({
         element: '.' + cls
         mode: 'ace/mode/' +classLang
         theme: 'ace/theme/textmate'
         left: {
-          content: view.levels.fingerprint(studentCode?[0]?.plan ? '', classLang)
+          content: view.levels.fingerprint(studentCode?[0]?.plan ? '', lang)
           editable: false
           copyLinkEnabled: false
         }

--- a/app/views/teachers/TeacherStudentView.coffee
+++ b/app/views/teachers/TeacherStudentView.coffee
@@ -32,8 +32,11 @@ module.exports = class TeacherStudentView extends RootView
   
   onClickSolutionTab: (e) ->
     link = $(e.target).closest('a')
+    levelOriginal = link.attr('id').split('-')[0].slice(0, -1)
     levelSlug = link.data('level-slug')
     solutionIndex = link.data('solution-index')
+    solutions = @levelSolutionsMap[levelOriginal]
+    @aceDiffs?[levelOriginal].editors.right.ace.setValue(solutions[solutionIndex].source, -1)
     tracker.trackEvent('Click Teacher Student Solution Tab', {levelSlug, solutionIndex})
 
   initialize: (options, classroomID, @studentID) ->
@@ -130,17 +133,18 @@ module.exports = class TeacherStudentView extends RootView
       # aceEditors.push aceEditor
 
     view = @
+    @aceDiffs = {}
     @$el.find('div[class*="ace-diff-"]').each ->
       cls = $(@).attr('class')
       levelOriginal = cls.split('-')[2]
       solutions = view.levelSolutionsMap[levelOriginal]
       studentCode = view.levelStudentCodeMap[levelOriginal]
-      differ = new AceDiff({
+      view.aceDiffs[levelOriginal] = new AceDiff({
         element: '.' + cls
         mode: 'ace/mode/' +classLang
         theme: 'ace/theme/textmate'
         left: {
-          content: studentCode[0].plan
+          content: view.levels.fingerprint(studentCode[0].plan, classLang)
           editable: false
           copyLinkEnabled: false
         }

--- a/app/views/teachers/TeacherStudentView.coffee
+++ b/app/views/teachers/TeacherStudentView.coffee
@@ -63,7 +63,7 @@ module.exports = class TeacherStudentView extends RootView
 
     # TODO: fetch only necessary thang data (i.e. levels with student progress, via separate API instead of complicated data.project values)
     @levels = new Levels()
-    @supermodel.trackRequest(@levels.fetchForClassroom(classroomID, {data: {project: 'name,original,i18n,primerLanguage,thangs.id,thangs.components.config.programmableMethods.plan.solutions,thangs.components.config.programmableMethods.plan.context'}}))
+    @supermodel.trackRequest(@levels.fetchForClassroom(classroomID, {data: {project: 'name,original,i18n,primerLanguage,thangs.id,thangs.components.config.programmableMethods.plan.solutions,thangs.components.config.programmableMethods.plan.context,thangs.components.config.programmableMethods.plan.i18n'}}))
     @urls = require('core/urls')
 
     # wrap templates so they translate when called
@@ -136,7 +136,6 @@ module.exports = class TeacherStudentView extends RootView
       solutions = view.levelSolutionsMap[levelOriginal]
       studentCode = view.levelStudentCodeMap[levelOriginal]
       differ = new AceDiff({
-        # ace: window.ace
         element: '.' + cls
         mode: 'ace/mode/' +classLang
         theme: 'ace/theme/textmate'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1934,6 +1934,13 @@
         "negotiator": "0.6.1"
       }
     },
+    "ace-diff": {
+      "version": "github:smallst/ace-diff#f3dc60aadf74b67ecf891c6f717d5de237806b70",
+      "from": "github:smallst/ace-diff",
+      "requires": {
+        "diff-match-patch": "^1.0.5"
+      }
+    },
     "acorn": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
@@ -4689,6 +4696,11 @@
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
       "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
       "dev": true
+    },
+    "diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
     },
     "diffie-hellman": {
       "version": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@stripe/stripe-js": "^1.14.0",
     "@vimeo/player": "^2.9.1",
     "acorn-loose": "^8.0.1",
+    "ace-diff": "^3.0.3",
     "adobe-animate-parser": "github:codecombat/adobe-animate-parser#master",
     "ajv": "^6.10.0",
     "algoliasearch": "^3.13.1",

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
   "dependencies": {
     "@stripe/stripe-js": "^1.14.0",
     "@vimeo/player": "^2.9.1",
+    "ace-diff": "github:smallst/ace-diff",
     "acorn-loose": "^8.0.1",
-    "ace-diff": "^3.0.3",
     "adobe-animate-parser": "github:codecombat/adobe-animate-parser#master",
     "ajv": "^6.10.0",
     "algoliasearch": "^3.13.1",
@@ -144,9 +144,9 @@
     "vue-moment": "^4.0.0",
     "vue-router": "^3.0.2",
     "vue-youtube": "^1.3.5",
+    "vuelidate": "^0.7.5",
     "vuex": "^2.4.0",
-    "vuex-router-sync": "^5.0.0",
-    "vuelidate": "^0.7.5"
+    "vuex-router-sync": "^5.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
Currently supported:
1. add ace-diff with basic usage in teacher-student-view.

Better to support:
1. localize the solution so don't have the comment be diff [ -x ]
2. ignore the stat.completed=true playerCode. [ ]
3. set the ace-diff div fit the height of player codes or solution codes [x]
4. support multiple solutions like before [ ]
5. maybe more views ? [ ]
6. fix the testing. [ ]



![image](https://user-images.githubusercontent.com/11417632/146697973-b2994170-0093-4081-96d5-ff374935b8f7.png)
