### PR TITLE
Start working on making type: "ladder" levels work in classroom

### DIFF
--- a/app/lib/LevelLoader.coco.coffee
+++ b/app/lib/LevelLoader.coco.coffee
@@ -102,7 +102,7 @@ module.exports = class LevelLoader extends CocoClass
           return 'hero' if arguments[0] is 'type'
           return 'web-dev' if arguments[0] is 'realType'
           originalGet.apply @, arguments
-    if (@courseID and not @level.isType('course', 'course-ladder', 'game-dev', 'web-dev')) or window.serverConfig.picoCTF
+    if (@courseID and not @level.isType('course', 'course-ladder', 'game-dev', 'web-dev', 'ladder')) or window.serverConfig.picoCTF
       # Because we now use original hero levels for both hero and course levels, we fake being a course level in this context.
       originalGet = @level.get
       realType = @level.get('type')
@@ -164,7 +164,7 @@ module.exports = class LevelLoader extends CocoClass
         else
           url += "?team=#{@team}"
         league = utils.getQueryVariable 'league'
-        if @level.isType('course-ladder') and league and not @courseInstanceID
+        if @level.isType('course-ladder') and league and not @courseInstanceID  # TODO check this for 'ladder' handling in classroom version
           url += "&courseInstance=#{league}"
       else if @courseID
         url += "?course=#{@courseID}"

--- a/app/lib/LevelLoader.coco.coffee
+++ b/app/lib/LevelLoader.coco.coffee
@@ -164,8 +164,12 @@ module.exports = class LevelLoader extends CocoClass
         else
           url += "?team=#{@team}"
         league = utils.getQueryVariable 'league'
-        if @level.isType('course-ladder') and league and not @courseInstanceID  # TODO check this for 'ladder' handling in classroom version
+        if @level.isType('course-ladder') and league and not @courseInstanceID
           url += "&courseInstance=#{league}"
+        else if @courseID
+          url += "&course=#{@courseID}"
+          if @courseInstanceID
+            url += "&courseInstance=#{@courseInstanceID}"
       else if @courseID
         url += "?course=#{@courseID}"
         if @courseInstanceID

--- a/app/templates/play/ladder/my_matches_tab.coco.pug
+++ b/app/templates/play/ladder/my_matches_tab.coco.pug
@@ -54,6 +54,8 @@
             td.watch-cell
               - var levelID = view.level.get('slug') || view.level.id
               - var league = view.options.league
+              - var leagueType = view.options.leagueType
+              - var course = view.options.course
               if (match.opTeam && match.opTeam == 'humans') || team.id == 'ogres'
                 - var yourTeam = 'ogres'
                 - var sessionOne = match.sessionID
@@ -66,7 +68,7 @@
                 span(data-i18n="play_level.watch_game")
             td.battle-cell
               if match.opTeam == 'ogres' || !view.level.isType('ladder')
-                a(href='/play/level/' + levelID + '?team=humans&opponent=' + match.sessionID + (league ? "&league=" + league.id : ""))
+                a(href='/play/level/' + levelID + '?team=humans&opponent=' + match.sessionID + (league ? `&${leagueType == 'clan' ? 'league=' : ('course=' + course.id + '&course-instance=')}` + league.id : ""))
                   if (match.state === 'win')
                     span(data-i18n="ladder.watch_victory") Watch your victory
                   else if (view.level.isType('ladder'))

--- a/app/templates/play/ladder/play_modal.pug
+++ b/app/templates/play/ladder/play_modal.pug
@@ -1,4 +1,25 @@
 extends /templates/core/modal-base
+ 
+mixin playLevelLink(levelID, league, leagueType, team, tournament, opponent)
+  - url = '/play/level/' + levelID
+  if team
+    - url += `?team=${team}`
+  else
+    - url += `?t=h`
+  if league
+    if leagueType == 'clan'
+      - url += `&league=${league.id}`
+    else
+      - url += `&course-instance=${league.id}`
+      if view.options.course
+        - url += `&course=${view.options.course.id}`
+  if tournament
+    - url += `&tournament=${tournament}`
+  if opponent
+    - url += `&opponent=${opponent}`
+  a(href=url, target='_blank')&attributes(attributes)
+    if block
+      block
 
 block modal-header-content
   h3(data-i18n="ladder.choose_opponent") Choose an Opponent
@@ -13,7 +34,7 @@ block modal-body-content
           option(value=option.id selected=(view.language === option.id))= option.name
 
   div#noob-view.secret
-    a(target="_blank" href=`/play/level/${view.levelID}-tutorial` + (view.options.league ? "?league=" + view.options.league.id : "")).btn.btn-success.btn-block.btn-lg
+    +playLevelLink(view.levelID + '-tutorial', view.options.league, view.options.leagueType).btn.btn-success.btn-block.btn-lg
       p
         strong(data-i18n="ladder.tutorial_play") Play Tutorial
       span(data-i18n="ladder.tutorial_recommended") Recommended if you've never played before
@@ -24,8 +45,8 @@ block modal-body-content
       p.tutorial-suggestion
         strong(data-i18n="ladder.tutorial_not_sure") Not sure what's going on?
         |
-        a(target="_blank" href=`/play/level/${view.levelID}-tutorial` + (view.options.league ? "?league=" + view.options.league.id : ""), data-i18n="ladder.tutorial_play_first") Play the tutorial first.
-    a(target="_blank" href=`/play/level/${view.levelID}?team=${view.team}` + (view.options.league ? "&league=" + view.options.league.id : "")+ (view.options.tournament ? "&tournament=" + view.options.tournament: ""))
+        +playLevelLink(view.levelID + '-tutorial', view.options.league, view.options.leagueType)(data-i18n="ladder.tutorial_play_first")
+    +playLevelLink(view.levelID, view.options.league, view.options.leagueType, view.team, view.options.tournament)
       div.play-option
         img(src=view.myPortrait).my-icon.only-one
         img(src=`/images/pages/play/ladder/${view.team}_ladder_tutorial.png`, style=`border: 1px solid ${view.teamColor}; background: ${view.teamBackgroundColor}`).my-team-icon.img-circle.only-one
@@ -40,7 +61,7 @@ block modal-body-content
           span(data-i18n="ladder.warmup") Warmup
 
     if view.challengers && view.challengers.easy
-      a(target="_blank" href=`/play/level/${view.levelID}?team=${view.team}&opponent=${view.challengers.easy.sessionID}` + (view.options.league ? "&league=" + view.options.league.id : "") + (view.options.tournament ? "&tournament=" + view.options.tournament: ""))
+      +playLevelLink(view.levelID, view.options.league, view.options.leagueType, view.team, view.options.tournament, view.challengers.easy.sessionID)
         div.play-option.easy-option
           img(src=view.myPortrait).my-icon.only-one
           img(src=`/images/pages/play/ladder/${view.team}_ladder_easy.png`, style=`border: 1px solid ${view.teamColor}; background: ${view.teamBackgroundColor}`).my-team-icon.img-circle.only-one
@@ -56,7 +77,7 @@ block modal-body-content
             span(data-i18n="general.easy") Easy
 
     if view.challengers && view.challengers.medium
-      a(target="_blank" href=`/play/level/${view.levelID}?team=${view.team}&opponent=${view.challengers.medium.sessionID}` + (view.options.league ? "&league=" + view.options.league.id : "")+ (view.options.tournament ? "&tournament=" + view.options.tournament: ""))
+      +playLevelLink(view.levelID, view.options.league, view.options.leagueType, view.team, view.options.tournament, view.challengers.medium.sessionID)
         div.play-option.medium-option
           img(src=view.myPortrait).my-icon.only-one
           img(src=`/images/pages/play/ladder/${view.team}_ladder_medium.png`, style=`border: 1px solid ${view.teamColor}; background: ${view.teamBackgroundColor}`).my-team-icon.img-circle.only-one
@@ -72,7 +93,7 @@ block modal-body-content
             span(data-i18n="general.medium") Medium
 
     if view.challengers && view.challengers.hard
-      a(target="_blank" href=`/play/level/${view.levelID}?team=${view.team}&opponent=${view.challengers.hard.sessionID}` + (view.options.league ? "&league=" + view.options.league.id : "")+ (view.options.tournament ? "&tournament=" + view.options.tournament: ""))
+      +playLevelLink(view.levelID, view.options.league, view.options.leagueType, view.team, view.options.tournament, view.challengers.hard.sessionID)
         div.play-option.hard-option
           img(src=view.myPortrait).my-icon.only-one
           img(src=`/images/pages/play/ladder/${view.team}_ladder_hard.png`, style=`border: 1px solid ${view.teamColor}; background: ${view.teamBackgroundColor}`).my-team-icon.img-circle.only-one

--- a/app/views/ladder/LadderView.coco.coffee
+++ b/app/views/ladder/LadderView.coco.coffee
@@ -330,7 +330,7 @@ module.exports = class LadderView extends RootView
 
   showPlayModal: (teamID) ->
     session = (s for s in @sessions.models when s.get('team') is teamID)[0]
-    modal = new LadderPlayModal({league: @league, tournament: @tournamentId}, @level, session, teamID)
+    modal = new LadderPlayModal({league: @league, leagueType: @leagueType, tournament: @tournamentId, course: @course}, @level, session, teamID)
     @openModalView modal
 
   onClickedLink: (e) ->

--- a/app/views/ladder/LadderView.coco.coffee
+++ b/app/views/ladder/LadderView.coco.coffee
@@ -238,12 +238,12 @@ module.exports = class LadderView extends RootView
     @$el.toggleClass 'single-ladder', @level.isType 'ladder'
     unless @tournamentState is 'ended'
       if @level.isType('ladder')
-        @insertSubView(@ladderTab = new TournamentLeaderboard({league: @league}, @level, @sessions, @anonymousPlayerName ))
+        @insertSubView(@ladderTab = new TournamentLeaderboard({league: @league, leagueType: @leagueType, course: @course}, @level, @sessions, @anonymousPlayerName ))
       else
         @insertSubView(@ladderTab = new LadderTabView({league: @league, tournament: @tournamentId}, @level, @sessions))
-      @insertSubView(@myMatchesTab = new MyMatchesTabView({league: @league}, @level, @sessions, @anonymousPlayerName))
+      @insertSubView(@myMatchesTab = new MyMatchesTabView({league: @league, leagueType: @leagueType, course: @course}, @level, @sessions, @anonymousPlayerName))
     else
-      @insertSubView(@ladderTab = new TournamentLeaderboard({league: @league, tournament: @tournamentId}, @level, @sessions ))
+      @insertSubView(@ladderTab = new TournamentLeaderboard({league: @league, tournament: @tournamentId, leagueType: 'clan'}, @level, @sessions )) # classroom ladder do not have tournament for now
     unless @level.isType('ladder') and me.isAnonymous()
       @insertSubView(@simulateTab = new SimulateTabView(league: @league, level: @level, leagueID: @leagueID))
     highLoad = true

--- a/app/views/ladder/components/Leaderboard.coffee
+++ b/app/views/ladder/components/Leaderboard.coffee
@@ -20,7 +20,7 @@ module.exports = class LeaderboardView extends CocoView
   template: require('templates/play/ladder/leaderboard-view')
   VueComponent: LeaderboardComponent
   constructor: (options, @level, @sessions, @anonymousPlayerName) ->
-    { @league, @tournament } = options
+    { @league, @tournament, @leagueType, @course } = options
     # params = @collectionParameters(order: -1, scoreOffset: HIGHEST_SCORE, limit: @limit)
     super options
     @tableTitles = [
@@ -35,7 +35,7 @@ module.exports = class LeaderboardView extends CocoView
       {slug: 'age', col: 1, title: $.i18n.t('ladder.age_bracket')},
       {slug: 'country', col:1, title: '🏴‍☠️'}
     ]
-    @propsData = { @tableTitles, @league, @level, scoreType: 'tournament' }
+    @propsData = { @tableTitles, @league, @level, @leagueType, @course, scoreType: 'tournament' }
     unless @tournament
       @propsData.tableTitles = [
         {slug: 'creator', col: 0, title: ''},

--- a/app/views/ladder/components/Leaderboard.vue
+++ b/app/views/ladder/components/Leaderboard.vue
@@ -1,255 +1,272 @@
 <script>
-  /**
-   * TODO: Extend or create an alternative leaderboard compatible with teams (humans/ogres)
-   * TODO: This leaderboard is not only shown on the league url but also the ladder url.
-   */
-  import utils from 'core/utils'
+/**
+ * TODO: Extend or create an alternative leaderboard compatible with teams (humans/ogres)
+ * TODO: This leaderboard is not only shown on the league url but also the ladder url.
+ */
+import utils from 'core/utils'
+const d3 = require('d3/d3.js')
 
-  export default Vue.extend({
-    name: 'leaderboard-component',
-    props: {
-      scoreType: {
-        type: String,
-        default: 'arena'
-      },
-      league: {
-        type: Object,
-        default: null
-      },
-      level: {
-        type: Object,
-        default: () => {}
-      },
-      playerCount: {
-        type: Number,
-        default: 0
-      },
-      clanId: {
-        type: String,
-        default: '_global'
-      },
-      title: {
-        type: String,
-        default: ''
-      },
-      tableTitles: {
-        type: Array,
-        default () {
-          return []
-        }
-      },
+export default Vue.extend({
+  name: 'LeaderboardComponent',
+  props: {
+    scoreType: {
+      type: String,
+      default: 'arena'
     },
-    data () {
-      return {
-        selectedRow: [],
-        ageFilter: false,
+    league: {
+      type: Object,
+      default: null
+    },
+    leagueType: {
+      type: String,
+      default: 'clan'
+    },
+    course: {
+      type: Object,
+      default: null
+    },
+    level: {
+      type: Object,
+      default: () => {}
+    },
+    playerCount: {
+      type: Number,
+      default: 0
+    },
+    clanId: {
+      type: String,
+      default: '_global'
+    },
+    title: {
+      type: String,
+      default: ''
+    },
+    tableTitles: {
+      type: Array,
+      default () {
+        return []
       }
     },
-    computed: {
-      ageBrackets () {
-        let brackets = utils.ageBrackets
-        if (this.$store.state.features.china) {
-           brackets = utils.ageBracketsChina
-        }
-        return brackets.map((b) => {
-          return {
-            name: this.getAgeBracket(b.slug),
-            slug: b.slug
-          }
-        })
-      }
-    },
-    mounted () {
-      let histogramWrapper = $('#histogram-display-humans')
-      let histogramData = null
-      let url = `/db/level/${this.level.get('original')}/rankings-histogram?team=humans&levelSlug=${this.level.get('slug')}`
-      if (this.league) {
-        url += '&leagues.leagueID=' + this.league.id
-      }
-      $.when(
-        $.get(url, (data) => histogramData = data)
-      ).then(() => this.generateHistogram(histogramWrapper, histogramData, 'humans'))
-    },
-    methods: {
-      loadMore () {
-        this.$emit('load-more')
-      },
-      generateHistogram (histogramElement, histogramData, teamName) {
-        console.log('generate hist 1')
-        // renders twice, hack fix
-        if ($('#' + histogramElement.attr('id')).has('svg').length)
-          return
-        if (!histogramData.length)
-          return histogramElement.hide()
-
-        histogramData = histogramData.map((d) => d * 100)
-        let margin = {
-          top: 20,
-          right: 20,
-          bottom: 30,
-          left: 15
-        }
-        let width = 470 - margin.left - margin.right
-        let height = 125 - margin.top - margin.bottom
-        let axisFactor = 1000
-        let minX = Math.floor(Math.min(...histogramData) / axisFactor) * axisFactor
-        let maxX = Math.ceil(Math.max(...histogramData) / axisFactor) * axisFactor
-        let x = d3.scale.linear().domain([minX, maxX]).range([0, width])
-        let data = d3.layout.histogram().bins(x.ticks(20))(histogramData)
-        let y = d3.scale.linear().domain([0, d3.max(data, (d) => d.y)]).range([height, 10])
-
-        // create the x axis
-        let xAxis = d3.svg.axis().scale(x).orient('bottom').ticks(5).outerTickSize(0)
-
-        let svg = d3.select('#histogram-display-humans').append('svg')
-                    .attr("preserveAspectRatio", "xMinYMin meet")
-                    .attr("viewBox", `0 0 ${width+margin.left+margin.right} ${height+margin.top+margin.bottom}`)
-                    .append('g')
-                    .attr('transform', `translate(${margin.left}, ${margin.top})`)
-        let barClass = 'humans-bar'
-
-        let bar = svg.selectAll('.bar')
-                     .data(data)
-                     .enter().append('g')
-                     .attr('class', barClass)
-                     .attr('transform', (d) => `translate(${x(d.x)}, ${y(d.y)})`)
-
-        bar.append('rect')
-                     .attr('x', 1)
-                     .attr('width', width/20)
-                     .attr('height', (d) => height - y(d.y))
-        if(this.session) {
-          let playerScore = this.session.get('totalScore')
-          if (this.league) {
-            let league = _.find(this.session.get('leagues'), { leagueID: this.league.id })
-            playerScore = league ? +league.stats.totalScore : 10
-          }
-          playerScore = playerScore * 100
-  
-          let scorebar = svg.selectAll('.specialbar')
-                            .data([playerScore])
-                            .enter().append('g')
-                            .attr('class', 'specialbar')
-                            .attr('transform', `translate(${x(playerScore)}, 0)`)
-
-          scorebar.append('rect')
-                            .attr('x', 1)
-                            .attr('width', 2)
-                            .attr('height', height)
-        }
-        let rankClass = 'rank-text humans-rank-text'
-
-        let message = `${histogramData.length.toLocaleString()} players`
-        /* if(@leaderboards[teamName].session)
-         *   //# TODO: i18n for these messages
-         *   if(this.league)
-         *     //# TODO: fix server handler to properly fetch myRank with a leagueID
-         *     message = "#{histogramData.length} players in league" */
-        /* else if(@leaderboards[teamName].myRank <= histogramData.length) {
-         *   message = "##{@leaderboards[teamName].myRank} of #{histogramData.length}"
-         *   message += "+" if histogramData.length >= 100000
-         * } */
-        /* else if(@leaderboards[teamName].myRank is 'unknown')
-         *   message = "#{if histogramData.length >= 100000 then '100,000+' else histogramData.length} players"
-         * else
-         *   message = 'Rank your session!' */
-        svg.append('g')
-           .append('text')
-           .attr('class', rankClass)
-           .attr('y', 0)
-           .attr('text-anchor', 'end')
-           .attr('x', width)
-           .text(message)
-
-        //#Translate the x-axis up
-        svg.append('g')
-           .attr('class', 'x axis')
-           .attr('transform', 'translate(0, ' + height + ')')
-           .call(xAxis)
-
-        histogramElement.show()
-
-      },
-      toggleAgeFilter () {
-        this.ageFilter = !this.ageFilter
-      },
-      filterAge (slug) {
-        this.$emit('filter-age', slug)
-        this.ageFilter = false
-      },
-      computeClass (slug, item='') {
-        if (slug == 'name') {
-          return {'name-col-cell': 1, ai: /(Bronze|Silver|Gold|Platinum|Diamond) AI/.test(item)}
-        }
-        if (slug == 'team') {
-          return {capitalize: 1, 'clan-col-cell': 1}
-        }
-        if (slug == 'language') {
-          return {'code-language-cell': 1}
-        }
-      },
-      computeStyle (item, index){
-        if (this.tableTitles[index].slug == 'language') {
-          return {'background-image': `url(/images/common/code_languages/${item}_icon.png)`}
-        }
-      },
-      getAgeBracket (item) {
-        return $.i18n.t(`ladder.bracket_${(item || 'open').replace(/-/g, '_')}`)
-      },
-
-      getCountry (code) {
-        return utils.countryCodeToFlagEmoji(code)
-      },
-
-      getCountryName (code) {
-        return utils.countryCodeToName(code)
-      },
-
-      computeTitle (slug, item) {
-        if(slug == 'country') {
-          return this.getCountryName(item)
-        }
-        else {
-          return ''
-        }
-      },
-      computeBody  (slug, item) {
-        if(slug == 'country') {
-          return this.getCountry(item)
-        } else if(slug == 'fight'){
-          return "<a href='" + `/play/level/${this.level.get('slug')}?team=humans&opponent=${item}` + (this.league ? `&league=${this.league.id}`: '')  + "'><span>" + $.i18n.t('ladder.fight') +"</span></a>"
-        } else {
-          return item
-        }
-      },
-      classForRow (row) {
-        if(this.session) {
-          if (row[0] === this.session.get('creator')) {
-            return 'my-row'
-          }
-        }
-        if (window.location.pathname === '/league' && row.fullName) {
-          return 'student-row'
-        }
-        return ''
-      },
-      onClickUserRow (rank, slug, nearby = false) {
-        if (slug !== 'fight')
-          this.$emit('click-player-name', rank, nearby)
-      },
-      onClickSpectateCell (rank) {
-        let index =this.selectedRow.indexOf(rank)
-        if (index !== -1) {
-          this.$delete(this.selectedRow, index)
-        }
-        else {
-          this.selectedRow = this.selectedRow.concat([rank]).slice(-2)
-        }
-        this.$emit('spectate', this.selectedRow)
-      }
-
+  },
+  data () {
+    return {
+      selectedRow: [],
+      ageFilter: false
     }
-  });
+  },
+  computed: {
+    ageBrackets () {
+      let brackets = utils.ageBrackets
+      if (this.$store.state.features.china) {
+        brackets = utils.ageBracketsChina
+      }
+      return brackets.map((b) => {
+        return {
+          name: this.getAgeBracket(b.slug),
+          slug: b.slug
+        }
+      })
+    }
+  },
+  mounted () {
+    const histogramWrapper = $('#histogram-display-humans')
+    let histogramData = null
+    let url = `/db/level/${this.level.get('original')}/rankings-histogram?team=humans&levelSlug=${this.level.get('slug')}`
+    if (this.league) {
+      url += '&leagues.leagueID=' + this.league.id
+    }
+    $.when(
+      $.get(url, (data) => { histogramData = data })
+    ).then(() => this.generateHistogram(histogramWrapper, histogramData, 'humans'))
+  },
+  methods: {
+    loadMore () {
+      this.$emit('load-more')
+    },
+    generateHistogram (histogramElement, histogramData, teamName) {
+      console.log('generate hist 1')
+      // renders twice, hack fix
+      if ($('#' + histogramElement.attr('id')).has('svg').length) {
+        return
+      }
+      if (!histogramData.length) {
+        return histogramElement.hide()
+      }
+
+      histogramData = histogramData.map((d) => d * 100)
+      const margin = {
+        top: 20,
+        right: 20,
+        bottom: 30,
+        left: 15
+      }
+      const width = 470 - margin.left - margin.right
+      const height = 125 - margin.top - margin.bottom
+      const axisFactor = 1000
+      const minX = Math.floor(Math.min(...histogramData) / axisFactor) * axisFactor
+      const maxX = Math.ceil(Math.max(...histogramData) / axisFactor) * axisFactor
+      const x = d3.scale.linear().domain([minX, maxX]).range([0, width])
+      const data = d3.layout.histogram().bins(x.ticks(20))(histogramData)
+      const y = d3.scale.linear().domain([0, d3.max(data, (d) => d.y)]).range([height, 10])
+
+      // create the x axis
+      const xAxis = d3.svg.axis().scale(x).orient('bottom').ticks(5).outerTickSize(0)
+
+      const svg = d3.select('#histogram-display-humans').append('svg')
+                  .attr('preserveAspectRatio', 'xMinYMin meet')
+                  .attr('viewBox', `0 0 ${width + margin.left + margin.right} ${height + margin.top + margin.bottom}`)
+                  .append('g')
+                  .attr('transform', `translate(${margin.left}, ${margin.top})`)
+      const barClass = 'humans-bar'
+
+      const bar = svg.selectAll('.bar')
+                   .data(data)
+                   .enter().append('g')
+                   .attr('class', barClass)
+                   .attr('transform', (d) => `translate(${x(d.x)}, ${y(d.y)})`)
+
+      bar.append('rect')
+                   .attr('x', 1)
+                   .attr('width', width / 20)
+                   .attr('height', (d) => height - y(d.y))
+      if (this.session) {
+        let playerScore = this.session.get('totalScore')
+        if (this.league) {
+          const league = window._.find(this.session.get('leagues'), { leagueID: this.league.id })
+          playerScore = league ? +league.stats.totalScore : 10
+        }
+        playerScore = playerScore * 100
+
+        const scorebar = svg.selectAll('.specialbar')
+                          .data([playerScore])
+                          .enter().append('g')
+                          .attr('class', 'specialbar')
+                          .attr('transform', `translate(${x(playerScore)}, 0)`)
+
+        scorebar.append('rect')
+                          .attr('x', 1)
+                          .attr('width', 2)
+                          .attr('height', height)
+      }
+      const rankClass = 'rank-text humans-rank-text'
+
+      const message = `${histogramData.length.toLocaleString()} players`
+      /* if(@leaderboards[teamName].session)
+       *   //# TODO: i18n for these messages
+       *   if(this.league)
+       *     //# TODO: fix server handler to properly fetch myRank with a leagueID
+       *     message = "#{histogramData.length} players in league" */
+      /* else if(@leaderboards[teamName].myRank <= histogramData.length) {
+       *   message = "##{@leaderboards[teamName].myRank} of #{histogramData.length}"
+       *   message += "+" if histogramData.length >= 100000
+       * } */
+      /* else if(@leaderboards[teamName].myRank is 'unknown')
+       *   message = "#{if histogramData.length >= 100000 then '100,000+' else histogramData.length} players"
+       * else
+       *   message = 'Rank your session!' */
+      svg.append('g')
+         .append('text')
+         .attr('class', rankClass)
+         .attr('y', 0)
+         .attr('text-anchor', 'end')
+         .attr('x', width)
+         .text(message)
+
+      // Translate the x-axis up
+      svg.append('g')
+         .attr('class', 'x axis')
+         .attr('transform', 'translate(0, ' + height + ')')
+         .call(xAxis)
+
+      histogramElement.show()
+    },
+    toggleAgeFilter () {
+      this.ageFilter = !this.ageFilter
+    },
+    filterAge (slug) {
+      this.$emit('filter-age', slug)
+      this.ageFilter = false
+    },
+    computeClass (slug, item = '') {
+      if (slug === 'name') {
+        return { 'name-col-cell': 1, ai: /(Bronze|Silver|Gold|Platinum|Diamond) AI/.test(item) }
+      }
+      if (slug === 'team') {
+        return { capitalize: 1, 'clan-col-cell': 1 }
+      }
+      if (slug === 'language') {
+        return { 'code-language-cell': 1 }
+      }
+    },
+    computeStyle (item, index) {
+      if (this.tableTitles[index].slug === 'language') {
+        return { 'background-image': `url(/images/common/code_languages/${item}_icon.png)` }
+      }
+    },
+    getAgeBracket (item) {
+      return $.i18n.t(`ladder.bracket_${(item || 'open').replace(/-/g, '_')}`)
+    },
+
+    getCountry (code) {
+      return utils.countryCodeToFlagEmoji(code)
+    },
+
+    getCountryName (code) {
+      return utils.countryCodeToName(code)
+    },
+
+    computeTitle (slug, item) {
+      if (slug === 'country') {
+        return this.getCountryName(item)
+      } else {
+        return ''
+      }
+    },
+    computeBody  (slug, item) {
+      if (slug === 'country') {
+        return this.getCountry(item)
+      } else if (slug === 'fight') {
+        let url = `/play/level/${this.level.get('slug')}?team=humans&opponent=${item}`
+        if (this.league) {
+          if (this.leagueType === 'clan') {
+            url += `&league=${this.league.id}`
+          } else if (this.leagueType === 'course') {
+            url += `&course=${this.course.id}&course-instance=${this.league.id}`
+          }
+        }
+        return '<a href="' + url + '"><span>' + $.i18n.t('ladder.fight') + '</span></a>'
+      } else {
+        return item
+      }
+    },
+    classForRow (row) {
+      if (this.session) {
+        if (row[0] === this.session.get('creator')) {
+          return 'my-row'
+        }
+      }
+      if (window.location.pathname === '/league' && row.fullName) {
+        return 'student-row'
+      }
+      return ''
+    },
+    onClickUserRow (rank, slug, nearby = false) {
+      if (slug !== 'fight') {
+        this.$emit('click-player-name', rank, nearby)
+      }
+    },
+    onClickSpectateCell (rank) {
+      const index = this.selectedRow.indexOf(rank)
+      if (index !== -1) {
+        this.$delete(this.selectedRow, index)
+      } else {
+        this.selectedRow = this.selectedRow.concat([rank]).slice(-2)
+      }
+      this.$emit('spectate', this.selectedRow)
+    }
+
+  }
+})
 </script>
 
 <template lang="pug">
@@ -310,193 +327,193 @@
 </template>
 
 <style scoped lang="scss">
-  .ladder-table {
-    /* background-color: #F2F2F2; */
-    background-color: white;
-  }
-  .ladder-table td {
-    padding: 1px 2px;
+.ladder-table {
+  /* background-color: #F2F2F2; */
+  background-color: white;
+}
+.ladder-table td {
+  padding: 1px 2px;
+}
+
+.ladder-table .code-language-cell {
+  height: 16px;
+  background-position: center;
+  background-size: 16px;
+  background-repeat: no-repeat;
+  padding: 0 10px
+}
+
+.ladder-table tr {
+  font-size: 14px;
+  text-align: center;
+}
+.ladder-table tbody tr:hover td{
+  background-color: #FFFFFF;
+}
+
+.ladder-table th {
+  text-align: center;
+}
+
+.name-col-cell, .clan-col-cell {
+  max-width: 170px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.capitalize {
+  text-transform: capitalize;
+}
+
+.name-col-cell.ai {
+  color: #3f44bf;
+}
+
+.my-row {
+  background-color: #d1b147;
+}
+
+.student-row {
+  background-color: #bcff16;
+}
+
+.age-filter {
+  position: relative;
+
+  .glyphicon {
+    cursor: pointer;
   }
 
-  .ladder-table .code-language-cell {
-    height: 16px;
-    background-position: center;
-    background-size: 16px;
-    background-repeat: no-repeat;
-    padding: 0 10px
-  }
+  #age-filter {
+    position: absolute;
+    display: none;
+    background-color: #fcf8f2;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    right: 0;
+    width: 5em;
 
-  .ladder-table tr {
-    font-size: 14px;
-    text-align: center;
-  }
-  .ladder-table tbody tr:hover td{
-    background-color: #FFFFFF;
-  }
+    &.display {
+      display: block;
+    }
 
-  .ladder-table th {
-    text-align: center;
-  }
-
-  .name-col-cell, .clan-col-cell {
-    max-width: 170px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-  }
-
-  .capitalize {
-    text-transform: capitalize;
-  }
-
-  .name-col-cell.ai {
-    color: #3f44bf;
-  }
-
-  .my-row {
-    background-color: #d1b147;
-  }
-
-  .student-row {
-    background-color: #bcff16;
-  }
-
-  .age-filter {
-    position: relative;
-
-    .glyphicon {
+    .slug {
+      margin: 5px 10px;
       cursor: pointer;
     }
-
-    #age-filter {
-      position: absolute;
-      display: none;
-      background-color: #fcf8f2;
-      border: 1px solid #ddd;
-      border-radius: 5px;
-      right: 0;
-      width: 5em;
-
-      &.display {
-        display: block;
-      }
-
-      .slug {
-        margin: 5px 10px;
-        cursor: pointer;
-      }
-    }
   }
+}
 </style>
 
 <style lang="scss">
-  #histogram-display-humans {
-    position: relative;
-    width: 100%;
-    padding-bottom: 28%;
-    vertical-align: top;
-    overflow: hidden;
-    height: 130px;
-    background-color: white;
+#histogram-display-humans {
+  position: relative;
+  width: 100%;
+  padding-bottom: 28%;
+  vertical-align: top;
+  overflow: hidden;
+  height: 130px;
+  background-color: white;
 
-    svg {
-      overflow: visible;
+  svg {
+    overflow: visible;
 
-      .humans-bar rect {
-        shape-rendering: crispEdges;
-      }
-      
-      .humans-bar text{
-        fill: #fff;
-      }
-      
-      .specialbar rect {
-        fill: #555555;
-      }
-      
-      .axis path , .axis line{
-        fill: none;
-        stroke: #555555;
-        shape-rendering: crispEdges;
-      }
-      
-      .humans-bar {
-        fill: #bf3f3f;
-        shape-rendering: crispEdges;
-      }
-      text {
-        fill: #555555;
-      }
-      
-      .rank-text {
-        font-size: 15px;
-        fill: #555555;
-      }
-      
-      .humans-rank-text {
-        fill: #bf3f3f;
-      }
-      
+    .humans-bar rect {
+      shape-rendering: crispEdges;
     }
+
+    .humans-bar text{
+      fill: #fff;
+    }
+
+    .specialbar rect {
+      fill: #555555;
+    }
+
+    .axis path , .axis line{
+      fill: none;
+      stroke: #555555;
+      shape-rendering: crispEdges;
+    }
+
+    .humans-bar {
+      fill: #bf3f3f;
+      shape-rendering: crispEdges;
+    }
+    text {
+      fill: #555555;
+    }
+
+    .rank-text {
+      font-size: 15px;
+      fill: #555555;
+    }
+
+    .humans-rank-text {
+      fill: #bf3f3f;
+    }
+
   }
-  #contact-us-info {
-    position: relative;
-    width: 100%;
-    padding-bottom: 28%;
-    vertical-align: top;
-    overflow: hidden;
-    /* height: 130px; */
-    color: white;
-    background: url(/images/pages/play/ladder/unlock_esports_background.png);
-    background-size: 100%;
-    font-size: 18px;
-    font-weight: 600;
-    padding: 12px 40px;
-    text-align: center;
-    border-radius: 10px;
+}
+#contact-us-info {
+  position: relative;
+  width: 100%;
+  padding-bottom: 28%;
+  vertical-align: top;
+  overflow: hidden;
+  /* height: 130px; */
+  color: white;
+  background: url(/images/pages/play/ladder/unlock_esports_background.png);
+  background-size: 100%;
+  font-size: 18px;
+  font-weight: 600;
+  padding: 12px 40px;
+  text-align: center;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .title {
+    width: 400px
+  }
+
+  .content {
+    width: 380px;
     display: flex;
-    flex-direction: column;
-    align-items: center;
 
-    .title {
-      width: 400px
+    .img {
+      height: 4em;
     }
 
-    .content {
-      width: 380px;
+    .right-info {
       display: flex;
+      flex-direction: column;
+      align-items: center;
 
-      .img {
-        height: 4em;
+      .unlock-button {
+        width: fit-content;
+        text-transform: uppercase;
+        color: white;
+        display: block;
+        padding: 0.5em;
+        background: linear-gradient(to left top , #DB36A4, #F1D521);
+        border-radius: 2em;
+
+        &:hover {
+          text-decoration: none;
+        }
       }
 
-      .right-info {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-
-        .unlock-button {
-          width: fit-content;
-          text-transform: uppercase;
-          color: white;
-          display: block;
-          padding: 0.5em;
-          background: linear-gradient(to left top , #DB36A4, #F1D521);
-          border-radius: 2em;
-
-          &:hover {
-            text-decoration: none;
-          }
-        }
-
-        p {
-          margin: 5px 0;
-          font-size: 14px;
-        }
+      p {
+        margin: 5px 0;
+        font-size: 14px;
       }
     }
   }
-  .hide {
-    display: none;
-  }
+}
+.hide {
+  display: none;
+}
 </style>

--- a/app/views/play/level/ControlBarView.coffee
+++ b/app/views/play/level/ControlBarView.coffee
@@ -118,7 +118,7 @@ module.exports = class ControlBarView extends CocoView
       @homeViewClass = 'views/ladder/LadderView'
       @homeViewArgs.push levelID
       if leagueID = utils.getQueryVariable('league') or utils.getQueryVariable('course-instance')
-        leagueType = if @level.isType('course-ladder') then 'course' else 'clan'
+        leagueType = if @level.isType('course-ladder') or @level.isType('ladder') and utils.getQueryVariable('course-instance') then 'course' else 'clan'  # TODO check this for 'ladder' handling in classroom version
         @homeViewArgs.push leagueType
         @homeViewArgs.push leagueID
         @homeLink += "/#{leagueType}/#{leagueID}"

--- a/app/views/play/level/ControlBarView.coffee
+++ b/app/views/play/level/ControlBarView.coffee
@@ -118,7 +118,7 @@ module.exports = class ControlBarView extends CocoView
       @homeViewClass = 'views/ladder/LadderView'
       @homeViewArgs.push levelID
       if leagueID = utils.getQueryVariable('league') or utils.getQueryVariable('course-instance')
-        leagueType = if @level.isType('course-ladder') or @level.isType('ladder') and utils.getQueryVariable('course-instance') then 'course' else 'clan'  # TODO check this for 'ladder' handling in classroom version
+        leagueType = if @level.isType('course-ladder') or (@level.isType('ladder') and utils.getQueryVariable('course-instance')) then 'course' else 'clan'
         @homeViewArgs.push leagueType
         @homeViewArgs.push leagueID
         @homeLink += "/#{leagueType}/#{leagueID}"

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -739,7 +739,7 @@ module.exports = class PlayLevelView extends RootView
     options = {level: @level, supermodel: @supermodel, session: @session, hasReceivedMemoryWarning: @hasReceivedMemoryWarning, courseID: @courseID, courseInstanceID: @courseInstanceID, world: @world, parent: @}
     ModalClass = if @level.isType('hero', 'hero-ladder', 'hero-coop', 'course', 'course-ladder', 'game-dev', 'web-dev', 'ladder') then HeroVictoryModal else VictoryModal
     ModalClass = CourseVictoryModal if @isCourseMode() or me.isSessionless()
-    if @level.isType('course-ladder')
+    if @level.isType('course-ladder') or @level.isType('ladder') and @courseInstanceID
       ModalClass = CourseVictoryModal
       options.courseInstanceID = utils.getQueryVariable('course-instance') or utils.getQueryVariable('league')
     ModalClass = PicoCTFVictoryModal if window.serverConfig.picoCTF

--- a/app/views/play/level/modal/CourseVictoryModal.coffee
+++ b/app/views/play/level/modal/CourseVictoryModal.coffee
@@ -231,7 +231,7 @@ module.exports = class CourseVictoryModal extends ModalView
     viewArgs = [{supermodel: if @options.hasReceivedMemoryWarning then null else @supermodel}, @level.get('slug')]
     ladderURL = "/play/ladder/#{@level.get('slug') || @level.id}"
     if leagueID = (@courseInstanceID or utils.getQueryVariable 'league')
-      leagueType = if @level.get('type') is 'course-ladder' then 'course' else 'clan'  # TODO check this for 'ladder' handling in classroom version
+      leagueType = if @level.isType('course-ladder') or (@level.isType('ladder') and utils.getQueryVariable('course-instance')) then 'course' else 'clan'
       viewArgs.push leagueType
       viewArgs.push leagueID
       ladderURL += "/#{leagueType}/#{leagueID}"

--- a/app/views/play/level/modal/CourseVictoryModal.coffee
+++ b/app/views/play/level/modal/CourseVictoryModal.coffee
@@ -73,7 +73,7 @@ module.exports = class CourseVictoryModal extends ModalView
       _.assign(properties, {concepts, succeededConcepts})
     window.tracker?.trackEvent 'Play Level Victory Modal Loaded', properties
 
-    if @level.isType('hero', 'course', 'course-ladder', 'game-dev', 'web-dev')
+    if @level.isType('hero', 'course', 'course-ladder', 'game-dev', 'web-dev', 'ladder')
       @achievements = options.achievements
       if not @achievements
         @achievements = new Achievements()
@@ -231,7 +231,7 @@ module.exports = class CourseVictoryModal extends ModalView
     viewArgs = [{supermodel: if @options.hasReceivedMemoryWarning then null else @supermodel}, @level.get('slug')]
     ladderURL = "/play/ladder/#{@level.get('slug') || @level.id}"
     if leagueID = (@courseInstanceID or utils.getQueryVariable 'league')
-      leagueType = if @level.get('type') is 'course-ladder' then 'course' else 'clan'
+      leagueType = if @level.get('type') is 'course-ladder' then 'course' else 'clan'  # TODO check this for 'ladder' handling in classroom version
       viewArgs.push leagueType
       viewArgs.push leagueID
       ladderURL += "/#{leagueType}/#{leagueID}"


### PR DESCRIPTION
This is so we can add Ace of Coders to CS6, and eventually refactor the type: "course-ladder" arenas to use the new structure.

Currently it doesn't work, because if you play Ace of Coders from the classroom as a student, you arrive on:

/play/level/ace-of-coders?course=5817d673e85d1220db624ca4&course-instance=5afb10979bb5895ee2557c90

So the "Back to ladder" link in the top left is formatted like this:

/play/ladder/ace-of-coders/course/5afb10979bb5895ee2557c90

But then after playing again, you go to:

/play/level/ace-of-coders?team=humans&league=5afb10979bb5895ee2557c90

And then the "Back to ladder" link becomes:

/play/ladder/ace-of-coders/clan/5afb10979bb5895ee2557c90

–which is a 404, because it's trying to load a clan instead of a course instance.

Maybe we should be making most of these fixes on /play/ladder/:handle instead of /play/level/:handle?