### PR TITLE
DT: Curriculum Guide content rows shouldn't move upon hover

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleRow.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleRow.vue
@@ -79,14 +79,15 @@
     height: 100%;
 
     box-sizing: border-box;
+    border: 1px solid transparent;
 
     & > div {
       display: flex;
       flex-direction: row;
       align-items: center;
 
-      padding-top: 5px;
-      padding-bottom: 5px;
+      padding-top: 4px;
+      padding-bottom: 4px;
 
       width:100%;
       height: 100%;
@@ -100,7 +101,7 @@
   }
 
   .module-row:hover:not(.locked) {
-    border: 1px solid #74C6DF;
+    border-color: #74C6DF;
   }
 
   .part-of-intro {


### PR DESCRIPTION
Row height fixed, in order to border on hover not to change height. Pls check difference below:
Before / After
![curriculum-hover](https://user-images.githubusercontent.com/11805970/172374009-cda1342b-345b-41f9-8f79-e0b0810111ad.gif)
 