### PR TITLE
fix google-analytics tracking not working

### DIFF
--- a/app/core/Tracker2/index.js
+++ b/app/core/Tracker2/index.js
@@ -30,7 +30,7 @@ export default class Tracker2 extends BaseTracker {
     this.cookieConsentTracker = new CookieConsentTracker(this.store)
     this.internalTracker = new InternalTracker(this.store)
     this.segmentTracker = new SegmentTracker(this.store)
-    this.googleAnalyticsTracker = new GoogleAnalyticsTracker()
+    this.googleAnalyticsTracker = new GoogleAnalyticsTracker(this.store)
     this.driftTracker = new DriftTracker(this.store)
     this.fullStoryTracker = new FullStoryTracker(this.store, this)
     this.googleOptimizeTracker = new GoogleOptimizeTracker()
@@ -131,10 +131,15 @@ export default class Tracker2 extends BaseTracker {
   async trackEvent (action, properties = {}) {
     try {
       await this.initializationComplete
-
-      await allSettled(
+      const result = await allSettled(
         this.trackers.map(t => t.trackEvent(action, properties))
       )
+      if (Array.isArray(result)) {
+        result.forEach((r) => {
+          if (r.status === 'rejected')
+            console.error('trackEvent failed', r)
+        })
+      }
     } catch (e) {
       this.log('trackEvent call failed', e)
     }


### PR DESCRIPTION
store wasn't passed to google-tracker causing it to fail since .isAdmin check failed and thus promise got rejected

why wasn't this caught in console logs?
allSettled returns array of results with reject/success state where we can see result of promise. We weren't iterating over it thus ignoring the error