### PR TITLE
Allow to prevent camera tracking of the Hero

### DIFF
--- a/app/lib/surface/Surface.coffee
+++ b/app/lib/surface/Surface.coffee
@@ -95,7 +95,7 @@ module.exports = Surface = class Surface extends CocoClass
     @options = _.clone(@defaults)
     @options = _.extend(@options, givenOptions) if givenOptions
     @handleEvents = @options.handleEvents ? true
-    @zoomToHero = @options.levelType isnt "game-dev" # In game-dev levels the hero is gameReferee
+    @zoomToHero = if @world.preventZoomToHero then false else @options.levelType isnt "game-dev" # In game-dev levels the hero is gameReferee
     @gameUIState = @options.gameUIState or new GameUIState({
       canDragCamera: true
     })


### PR DESCRIPTION
For some levels we need better control on the camera and using Scripts for interactive stories. This way we won't break existing levels as the added property is `preventZoomToHero` is opposite to Surface.zoomToHero.