### PR TITLE
Bug: on ipad, the home version map can not move by finger

### DIFF
--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -770,6 +770,10 @@ $gameControlMargin: 30px
     align-items: center
     justify-content: center
     overflow: hidden
+    @media (hover: none)
+      overflow: scroll
+      @media (orientation: landscape)
+        align-items: initial
 
     .portals
       $campaignWidth: 317px
@@ -779,6 +783,8 @@ $gameControlMargin: 30px
       flex-wrap: nowrap
       display: flex
       overflow: hidden
+      @media (hover: none)
+        overflow: scroll
 
       .campaign
         width: $campaignWidth

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -603,6 +603,11 @@ module.exports = class CampaignView extends RootView
 
   afterRender: ->
     super()
+    if $.isTouchCapable() and screen.availHeight < screen.availWidth
+      # scroll to vertical center on landscape touchscreens
+      $('.portal').animate({
+        scrollTop: ( $(".portals").height() - $(".portal").height() ) / 2
+      }, 100);
     @onWindowResize()
 
     $('#anon-classroom-signup-code').keydown (event) ->


### PR DESCRIPTION
The home version map made scrollable on touchscreens.
Pls check screen recording gif:

![map](https://user-images.githubusercontent.com/11805970/153285741-8a6f057a-3337-4fcd-a181-a5c9881208ef.gif)

