### PR TITLE
use index to sort

### DIFF
--- a/app/lib/coursesHelper.coco.coffee
+++ b/app/lib/coursesHelper.coco.coffee
@@ -107,6 +107,7 @@ module.exports =
             courseName: utils.i18n(course.attributes, 'name')
             courseNumber: courseIndex + 1
             levelNumber
+            levelIndex
             levelName: level.get('name')
             users: users
           }

--- a/app/views/courses/TeacherClassView.coco.coffee
+++ b/app/views/courses/TeacherClassView.coco.coffee
@@ -160,7 +160,7 @@ module.exports = class TeacherClassView extends RootView
         level2 = s2.latestCompleteLevel
         return -dir if not level1
         return dir if not level2
-        return dir * (level1.courseNumber - level2.courseNumber or level1.levelNumber - level2.levelNumber)
+        return dir * (level1.courseNumber - level2.courseNumber or level1.levelIndex - level2.levelIndex)
 
       if value is 'status'
         statusMap = { expired: 0, 'not-enrolled': 1, enrolled: 2 }


### PR DESCRIPTION
Link to asana task:

# Context



# Short summary of why this is needed

we uses `a - b` to sort the levelNumber, which cause `11 - '7a'` number - string. so i think use levelIndex to sort will be better

# Short summary of how changes were done



# Are we adding any new text that does not have i18n?



# Test summary



### As a reviewer, how do I reproduce the issue?



### As a reviewer, how do I verify the fix?



## If no tests


### Is this a good candidate for [Preflight](https://app.preflight.com/tests/all)?



### What would be necessary to make this testable?



# Short summary of potential risks



# Screenshots or videos illustrating changes if relevant


