### PR TITLE
World.UI can control when we want to show target mark

### DIFF
--- a/app/lib/surface/LankBoss.coffee
+++ b/app/lib/surface/LankBoss.coffee
@@ -91,7 +91,8 @@ module.exports = class LankBoss extends CocoClass
     lank
 
   createMarks: ->
-    @targetMark = new Mark name: 'target', camera: @camera, layer: @layerAdapters['Ground'], thangType: 'target'
+    if @world.showTargetMark
+      @targetMark = new Mark name: 'target', camera: @camera, layer: @layerAdapters['Ground'], thangType: 'target'
     @selectionMark = new Mark name: 'selection', camera: @camera, layer: @layerAdapters['Ground'], thangType: 'selection'
 
   createLankOptions: (options) ->


### PR DESCRIPTION
For early levels we don't want to show the target mark as it ovelays with ground points. With the option in UI system showTargetMark we can disable it for certain levels. By default this option is true.