### PR TITLE
Don't dim talking thangs

### DIFF
--- a/app/lib/surface/Dimmer.coffee
+++ b/app/lib/surface/Dimmer.coffee
@@ -65,7 +65,7 @@ module.exports = class Dimmer extends CocoClass
   updateDimMask: =>
     @dimMask.graphics.clear()
     for thangID, sprite of @sprites
-      continue unless (thangID in @highlightedThangIDs) or sprite.isTalking?()
+      continue unless (thangID in @highlightedThangIDs)
       sup = x: sprite.sprite.x, y: sprite.sprite.y
       cap = @camera.surfaceToCanvas sup
       r = 50 * @camera.zoom  # TODO: find better way to get the radius based on the sprite's size


### PR DESCRIPTION
Currently we highlight all "talking" thangs, it can be useful for "auto" highlighting, however I can't imagine the case for that and I'd prefer to manually control what to highlight instead of dimming what we don't need.