### PR TITLE
make sure we call deactivate on focus-trap

### DIFF
--- a/ozaria/site/components/char-customization/ModalCharCustomization/index.vue
+++ b/ozaria/site/components/char-customization/ModalCharCustomization/index.vue
@@ -234,7 +234,7 @@
       },
 
       handleSubmit () {
-        this.submitButtonDisabled = true;
+        this.submitButtonDisabled = true
         let valid = null
         try {
           valid = this.$refs['name-form'].reportValidity()
@@ -245,10 +245,12 @@
         }
         const name = this.characterName.trim()
         if (!valid) {
+          this.submitButtonDisabled = false
           return
         }
         if (name === '') {
           // TODO: handle_error_ozaria
+          this.submitButtonDisabled = false
           return noty({ text: 'Invalid Name', layout: 'topCenter', type: 'error', timeout: 8000 })
         }
 

--- a/ozaria/site/components/common/ModalTransition.vue
+++ b/ozaria/site/components/common/ModalTransition.vue
@@ -152,19 +152,23 @@
           initialFocus: '.next-button.ozaria-primary-button'
         })
         this.focusTrap.activate()
-      }, 1000)
+      }, 500)
     },
 
     beforeDestroy () {
-      if (this.focusTrap) {
-        this.focusTrap.deactivate()
-      }
+      // seems not work when this component is destroyed by parent conditional-render
+      this.deactivateFocusTrap()
     },
 
     methods: {
       ...mapActions({
         buildLevelsData: 'unitMap/buildLevelsData'
       }),
+      deactivateFocusTrap () {
+        if (this.focusTrap) {
+          this.focusTrap.deactivate()
+        }
+      },
       async fetchRequiredData (campaignHandle) {
         this.loading = true;
         // TODO: Fix duplicate fetching here. The `buildLevelsData` also fetches this.
@@ -265,6 +269,7 @@
         }
       },
       nextButtonClick () {
+        this.deactivateFocusTrap()
         if (this.supermodel && !this.doReload) {
           // Hack: save the current supermodel globally so that the next content view can grab it during initialization and doesn't have to reload everything
           window.temporarilyPreservedSupermodel = this.supermodel
@@ -282,6 +287,7 @@
       // PlayLevelView is a backbone view, so replay button dismisses modal for that
       // IntroLevelPage is vue component and handles the event `replay`
       replayButtonClick () {
+        this.deactivateFocusTrap()
         this.$emit('replay', this.currentIntroContent)
       },
       continueEditingButtonClick () {


### PR DESCRIPTION
1. make sure we re-enable hero-selection button if name is missing
2. make sure we call deactivate on focus-trap when we dismiss the victory modal
3. make delay little shorter since 1s is easy to conflict with user click (`Error: initialFocus refers to no known node`)