### PR TITLE
More screen reader updates

### DIFF
--- a/app/components/common/MetaManager.vue
+++ b/app/components/common/MetaManager.vue
@@ -29,8 +29,16 @@
         links.push({ vmid: 'rel-canonical', rel: 'canonical', href: urlWithoutUtm.toString() })
       }
 
+      let defaultTitleKey
+      if (me.get('aceConfig') && me.get('aceConfig').screenReaderMode) {
+        // Shorten page titles when in screen reader mode
+        defaultTitleKey = isOzaria ? 'common.ozaria' : 'new_home.codecombat'
+      } else {
+        defaultTitleKey = 'common.default_title'
+      }
+
       return {
-        title: this.$t('common.default_title'),
+        title: this.$t(defaultTitleKey),
         ...(isOzaria ? {} : { titleTemplate: '%s | CodeCombat' }),
         meta: [
           { vmid: 'meta-description', name: 'description', content: this.$t('common.default_meta_description') },

--- a/app/core/store/modules/layoutChrome.js
+++ b/app/core/store/modules/layoutChrome.js
@@ -5,15 +5,9 @@ export default {
   namespaced: true,
 
   state () {
-    // TODO: Currently saving volume to session instead of database.
-    // TODO: Investigate using vuex-persist for caching state.
-    let cachedSound
-    if (window.localStorage) {
-      cachedSound = window.localStorage.getItem('layoutChrome/soundOn')
-    }
-
     return {
-      soundOn: cachedSound !== 'false',
+      // TODO: sync this from store me module instead of the actual Backbone object
+      soundOn: me.get('volume', true) > 0,
       // TODO: Move this into a dedicated courseInstance, and course module like the currentCampaignId in campaigns module
       currentCourseInstanceId: null,
       currentCourseId: null
@@ -23,9 +17,11 @@ export default {
   mutations: {
     toggleSound (state) {
       state.soundOn = !state.soundOn
-      if (window.localStorage) {
-        window.localStorage.setItem('layoutChrome/soundOn', state.soundOn)
-      }
+
+      // Also propagate this update to older Backbone/User volume settings
+      me.set('volume', state.soundOn ? 1 : 0)
+      me.patch()
+      Backbone.Mediator.publish('level:set-volume', { volume: me.get('volume') })
     },
 
     setUnitMapUrlDetails (state, payload) {

--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -367,11 +367,12 @@ module.exports = class World
     @bounds = bounds
     [@width, @height]
 
-  calculateSimpleMovementBounds: ->
+  calculateSimpleMovementBounds: (thangs)->
     # Figure out corners based solely on where simple movement dots are
     # This could also calculate automatically from GridMovement2 System, but that's not used in all levels
+    thangs ?= @thangs
     bounds = {left: 9001, top: -9001, right: -9001, bottom: 9001}
-    for thang in @thangs when /^Dot/.test thang.spriteName  # Dot Stateless, Dot Underwater, etc.
+    for thang in thangs when /^Dot/.test thang.spriteName  # Dot Stateless, Dot Underwater, etc.
       bounds.left = Math.min(bounds.left, thang.pos.x)
       bounds.right = Math.max(bounds.right, thang.pos.x)
       bounds.bottom = Math.min(bounds.bottom, thang.pos.y)

--- a/app/locale/en.ozar.coffee
+++ b/app/locale/en.ozar.coffee
@@ -1256,6 +1256,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     editor_config_behaviors_label: "Enable Smart Behaviors"
     editor_config_behaviors_description: "Autocompletes brackets, braces, and quotes."
     editor_config_screen_reader_mode_label: "Enable Screen Reader Mode"
+    editor_config_screen_reader_mode_label_disable: "Disable Screen Reader Mode"
     editor_config_screen_reader_mode_description: "Display levels in text rather than visually."
     editor_config_livecompletion_disabled_by_teacher: "Your teacher has disabled your autocomplete."
 
@@ -2732,8 +2733,8 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     you_can3: "that can be applied to your own account or given to others."
 
   ozaria_chrome:
-    sound_off: 'Sound Off',
-    sound_on: 'Sound On',
+    sound_off: 'Mute',
+    sound_on: 'Unmute',
     back_to_map: 'Back to Map',
     level_options: 'Level Options',
     restart_level: 'Restart Level',
@@ -3587,4 +3588,3 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     license_modal_members: "Members Needing Access"
     license_modal_members_placeholder: "Approximately how many members will need access?"
     license_modal_contact: "Contact Our Team"
-

--- a/app/schemas/subscriptions/surface.coffee
+++ b/app/schemas/subscriptions/surface.coffee
@@ -182,3 +182,4 @@ module.exports =  # /app/lib/surface
 
   'surface:update-screen-reader-map': c.object {required: ['grid']},
     grid: {type: 'object'}
+    bounds: {type: 'object'}

--- a/app/styles/play/level/screen-reader-surface-view.sass
+++ b/app/styles/play/level/screen-reader-surface-view.sass
@@ -8,16 +8,14 @@
   z-index: 4
   top: 0
   left: 0
-  /* Width/height will be scaled to viewport with transform */
+  /* Width/height will be scaled to grid size within viewport dynamically */
   width: 924px
   height: 589px
   pointer-events: all
-  /* Not sure what the right user-select setting is for screen readers */
-  /* user-select: all */
   white-space: pre
   font-family: Courier, monospace
-  color: white
-  background-color: rgba(14, 59, 130, 0.25)
+  color: transparent
+  /* color: white */ /* for debugging */
   transform-origin: 0 0 0
   font-size: 30px
   line-height: 30px
@@ -39,13 +37,13 @@
       .map-cell
         width: 100%
         height: 100%
-        border: 1px dotted rgba(200, 200, 200, 0.2)
+        border: 1px dotted rgba(200, 200, 200, 0.5)
         display: flex
         align-items: center
         justify-content: center
 
         &.cursor
-          background-color: rgba(200, 200, 255, 0.25)
+          background-color: rgba(0, 0, 255, 0.5)
 
         .sr-only
           top: 50%
@@ -58,12 +56,9 @@
     font-size: 20px
     line-height: 20px
     text-align: right
+    color: white
 
 body.screen-reader-mode
   #level-view
     #screen-reader-surface-view
       visibility: visible
-
-    canvas#webgl-surface, canvas#normal-surface
-      opacity: 0.2
-      /* opacity: 1 */

--- a/app/templates/play/level/level-playback-view.coco.pug
+++ b/app/templates/play/level/level-playback-view.coco.pug
@@ -1,4 +1,4 @@
-button.btn.btn-xs.btn-inverse#play-button.paused(title="Ctrl/Cmd + P: Toggle level play/pause")
+button.btn.btn-xs.btn-inverse#play-button.paused
   .glyphicon.glyphicon-play
   .glyphicon.glyphicon-pause
   .glyphicon.glyphicon-repeat

--- a/app/templates/play/level/level-playback-view.ozar.pug
+++ b/app/templates/play/level/level-playback-view.ozar.pug
@@ -1,4 +1,4 @@
-button.btn.btn-xs.btn-inverse#play-button.paused(title="Ctrl/Cmd + P: Toggle level play/pause")
+button.btn.btn-xs.btn-inverse#play-button.paused
   .glyphicon.glyphicon-play
   .glyphicon.glyphicon-pause
 

--- a/app/templates/play/level/screen-reader-surface.pug
+++ b/app/templates/play/level/screen-reader-surface.pug
@@ -1,3 +1,3 @@
-.screen-reader-surface-application(role="application" aria-label="Level Map" tabindex=1)
+.screen-reader-surface-application(role="application" aria-label="Level Map" tabindex="0")
   .map-grid
   .map-screen-reader-live-updates(aria-live="polite")

--- a/app/views/play/level/LevelPlaybackView.coffee
+++ b/app/views/play/level/LevelPlaybackView.coffee
@@ -160,6 +160,8 @@ module.exports = class LevelPlaybackView extends CocoView
     ended = button.hasClass 'ended'
     changed = button.hasClass('playing') isnt playing
     button.toggleClass('playing', playing and not ended).toggleClass('paused', not playing and not ended)
+    modifierKey = if /Mac/.test(navigator?.appVersion) then "⌘" else "Ctrl"
+    button.attr 'title', "#{modifierKey} + P: #{if playing then 'Play' else 'Pause'}"
     @playSound (if playing then 'playback-play' else 'playback-pause') unless @options.level.isType('game-dev')
     return   # don't stripe the bar
     bar = @$el.find '.scrubber .progress'

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -193,6 +193,15 @@ module.exports = class SpellView extends CocoView
       exec: ->
         Backbone.Mediator.publish 'level:escape-pressed', {}
     addCommand
+      name: 'unfocus-editor'
+      bindKey: {win: 'Escape', mac: 'Escape'}
+      readOnly: true
+      exec: ->
+        return unless me.get('aceConfig')?.screenReaderMode and utils.isOzaria
+        # In screen reader mode, we need to move focus to next element on escape, since tab won't.
+        # Next element happens to be #run button, or maybe #update-code button in game-dev.
+        $('#run, #update-code').focus()
+    addCommand
       name: 'toggle-grid'
       bindKey: {win: 'Ctrl-G', mac: 'Command-G|Ctrl-G'}
       readOnly: true

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -197,10 +197,12 @@ module.exports = class SpellView extends CocoView
       bindKey: {win: 'Escape', mac: 'Escape'}
       readOnly: true
       exec: ->
-        return unless me.get('aceConfig')?.screenReaderMode and utils.isOzaria
+        return unless utils.isOzaria
         # In screen reader mode, we need to move focus to next element on escape, since tab won't.
         # Next element happens to be #run button, or maybe #update-code button in game-dev.
-        $('#run, #update-code').focus()
+        # We need this even when you're not in screen reader mode, so you can tab over to enable it.
+        if $(document.activeElement).hasClass 'ace_text-input'
+          $('#run, #update-code').focus()
     addCommand
       name: 'toggle-grid'
       bindKey: {win: 'Ctrl-G', mac: 'Command-G|Ctrl-G'}
@@ -1149,8 +1151,9 @@ module.exports = class SpellView extends CocoView
   focus: ->
     # TODO: it's a hack checking if a modal is visible; the events should be removed somehow
     # but this view is not part of the normal subview destroying because of how it's swapped
-    return unless @controlsEnabled and @writable and $('.modal:visible').length is 0
+    return unless @controlsEnabled and @writable and $('.modal:visible, .shepherd-button:visible').length is 0
     return if @ace.isFocused()
+    return if me.get('aceConfig')?.screenReaderMode and utils.isOzaria  # Screen reader users get to control their own focus manually
     @ace.focus()
     @ace.clearSelection()
 

--- a/ozaria/site/components/common/BaseModal.vue
+++ b/ozaria/site/components/common/BaseModal.vue
@@ -9,7 +9,7 @@
 </script>
 
 <template>
-  <base-modal-container class="ozaria-modal">
+  <base-modal-container class="ozaria-modal" role="dialog" tabindex="0" >
     <slot name="close-icon" />
     <div class="ozaria-modal-content">
       <div class="ozaria-modal-header">

--- a/ozaria/site/components/common/LayoutChrome.vue
+++ b/ozaria/site/components/common/LayoutChrome.vue
@@ -148,6 +148,11 @@
 
 <template>
   <div class="chrome-container">
+    <!-- This comes first, because we want the tabindex to start on the code editor and level map -->
+    <div class="background-img">
+      <slot />
+    </div>
+
     <div v-if="classCode" class="class-code-container">
       <label for="classCode" class="class-code-descriptor"> {{ $t("teachers.class_code") }} </label>
       <div class="class-code-text-container">
@@ -169,7 +174,7 @@
       <div :class="[ chromeOn ? 'side-center-on' : 'side-center-off']" />
 
       <div id="chrome-menu">
-        <div
+        <button
           class="button-flex-item options-btn"
           :class="{ hideBtn: !displayOptionsMenuItem }"
 
@@ -178,10 +183,10 @@
             placement: 'right',
             classes: 'layoutChromeTooltip',
           }"
-
+          :aria-label="$t('ozaria_chrome.level_options')"
           @click="clickOptions"
         />
-        <div
+        <button
           class="button-flex-item restart-btn"
           :class="{ hideBtn: !displayRestartMenuItem }"
 
@@ -190,28 +195,29 @@
             placement: 'right',
             classes: 'layoutChromeTooltip',
           }"
-
+          :aria-label="$t('ozaria_chrome.restart_level')"
           @click="clickRestart"
         />
         <div class="spacer" />
-        <a :href="mapLink">
-          <div class="button-flex-item map-btn"
+        <a :href="mapLink" tabindex="-1">
+          <button class="button-flex-item map-btn"
             v-tooltip="{
               content: $t('ozaria_chrome.back_to_map'),
               placement: 'right',
               classes: 'layoutChromeTooltip',
             }"
+            :aria-label="$t('ozaria_chrome.back_to_map')"
           />
         </a>
-        <div class="button-flex-item fullscreen-btn"
+        <button class="button-flex-item fullscreen-btn"
             v-tooltip="{
               content: $t('ozaria_chrome.max_browser'),
               placement: 'right',
               classes: 'layoutChromeTooltip',
             }"
-
+            :aria-label="$t('ozaria_chrome.max_browser')"
             @click="toggleFullScreen" />
-        <div
+        <button
           class="button-flex-item sound-btn"
           :class="{ menuVolumeOff: soundOn }"
 
@@ -222,7 +228,9 @@
             placement: 'right',
             classes: 'layoutChromeTooltip'
           }"
-
+          :aria-label="soundOn
+            ? $t('ozaria_chrome.sound_off')
+            : $t('ozaria_chrome.sound_on')"
           @click="toggleSoundAction" />
       </div>
 
@@ -232,20 +240,16 @@
           class="text-contents"
           :class="[ chromeOn ? 'chrome-on' : 'chrome-off']"
         >
-          <span>{{ title }}</span>
+          <span role="heading" aria-level="1">{{ title }}</span>
         </div>
-        <div
+        <button
           v-if="displaySaveProgressButton"
-          class="save-progress-div"
+          class="save-progress-button"
           @click="clickSaveProgress"
         >
           <span class="save-progress-text"> {{ $t("hoc_2019.save_progress") }} </span>
-        </div>
+        </button>
       </div>
-    </div>
-
-    <div class="background-img">
-      <slot />
     </div>
 
     <signup-modal
@@ -389,6 +393,8 @@
         height: 7vh
         margin: 1vh -0.2vw
         cursor: pointer
+        padding: 0
+        border: 0
 
       .spacer
         flex-grow: 1
@@ -462,7 +468,7 @@
         text-shadow: 0 2px 4px rgba(51,236,201,0.55)
         min-width: 40vw
 
-      .save-progress-div
+      .save-progress-button
         height: 28px
         width: 158px
         border-radius: 10px
@@ -473,6 +479,8 @@
         position: absolute
         cursor: pointer
         pointer-events: auto
+        padding: 0
+        border: 0
 
         .save-progress-text
           height: 30px

--- a/ozaria/site/components/common/ModalTransition.vue
+++ b/ozaria/site/components/common/ModalTransition.vue
@@ -7,6 +7,7 @@
   import api from 'core/api'
   import ModalCharCustomization from 'ozaria/site/components/char-customization/ModalCharCustomization'
   import ClassroomLib from '../../../../app/models/ClassroomLib'
+  import * as focusTrap from 'focus-trap'
 
   export default Vue.extend({
     components: {
@@ -140,6 +141,23 @@
       } catch (e) {
         // TODO handle_error_ozaria
         console.error('Error in victory modal', e)
+      }
+
+      _.delay(() => {
+        // Let screen reader users easily go to the next level by trapping focus into the modal and focusing the next button.
+        // Hack: can't focus it right away, have to wait a bit
+        // If we knew when we could focus it, we could use checkCanFocusTrap option to create a Promise for when it would be ready to trap. When some animation finishes? When some data loads? When some other Vue lifecycle step finishes?
+        // TODO: do this generally for all modals
+        this.focusTrap = focusTrap.createFocusTrap($('.ozaria-modal')[0], {
+          initialFocus: '.next-button.ozaria-primary-button'
+        })
+        this.focusTrap.activate()
+      }, 1000)
+    },
+
+    beforeDestroy () {
+      if (this.focusTrap) {
+        this.focusTrap.deactivate()
       }
     },
 
@@ -295,6 +313,7 @@
   <base-modal
     v-if="!goToNextDirectly && !showCharCx"
     class="victory-modal"
+    :aria-label="`${contentType} ${$t('common.complete')}`"
   >
     <template #header>
       <div class="victory-header">

--- a/ozaria/site/views/play/level/LevelPlaybackView.coffee
+++ b/ozaria/site/views/play/level/LevelPlaybackView.coffee
@@ -142,6 +142,8 @@ module.exports = class LevelPlaybackView extends CocoView
     ended = button.hasClass 'ended'
     changed = button.hasClass('playing') isnt playing
     button.toggleClass('playing', playing and not ended).toggleClass('paused', not playing and not ended)
+    modifierKey = if /Mac/.test(navigator?.appVersion) then "⌘" else "Ctrl"
+    button.attr 'title', "#{modifierKey} + P: #{if playing then 'Play' else 'Pause'}"
 
     # TODO: replace with Ozaria sound
     # @playSound (if playing then 'playback-play' else 'playback-pause') unless @options.level.isType('game-dev')

--- a/ozaria/site/views/play/level/PlayLevelView.js
+++ b/ozaria/site/views/play/level/PlayLevelView.js
@@ -304,9 +304,6 @@ class PlayLevelView extends RootView {
     ) // May not have @level loaded yet
     this.$el.find('#level-done-button').hide()
     $('body').addClass('is-playing')
-    if (me.get('aceConfig') && me.get('aceConfig').screenReaderMode) {
-      $('body').addClass('screen-reader-mode')  // TODO: keep this updated
-    };
   }
 
   afterInsert () {

--- a/ozaria/site/views/play/level/TutorialPlayComponent.vue
+++ b/ozaria/site/views/play/level/TutorialPlayComponent.vue
@@ -548,9 +548,13 @@
               }
 
               if (this.animator.done()) {
-                this.tour.getCurrentStep().updateStepOptions({
-                  text: marked(message)
-                })
+                if (!this.tour) {
+                  console.warn('Problem trying to finish a tour that is already null')
+                } else {
+                  this.tour.getCurrentStep().updateStepOptions({
+                    text: marked(message)
+                  })
+                }
                 this.clearAsyncTimers()
                 return
               }
@@ -849,7 +853,7 @@
     background-repeat: no-repeat !important
     background-size: contain
     background-color: unset
-    outline: none
+    /* outline: none */ /* bad for accessibility, can't see keyboard focus */
     transition: none
 
     &:hover:not(:disabled)

--- a/ozaria/site/views/play/level/TutorialPlayComponent.vue
+++ b/ozaria/site/views/play/level/TutorialPlayComponent.vue
@@ -187,18 +187,22 @@
           const backButton = {
             classes: 'shepherd-back-button shepherd-back-button-active',
             text: '',
+            label: 'Back',
             action: () => {
               this.tour.back()
-            }
+            },
           }
           const inactiveBackButton = {
             classes: 'shepherd-back-button shepherd-back-button-inactive',
             text: '',
+            label: 'Back',
+            disabled: true,
             action: () => {}
           }
           const nextButton = {
             classes: 'shepherd-next-button shepherd-next-button-active',
             text: '',
+            label: 'Next',
             action: () => {
               this.tour.next()
             }
@@ -206,11 +210,14 @@
           const inactiveNextButton = {
             classes: 'shepherd-next-button shepherd-next-button-inactive',
             text: '',
+            label: 'Next',
+            disabled: true,
             action: () => {}
           }
           const startButton = {
             classes: 'shepherd-start-button',
             text: '',
+            label: 'Start',
             action: () => {
               this.tour.next()
             }

--- a/ozaria/site/views/play/level/tome/SpellView.coffee
+++ b/ozaria/site/views/play/level/tome/SpellView.coffee
@@ -199,10 +199,12 @@ module.exports = class SpellView extends CocoView
       bindKey: {win: 'Escape', mac: 'Escape'}
       readOnly: true
       exec: ->
-        return unless me.get('aceConfig')?.screenReaderMode and utils.isOzaria
+        return unless utils.isOzaria
         # In screen reader mode, we need to move focus to next element on escape, since tab won't.
         # Next element happens to be #run button, or maybe #update-code button in game-dev.
-        $('#run, #update-code').focus()
+        # We need this even when you're not in screen reader mode, so you can tab over to enable it.
+        if $(document.activeElement).hasClass 'ace_text-input'
+          $('#run, #update-code').focus()
     addCommand
       name: 'toggle-grid'
       bindKey: {win: 'Ctrl-G', mac: 'Command-G|Ctrl-G'}
@@ -1120,9 +1122,9 @@ module.exports = class SpellView extends CocoView
   focus: ->
     # TODO: it's a hack checking if a modal is visible; the events should be removed somehow
     # but this view is not part of the normal subview destroying because of how it's swapped
-    return unless @controlsEnabled and @writable and $('.modal:visible').length is 0
+    return unless @controlsEnabled and @writable and $('.modal:visible, .shepherd-button:visible').length is 0
     return if @ace.isFocused()
-    return if me.get('aceConfig')?.screenReaderMode  # Screen reader users get to control their own focus manually
+    return if me.get('aceConfig')?.screenReaderMode and utils.isOzaria  # Screen reader users get to control their own focus manually
     @ace.focus()
     @ace.clearSelection()
 

--- a/ozaria/site/views/play/level/tome/SpellView.coffee
+++ b/ozaria/site/views/play/level/tome/SpellView.coffee
@@ -195,6 +195,15 @@ module.exports = class SpellView extends CocoView
       exec: ->
         Backbone.Mediator.publish 'level:escape-pressed', {}
     addCommand
+      name: 'unfocus-editor'
+      bindKey: {win: 'Escape', mac: 'Escape'}
+      readOnly: true
+      exec: ->
+        return unless me.get('aceConfig')?.screenReaderMode and utils.isOzaria
+        # In screen reader mode, we need to move focus to next element on escape, since tab won't.
+        # Next element happens to be #run button, or maybe #update-code button in game-dev.
+        $('#run, #update-code').focus()
+    addCommand
       name: 'toggle-grid'
       bindKey: {win: 'Ctrl-G', mac: 'Command-G|Ctrl-G'}
       readOnly: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -5037,6 +5037,14 @@
       "resolved": "https://registry.npmjs.org/flexsearch/-/flexsearch-0.6.32.tgz",
       "integrity": "sha512-EF1BWkhwoeLtbIlDbY/vDSLBen/E5l/f1Vg7iX5CDymQCamcx1vhlc3tIZxIDplPjgi0jhG37c67idFbjg+v+Q=="
     },
+    "focus-trap": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
+      "integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
+      "requires": {
+        "tabbable": "^5.3.3"
+      }
+    },
     "follow-redirects": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
@@ -8941,6 +8949,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/svg-attribute-namespace/-/svg-attribute-namespace-2.1.0.tgz",
       "integrity": "sha1-Chb66Xmnjs7IAqPaM8jdPyi75dQ="
+    },
+    "tabbable": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
     },
     "tapable": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "file-saver": "1.3.3",
     "fitty": "^2.2.6",
     "flexsearch": "^0.6.32",
+    "focus-trap": "^6.9.4",
     "graceful-fs": "4.2.9",
     "howler": "^2.2.0",
     "htmlparser2": "^3.9.1",


### PR DESCRIPTION
* **Shorten page titles when in screen reader mode**
* **PlayLevelView keyboard navigation and button labeling improvements**
* **Ozaria sound on/off now toggles user.volume**
Before, it was saving mute/unmute to local storage. I think ideally, user.volume would get added to the `me` store module
to better integrate with Vue, but this seemed to do the job for now.
* **Fix Oz PlayLevelView keyboard navigation**
This fixes several keyboard accessibility issues on the PlayLevelView, its code editor, and some of its modals. Some of this is using the new focus-trap package, which is something we should be generally using on all modals so that keyboard tab navigation doesn't leak out of the modal to all the content behind the modal. This only applies it to the ModalTransition (victory modal) for now. A general solution for all modals would be a good next step. This also adds a top-level screen reader mode enable button that is visible to screen readers, so you don't have to go looking through the game options to find it.
* **Accurately overlay screen reader grid onto normal surface**
Makes the screen reader mode go together with the regular view of the game, so that sighted, limited-vision, and non-sighted players can all view without obstruction. In this conception, screen reader mode is just the ability to also navigate the high-level layout via keyboard, plus a couple convenience shortcuts to give better control over conflicting behaviors like text animations and overeager autofocus.
* **Defensive logging for a TutorialPlayComponent dealloc race condition**
We see this in the logs all the time. Noticed it happening when quickly closing out of a dialog in a certain way. Not sure why it triggers, but we don't need to error out at 20 FPS forever when it does.

Quick demo of what it looks like when using VoiceOver (the built-in MacOS screen reader) to play a level now, including enabling screen reader mode:
![more-screen-reader-updates](https://user-images.githubusercontent.com/99704/182004551-23d7c89d-cc91-4f1b-8ca5-95bbb9ef1428.gif)