### PR TITLE
add ageBracket for leaderboard-my-row

### DIFF
--- a/app/views/ladder/LadderTabView.coffee
+++ b/app/views/ladder/LadderTabView.coffee
@@ -439,6 +439,9 @@ module.exports.LeaderboardData = LeaderboardData = class LeaderboardData extends
     above = @playersAbove.models
     l = l.concat(above)
     l.reverse()
+    if @session?.get('creatorAge') and !(@session?.get('ageBracket'))
+      # add ageBracket for @session
+      @session.set('ageBracket', utils.ageToBracket(@session.get('creatorAge')))
     l.push @session
     l = l.concat(@playersBelow.models)
     if @myRank is 'unknown'


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11417632/156523861-a2e070da-692e-431b-94be-aa94934c3795.png)

issue: our `my-row` doesn't contains a `ageBracket` so always show "open". 
this pr to fix this issue