### PR TITLE
Add ?landing=true option for more focused top/bottom nav

### DIFF
--- a/app/components/common/Navigation.coco.vue
+++ b/app/components/common/Navigation.coco.vue
@@ -6,7 +6,8 @@
     OZARIA_CHINA,
     isOldBrowser,
     isCodeCombat,
-    isOzaria
+    isOzaria,
+    getQueryVariable
   } from 'core/utils'
 
   /**
@@ -55,6 +56,10 @@
         return `${document.location.protocol}//${document.location.host}`
           .replace(CODECOMBAT, OZARIA)
           .replace(CODECOMBAT_CHINA, OZARIA_CHINA)
+      },
+
+      hideNav () {
+        return getQueryVariable('landing', false)
       }
     },
 
@@ -144,7 +149,7 @@
                 img.code-ninjas-logo(src="/images/pages/base/code-ninjas-logo-right.png" alt="Code Ninjas logo")
               a.navbar-brand(v-else-if="me.showChinaResourceInfo()" href="/home")
                 img#logo-img(src="/images/pages/base/logo-en+cn.png" alt="CodeCombat logo")
-              a.navbar-brand(v-else href="/home")
+              a.navbar-brand(v-else :href="hideNav ? '#' : '/home'")
                 img#logo-img(src="/images/pages/base/logo.png" alt="CodeCombat logo")
 
             .navbar-browser-recommendation.navbar-header(v-if="isOldBrowser")
@@ -154,7 +159,7 @@
 
             #navbar-collapse.collapse.navbar-collapse
               .nav-spacer
-              ul.nav.navbar-nav(v-if="!me.hideTopRightNav()")
+              ul.nav.navbar-nav(v-if="!me.hideTopRightNav() && !hideNav")
                 template(v-if="me.showChinaResourceInfo()")
                   li
                     a.text-p(href="https://blog.koudashijie.com") {{ $t('nav.blog') }}
@@ -264,7 +269,7 @@
                     li
                       a.account-dropdown-item#logout-button {{ $t('login.log_out') }}
 
-              ul.nav.navbar-nav.text-p.login-buttons(v-if="me.isAnonymous()")
+              ul.nav.navbar-nav.text-p.login-buttons(v-if="me.isAnonymous() && !hideNav")
                 li
                   a#create-account-link.signup-button(data-event-action="Header Sign Up CTA") {{ $t('signup.sign_up') }}
                 li
@@ -412,6 +417,7 @@
   .language-dropdown {
     max-height: 60vh;
     overflow-y: auto;
+    left: -55px;
   }
 
   #navbar-collapse {

--- a/app/components/common/Navigation.ozar.vue
+++ b/app/components/common/Navigation.ozar.vue
@@ -6,7 +6,8 @@
     OZARIA_CHINA,
     isOldBrowser,
     isCodeCombat,
-    isOzaria
+    isOzaria,
+    getQueryVariable
   } from 'core/utils'
 
   /**
@@ -55,6 +56,10 @@
         return `${document.location.protocol}//${document.location.host}`
           .replace(CODECOMBAT, OZARIA)
           .replace(CODECOMBAT_CHINA, OZARIA_CHINA)
+      },
+
+      hideNav () {
+        return getQueryVariable('landing', false)
       }
     },
 
@@ -144,7 +149,7 @@
                 img.code-ninjas-logo(src="/images/pages/base/code-ninjas-logo-right.png" alt="Code Ninjas logo")
               a.navbar-brand(v-else-if="me.showChinaResourceInfo()" href="/home")
                 img#logo-img(src="/images/pages/base/logo-en+cn.png" alt="CodeCombat logo")
-              a.navbar-brand(v-else href="/home")
+              a.navbar-brand(v-else :href="hideNav ? '#' : '/home'")
                 img#logo-img(src="/images/pages/base/logo.png" alt="CodeCombat logo")
 
             .navbar-browser-recommendation.navbar-header(v-if="isOldBrowser")
@@ -154,7 +159,7 @@
 
             #navbar-collapse.collapse.navbar-collapse
               .nav-spacer
-              ul.nav.navbar-nav(v-if="!me.hideTopRightNav()")
+              ul.nav.navbar-nav(v-if="!me.hideTopRightNav() && !hideNav")
                 template(v-if="me.showChinaResourceInfo()")
                   li
                     a.text-p(href="https://blog.koudashijie.com") {{ $t('nav.blog') }}
@@ -260,7 +265,7 @@
                     li
                       a.account-dropdown-item#logout-button {{ $t('login.log_out') }}
 
-              ul.nav.navbar-nav.text-p.login-buttons(v-if="me.isAnonymous()")
+              ul.nav.navbar-nav.text-p.login-buttons(v-if="me.isAnonymous() && !hideNav")
                 li
                   a#create-account-link.signup-button(data-event-action="Header Sign Up CTA") {{ $t('signup.sign_up') }}
                 li
@@ -408,6 +413,7 @@
   .language-dropdown {
     max-height: 60vh;
     overflow-y: auto;
+    left: -55px;
   }
 
   #navbar-collapse {

--- a/app/templates/base-flat.coco.pug
+++ b/app/templates/base-flat.coco.pug
@@ -41,116 +41,117 @@
   block footer
     #footer.small
       if !me.hideFooter()
-        .container
-          .row
-            if me.showChinaResourceInfo()
-              .col-lg-12
-                .row
-                  .col-lg-3
-                    h3(data-i18n="nav.general")
-                    ul.list-unstyled
-                      li
-                        a(href="/about", data-i18n="nav.about")
-                      //li
-                      //  a(href="/about#careers", data-i18n="nav.careers")
+        if !getQueryVariable('landing', false)
+          .container
+            .row
+              if me.showChinaResourceInfo()
+                .col-lg-12
+                  .row
+                    .col-lg-3
+                      h3(data-i18n="nav.general")
+                      ul.list-unstyled
+                        li
+                          a(href="/about", data-i18n="nav.about")
+                        //li
+                        //  a(href="/about#careers", data-i18n="nav.careers")
+                        if !me.isStudent()
+                          li
+                            a(href="/contact-cn", data-i18n="nav.contact")
+                        li
+                          a(href="/parents", data-i18n="nav.parent")
+                        li
+                          a(href="http://blog.koudashijie.com/", data-i18n="nav.blog")
+                        li
+                          a(href="https://beian.miit.gov.cn/") 京ICP备19012263号
+                    .col-lg-3
                       if !me.isStudent()
-                        li
-                          a(href="/contact-cn", data-i18n="nav.contact")
-                      li
-                        a(href="/parents", data-i18n="nav.parent")
-                      li
-                        a(href="http://blog.koudashijie.com/", data-i18n="nav.blog")
-                      li
-                        a(href="https://beian.miit.gov.cn/") 京ICP备19012263号
-                  .col-lg-3
-                    if !me.isStudent()
-                      h3(data-i18n="nav.educators")
+                        h3(data-i18n="nav.educators")
+                        ul.list-unstyled
+                          li
+                            - var faqURL = "/teachers/resources/faq";
+                            - if (me.get('preferredLanguage') == 'nl-NL' || me.get('preferredLanguage') == 'nl-BE')
+                            -     faqURL = "/teachers/resources/faq-nl-NL";
+                            - if (me.get('preferredLanguage') == 'he')
+                            -     faqURL = "/teachers/resources/faq-HE";
+                            - if (me.get('preferredLanguage') == 'pt-BR' || me.get('preferredLanguage') == 'pt-PT')
+                            -     faqURL = "/teachers/resources/faq-pt-BR";
+                            - if (me.get('preferredLanguage') == 'zh-HANS' || me.get('preferredLanguage') == 'zh-HANT')
+                            -     faqURL = "/teachers/resources/faq-zh-HANS";
+                            a(href=faqURL, data-i18n="teacher.educator_faq")
+                          li
+                            a(href="/teachers/resources", data-i18n="nav.resource_hub")
+                          li
+                            a(href="https://ozaria.com", data-i18n="new_home.try_ozaria")
+                          li
+                            a(href="/teachers/classes", data-i18n="nav.my_classrooms")
+                    .col-lg-3
+                      h3 相关链接
                       ul.list-unstyled
                         li
-                          - var faqURL = "/teachers/resources/faq";
-                          - if (me.get('preferredLanguage') == 'nl-NL' || me.get('preferredLanguage') == 'nl-BE')
-                          -     faqURL = "/teachers/resources/faq-nl-NL";
-                          - if (me.get('preferredLanguage') == 'he')
-                          -     faqURL = "/teachers/resources/faq-HE";
-                          - if (me.get('preferredLanguage') == 'pt-BR' || me.get('preferredLanguage') == 'pt-PT')
-                          -     faqURL = "/teachers/resources/faq-pt-BR";
-                          - if (me.get('preferredLanguage') == 'zh-HANS' || me.get('preferredLanguage') == 'zh-HANT')
-                          -     faqURL = "/teachers/resources/faq-zh-HANS";
-                          a(href=faqURL, data-i18n="teacher.educator_faq")
+                          a(href="https://codecombat.163.com") 极客战记（个人版）
                         li
-                          a(href="/teachers/resources", data-i18n="nav.resource_hub")
+                          a(href="https://aojiarui.com") 奥佳睿 - CodeCombat原创新作
                         li
-                          a(href="https://ozaria.com", data-i18n="new_home.try_ozaria")
-                        li
-                          a(href="/teachers/classes", data-i18n="nav.my_classrooms")
-                  .col-lg-3
-                    h3 相关链接
-                    ul.list-unstyled
-                      li
-                        a(href="https://codecombat.163.com") 极客战记（个人版）
-                      li
-                        a(href="https://aojiarui.com") 奥佳睿 - CodeCombat原创新作
-                      li
-                        a(href="https://codecombat.com") CodeCombat全球官网
+                          a(href="https://codecombat.com") CodeCombat全球官网
 
-                  .col-lg-3
-                    h3(data-i18n="nav.follow_us")
-                    img.mpqr(src="https://assets.koudashijie.com/images/mpqrcode.jpeg")
-            else
-              .col-lg-12
-                .row
-                  .col-lg-3
-                    h3(data-i18n="nav.general")
-                    ul.list-unstyled
-                      li
-                        a(href="/about", data-i18n="nav.about")
-                      li
-                        - var faqURL = "https://codecombat.zendesk.com/hc/en-us"
-                        a(href=faqURL, data-i18n="contact.faq", target="_blank")
-                      li
-                        a(href="/about#careers", data-i18n="nav.careers")
-                      li
-                        a.contact-modal(tabindex=-1, data-i18n="nav.contact")
-                      li
-                        a(href="/parents", data-i18n="nav.parent")
-                      li
-                        a(href="https://blog.codecombat.com/", data-i18n="nav.blog", target="_blank")
-                  .col-lg-3
-                    if !me.isStudent()
-                      h3(data-i18n="nav.educators")
+                    .col-lg-3
+                      h3(data-i18n="nav.follow_us")
+                      img.mpqr(src="https://assets.koudashijie.com/images/mpqrcode.jpeg")
+              else
+                .col-lg-12
+                  .row
+                    .col-lg-3
+                      h3(data-i18n="nav.general")
                       ul.list-unstyled
                         li
-                          a(href="/impact", data-i18n="nav.impact")
+                          a(href="/about", data-i18n="nav.about")
                         li
-                          a(href="/teachers/resources", data-i18n="nav.resource_hub")
+                          - var faqURL = "https://codecombat.zendesk.com/hc/en-us"
+                          a(href=faqURL, data-i18n="contact.faq", target="_blank")
                         li
-                          a(href="/teachers/classes", data-i18n="nav.my_classrooms")
+                          a(href="/about#careers", data-i18n="nav.careers")
                         li
-                          a(href="https://ozaria.com", data-i18n="new_home.try_ozaria")
-                  .col-lg-3
-                    h3(data-i18n="nav.get_involved")
-                    ul.list-unstyled
-                      li
-                        a(href="https://github.com/codecombat/codecombat") GitHub
-                      li
-                        a(href='/community', data-i18n="nav.community")
-                      li
-                        a(href="/contribute", data-i18n="nav.contribute")
-                      li
-                        a(href="/league", data-i18n="game_menu.multiplayer_tab")
-                      if !me.isStudent() && me.showForumLink()
+                          a.contact-modal(tabindex=-1, data-i18n="nav.contact")
                         li
-                          a(href=view.forumLink(), data-i18n="nav.forum", target="_blank")
-                  .col-lg-3
-                    if !me.showingStaticPagesWhileLoading() && me.useSocialSignOn()
-                      h3(data-i18n="nav.follow_us")
-                      div.social-buttons
-                        a(href="https://www.youtube.com/channel/UCEl7Rs_jtl3hcbnp0xZclQA", target="_blank")
-                          img(src="/images/pages/base/youtube_symbol_button.png", width="40")
-                        a(href="https://twitter.com/codecombat", target="_blank")
-                          img(src="/images/pages/base/twitter_logo_btn.png", width="40")
-                        a(href="https://www.facebook.com/codecombat", target="_blank")
-                          img(src="/images/pages/base/facebook_logo_btn.png", width="40")
+                          a(href="/parents", data-i18n="nav.parent")
+                        li
+                          a(href="https://blog.codecombat.com/", data-i18n="nav.blog", target="_blank")
+                    .col-lg-3
+                      if !me.isStudent()
+                        h3(data-i18n="nav.educators")
+                        ul.list-unstyled
+                          li
+                            a(href="/impact", data-i18n="nav.impact")
+                          li
+                            a(href="/teachers/resources", data-i18n="nav.resource_hub")
+                          li
+                            a(href="/teachers/classes", data-i18n="nav.my_classrooms")
+                          li
+                            a(href="https://ozaria.com", data-i18n="new_home.try_ozaria")
+                    .col-lg-3
+                      h3(data-i18n="nav.get_involved")
+                      ul.list-unstyled
+                        li
+                          a(href="https://github.com/codecombat/codecombat") GitHub
+                        li
+                          a(href='/community', data-i18n="nav.community")
+                        li
+                          a(href="/contribute", data-i18n="nav.contribute")
+                        li
+                          a(href="/league", data-i18n="game_menu.multiplayer_tab")
+                        if !me.isStudent() && me.showForumLink()
+                          li
+                            a(href=view.forumLink(), data-i18n="nav.forum", target="_blank")
+                    .col-lg-3
+                      if !me.showingStaticPagesWhileLoading() && me.useSocialSignOn()
+                        h3(data-i18n="nav.follow_us")
+                        div.social-buttons
+                          a(href="https://www.youtube.com/channel/UCEl7Rs_jtl3hcbnp0xZclQA", target="_blank")
+                            img(src="/images/pages/base/youtube_symbol_button.png", width="40")
+                          a(href="https://twitter.com/codecombat", target="_blank")
+                            img(src="/images/pages/base/twitter_logo_btn.png", width="40")
+                          a(href="https://www.facebook.com/codecombat", target="_blank")
+                            img(src="/images/pages/base/facebook_logo_btn.png", width="40")
 
         #final-footer(dir="ltr")
           img(src="/images/pages/base/logo.png" alt="CodeCombat")

--- a/app/templates/base-flat.ozar.pug
+++ b/app/templates/base-flat.ozar.pug
@@ -35,52 +35,53 @@
               .col-md-12
                 .row
                   img.img-responsive.ozaria-watermark(src="/images/ozaria/layout/footer/OzariaWordmark_White_325px.png" alt="Ozaria by CodeCombat logo")
-                .row
-                  .col-md-6.col-md-offset-2.col-sm-12
-                    h2.subtitile-moon(data-i18n="nav.general")
-                    ul.list-unstyled
-                      if !me.showChinaResourceInfo()
+                if !getQueryVariable('landing', false)
+                  .row
+                    .col-md-6.col-md-offset-2.col-sm-12
+                      h2.subtitile-moon(data-i18n="nav.general")
+                      ul.list-unstyled
+                        if !me.showChinaResourceInfo()
+                          li
+                            a.contact-modal(tabindex=-1, data-i18n="nav.contact")
                         li
-                          a.contact-modal(tabindex=-1, data-i18n="nav.contact")
-                      li
-                        - var aboutURL = me.showChinaResourceInfo() ? 'https://koudashijie.com/about' : 'https://codecombat.com/about';
-                        a(href=aboutURL, data-i18n="nav.about", data-event-action="Click: Footer About")
-                      li
-                        - var faqURL = "/teachers/resources/faq";
-                        - if (me.get('preferredLanguage') == 'nl-NL' || me.get('preferredLanguage') == 'nl-BE')
-                        -     faqURL += "-nl-NL";
-                        - if (me.get('preferredLanguage') == 'he')
-                        -     faqURL += "-HE";
-                        - if (me.get('preferredLanguage') == 'pt-BR' || me.get('preferredLanguage') == 'pt-PT')
-                        -     faqURL += "-pt-BR";
-                        - if (me.get('preferredLanguage') == 'zh-HANS' || me.get('preferredLanguage') == 'zh-HANT')
-                        -     faqURL += "-zh-HANS";
-                        a(href=faqURL data-i18n="nav.faq", data-event-action="Click: Footer FAQ")
-                      li
-                        a(href="http://press.ozaria.com" data-i18n="nav.press" data-event-action="Click: Footer Press")
-                      if me.showChinaResourceInfo()
+                          - var aboutURL = me.showChinaResourceInfo() ? 'https://koudashijie.com/about' : 'https://codecombat.com/about';
+                          a(href=aboutURL, data-i18n="nav.about", data-event-action="Click: Footer About")
                         li
-                          a(href="https://ozaria.com") 奥佳睿全球官网
+                          - var faqURL = "/teachers/resources/faq";
+                          - if (me.get('preferredLanguage') == 'nl-NL' || me.get('preferredLanguage') == 'nl-BE')
+                          -     faqURL += "-nl-NL";
+                          - if (me.get('preferredLanguage') == 'he')
+                          -     faqURL += "-HE";
+                          - if (me.get('preferredLanguage') == 'pt-BR' || me.get('preferredLanguage') == 'pt-PT')
+                          -     faqURL += "-pt-BR";
+                          - if (me.get('preferredLanguage') == 'zh-HANS' || me.get('preferredLanguage') == 'zh-HANT')
+                          -     faqURL += "-zh-HANS";
+                          a(href=faqURL data-i18n="nav.faq", data-event-action="Click: Footer FAQ")
                         li
-                          a(href="https://koudashijie.com" data-i18n="nav.return_coco" data-event-action="Click: Footer Return to CodeCombat")
-                        li
-                          a(href="http://beian.miit.gov.cn/") 京ICP备19012263号-7
-                      else
-                        li
-                          a(href="https://codecombat.com" data-i18n="nav.return_coco" data-event-action="Click: Footer Return to CodeCombat")
+                          a(href="http://press.ozaria.com" data-i18n="nav.press" data-event-action="Click: Footer Press")
+                        if me.showChinaResourceInfo()
+                          li
+                            a(href="https://ozaria.com") 奥佳睿全球官网
+                          li
+                            a(href="https://koudashijie.com" data-i18n="nav.return_coco" data-event-action="Click: Footer Return to CodeCombat")
+                          li
+                            a(href="http://beian.miit.gov.cn/") 京ICP备19012263号-7
+                        else
+                          li
+                            a(href="https://codecombat.com" data-i18n="nav.return_coco" data-event-action="Click: Footer Return to CodeCombat")
 
-                  .col-md-4.col-sm-12
-                    if !me.showingStaticPagesWhileLoading() && me.useSocialSignOn()
-                      h2.subtitile-moon(data-i18n="nav.follow_us")
-                      div.social-buttons
-                        a(href="https://www.youtube.com/channel/UCU7Wh4ME_G-_C-8qrQuPNyA", target="_blank", data-event-action="Click: Footer Youtube" rel="noreferrer")
-                          img(src="/images/pages/base/youtube_symbol_button.png", width="40" alt="Youtube")
-                        a(href="https://twitter.com/playozaria", target="_blank", data-event-action="Click: Footer Twitter" rel="noreferrer")
-                          img(src="/images/pages/base/twitter_logo_btn.png", width="40" alt="Twitter")
-                        a(href="https://www.facebook.com/playozaria", target="_blank", data-event-action="Click: Footer Facebook" rel="noreferrer")
-                          img(src="/images/pages/base/facebook_logo_btn.png", width="40" alt="Facebook")
-                        a(href="https://www.instagram.com/playozaria/", target="_blank", data-event-action="Click: Footer Instagram" rel="noreferrer")
-                          img(src="/images/pages/base/instagram-logo.png", width="40" alt="Instagram")
+                    .col-md-4.col-sm-12
+                      if !me.showingStaticPagesWhileLoading() && me.useSocialSignOn()
+                        h2.subtitile-moon(data-i18n="nav.follow_us")
+                        div.social-buttons
+                          a(href="https://www.youtube.com/channel/UCU7Wh4ME_G-_C-8qrQuPNyA", target="_blank", data-event-action="Click: Footer Youtube" rel="noreferrer")
+                            img(src="/images/pages/base/youtube_symbol_button.png", width="40" alt="Youtube")
+                          a(href="https://twitter.com/playozaria", target="_blank", data-event-action="Click: Footer Twitter" rel="noreferrer")
+                            img(src="/images/pages/base/twitter_logo_btn.png", width="40" alt="Twitter")
+                          a(href="https://www.facebook.com/playozaria", target="_blank", data-event-action="Click: Footer Facebook" rel="noreferrer")
+                            img(src="/images/pages/base/facebook_logo_btn.png", width="40" alt="Facebook")
+                          a(href="https://www.instagram.com/playozaria/", target="_blank", data-event-action="Click: Footer Instagram" rel="noreferrer")
+                            img(src="/images/pages/base/instagram-logo.png", width="40" alt="Instagram")
 
       #final-footer
         if me.showChinaResourceInfo()

--- a/app/views/core/CocoView.coco.coffee
+++ b/app/views/core/CocoView.coco.coffee
@@ -209,6 +209,7 @@ module.exports = class CocoView extends Backbone.View
     context.serverConfig = window.serverConfig
     context.serverSession = window.serverSession
     context.features = window.features
+    context.getQueryVariable = utils.getQueryVariable
     context
 
   afterRender: ->

--- a/app/views/core/CocoView.ozar.coffee
+++ b/app/views/core/CocoView.ozar.coffee
@@ -208,6 +208,7 @@ module.exports = class CocoView extends Backbone.View
     context.serverConfig = window.serverConfig
     context.serverSession = window.serverSession
     context.features = window.features
+    context.getQueryVariable = utils.getQueryVariable
     context
 
   afterRender: ->

--- a/static-mock.coffee
+++ b/static-mock.coffee
@@ -49,3 +49,5 @@ exports.view =
   isMobile: () -> false
   isOldBrowser: () -> false
   isIPadBrowser: () -> false
+
+exports.getQueryVariable = -> null


### PR DESCRIPTION
Most pages with `?landing=true` in the URL (including target /parents page) will now hide extraneous header/footer nav, focusing new visitors on the product offering at hand.
<img width="2363" alt="Screen Shot 2022-06-09 at 11 36 13" src="https://user-images.githubusercontent.com/99704/172920137-6cb22b85-e9b0-46e0-8cf8-686180cbdf50.png">

Not sure if this is the cleanest way to do this kind of conditional top nav display in Vue, and base-flat footer `if` isn't very elegant.