### PR TITLE
Screen reader updates

### DIFF
--- a/app/core/store/modules/audio.js
+++ b/app/core/store/modules/audio.js
@@ -273,6 +273,11 @@ export default {
         return
       }
 
+      if (track && track === 'background' && !me.get('music', true)) {
+        // Take this opportunity to mute the background music track if we me.get('music') has been disabled
+        dispatch('muteTrack', track)
+      }
+
       // Default to playing sounds immediately upon load but allow
       // consumers to specify autoplay behavior to support scenarios
       // such as pre loading sound effects.

--- a/app/lib/AudioPlayer.coffee
+++ b/app/lib/AudioPlayer.coffee
@@ -35,7 +35,7 @@ class Media
 
 class AudioPlayer extends CocoClass
   subscriptions:
-    'audio-player:play-sound': (e) -> @playInterfaceSound e.trigger, e.volume
+    'audio-player:play-sound': (e) -> @playInterfaceSound e.trigger, e.volume, e.delay, e.pos, e.pan
 
   constructor: () ->
     super()
@@ -96,16 +96,16 @@ class AudioPlayer extends CocoClass
       filename = "/file/interface/#{name}#{@ext}"
       @preloadSound filename, name
 
-  playInterfaceSound: (name, volume=1) ->
+  playInterfaceSound: (name, volume=1, delay=0, pos=null, pan=0) ->
     return unless volume and me.get 'volume'
     filename = "/file/interface/#{name}#{@ext}"
     if @hasLoadedSound filename
-      @playSound name, volume
+      @playSound name, volume, delay, pos, pan
     else
       @preloadInterfaceSounds [name] unless filename of cache
       @soundsToPlayWhenLoaded[name] = volume
 
-  playSound: (name, volume=1, delay=0, pos=null) ->
+  playSound: (name, volume=1, delay=0, pos=null, pan=0) ->
     return console.error 'Trying to play empty sound?' unless name
     return unless volume and me.get 'volume'
     audioOptions = {volume: volume, delay: delay}
@@ -113,6 +113,7 @@ class AudioPlayer extends CocoClass
     unless @hasLoadedSound filename
       @soundsToPlayWhenLoaded[name] = audioOptions.volume
     audioOptions = @applyPanning audioOptions, pos if @camera and not @camera.destroyed and pos
+    audioOptions.pan ||= pan
     instance = createjs.Sound.play name, audioOptions
     instance
 

--- a/app/lib/surface/LankBoss.ozar.coffee
+++ b/app/lib/surface/LankBoss.ozar.coffee
@@ -177,87 +177,18 @@ module.exports = class LankBoss extends CocoClass
     @updateScreenReader()
 
   updateScreenReader: ->
-    # Testing ASCII map for screen readers
-    return unless me.get('aceConfig')?.screenReaderMode
-    #ascii = $('#ascii-surface').removeClass('hide')  # table version has better accessibility
-    asciiTable = $('#ascii-surface-table').removeClass('hide')
+    return unless me.get('aceConfig')?.screenReaderMode and utils.isOzaria
     thangs = (lank.thang for lank in @lankArray)
-    [maxWidth, maxHeight] = @world.calculateBounds()
-    width = Math.min maxWidth, Math.round(@camera.worldViewport.width)
-    height = Math.min maxHeight, Math.round(@camera.worldViewport.height)
+    bounds = @world.calculateSimpleMovementBounds()
+    width = Math.min bounds.right - bounds.left, Math.round(@camera.worldViewport.width)
+    height = Math.min bounds.top - bounds.bottom, Math.round(@camera.worldViewport.height)
+    left = Math.max bounds.left, Math.round(@camera.worldViewport.x)
+    bottom = Math.max bounds.bottom, Math.round(@camera.worldViewport.y - @camera.worldViewport.height)  # y is inverted
+    simpleMovementResolution = 10  # It's always 10 in Ozaria
     padding = 0
-    left = Math.max 0, Math.round(@camera.worldViewport.x)
-    bottom = Math.max 0, Math.round(@camera.worldViewport.y - @camera.worldViewport.height)  # y is inverted
     rogue = true
-    resolution = 10 / 2  # TODO: dynamically find from GridMovement2 System gridStep, along with bounds as gridBottomLeftPoint and gridTopRightPoint
-    grid = new Grid thangs, width, height, padding, left, bottom, rogue, resolution
-    #utils.replaceText ascii, grid.toString true
-
-    # Update table in-place for performance, handling changes in table size as needed
-    tableChars = grid.toTable true
-    tableNames = grid.toTableNames()
-    if not @$asciiTableHeader
-      asciiTable.append(@$caption = $('<caption id="ascii-table-caption" class="sr-only">Level Map</caption>'))
-      asciiTable.append(@$asciiTableHeader = $('<thead role="rowgroup"></thead>')).append(@$asciiTableBody = $('<tbody role="rowgroup"></tbody>'))
-      @asciiTableRows = []
-      @asciiTableCells = []
-    for row, c in tableChars
-      parent = if c is 0 then @$asciiTableHeader else @$asciiTableBody
-      $tr = @asciiTableRows[c]
-      cells = @asciiTableCells[c]
-      if not $tr
-        parent.append($tr = $('<tr role="row"></tr>'))
-        @asciiTableRows.push $tr
-        @asciiTableCells.push cells = []
-      for char, r in row
-        if r is 0
-          el = 'th'
-          scope = 'scope="row"'
-          role = 'role="rowheader"'
-        else if c is 0
-          el = 'th'
-          scope = 'scope="col"'
-          role = 'role="columnheader"'
-        else
-          el = 'td'
-          scope = ''
-          role = 'role="gridcell"'
-        $td = cells[r]
-        name = ''
-        if el is 'td'
-          name = tableNames[c][r]
-          name = 'Blank' if not name or name is ' '
-        if not $td
-          $tr.append($td = $("<#{el} #{scope} #{role} tabindex='-1'></#{el}>"))
-          cells.push $td
-          $td.append($("<span aria-hidden='true'>#{char}</span>"))
-          $td.append($("<span class='sr-only'>#{name}</span>"))
-        else
-          if $td.previousChar isnt char
-            utils.replaceText $td.find('span[aria-hidden="true"]'), char
-          if $td.previousName isnt name
-            utils.replaceText $td.find('span.sr-only'), name
-        $td.previousChar = char
-        $td.previousName = name
-      if r < cells.length - 1
-        # Table has shrunk width; remove extra cells
-        $td.remove() for $td in cells.splice r + 1
-    if c < @asciiTableRows.length - 1
-      # Table has shrunk height; remove extra rows and their cells
-      $tr.remove() for $tr in @asciiTableRows.splice c + 1
-      for cells in @asciiTableCells.splice c + 1
-        $td.remove() for $td in cells
-
-    for $el in [asciiTable]  #[ascii, asciiTable]
-      # Scale the table to match how the visual surface is scaled
-      $el.css 'transform', 'initial'
-      fullWidth = $el.innerWidth()
-      fullHeight = $el.innerHeight()
-      availableWidth = $el.parent().innerWidth()
-      availableHeight = $el.parent().innerHeight()
-      scaleX = availableWidth / fullWidth
-      scaleY = availableHeight / fullHeight
-      $el.css 'transform', "scaleX(#{scaleX}) scaleY(#{scaleY})"
+    simpleMovementGrid = new Grid thangs, width, height, padding, left, bottom, rogue, simpleMovementResolution
+    Backbone.Mediator.publish 'surface:update-screen-reader-map', grid: simpleMovementGrid
 
   equipNewItems: (thang) ->
     itemsJustEquipped = []

--- a/app/lib/surface/LankBoss.ozar.coffee
+++ b/app/lib/surface/LankBoss.ozar.coffee
@@ -197,7 +197,8 @@ module.exports = class LankBoss extends CocoClass
     tableChars = grid.toTable true
     tableNames = grid.toTableNames()
     if not @$asciiTableHeader
-      asciiTable.append(@$asciiTableHeader = $('<thead></thead>')).append(@$asciiTableBody = $('<tbody></tbody>'))
+      asciiTable.append(@$caption = $('<caption id="ascii-table-caption" class="sr-only">Level Map</caption>'))
+      asciiTable.append(@$asciiTableHeader = $('<thead role="rowgroup"></thead>')).append(@$asciiTableBody = $('<tbody role="rowgroup"></tbody>'))
       @asciiTableRows = []
       @asciiTableCells = []
     for row, c in tableChars
@@ -205,28 +206,31 @@ module.exports = class LankBoss extends CocoClass
       $tr = @asciiTableRows[c]
       cells = @asciiTableCells[c]
       if not $tr
-        parent.append($tr = $('<tr></tr>'))
+        parent.append($tr = $('<tr role="row"></tr>'))
         @asciiTableRows.push $tr
         @asciiTableCells.push cells = []
       for char, r in row
         if r is 0
           el = 'th'
           scope = 'scope="row"'
+          role = 'role="rowheader"'
         else if c is 0
           el = 'th'
           scope = 'scope="col"'
+          role = 'role="columnheader"'
         else
           el = 'td'
           scope = ''
+          role = 'role="gridcell"'
         $td = cells[r]
+        name = ''
+        if el is 'td'
+          name = tableNames[c][r]
+          name = 'Blank' if not name or name is ' '
         if not $td
-          $tr.append($td = $("<#{el} #{scope}></#{el}>"))
+          $tr.append($td = $("<#{el} #{scope} #{role} tabindex='-1'></#{el}>"))
           cells.push $td
           $td.append($("<span aria-hidden='true'>#{char}</span>"))
-          name = ''
-          if el is 'td'
-            name = tableNames[c][r]
-            name = 'Blank' if not name or name is ' '
           $td.append($("<span class='sr-only'>#{name}</span>"))
         else
           if $td.previousChar isnt char

--- a/app/lib/world/Grid.coffee
+++ b/app/lib/world/Grid.coffee
@@ -7,8 +7,8 @@ module.exports = class Grid
     # Ex.: if resolution is 2, then w: 8.1, h: 9.9, l: 1.9, b: -0.1 -> w: 10, h: 10, l: 0, b: -2
     @width  = Math.ceil( @width  / @resolution) * @resolution
     @height = Math.ceil( @height / @resolution) * @resolution
-    @left   = Math.floor(@left   / @resolution) * @resolution
-    @bottom = Math.floor(@bottom / @resolution) * @resolution
+    @left   = Math.floor(@left   / @resolution) * @resolution unless @rogue
+    @bottom = Math.floor(@bottom / @resolution) * @resolution unless @rogue
     @update thangs
 
   update: (thangs) ->
@@ -76,15 +76,16 @@ module.exports = class Grid
     upsideDown.reverse()
     ((@charForThangs thangs, rogue, r, c, axisLabels for thangs, c in row).join(' ') for row, r in upsideDown).join("\n")
 
-  toTable: (rogue=false, axisLabels=true) ->
+  toSimpleMovementChars: (rogue=false, axisLabels=true) ->
     upsideDown = _.clone @grid
     upsideDown.reverse()
     ((@charForThangs thangs, rogue, r, c, axisLabels for thangs, c in row) for row, r in upsideDown)
 
-  toTableNames: ->
+  toSimpleMovementNames: ->
     upsideDown = _.clone @grid
     upsideDown.reverse()
-    ((@nameForThangs thangs, r, c for thangs, c in row) for row, r in upsideDown)
+    # Comma-separated list of names for all Thangs significant enough to read aloud to the player
+    (((@nameForThangs([thang], r, c) for thang in thangs).filter((name) -> name isnt ' ').join(', ') for thangs, c in row) for row, r in upsideDown)
 
   charForThangs: (thangs, rogue, row, col, axisLabels) ->
     # TODO: have the Thang know its own letter
@@ -99,6 +100,7 @@ module.exports = class Grid
       return '#' if col is @grid.length - 1
     return ' ' unless thangs.length or (axisLabels and isAxis)
     for t in thangs
+      # TODO: order thangs by significance
       return '@' if /Hero Placeholder/.test t.id
       return '$' if /Hero Goal/.test t.spriteName
       return '%' if /Dog Goal/.test t.spriteName
@@ -130,6 +132,7 @@ module.exports = class Grid
       return 'Edge' if col is @grid.length - 1
     return ' ' unless thangs.length
     for t in thangs
+      # TODO: order thangs by significance
       return 'Hero' if /Hero Placeholder/.test t.id
       return 'Goal' if /Hero Goal/.test t.spriteName
       return 'Dog Goal' if /Dog Goal/.test t.spriteName

--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -367,6 +367,17 @@ module.exports = class World
     @bounds = bounds
     [@width, @height]
 
+  calculateSimpleMovementBounds: ->
+    # Figure out corners based solely on where simple movement dots are
+    # This could also calculate automatically from GridMovement2 System, but that's not used in all levels
+    bounds = {left: 9001, top: -9001, right: -9001, bottom: 9001}
+    for thang in @thangs when /^Dot/.test thang.spriteName  # Dot Stateless, Dot Underwater, etc.
+      bounds.left = Math.min(bounds.left, thang.pos.x)
+      bounds.right = Math.max(bounds.right, thang.pos.x)
+      bounds.bottom = Math.min(bounds.bottom, thang.pos.y)
+      bounds.top = Math.max(bounds.top, thang.pos.y)
+    bounds
+
   publishNote: (channel, event) ->
     event ?= {}
     channel = 'world:' + channel

--- a/app/schemas/subscriptions/misc.coffee
+++ b/app/schemas/subscriptions/misc.coffee
@@ -20,6 +20,9 @@ module.exports =
   'audio-player:play-sound': c.object {required: ['trigger']},
     trigger: {type: 'string'}
     volume: {type: 'number', minimum: 0, maximum: 1}
+    delay: {type: 'number', minimum: 0}
+    pos: {type: ['object', 'null']}
+    pan: {type: 'number', minimum: -1, maximum: 1}
 
   'music-player:play-music': c.object {required: ['play']},
     play: {type: 'boolean'}

--- a/app/schemas/subscriptions/misc.coffee
+++ b/app/schemas/subscriptions/misc.coffee
@@ -20,9 +20,9 @@ module.exports =
   'audio-player:play-sound': c.object {required: ['trigger']},
     trigger: {type: 'string'}
     volume: {type: 'number', minimum: 0, maximum: 1}
-    delay: {type: 'number', minimum: 0}
-    pos: {type: ['object', 'null']}
-    pan: {type: 'number', minimum: -1, maximum: 1}
+    delay: {type: 'number', minimum: 0, description: 'Delay in seconds before the sound should play'}
+    pos: {type: ['object', 'null'], description: 'World coordinates for where the sound is coming from, for in-game sounds'}
+    pan: {type: 'number', minimum: -1, maximum: 1, description: 'Left/right panning (default: 0, center)'}
 
   'music-player:play-music': c.object {required: ['play']},
     play: {type: 'boolean'}

--- a/app/schemas/subscriptions/surface.coffee
+++ b/app/schemas/subscriptions/surface.coffee
@@ -179,3 +179,6 @@ module.exports =  # /app/lib/surface
 
   'surface:remove-flag': c.object {required: ['color']},
     color: {type: 'string'}
+
+  'surface:update-screen-reader-map': c.object {required: ['grid']},
+    grid: {type: 'object'}

--- a/app/styles/play/level/screen-reader-surface-view.sass
+++ b/app/styles/play/level/screen-reader-surface-view.sass
@@ -44,7 +44,7 @@
         align-items: center
         justify-content: center
 
-        &.highlighted
+        &.cursor
           background-color: rgba(200, 200, 255, 0.25)
 
         .sr-only

--- a/app/styles/play/level/screen-reader-surface-view.sass
+++ b/app/styles/play/level/screen-reader-surface-view.sass
@@ -1,0 +1,69 @@
+@import "app/styles/mixins"
+@import "app/styles/bootstrap/variables"
+@import "app/styles/play/variables"
+
+#screen-reader-surface-view
+  visibility: hidden
+  position: absolute
+  z-index: 4
+  top: 0
+  left: 0
+  /* Width/height will be scaled to viewport with transform */
+  width: 924px
+  height: 589px
+  pointer-events: all
+  /* Not sure what the right user-select setting is for screen readers */
+  /* user-select: all */
+  white-space: pre
+  font-family: Courier, monospace
+  color: white
+  background-color: rgba(14, 59, 130, 0.25)
+  transform-origin: 0 0 0
+  font-size: 30px
+  line-height: 30px
+  position: reolative
+
+  .screen-reader-surface-application
+    width: 100%
+    height: 100%
+
+  .map-grid
+    width: 100%
+    height: 100%
+    display: grid
+
+    .map-row
+      height: 100%
+      display: flex
+
+      .map-cell
+        width: 100%
+        height: 100%
+        border: 1px dotted rgba(200, 200, 200, 0.2)
+        display: flex
+        align-items: center
+        justify-content: center
+
+        &.highlighted
+          background-color: rgba(200, 200, 255, 0.25)
+
+        .sr-only
+          top: 50%
+          left: 50%
+
+  .map-screen-reader-live-updates
+    position: absolute
+    right: 5px
+    bottom: 15px
+    font-size: 20px
+    line-height: 20px
+    text-align: right
+
+body.screen-reader-mode
+  #level-view
+    #screen-reader-surface-view
+      visibility: visible
+
+    canvas#webgl-surface, canvas#normal-surface
+      opacity: 0.2
+      /* opacity: 1 */

--- a/app/styles/play/play-level-view.sass
+++ b/app/styles/play/play-level-view.sass
@@ -151,19 +151,6 @@ $level-resize-transition-time: 0.5s
     &.flag-color-selected
       cursor: crosshair
 
-  #ascii-surface
-    position: absolute
-    z-index: 3
-    top: 0
-    left: 0
-    pointer-events: none
-    white-space: pre
-    font-family: Courier, monospace
-    color: white
-    background-color: rgba(14, 59, 130, 0.25)
-    transform-origin: 0 0 0
-    line-height: 15px
-
   min-width: 1024px
 
   #code-area

--- a/app/templates/play/level/screen-reader-surface.pug
+++ b/app/templates/play/level/screen-reader-surface.pug
@@ -1,0 +1,3 @@
+.screen-reader-surface-application(role="application" aria-label="Level Map")
+  .map-grid
+  .map-screen-reader-live-updates(aria-live="polite")

--- a/app/templates/play/level/screen-reader-surface.pug
+++ b/app/templates/play/level/screen-reader-surface.pug
@@ -1,3 +1,3 @@
-.screen-reader-surface-application(role="application" aria-label="Level Map")
+.screen-reader-surface-application(role="application" aria-label="Level Map" tabindex=1)
   .map-grid
   .map-screen-reader-live-updates(aria-live="polite")

--- a/app/templates/play/menu/options-view.ozar.pug
+++ b/app/templates/play/menu/options-view.ozar.pug
@@ -2,6 +2,19 @@
 
   h3.options-title(data-i18n="options.editor_config_title") Level Options:
 
+  .form-group.slider-group#volume-group
+    span.glyphicon.glyphicon-volume-down
+    #option-volume.slider.spr.spl
+    span.glyphicon.glyphicon-volume-up
+
+  .form-group.checkbox
+    label(for="option-music").control-label
+      input#option-music(name="option-music", type="checkbox", checked=music)
+      span.custom-checkbox
+        .glyphicon.glyphicon-ok
+      span(data-i18n="options.music_label") Music
+    span.help-block(data-i18n="options.music_description") Turn background music on/off.
+
   .form-group.checkbox
     label(for="option-live-completion")
       input#option-live-completion(name="liveCompletion", type="checkbox", disabled=!view.options.classroomAceConfig.liveCompletion checked=view.options.classroomAceConfig.liveCompletion && aceConfig.liveCompletion)

--- a/app/templates/play/play-level-view.pug
+++ b/app/templates/play/play-level-view.pug
@@ -22,7 +22,6 @@ include game-dev-goals
         canvas(width=924, height=589)#normal-surface
 
         #web-surface-view
-        #ascii-surface
         #canvas-left-gradient.gradient
         #canvas-top-gradient.gradient
         #goals-view

--- a/app/views/core/CocoView.coco.coffee
+++ b/app/views/core/CocoView.coco.coffee
@@ -581,8 +581,8 @@ module.exports = class CocoView extends Backbone.View
       @playSound 'full-screen-end' if req
     return
 
-  playSound: (trigger, volume=1) ->
-    Backbone.Mediator.publish 'audio-player:play-sound', trigger: trigger, volume: volume
+  playSound: (trigger, volume=1, delay=0, pos=null, pan=0) ->
+    Backbone.Mediator.publish 'audio-player:play-sound', trigger: trigger, volume: volume, delay: delay, pos: pos, pan: pan
 
   tryCopy: ->
     try

--- a/app/views/core/CocoView.ozar.coffee
+++ b/app/views/core/CocoView.ozar.coffee
@@ -572,8 +572,8 @@ module.exports = class CocoView extends Backbone.View
       @playSound 'full-screen-end' if req
     return
 
-  playSound: (trigger, volume=1) ->
-    Backbone.Mediator.publish 'audio-player:play-sound', trigger: trigger, volume: volume
+  playSound: (trigger, volume=1, delay=0, pos=null, pan=0) ->
+    Backbone.Mediator.publish 'audio-player:play-sound', trigger: trigger, volume: volume, delay: delay, pos: pos, pan: pan
 
   tryCopy: ->
     try

--- a/app/views/play/level/DialogueAnimator.coffee
+++ b/app/views/play/level/DialogueAnimator.coffee
@@ -1,3 +1,5 @@
+utils = require 'core/utils'
+
 module.exports = class DialogueAnimator
   jqueryElement: null
   childrenToAdd: null
@@ -5,11 +7,15 @@ module.exports = class DialogueAnimator
   childAnimator: null
 
   constructor: (html, @jqueryElement) ->
+    if me.get('aceConfig')?.screenReaderMode and utils.isOzaria
+      # Render instantly when in screen reader mode; don't animate anything.
+      @jqueryElement.html(html)
+      return
     d = $('<div></div>').html(html)
     @childrenToAdd = _.map(d[0].childNodes, (e) -> return e)
     @t0 = new Date()
     @charsAdded = 0
-    @charsPerSecond = 25
+    @charsPerSecond = 27
 
   tick: ->
     if not @charsToAdd and not @childAnimator
@@ -53,7 +59,7 @@ module.exports = class DialogueAnimator
     @charsAdded + (@childAnimator?.charsAdded ? 0)
 
   done: ->
-    return false if @childrenToAdd.length > 0
+    return false if @childrenToAdd?.length > 0
     return false if @charsToAdd
     return false if @childAnimator
     return true

--- a/app/views/play/level/ScreenReaderSurfaceView.coffee
+++ b/app/views/play/level/ScreenReaderSurfaceView.coffee
@@ -26,6 +26,7 @@ module.exports = class ScreenReaderSurfaceView extends CocoView
     super()
 
   onUpdateScreenReaderMap: (e) ->
+    # Called whenver we need to instantiate/update the map and what's in it
     if e?.grid
       @grid = e.grid
       @gridChars = @grid.toSimpleMovementChars(true, false)
@@ -46,6 +47,7 @@ module.exports = class ScreenReaderSurfaceView extends CocoView
       return @announceCursor()
 
   handleArrowKey: (key) ->
+    # Move cursor in the specified direction, if valid
     adjacent = @adjacentCells @cursor
     newCursor = switch key.toLowerCase()
       when 'arrowleft'  then adjacent.left
@@ -76,6 +78,7 @@ module.exports = class ScreenReaderSurfaceView extends CocoView
           return @cursor
 
   adjacentCells: (cell) ->
+    # Find the visitable cells next to this cell
     result = {}
     for dirName, dirVec of {
       left:  [-1,  0]
@@ -93,6 +96,7 @@ module.exports = class ScreenReaderSurfaceView extends CocoView
     @gridNames[cell.row][cell.col].replace /,? ?Dot,? ?/g, ''
 
   announceCursor: (full=false) ->
+    # Say what's at the current cursor, if a screen reader is active. Full: includes extra detail on what's around this cell.
     update = @formatCellContents @cursor
     if full
       update ||= 'Empty'
@@ -108,6 +112,7 @@ module.exports = class ScreenReaderSurfaceView extends CocoView
     @$el.find('.map-screen-reader-live-updates').text(update)
 
   updateCells: ->
+    # Create/remove/update .map-cell divs to visually correspond to the current state of the level map grid
     return unless @gridChars
     @mapRows ?= []
     @mapCells ?= []

--- a/app/views/play/level/ScreenReaderSurfaceView.coffee
+++ b/app/views/play/level/ScreenReaderSurfaceView.coffee
@@ -1,0 +1,116 @@
+require('app/styles/play/level/screen-reader-surface-view.sass')
+CocoView = require 'views/core/CocoView'
+template = require 'app/templates/play/level/screen-reader-surface'
+utils = require 'core/utils'
+
+module.exports = class ScreenReaderSurfaceView extends CocoView
+  id: 'screen-reader-surface-view'
+  template: template
+
+  subscriptions:
+    'surface:update-screen-reader-map': 'onUpdateScreenReaderMap'
+    'camera:zoom-updated': 'onUpdateScreenReaderMap'
+
+  constructor: (options) ->
+    super options
+
+  afterInsert: ->
+    super()
+    $(window).on('keydown', @onKeyEvent)
+    $(window).on('keyup', @onKeyEvent)
+    @updateScale()
+
+  destroy: ->
+    $(window).off('keydown', @onKeyEvent)
+    $(window).off('keyup', @onKeyEvent)
+    super()
+
+  onUpdateScreenReaderMap: (e) ->
+    if e?.grid
+      @grid = e.grid
+      @gridChars = @grid.toSimpleMovementChars(true, false)
+      @gridNames = @grid.toSimpleMovementNames()
+      #console.log @grid, @gridNames
+      #console.log @grid.toString(true, false)
+    @updateCells()
+    @updateScale()
+
+  onKeyEvent: (e) =>
+    event = _.pick(e, 'type', 'key', 'keyCode', 'ctrlKey', 'metaKey', 'shiftKey')
+    #console.log 'got event', event, @highlight, /^arrow/.test(event.key.toLowerCase()), event.key.toLowerCase()
+    # TODO: only do this if we have the map area focused
+    return unless @highlight
+    return unless /^arrow/.test event.key.toLowerCase()
+    return unless event.type is 'keydown'
+    newHighlight = {row: @highlight.row, col: @highlight.col}
+    switch event.key.toLowerCase()
+      when 'arrowleft'  then --newHighlight.col
+      when 'arrowright' then ++newHighlight.col
+      when 'arrowup'    then --newHighlight.row
+      when 'arrowdown'  then ++newHighlight.row
+    pan = Math.max -1, Math.min 1, -1 + 2 * newHighlight.col / (@gridNames[0].length - 1)
+    if (newHighlight.$cell = @mapCells[newHighlight.row]?[newHighlight.col]) and newHighlight.$cell.previousChar.trim()
+      # There's something here (a movable area and/or an object)
+      @highlight.$cell.removeClass 'highlighted'
+      newHighlight.$cell.addClass 'highlighted'
+      @highlight = newHighlight
+      update = @gridNames[@highlight.row][@highlight.col]
+      update = update.replace /,? ?Dot,? ?/g, ''
+      @$el.find('.map-screen-reader-live-updates').text(update)
+      @playSound 'game-menu-tab-switch', 1, 0, null, pan  # temporary sfx we already have
+    else
+      # There's nothing here, and the hero can't move here--don't move the highlight cursor
+      @playSound 'menu-button-click', 1, 0, null, pan  # temporary sfx we already have, need something more different from success sound
+
+  updateCells: ->
+    return unless @gridChars
+    @mapRows ?= []
+    @mapCells ?= []
+    $mapGrid = @$el.find('.map-grid')
+    for row, r in @gridChars
+      $row = @mapRows[r]
+      cells = @mapCells[r]
+      if not $row
+        $mapGrid.append($row = $('<div class="map-row"></div>'))
+        @mapRows.push $row
+        @mapCells.push cells = []
+      for char, c in row
+        $cell = cells[c]
+        name = @gridNames[r][c] or 'Blank'
+        if not $cell
+          $row.append($cell = $("<div class='map-cell'></div>"))
+          cells.push $cell
+          $cell.append($("<span aria-hidden='true'>#{char}</span>"))
+          $cell.append($("<span class='sr-only'>#{name}</span>"))
+        else
+          if $cell.previousChar isnt char
+            utils.replaceText $cell.find('span[aria-hidden="true"]'), char
+          if $cell.previousName isnt name
+            utils.replaceText $cell.find('span.sr-only'), name
+        if char is '@' and not @highlight
+          @highlight = {row: r, col: c, $cell: $cell}
+          $cell.addClass 'highlighted'
+        $cell.previousChar = char
+        $cell.previousName = name
+      if c < cells.length - 1
+        # Grid has shrunk width; remove extra cells
+        $cell.remove() for $cell in cells.splice c + 1
+    if r < @mapRows.length - 1
+      # Grid has shrunk height; remove extra rows and their cells
+      $row.remove() for $row in @mapRows.splice r + 1
+      for cells in @mapCells.splice r + 1
+        $cell.remove() for $cell in cells
+
+  updateScale: ->
+    # Scale the map to match how the visual surface is scaled
+    availableWidth = @$el.parent().innerWidth()
+    availableHeight = @$el.parent().innerHeight()
+    return if availableWidth is @lastAvailableWidth and availableHeight is @lastAvailableHeight
+    @$el.css 'transform', 'initial'
+    fullWidth = @$el.innerWidth()
+    fullHeight = @$el.innerHeight()
+    scaleX = availableWidth / fullWidth
+    scaleY = availableHeight / fullHeight
+    @$el.css 'transform', "scaleX(#{scaleX}) scaleY(#{scaleY})"
+    @lastAvailableWidth = availableWidth
+    @lastAvailableHeight = availableHeight

--- a/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
+++ b/ozaria/engine/cinematic/dialogsystem/DialogSystem.js
@@ -196,6 +196,10 @@ class SpeechBubble {
     if (textDuration === undefined) {
       textDuration = letters * LETTER_ANIMATE_TIME
     }
+    if (me.get('aceConfig') && me.get('aceConfig').screenReaderMode) {
+      // Render instantly when in screen reader mode; don't animate anything.
+      textDuration = 0
+    }
 
     this.resetSpeechBubble = () => {
       speechBubbleDiv.style.opacity = 0

--- a/ozaria/site/styles/play/menu/game-menu-modal.sass
+++ b/ozaria/site/styles/play/menu/game-menu-modal.sass
@@ -10,7 +10,7 @@
     background: #ffffff
     border-radius: 8px
     width: 478px
-    height: 395px
+    height: 500px
     margin-top: 15px
     padding: 35px
     overflow-y: scroll

--- a/ozaria/site/styles/play/menu/options-view.sass
+++ b/ozaria/site/styles/play/menu/options-view.sass
@@ -3,6 +3,47 @@
 
 #options-view
     
+  //- Volume slider
+
+  #volume-group
+    position: relative
+    width: 100%
+    height: 25px
+    margin: 15px 0
+
+    & > *
+      position: absolute
+
+    .ui-slider
+      left: 40px
+      right: 40px
+      top: 4px
+      background-color: $teal
+      border: 2px solid rgb(26,21,18)
+      height: 18px
+      border-radius: 18px
+
+      .ui-slider-handle
+        background-color: rgb(26,21,18)
+        width: 28px
+        height: 28px
+        border-radius: 28px
+        top: -7px
+        outline: 0
+
+    .glyphicon
+      font-size: 30px
+      top: -2px
+      color: rgb(26,21,18)
+
+    .glyphicon-volume-down
+      position: absolute
+      left: 0
+
+    .glyphicon-volume-up
+      position: absolute
+      right: -10px
+
   .options-title
     margin-top: 5px
     color: #000000
@@ -12,7 +53,7 @@
     line-height: 28px
     font-family: $label-font-style
     font-variant: unset
-    
+
 
   //- All form groups
   

--- a/ozaria/site/styles/play/play-level-view.sass
+++ b/ozaria/site/styles/play/play-level-view.sass
@@ -167,55 +167,6 @@ $level-resize-transition-time: 0.5s
     &.flag-color-selected
       cursor: crosshair
 
-  #ascii-surface
-    position: absolute
-    z-index: 3
-    top: 0
-    left: 0
-    pointer-events: all
-    /* Not sure what the right user-select setting is for screen readers */
-    user-select: all
-    white-space: pre
-    font-family: Courier, monospace
-    color: white
-    background-color: rgba(14, 59, 130, 0.25)
-    transform-origin: 0 0 0
-    font-size: 30px
-    line-height: 30px
-
-  #ascii-surface-table
-    visibility: hidden
-    position: absolute
-    z-index: 4
-    top: 0
-    left: 0
-    /* Width/height will be scaled to viewport with transform */
-    width: 924px
-    height: 589px
-    pointer-events: all
-    /* Not sure what the right user-select setting is for screen readers */
-    /* user-select: all */
-    white-space: pre
-    font-family: Courier, monospace
-    color: white
-    background-color: rgba(14, 59, 130, 0.25)
-    transform-origin: 0 0 0
-    font-size: 30px
-    line-height: 30px
-    table-layout: fixed
-    tr
-      height: 1px
-      td, th
-        width: 1px
-        height: 1px
-        border: 1px dotted rgba(200, 200, 200, 0.2)
-        text-align: center
-        vertical-align: middle
-        position: relative
-        .sr-only
-          top: 50%
-          left: 50%
-
   #code-area
     @include box-sizing(border-box)
     width: $code-area-width
@@ -501,10 +452,3 @@ body.ipad #level-view
   background-size: 100% 400px
   height: 400px
   z-index: -9001
-
-body.screen-reader-mode
-  #level-view
-    canvas#webgl-surface, canvas#normal-surface
-      opacity: 0.2
-    #ascii-surface-table
-      visibility: visible

--- a/ozaria/site/styles/play/play-level-view.sass
+++ b/ozaria/site/styles/play/play-level-view.sass
@@ -194,7 +194,7 @@ $level-resize-transition-time: 0.5s
     height: 589px
     pointer-events: all
     /* Not sure what the right user-select setting is for screen readers */
-    user-select: all
+    /* user-select: all */
     white-space: pre
     font-family: Courier, monospace
     color: white

--- a/ozaria/site/templates/play/play-level-view.pug
+++ b/ozaria/site/templates/play/play-level-view.pug
@@ -20,7 +20,7 @@ include game-dev-goals
 
         #web-surface-view
         //#ascii-surface.hide(aria-hidden=true)
-        table#ascii-surface-table.hide(aria-label="Level Map" role="grid")
+        table#ascii-surface-table.hide(aria-label="Map" role="grid" aria-readonly="true" aria-described-by="#ascii-table-caption")
         #canvas-left-gradient.gradient
         #canvas-top-gradient.gradient
 

--- a/ozaria/site/templates/play/play-level-view.pug
+++ b/ozaria/site/templates/play/play-level-view.pug
@@ -19,8 +19,7 @@ include game-dev-goals
         canvas(width=924, height=589)#normal-surface
 
         #web-surface-view
-        //#ascii-surface.hide(aria-hidden=true)
-        table#ascii-surface-table.hide(aria-label="Map" role="grid" aria-readonly="true" aria-described-by="#ascii-table-caption")
+        #screen-reader-surface-view
         #canvas-left-gradient.gradient
         #canvas-top-gradient.gradient
 

--- a/ozaria/site/views/play/level/DialogueAnimator.coffee
+++ b/ozaria/site/views/play/level/DialogueAnimator.coffee
@@ -1,3 +1,5 @@
+utils = require 'core/utils'
+
 module.exports = class DialogueAnimator
   jqueryElement: null
   childrenToAdd: null
@@ -5,6 +7,10 @@ module.exports = class DialogueAnimator
   childAnimator: null
 
   constructor: (html, @jqueryElement) ->
+    if me.get('aceConfig')?.screenReaderMode and utils.isOzaria
+      # Render instantly when in screen reader mode; don't animate anything.
+      @jqueryElement.html(html)
+      return
     d = $('<div></div>').html(html)
     @childrenToAdd = _.map(d[0].childNodes, (e) -> return e)
     @t0 = new Date()
@@ -53,7 +59,7 @@ module.exports = class DialogueAnimator
     @charsAdded + (@childAnimator?.charsAdded ? 0)
 
   done: ->
-    return false if @childrenToAdd.length > 0
+    return false if @childrenToAdd?.length > 0
     return false if @charsToAdd
     return false if @childAnimator
     return true

--- a/ozaria/site/views/play/level/PlayLevelView.js
+++ b/ozaria/site/views/play/level/PlayLevelView.js
@@ -62,6 +62,7 @@ const store = require('core/store')
 const GameMenuModal = require('ozaria/site/views/play/menu/GameMenuModal')
 const TutorialPlayView = require('./TutorialPlayView').default
 const ThangTypeHUDComponent = require('./ThangTypeHUDComponent').default
+const ScreenReaderSurfaceView = require('app/views/play/level/ScreenReaderSurfaceView')
 
 require('lib/game-libraries')
 window.Box2D = require('exports-loader?Box2D!vendor/scripts/Box2dWeb-2.1.a.3')
@@ -725,6 +726,8 @@ class PlayLevelView extends RootView {
       })
       this.insertSubView(this.webSurface)
     }
+
+    this.insertSubView(new ScreenReaderSurfaceView())
   }
 
   initVolume () {

--- a/ozaria/site/views/play/menu/OptionsView.coffee
+++ b/ozaria/site/views/play/menu/OptionsView.coffee
@@ -5,6 +5,7 @@ template = require 'app/templates/play/menu/options-view'
 ThangType = require 'models/ThangType'
 User = require 'models/User'
 forms = require 'core/forms'
+store = require 'core/store'
 
 module.exports = class OptionsView extends CocoView
   id: 'options-view'
@@ -20,6 +21,7 @@ module.exports = class OptionsView extends CocoView
 
   events:
     'click .done-button': 'onDoneClicked'
+    'change #option-music': 'updateMusic'
 
   constructor: (options) ->
     super options
@@ -29,7 +31,26 @@ module.exports = class OptionsView extends CocoView
     @aceConfig = _.cloneDeep me.get('aceConfig') ? {}
     @aceConfig = _.defaults @aceConfig, @defaultConfig
     c.aceConfig = @aceConfig
+    c.music = me.get('music', true)
     c
+
+  afterRender: ->
+    super()
+    @volumeSlider = @$el.find('#option-volume').slider(animate: 'fast', min: 0, max: 1, step: 0.05)
+    @volumeSlider.slider('value', me.get('volume'))
+    @volumeSlider.on('slide', @onVolumeSliderChange)
+    @volumeSlider.on('slidechange', @onVolumeSliderChange)
+
+  destroy: ->
+    @volumeSlider?.slider?('destroy')
+    super()
+
+  onVolumeSliderChange: (e) =>
+    volume = @volumeSlider.slider('value')
+    me.set 'volume', volume
+    @$el.find('#option-volume-value').text (volume * 100).toFixed(0) + '%'
+    Backbone.Mediator.publish 'level:set-volume', volume: volume
+    @playSound 'menu-button-click'  # Could have another volume-indicating noise
 
   onDoneClicked: ->
     @aceConfig.behaviors = @$el.find('#option-behaviors').prop('checked')
@@ -37,5 +58,13 @@ module.exports = class OptionsView extends CocoView
     @aceConfig.screenReaderMode = @$el.find('#option-screen-reader-mode').prop('checked')
     $('body').toggleClass('screen-reader-mode', @aceConfig.screenReaderMode)
     me.set 'aceConfig', @aceConfig
+    me.set 'music', @$el.find('#option-music').prop('checked')
     me.patch()
     Backbone.Mediator.publish 'tome:change-config', {}
+
+  updateMusic: ->
+    musicEnabled = Boolean @$el.find('#option-music').prop('checked')
+    return if me.get('music', true) is musicEnabled
+    me.set 'music', musicEnabled
+    command = {true: 'audio/unmuteTrack', false: 'audio/muteTrack'}[musicEnabled]
+    store.dispatch(command, 'background')


### PR DESCRIPTION
Replaces `<table role="grid">`-based screen reader implementation with a new custom `<div role="application">`-based one. Cleans up a lot of the code. Gets the grid spacing much tighter and more correct, and starts to only navigate navigable cells with a cursor.
<img width="1054" alt="Screen Shot 2022-07-27 at 17 29 52" src="https://user-images.githubusercontent.com/99704/181395170-109a7fad-6535-4002-b691-7add91271706.png">

Compare to old screen reader view:

<img width="1044" alt="Screen Shot 2022-07-27 at 17 33 44" src="https://user-images.githubusercontent.com/99704/181395424-3aa4d212-e471-4670-80d6-0ebf52fa5963.png">

While I was at it, I updated some music/sound handling in Ozaria to give more control over independent music tracks and interface sound panning.

<img width="625" alt="Screen Shot 2022-07-27 at 17 32 42" src="https://user-images.githubusercontent.com/99704/181395312-a9b34acf-f6e6-4e56-b61c-f51592ffeff4.png">


Don't squash this one, each commit is useful history.