### PR TITLE
Treema autocomplete z-indexed behind ModelModal

### DIFF
--- a/app/styles/bootstrap/_variables.scss
+++ b/app/styles/bootstrap/_variables.scss
@@ -228,6 +228,7 @@ $zindex-tooltip:           1030 !default;
 $zindex-navbar-fixed:      1030 !default;
 $zindex-modal-background:  1040 !default;
 $zindex-modal:             1050 !default;
+$zindex-autocomplete:      1060 !default;
 
 // Media queries breakpoints
 // --------------------------------------------------

--- a/app/styles/common/common.sass
+++ b/app/styles/common/common.sass
@@ -105,8 +105,8 @@ iframe
 table.table
   background-color: white
 
-//.ui-autocomplete
-//  z-index: $zindexAutocomplete
+.ui-autocomplete.ui-front
+  z-index: $zindex-autocomplete
   
 .ui-slider
   border: 1px solid black


### PR DESCRIPTION
I don't understand why, but the `z-index` was removed from autocomplete by this commit:
https://github.com/codecombat/codecombat/commit/cd33376#diff-06bfc89545a034a8ee956a922c5aedfc071c159cf0978fdfafd505150fe27eadL217-R231

Now it is back, and the autocomplete is visible:
![Admin___CodeCombat](https://user-images.githubusercontent.com/11805970/148120694-d3467011-c825-4845-a491-10f6bb41f38e.png)

