### PR TITLE
Oz Levels - Focus from Vega messages to code editor

### DIFF
--- a/ozaria/site/views/play/level/TutorialPlayComponent.vue
+++ b/ozaria/site/views/play/level/TutorialPlayComponent.vue
@@ -504,11 +504,17 @@
 
           headerElement.append(`<div class="${headerClasses.join(' ')}"></div>`)
 
-          if (tutorialStep.targetElement === 'Run Button' || (tutorialStep.position === 'stationary' &&
-            !tutorialStep.targetElement && !tutorialStep.animation)) {
-            overlayElement.css('display', 'none')
-          } else {
-            overlayElement.css('display', 'block')
+          const hideOverlay = (
+              tutorialStep.targetElement === 'Run Button' ||
+              (tutorialStep.position === 'stationary' && !tutorialStep.targetElement && !tutorialStep.animation)
+          )
+          overlayElement.css('display', hideOverlay ? 'none' : 'block')
+
+          // We should only focus the code editor if it is visible,
+          // which happens when it is the target element, and shepherd highlights it
+          // or when the shepherd overlay is hidden.
+          if (tutorialStep.targetElement === 'Code Editor Window' || hideOverlay) {
+            Backbone.Mediator.publish('tome:focus-editor', {})
           }
 
           if (tutorialStep.animation === 'Glow') {

--- a/ozaria/site/views/play/level/tome/SpellView.coffee
+++ b/ozaria/site/views/play/level/tome/SpellView.coffee
@@ -1141,7 +1141,7 @@ module.exports = class SpellView extends CocoView
   focus: ->
     # TODO: it's a hack checking if a modal is visible; the events should be removed somehow
     # but this view is not part of the normal subview destroying because of how it's swapped
-    return unless @controlsEnabled and @writable and $('.modal:visible, .shepherd-button:visible').length is 0
+    return unless @controlsEnabled and @writable and $('.modal:visible').length is 0
     return if @ace.isFocused()
     return if me.get('aceConfig')?.screenReaderMode and utils.isOzaria  # Screen reader users get to control their own focus manually
     @ace.focus()


### PR DESCRIPTION
Clicking back/forward buttons on Vega messages the focus returns back to the code editor. (If the editor is not hidden behind grey overlay):

![shepherd-focus](https://user-images.githubusercontent.com/11805970/186436909-ffc90645-146c-46ed-aafc-7d49d32f01f4.gif)

