### PR TITLE
make details unclickable so that it won't cover other div

### DIFF
--- a/app/styles/courses/teacher-class-view.sass
+++ b/app/styles/courses/teacher-class-view.sass
@@ -485,6 +485,7 @@
         margin-left: -80px
         text-align: right
         z-index: 9999
+        pointer-events: none
 
       .more
         display: inline-block


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11417632/163569392-f46fce4f-71e0-40d5-bc82-b9c52d7c63c0.png)
![image](https://user-images.githubusercontent.com/11417632/163569404-53970c3a-bb52-42bd-b27a-2ed345663ad3.png)
now the details panel is 9999 z-index and cover other div and makes other div unclickable 😂 