### PR TITLE
DT Resource Hub: Left Panel visual polish bug

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseResourceHub/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseResourceHub/index.vue
@@ -211,9 +211,6 @@
 </template>
 
 <style lang="scss" scoped>
-#base-resource-hub {
-  margin-bottom: -50px;
-}
 
 .contact-icon {
   display: flex;
@@ -269,7 +266,7 @@
 }
 
 .resource-hub {
-  padding: 40px 30px;
+  padding: 40px 30px 0;
 
   .resource-hub-section {
     /* Offset by rough header height so that we don't underscroll the header */


### PR DESCRIPTION
The left-hand panel ovarlaid on top of the footer. See fix on screenshot below: 
![Ozaria_-_Teacher_Dashboard_and_Ozaria_-_Computer_science_that_captivates_and_codecombat_–_BaseResourceHub_index_vue_and_codecombat-server_–_routes_index_coffee](https://user-images.githubusercontent.com/11805970/172371554-badde5f0-6389-4e93-bcf5-daa57bcb4234.png)

