### PR TITLE
DT: show reminder that licenses won't be revoked on removing shared teacher licenses

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -2527,6 +2527,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     licenses_used_no_braces: "__licensesUsed__ licenses used"
     more_info: "More info"
     shared_pool_label: "Teachers in your shared pool:"
+    teacher_delete_warning: "The shared licenses assigned to the teacher won't be revoked!"
 
   sharing:
     game: "Game"

--- a/app/templates/teachers/share-licenses-joiner-row.coco.pug
+++ b/app/templates/teachers/share-licenses-joiner-row.coco.pug
@@ -8,13 +8,13 @@ div.row.p-t-1.p-b-1(v-if="joiner")
           | {{ $t("share_licenses.you") }}
     div.small
       | {{ joiner.email }}
-      
+
   div.col-xs-4
     b(v-if="joiner.licensesUsed === 1")
       | {{ $t("share_licenses.one_license_used") }}
     b(v-else)
       | {{ $t("share_licenses.licenses_used", { licensesUsed: joiner.licensesUsed }) }}
-  
+
   div.col-xs-2
     b
       button.btn.btn-danger(v-if="joiner.email !== me.get('email')" type="button", v-on:click.prevent="revokeTeacher(joiner)") {{$t("editor.delete")}}

--- a/app/views/teachers/ShareLicensesJoinerRow.coco.coffee
+++ b/app/views/teachers/ShareLicensesJoinerRow.coco.coffee
@@ -25,5 +25,26 @@ module.exports = ShareLicensesJoinerRow =
   methods:
     {
       revokeTeacher: ->
-        @$emit 'revokeJoiner', @prepaid._id, @joiner
+        if @joiner.licensesUsed > 0
+          noty
+            text: $.i18n.t 'share_licenses.teacher_delete_warning'
+            layout: 'center',
+            type: 'warning',
+            buttons: [
+              {
+                addClass: 'btn btn-primary',
+                text: 'Ok',
+                onClick: ($noty) =>
+                  @$emit 'revokeJoiner', @prepaid._id, @joiner
+                  $noty.close()
+              }
+              {
+                addClass: 'btn btn-danger',
+                text: 'Cancel',
+                onClick: ($noty) =>
+                  $noty.close()
+              }
+            ]
+        else
+          @$emit 'revokeJoiner', @prepaid._id, @joiner
     }

--- a/ozaria/site/components/teacher-dashboard/modals/ModalShareLicenses/SharedPoolRow.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalShareLicenses/SharedPoolRow.vue
@@ -1,4 +1,3 @@
-
 <script>
   import { mapActions } from "vuex";
 
@@ -40,10 +39,37 @@
       ...mapActions({
         revokeJoiner: 'prepaids/revokeJoiner'
       }),
-      async revokeTeacher() {
-        this.revoking = true;
-        await this.revokeJoiner({ prepaidId: this.prepaid._id, email: this.email });
-        this.revoking = false;
+      async revokeTeacher () {
+        this.revoking = true
+        if (this.licensesUsed > 0) {
+          noty({
+            text: $.i18n.t('share_licenses.teacher_delete_warning'),
+            layout: 'center',
+            type: 'warning',
+            buttons: [
+              {
+                addClass: 'btn btn-primary',
+                text: 'Ok',
+                onClick: async ($noty) => {
+                  await this.revokeJoiner({ prepaidId: this.prepaid._id, email: this.email })
+                  this.revoking = false
+                  $noty.close()
+                }
+              },
+              {
+                addClass: 'btn btn-danger',
+                text: 'Cancel',
+                onClick: ($noty) => {
+                  this.revoking = false
+                  $noty.close()
+                }
+              }
+            ]
+          })
+        } else {
+          await this.revokeJoiner({ prepaidId: this.prepaid._id, email: this.email })
+          this.revoking = false
+        }
       }
     }
   }
@@ -59,7 +85,7 @@
       > {{ email }} </a>
     </div>
     <span class="licenses-used"> {{ $t("share_licenses.licenses_used_no_braces", { licensesUsed: licensesUsed }) }} </span>
-    <button :disabled="isOwner || revoking" class="btn btn-danger" type="button" @click.once="revokeTeacher"> {{$t("editor.delete")}} </button>
+    <button :disabled="isOwner || revoking" class="btn btn-danger" type="button" @click="revokeTeacher"> {{$t("editor.delete")}} </button>
 
   </div>
 </template>


### PR DESCRIPTION
Confirm modal shown if teacher is removed from shared licenses.

Coco:
![remove-teacher](https://user-images.githubusercontent.com/11805970/184849296-c5905895-e82f-4233-b788-cc90a234437b.gif)

Ozar:
![ozar-remove-teacher](https://user-images.githubusercontent.com/11805970/184849312-f9da7c44-9595-4b6b-9e40-f17ac9565d35.gif)

