### PR TITLE
Start M7 beta content experiment

### DIFF
--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -672,8 +672,14 @@ module.exports = class User extends CocoModel
     true
 
   getM7ExperimentValue: ->
-    value = {true: 'beta', false: 'control'}[utils.getQueryVariable 'beta']
-    value ?= me.getExperimentValue('m7', null, 'beta')
+    value = {true: 'beta', false: 'control', control: 'control', beta: 'beta'}[utils.getQueryVariable 'm7']
+    value ?= me.getExperimentValue('m7', null, 'control')
+    if value is 'beta' and (new Date() - _.find(me.get('experiments') ? [], name: 'm7')?.startDate) > 1 * 24 * 60 * 60 * 1000
+      # Experiment only lasts one day so that users don't get stuck in it
+      value = 'control'
+    if not value? and me.get('stats')?.gamesCompleted
+      # Don't include players who have already started playing
+      value = 'control'
     if not value? and new Date(me.get('dateCreated')) < new Date('2022-03-14')
       # Don't include users created before experiment start date
       value = 'control'

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -671,6 +671,35 @@ module.exports = class User extends CocoModel
     return false unless @get('emails')?.generalNews?.enabled
     true
 
+  getM7ExperimentValue: ->
+    value = {true: 'beta', false: 'control'}[utils.getQueryVariable 'beta']
+    value ?= me.getExperimentValue('m7', null, 'beta')
+    if not value? and new Date(me.get('dateCreated')) < new Date('2022-03-14')
+      # Don't include users created before experiment start date
+      value = 'control'
+    if not value? and not /^en/.test me.get('preferredLanguage', true)
+      # Don't include non-English-speaking users before beta levels are translated
+      value = 'control'
+    if not value? and me.get('hourOfCode')
+      # Don't include users coming in through Hour of Code
+      value = 'control'
+    if not value? and not me.get('anonymous')
+      # Don't include registered users
+      value = 'control'
+    if not value? and features?.china
+      # Don't include China players
+      value = 'control'
+    if not value?
+      probability = window.serverConfig?.experimentProbabilities?.m7?.beta ? 0
+      if me.get('testGroupNumber') / 256 < probability
+        value = 'beta'
+        valueProbability = probability
+      else
+        value = 'control'
+        valueProbability = 1 - probability
+      me.startExperiment('m7', value, probability)
+    value
+
   # Feature Flags
   # Abstract raw settings away from specific UX changes
   allowStudentHeroPurchase: -> features?.classroomItems ? false and @isStudent()

--- a/app/schemas/models/campaign.schema.coffee
+++ b/app/schemas/models/campaign.schema.coffee
@@ -125,6 +125,7 @@ CampaignSchema.denormalizedLevelProperties = [
   'primerLanguage'
   'shareable'
   'adminOnly'
+  'releasePhase'
   'disableSpaces'
   'hidesSubmitUntilRun'
   'hidesPlayButton'

--- a/app/schemas/models/level.coffee
+++ b/app/schemas/models/level.coffee
@@ -406,6 +406,7 @@ _.extend LevelSchema.properties,
   # Admin flags
   adventurer: { type: 'boolean' }
   adminOnly: { type: 'boolean' }
+  releasePhase: { enum: ['beta', 'internalRelease', 'released'], title: 'Release status', description: "Release status of the level, determining who sees it.", default: 'internalRelease' }
   disableSpaces: { type: ['boolean','integer'] }
   hidesSubmitUntilRun: { type: 'boolean' }
   hidesPlayButton: { type: 'boolean' }

--- a/app/schemas/models/mandate.schema.coffee
+++ b/app/schemas/models/mandate.schema.coffee
@@ -38,6 +38,7 @@ module.exports = MandateSchema = {
           properties:
             min: {type: 'number', minimum: 1, exclusiveMinimum: true, format: 'seconds'}
             max: {type: 'number', minimum: 5, exclusiveMinimum: true, format: 'seconds'}
+    latestAnnouncement: c.int()
     currentTournament:
       c.array {description: 'The arrays of the current active tournament, if any.'},
       c.object {},
@@ -47,6 +48,13 @@ module.exports = MandateSchema = {
         endAt: 'integer',
         name: 'string'
     tournamentOnlyLevels: c.array { description: 'levels only accessible during tournament with specific course instance id'}, 'string'
+    experimentProbabilities:
+      type: 'object'
+      description: 'Mapping of experiment names to experimental values and their probabilities, like `{m7: {control: 0.75, experiment: 0.25}}`'
+      additionalProperties:
+        type: 'object'
+        description: 'Mapping of experimental values to their probabilities, like `{control: 0.75, experiment: 0.25}`'
+        additionalProperties: c.pct {description: 'Probability of being assigned to this experiment value'}
 }
 
 c.extendBasicProperties MandateSchema, 'Mandate'

--- a/app/templates/admin.pug
+++ b/app/templates/admin.pug
@@ -57,6 +57,8 @@ block content
         a(href="/admin/trial-requests") Trial Requests
       li
         a(href="/admin/user-code-problems") User Code Problems
+      li
+        a.edit-mandate(href="#mandate") Edit Mandate
 
     h4 Analytics
     ul

--- a/app/views/admin/MainAdminView.coffee
+++ b/app/views/admin/MainAdminView.coffee
@@ -4,6 +4,7 @@ errors = require 'core/errors'
 RootView = require 'views/core/RootView'
 template = require 'app/templates/admin'
 AdministerUserModal = require 'views/admin/AdministerUserModal'
+ModelModal = require 'views/modal/ModelModal'
 forms = require 'core/forms'
 utils = require 'core/utils'
 
@@ -17,6 +18,7 @@ InteractiveSessions = require 'collections/InteractiveSessions'
 Prepaid = require 'models/Prepaid'
 User = require 'models/User'
 Users = require 'collections/Users'
+Mandate = require 'models/Mandate'
 window.saveAs ?= require 'file-saver/FileSaver.js' # `window.` is necessary for spec to spy on it
 window.saveAs = window.saveAs.saveAs if window.saveAs.saveAs  # Module format changed with webpack?
 
@@ -38,6 +40,7 @@ module.exports = class MainAdminView extends RootView
     'click #terminal-activation-create': 'onClickTerminalActivationLink'
     'click .classroom-progress-csv': 'onClickExportProgress'
     'click #clear-feature-mode-btn': 'onClickClearFeatureModeButton'
+    'click .edit-mandate': 'onClickEditMandate'
 
   getTitle: -> return $.i18n.t('account_settings.admin')
 
@@ -382,3 +385,14 @@ module.exports = class MainAdminView extends RootView
       $('.classroom-progress-csv').prop('disabled', false)
       console.error error
       throw error
+
+  onClickEditMandate: (e) ->
+    @mandate ?= @supermodel.loadModel(new Mandate()).model
+    if @mandate.loaded
+      @editMandate @mandate
+    else
+      @listenTo @mandate, 'sync', @editMandate
+
+  editMandate: (mandate) =>
+    mandate = new Mandate _id: mandate.get('0')._id  # Work around weirdness in this actually being a singleton
+    @openModalView? new ModelModal models: [mandate]

--- a/app/views/editor/campaign/CampaignEditorView.coffee
+++ b/app/views/editor/campaign/CampaignEditorView.coffee
@@ -385,6 +385,9 @@ class LevelNode extends TreemaObjectNode
       el = 'span'
     else if data.adventurer
       status += " (adventurer)"
+    else if data.releasePhase is 'beta'
+      status += " (beta)"
+      el = 'span'
 
     completion = ''
 

--- a/app/views/editor/level/settings/SettingsTabView.coffee
+++ b/app/views/editor/level/settings/SettingsTabView.coffee
@@ -17,7 +17,7 @@ module.exports = class SettingsTabView extends CocoView
   # not thangs or scripts or the backend stuff
   editableSettings: [
     'name', 'description', 'documentation', 'nextLevel', 'victory', 'i18n', 'goals', 'clans',
-    'type', 'kind', 'terrain', 'banner', 'loadingTip', 'requiresSubscription', 'adventurer', 'adminOnly',
+    'type', 'kind', 'terrain', 'banner', 'loadingTip', 'requiresSubscription', 'adventurer', 'adminOnly', 'releasePhase',
     'helpVideos', 'replayable', 'scoreTypes', 'concepts', 'primaryConcepts', 'picoCTFProblem', 'practice', 'assessment',
     'practiceThresholdMinutes', 'primerLanguage', 'shareable', 'studentPlayInstructions', 'requiredCode', 'suspectCode',
     'requiredGear', 'restrictedGear', 'requiredProperties', 'restrictedProperties', 'recommendedHealth', 'allowedHeroes',

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -795,10 +795,10 @@ module.exports = class CampaignView extends RootView
             # This beta level is not unlocked yet
             level.locked = level.hidden = true
             level.color = 'rgb(193, 193, 193)'
+          ++betaLevelIndex
+          ++betaLevelCompletedIndex if @levelStatusMap[level.slug] is 'complete'
         else
           level.hidden = level.locked = level.disabled = true
-        ++betaLevelIndex
-        ++betaLevelCompletedIndex if @levelStatusMap[level.slug] is 'complete'
     if betaLevelIndex and betaLevelCompletedIndex < betaLevelIndex
       # Lock all non-beta levels until beta levels are completed
       for level, levelIndex in orderedLevels when level.releasePhase isnt 'beta' and not level.locked

--- a/app/views/play/level/tome/SpellPaletteView.coffee
+++ b/app/views/play/level/tome/SpellPaletteView.coffee
@@ -267,6 +267,9 @@ module.exports = class SpellPaletteView extends CocoView
               for prop in _.sortBy(props) when prop[0] isnt '_' and not itemsByProp[prop]  # no private properties
                 continue if prop is 'moveXY' and @options.level.get('slug') is 'slalom'  # Hide for Slalom
                 continue if @thang.excludedProperties and prop in @thang.excludedProperties
+                # Temporary: switching up method documentation for M7 levels
+                continue if @options.level.get('releasePhase') is 'beta' and (prop in ['moveUp', 'moveRight', 'moveDown', 'moveLeft'])
+                continue if @options.level.get('releasePhase') isnt 'beta' and (prop in ['moveTo', 'use'])
                 propsByItem[item.get('name')] ?= []
                 propsByItem[item.get('name')].push owner: owner, prop: prop, item: item
                 itemsByProp[prop] = item
@@ -295,6 +298,9 @@ module.exports = class SpellPaletteView extends CocoView
         continue if prop is 'say' and @options.level.get 'hidesSay'  # Hide for Dungeon Campaign
         continue if prop is 'moveXY' and @options.level.get('slug') is 'slalom'  # Hide for Slalom
         continue if @thang.excludedProperties and prop in @thang.excludedProperties
+        # Temporary: switching up method documentation for M7 levels
+        continue if @options.level.get('releasePhase') is 'beta' and (prop in ['moveUp', 'moveRight', 'moveDown', 'moveLeft'])
+        continue if @options.level.get('releasePhase') isnt 'beta' and (prop in ['moveTo', 'use'])
         propsByItem['Hero'] ?= []
         propsByItem['Hero'].push owner: owner, prop: prop, item: itemThangTypes[@thang.spriteName]
         ++propCount


### PR DESCRIPTION
This allows us to insert new beta levels into a campaign with the `releasePhase: "beta"` property set and have them hidden for some players, while locking normal levels until those beta levels have been completed.

Code changes:
* Make Mandate editable
* Use it to control experiment probabilities
* Have the m7 `"control"` vs. `"beta"` experiment value affect whether players see beta levels
* Make some adjustments for m7 method docs in beta levels
* Support denormalizing `releasePhase` onto Level models

To test: go to /play/dungeon?m7=true vs. /play/dungeon?m7=false (or just /play/dungeon). If m7 is not enabled, Dungeons of Kithgard will show up as the first level. If it is enabled, the beta level series should show up (currently three levels starting with temporarily-named "Into the Journey"), and on completion, Dungeons of Kithgard will show up.
<img width="1126" alt="Screen Shot 2022-03-13 at 12 09 14" src="https://user-images.githubusercontent.com/99704/158075195-1ee5b0b4-3dd8-4ac6-ab78-75d3182187bb.png">