### PR TITLE
Remove 'ozar' from codecombat title

### DIFF
--- a/app/components/common/MetaManager.vue
+++ b/app/components/common/MetaManager.vue
@@ -34,7 +34,7 @@
         // Shorten page titles when in screen reader mode
         defaultTitleKey = isOzaria ? 'common.ozaria' : 'new_home.codecombat'
       } else {
-        defaultTitleKey = 'common.default_title_' + isOzaria ? 'ozar' : 'coco'
+        defaultTitleKey = 'common.default_title_' + (isOzaria ? 'ozar' : 'coco')
       }
 
       return {


### PR DESCRIPTION
The unintentional 'ozar' string removed from codecombat titles.
Pls check screenshot below:
![CodeCombat_-_Coding_games_to_learn_Python_and_JavaScript___CodeCombat_and_ozar___CodeCombat_and_codecombat_–_MetaManager_vue](https://user-images.githubusercontent.com/11805970/185318431-32b20588-5b35-4ce2-82b1-998060c86cca.png)

