### PR TITLE
Update DiplomatView.coco.coffee: Linkfix

### DIFF
--- a/app/views/contribute/DiplomatView.coco.coffee
+++ b/app/views/contribute/DiplomatView.coco.coffee
@@ -15,7 +15,7 @@ module.exports = class DiplomatView extends ContributeClassView
       console.log "processing #{languageCode}"
       language = locale[languageCode]
       @languageStats[languageCode] = {
-        githubURL: "https://github.com/codecombat/codecombat/blob/master/app/locale/#{languageCode}.coffee"
+        githubURL: "https://github.com/codecombat/codecombat/blob/master/app/locale/#{languageCode}.coco.coffee"
         nativeDescription: language.nativeDescription
         englishDescription: language.englishDescription
         diplomats: @diplomats[languageCode] ? []


### PR DESCRIPTION
Linkfix: Added ".coco" to the path of the i18n-files at github. Apparently there is a new path required after adding  ozar. 
Link to github went to 404 when clicking on an particular file at the diplomat page https://codecombat.com/contribute/diplomat.