### PR TITLE
Added sayLabelOptions groundLayer:boolean to put texts on the game layer

### DIFF
--- a/app/lib/surface/Lank.coffee
+++ b/app/lib/surface/Lank.coffee
@@ -658,7 +658,8 @@ module.exports = Lank = class Lank extends CocoClass
       d.updatePosition()
 
   addLabel: (name, style, labelOptions={}) ->
-    @labels[name] ?= new Label sprite: @, camera: @options.camera, layer: @options.textLayer, style: style, labelOptions: labelOptions
+    layer = if labelOptions.groundLayer then @options.groundLayer else @options.textLayer
+    @labels[name] ?= new Label sprite: @, camera: @options.camera, layer: layer, style: style, labelOptions: labelOptions
     @labels[name]
 
   addMark: (name, layer, thangType=null) ->


### PR DESCRIPTION
Sometime we need to put texts on the game field that doesn't scaling on the camera zoom.

![image](https://user-images.githubusercontent.com/343120/154430322-44bd6e2f-c48a-4d9f-93a4-1f9e589cc052.png)
