### PR TITLE
Remove 'ozar' from codecombat meta description

### DIFF
--- a/app/components/common/MetaManager.vue
+++ b/app/components/common/MetaManager.vue
@@ -41,7 +41,7 @@
         title: this.$t(defaultTitleKey),
         ...(isOzaria ? {} : { titleTemplate: '%s | CodeCombat' }),
         meta: [
-          { vmid: 'meta-description', name: 'description', content: this.$t('common.default_meta_description_' + isOzaria ? 'ozar' : 'coco') },
+          { vmid: 'meta-description', name: 'description', content: this.$t('common.default_meta_description_' + (isOzaria ? 'ozar' : 'coco')) },
           { vmid: 'viewport', name: 'viewport', content: 'width=device-width,initial-scale=1.0' }
         ],
 

--- a/app/components/common/MetaManager.vue
+++ b/app/components/common/MetaManager.vue
@@ -34,7 +34,7 @@
         // Shorten page titles when in screen reader mode
         defaultTitleKey = isOzaria ? 'common.ozaria' : 'new_home.codecombat'
       } else {
-        defaultTitleKey = 'common.default_title_' + isOzaria ? 'ozar' : 'coco'
+        defaultTitleKey = 'common.default_title_' + (isOzaria ? 'ozar' : 'coco')
       }
 
       return {


### PR DESCRIPTION
~ same as https://github.com/codecombat/codecombat/pull/6749 but `description` instead of `title`
