### PR TITLE
Keyboard accessibility for Oz home page, char select, and world map

### DIFF
--- a/app/components/common/Navigation.coco.vue
+++ b/app/components/common/Navigation.coco.vue
@@ -170,21 +170,21 @@
                   li
                     a.text-p(data-event-action="Header Request Quote CTA", href="/contact-cn") {{ $t('new_home.request_quote') }}
 
-                ul.nav.navbar-nav(v-if="me.isAnonymous()")
-                  li.dropdown.dropdown-hover
-                    a.text-p(:href="isCodeCombat ? '/impact' : '#'", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" :class="isOzaria && 'text-teal'")
-                      span {{ $t('nav.educators') }}
-                      span.caret
-                    ul(class="dropdown-menu")
-                      li
-                        a.text-p(:href="ozPath('/')")
-                          span(:class="isOzaria && !checkLocation('/professional-development') && 'text-teal'") {{ $t('nav.ozaria_classroom') }}
-                      li
-                        a.text-p(:href="cocoPath('/impact')" :class="checkLocation('/impact', CODECOMBAT) && 'text-teal'") {{ $t('nav.codecombat_classroom') }}
-                      li
-                        a.text-p(:href="ozPath('/professional-development')")
-                          span(:class="checkLocation('/professional-development') && 'text-teal'") {{ $t('nav.professional_development') }}
-                          span.new-pill {{ $t('nav.new') }}
+                li
+                  ul.nav.navbar-nav(v-if="me.isAnonymous()")
+                    li.dropdown.dropdown-hover
+                      a.text-p(:href="isCodeCombat ? '/impact' : '#'", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" :class="isOzaria && 'text-teal'")
+                        span {{ $t('nav.educators') }}
+                        span.caret
+                      ul(class="dropdown-menu")
+                        li
+                          a.text-p(:href="ozPath('/')")
+                            span(:class="isOzaria && !checkLocation('/professional-development') && 'text-teal'") {{ $t('nav.ozaria_classroom') }}
+                        li
+                          a.text-p(:href="cocoPath('/impact')" :class="checkLocation('/impact', CODECOMBAT) && 'text-teal'") {{ $t('nav.codecombat_classroom') }}
+                        li
+                          a.text-p(:href="ozPath('/professional-development')")
+                            span(:class="checkLocation('/professional-development') && 'text-teal'") {{ $t('nav.professional_development') }}
 
                 li(v-if="!me.isStudent() && !me.isTeacher()")
                   a.text-p(:class="checkLocation('/parents') && 'text-teal'" :href="cocoPath('/parents')") {{ $t('nav.parent') }}
@@ -192,34 +192,34 @@
                 li
                   a.text-p(:class="checkLocation('/league') && 'text-teal'" :href="cocoPath('/league')") {{ $t('nav.esports') }}
 
-                ul.nav.navbar-nav(v-if="me.isTeacher()")
-                  li.dropdown.dropdown-hover
-                    a.dropdown-toggle.text-p(href="/teachers/classes", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false")
-                      span {{ $t('nav.educators') }}
-                      span.caret
-                    ul(class="dropdown-menu")
-                      li
-                        a.text-p(:href="ozPath('/teachers/classes')")
-                          span(:class="checkLocation('/teachers/classes', OZARIA) && 'text-teal'") {{ $t('nav.ozaria_dashboard') }}
-                      li
-                        a.text-p(:class="checkLocation('/teachers/classes', CODECOMBAT) && 'text-teal'" :href="cocoPath('/teachers/classes')") {{ $t('nav.codecombat_dashboard') }}
-                      li
-                        a.text-p(:href="ozPath('/professional-development')")
-                          span(:class="checkLocation('/professional-development') && 'text-teal'") {{ $t('nav.professional_development') }}
-                          span.new-pill {{ $t('nav.new') }}
+                li
+                  ul.nav.navbar-nav(v-if="me.isTeacher()")
+                    li.dropdown.dropdown-hover
+                      a.dropdown-toggle.text-p(href="/teachers/classes", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false")
+                        span {{ $t('nav.educators') }}
+                        span.caret
+                      ul(class="dropdown-menu")
+                        li
+                          a.text-p(:href="ozPath('/teachers/classes')")
+                            span(:class="checkLocation('/teachers/classes', OZARIA) && 'text-teal'") {{ $t('nav.ozaria_dashboard') }}
+                        li
+                          a.text-p(:class="checkLocation('/teachers/classes', CODECOMBAT) && 'text-teal'" :href="cocoPath('/teachers/classes')") {{ $t('nav.codecombat_dashboard') }}
+                        li
+                          a.text-p(:href="ozPath('/professional-development')")
+                            span(:class="checkLocation('/professional-development') && 'text-teal'") {{ $t('nav.professional_development') }}
 
-                ul.nav.navbar-nav(v-else-if="me.isStudent()")
-                  li.dropdown.dropdown-hover
-                    a.dropdown-toggle.text-p(href="#", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false")
-                      span {{ $t('nav.my_courses') }}
-                      span.caret
-                    ul(class="dropdown-menu")
-                      li
-                        a.text-p(:href="ozPath('/students')")
-                          span(:class="checkLocation('/students', OZARIA) && 'text-teal'") {{ $t('nav.ozaria_classroom') }}
-                          span.new-pill {{ $t('nav.new') }}
-                      li
-                        a.text-p(:class="checkLocation('/students', CODECOMBAT) && 'text-teal'" :href="cocoPath('/students')") {{ $t('nav.codecombat_classroom') }}
+                li
+                  ul.nav.navbar-nav(v-else-if="me.isStudent()")
+                    li.dropdown.dropdown-hover
+                      a.dropdown-toggle.text-p(href="#", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false")
+                        span {{ $t('nav.my_courses') }}
+                        span.caret
+                      ul(class="dropdown-menu")
+                        li
+                          a.text-p(:href="ozPath('/students')")
+                            span(:class="checkLocation('/students', OZARIA) && 'text-teal'") {{ $t('nav.ozaria_classroom') }}
+                        li
+                          a.text-p(:class="checkLocation('/students', CODECOMBAT) && 'text-teal'" :href="cocoPath('/students')") {{ $t('nav.codecombat_classroom') }}
 
                 li.dashboard-toggle(v-if="me.isSchoolAdmin()")
                   //- Only show divider if neither side is toggled.
@@ -261,24 +261,24 @@
                       a.account-dropdown-item(href="/account/payments") {{ $t('account.payments') }}
                     li(v-if="isCodeCombat && (me.isAdmin() || !(me.isTeacher() || me.isStudent() || me.freeOnly()) || me.hasSubscription())")
                       a.account-dropdown-item(href="/account/subscription") {{ $t('account.subscription') }}
-                    li(v-if="me.isAdmin() || (me.get('emailVerified') && (me.isTeacher() || (!me.get('role') && !me.isAnonymous())))")
+                    li(v-if="isCodeCombat && (me.isAdmin() || (me.get('emailVerified') && (me.isTeacher() || (!me.get('role') && !me.isAnonymous()))))")
                       a.account-dropdown-item#manage-billing(href="/payments/manage-billing", target="_blank") {{ $t('account.manage_billing') }}
                     li(v-if="me.isAPIClient()")
                       a.account-dropdown-item(href="/api-dashboard", target="_blank") {{ $t('nav.api_dashboard') }}
                     li(v-if="me.isAdmin()")
                       a.account-dropdown-item(href="/admin") {{ $t('account_settings.admin') }}
                     li(v-if="serverSession && serverSession.amActually")
-                      a.account-dropdown-item#nav-stop-spying-button {{ $t('login.stop_spying') }}
+                      a.account-dropdown-item#nav-stop-spying-button(href="#") {{ $t('login.stop_spying') }}
                     li(v-else-if="serverSession && serverSession.switchingUserActualId")
-                      a.account-dropdown-item#nav-stop-spying-button {{ $t('login.stop_switching') }}
+                      a.account-dropdown-item#nav-stop-spying-button(href="#") {{ $t('login.stop_switching') }}
                     li
-                      a.account-dropdown-item#logout-button {{ $t('login.log_out') }}
+                      a.account-dropdown-item#logout-button(href="#") {{ $t('login.log_out') }}
 
               ul.nav.navbar-nav.text-p.login-buttons(v-if="me.isAnonymous() && !hideNav")
                 li
-                  a#create-account-link.signup-button(data-event-action="Header Sign Up CTA") {{ $t('signup.sign_up') }}
+                  button#create-account-link.signup-button(data-event-action="Header Sign Up CTA") {{ $t('signup.sign_up') }}
                 li
-                  a#login-link.login-button(data-event-action="Header Login CTA") {{ $t('signup.login') }}
+                  button#login-link.login-button(data-event-action="Header Login CTA") {{ $t('signup.login') }}
 </template>
 
 <style lang="scss" scoped>
@@ -308,7 +308,7 @@
     margin: 0;
   }
 
-  p, .text-p {
+  p, .text-p, .text-p button {
     font-family: $body-font;
     font-size: 18px;
     font-weight: 400;
@@ -333,7 +333,9 @@
     width: 94px;
     border: 1px solid $teal;
     border-radius: 0 4px 4px 0;
-    color: $teal;
+    /*color: $teal;*/ /* too faint for WCAG AAA */
+    color: #16837f; /* increased contrast by lowering luminance */
+    background: transparent;
     &:hover {
       background-color: #1FBAB4;
       color: white;
@@ -370,6 +372,9 @@
     }
     & li {
       display: inline-block;
+    }
+    & button {
+      line-height: 20px;
     }
   }
   a.navbar-brand {
@@ -429,11 +434,13 @@
     max-height: 100vh;
 
     .text-teal {
-      color: $teal;
+      /*color: $teal;*/ /* too faint for WCAG AAA */
+      color: #16837f; /* increased contrast by lowering luminance */
+      font-weight: 600;  /* increased contrast by increasing weight */
     }
   }
 
-  .nav > li > a {
+  .nav > li > a, .nav > li > button {
     // TODO: Move this to bootstrap variables for navbars
 
     // TODO: getting overridden by .navbar .nav > li > a for some reason
@@ -450,7 +457,7 @@
     }
   }
   // TODO: what is this for?
-  .nav > li.disabled > a {
+  .nav > li.disabled > a, .nav > li.disabled > button {
     color: black;
     &:hover {
       background: white;
@@ -489,7 +496,7 @@
   }
 
   @media (max-width: $grid-float-breakpoint) {
-    .nav > li > a {
+    .nav > li > a, .nav > li > button {
       padding: 10px 20px;
       height: 45px;
     }

--- a/app/components/common/Navigation.coco.vue
+++ b/app/components/common/Navigation.coco.vue
@@ -170,8 +170,8 @@
                   li
                     a.text-p(data-event-action="Header Request Quote CTA", href="/contact-cn") {{ $t('new_home.request_quote') }}
 
-                li
-                  ul.nav.navbar-nav(v-if="me.isAnonymous()")
+                li(v-if="me.isAnonymous()")
+                  ul.nav.navbar-nav
                     li.dropdown.dropdown-hover
                       a.text-p(:href="isCodeCombat ? '/impact' : '#'", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" :class="isOzaria && 'text-teal'")
                         span {{ $t('nav.educators') }}
@@ -192,8 +192,8 @@
                 li
                   a.text-p(:class="checkLocation('/league') && 'text-teal'" :href="cocoPath('/league')") {{ $t('nav.esports') }}
 
-                li
-                  ul.nav.navbar-nav(v-if="me.isTeacher()")
+                li(v-if="me.isTeacher()")
+                  ul.nav.navbar-nav
                     li.dropdown.dropdown-hover
                       a.dropdown-toggle.text-p(href="/teachers/classes", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false")
                         span {{ $t('nav.educators') }}
@@ -208,8 +208,8 @@
                           a.text-p(:href="ozPath('/professional-development')")
                             span(:class="checkLocation('/professional-development') && 'text-teal'") {{ $t('nav.professional_development') }}
 
-                li
-                  ul.nav.navbar-nav(v-else-if="me.isStudent()")
+                li(v-else-if="me.isStudent()")
+                  ul.nav.navbar-nav
                     li.dropdown.dropdown-hover
                       a.dropdown-toggle.text-p(href="#", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false")
                         span {{ $t('nav.my_courses') }}

--- a/app/components/common/Navigation.ozar.vue
+++ b/app/components/common/Navigation.ozar.vue
@@ -131,7 +131,7 @@
 </script>
 
 <template lang="pug">
-    nav#main-nav.navbar.navbar-default.navbar-fixed-top.text-center(:class="document.location.href.search('/league') >= 0 ? 'dark-mode' : ''" @click="navEvent")
+    nav#main-nav.navbar.navbar-default.navbar-fixed-top.text-center(:class="/^\\/(league|play\\/ladder)/.test(document.location.pathname) ? 'dark-mode' : ''" @click="navEvent")
       .container-fluid
         .row
           .col-md-12
@@ -147,8 +147,8 @@
               a.navbar-brand(v-else-if="serverConfig.codeNinjas" href="/home")
                 img#logo-img.powered-by(src="/images/pages/base/logo.png" alt="CodeCombat logo")
                 img.code-ninjas-logo(src="/images/pages/base/code-ninjas-logo-right.png" alt="Code Ninjas logo")
-              a.navbar-brand(v-else-if="me.isTecmilenio()")
-                img#logo-img(src="/images/pages/base/logo.png" alt="CodeCombat logo")
+              a.navbar-brand(v-else-if="me.isTecmilenio()" href="/home")
+                img#logo-img.powered-by(src="/images/pages/base/logo.png" alt="CodeCombat logo")
                 img.tecmilenio-logo(src="/images/pages/payment/tecmilenio-logo-2.png" alt="Tecmilenio logo")
               a.navbar-brand(v-else-if="me.showChinaResourceInfo()" href="/home")
                 img#logo-img(src="/images/pages/base/logo-en+cn.png" alt="CodeCombat logo")
@@ -170,21 +170,21 @@
                   li
                     a.text-p(data-event-action="Header Request Quote CTA", href="/contact-cn") {{ $t('new_home.request_quote') }}
 
-                ul.nav.navbar-nav(v-if="me.isAnonymous()")
-                  li.dropdown.dropdown-hover
-                    a.text-p(:href="isCodeCombat ? '/impact' : '#'", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" :class="isOzaria && 'text-teal'")
-                      span {{ $t('nav.educators') }}
-                      span.caret
-                    ul(class="dropdown-menu")
-                      li
-                        a.text-p(:href="ozPath('/')")
-                          span(:class="isOzaria && !checkLocation('/professional-development') && 'text-teal'") {{ $t('nav.ozaria_classroom') }}
-                      li
-                        a.text-p(:href="cocoPath('/impact')" :class="checkLocation('/impact', CODECOMBAT) && 'text-teal'") {{ $t('nav.codecombat_classroom') }}
-                      li
-                        a.text-p(:href="ozPath('/professional-development')")
-                          span(:class="checkLocation('/professional-development') && 'text-teal'") {{ $t('nav.professional_development') }}
-                          span.new-pill {{ $t('nav.new') }}
+                li
+                  ul.nav.navbar-nav(v-if="me.isAnonymous()")
+                    li.dropdown.dropdown-hover
+                      a.text-p(:href="isCodeCombat ? '/impact' : '#'", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" :class="isOzaria && 'text-teal'")
+                        span {{ $t('nav.educators') }}
+                        span.caret
+                      ul(class="dropdown-menu")
+                        li
+                          a.text-p(:href="ozPath('/')")
+                            span(:class="isOzaria && !checkLocation('/professional-development') && 'text-teal'") {{ $t('nav.ozaria_classroom') }}
+                        li
+                          a.text-p(:href="cocoPath('/impact')" :class="checkLocation('/impact', CODECOMBAT) && 'text-teal'") {{ $t('nav.codecombat_classroom') }}
+                        li
+                          a.text-p(:href="ozPath('/professional-development')")
+                            span(:class="checkLocation('/professional-development') && 'text-teal'") {{ $t('nav.professional_development') }}
 
                 li(v-if="!me.isStudent() && !me.isTeacher()")
                   a.text-p(:class="checkLocation('/parents') && 'text-teal'" :href="cocoPath('/parents')") {{ $t('nav.parent') }}
@@ -192,34 +192,34 @@
                 li
                   a.text-p(:class="checkLocation('/league') && 'text-teal'" :href="cocoPath('/league')") {{ $t('nav.esports') }}
 
-                ul.nav.navbar-nav(v-if="me.isTeacher()")
-                  li.dropdown.dropdown-hover
-                    a.dropdown-toggle.text-p(href="/teachers/classes", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false")
-                      span {{ $t('nav.educators') }}
-                      span.caret
-                    ul(class="dropdown-menu")
-                      li
-                        a.text-p(:href="ozPath('/teachers/classes')")
-                          span(:class="checkLocation('/teachers/classes', OZARIA) && 'text-teal'") {{ $t('nav.ozaria_dashboard') }}
-                      li
-                        a.text-p(:class="checkLocation('/teachers/classes', CODECOMBAT) && 'text-teal'" :href="cocoPath('/teachers/classes')") {{ $t('nav.codecombat_dashboard') }}
-                      li
-                        a.text-p(:href="ozPath('/professional-development')")
-                          span(:class="checkLocation('/professional-development') && 'text-teal'") {{ $t('nav.professional_development') }}
-                          span.new-pill {{ $t('nav.new') }}
+                li
+                  ul.nav.navbar-nav(v-if="me.isTeacher()")
+                    li.dropdown.dropdown-hover
+                      a.dropdown-toggle.text-p(href="/teachers/classes", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false")
+                        span {{ $t('nav.educators') }}
+                        span.caret
+                      ul(class="dropdown-menu")
+                        li
+                          a.text-p(:href="ozPath('/teachers/classes')")
+                            span(:class="checkLocation('/teachers/classes', OZARIA) && 'text-teal'") {{ $t('nav.ozaria_dashboard') }}
+                        li
+                          a.text-p(:class="checkLocation('/teachers/classes', CODECOMBAT) && 'text-teal'" :href="cocoPath('/teachers/classes')") {{ $t('nav.codecombat_dashboard') }}
+                        li
+                          a.text-p(:href="ozPath('/professional-development')")
+                            span(:class="checkLocation('/professional-development') && 'text-teal'") {{ $t('nav.professional_development') }}
 
-                ul.nav.navbar-nav(v-else-if="me.isStudent()")
-                  li.dropdown.dropdown-hover
-                    a.dropdown-toggle.text-p(href="#", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false")
-                      span {{ $t('nav.my_courses') }}
-                      span.caret
-                    ul(class="dropdown-menu")
-                      li
-                        a.text-p(:href="ozPath('/students')")
-                          span(:class="checkLocation('/students', OZARIA) && 'text-teal'") {{ $t('nav.ozaria_classroom') }}
-                          span.new-pill {{ $t('nav.new') }}
-                      li
-                        a.text-p(:class="checkLocation('/students', CODECOMBAT) && 'text-teal'" :href="cocoPath('/students')") {{ $t('nav.codecombat_classroom') }}
+                li
+                  ul.nav.navbar-nav(v-else-if="me.isStudent()")
+                    li.dropdown.dropdown-hover
+                      a.dropdown-toggle.text-p(href="#", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false")
+                        span {{ $t('nav.my_courses') }}
+                        span.caret
+                      ul(class="dropdown-menu")
+                        li
+                          a.text-p(:href="ozPath('/students')")
+                            span(:class="checkLocation('/students', OZARIA) && 'text-teal'") {{ $t('nav.ozaria_classroom') }}
+                        li
+                          a.text-p(:class="checkLocation('/students', CODECOMBAT) && 'text-teal'" :href="cocoPath('/students')") {{ $t('nav.codecombat_classroom') }}
 
                 li.dashboard-toggle(v-if="me.isSchoolAdmin()")
                   //- Only show divider if neither side is toggled.
@@ -261,20 +261,24 @@
                       a.account-dropdown-item(href="/account/payments") {{ $t('account.payments') }}
                     li(v-if="isCodeCombat && (me.isAdmin() || !(me.isTeacher() || me.isStudent() || me.freeOnly()) || me.hasSubscription())")
                       a.account-dropdown-item(href="/account/subscription") {{ $t('account.subscription') }}
+                    li(v-if="isCodeCombat && (me.isAdmin() || (me.get('emailVerified') && (me.isTeacher() || (!me.get('role') && !me.isAnonymous()))))")
+                      a.account-dropdown-item#manage-billing(href="/payments/manage-billing", target="_blank") {{ $t('account.manage_billing') }}
+                    li(v-if="me.isAPIClient()")
+                      a.account-dropdown-item(href="/api-dashboard", target="_blank") {{ $t('nav.api_dashboard') }}
                     li(v-if="me.isAdmin()")
                       a.account-dropdown-item(href="/admin") {{ $t('account_settings.admin') }}
                     li(v-if="serverSession && serverSession.amActually")
-                      a.account-dropdown-item#nav-stop-spying-button {{ $t('login.stop_spying') }}
+                      a.account-dropdown-item#nav-stop-spying-button(href="#") {{ $t('login.stop_spying') }}
                     li(v-else-if="serverSession && serverSession.switchingUserActualId")
-                      a.account-dropdown-item#nav-stop-spying-button {{ $t('login.stop_switching') }}
+                      a.account-dropdown-item#nav-stop-spying-button(href="#") {{ $t('login.stop_switching') }}
                     li
-                      a.account-dropdown-item#logout-button {{ $t('login.log_out') }}
+                      a.account-dropdown-item#logout-button(href="#") {{ $t('login.log_out') }}
 
               ul.nav.navbar-nav.text-p.login-buttons(v-if="me.isAnonymous() && !hideNav")
                 li
-                  a#create-account-link.signup-button(data-event-action="Header Sign Up CTA") {{ $t('signup.sign_up') }}
+                  button#create-account-link.signup-button(data-event-action="Header Sign Up CTA") {{ $t('signup.sign_up') }}
                 li
-                  a#login-link.login-button(data-event-action="Header Login CTA") {{ $t('signup.login') }}
+                  button#login-link.login-button(data-event-action="Header Login CTA") {{ $t('signup.login') }}
 </template>
 
 <style lang="scss" scoped>
@@ -304,7 +308,7 @@
     margin: 0;
   }
 
-  p, .text-p {
+  p, .text-p, .text-p button {
     font-family: $body-font;
     font-size: 18px;
     font-weight: 400;
@@ -329,7 +333,9 @@
     width: 94px;
     border: 1px solid $teal;
     border-radius: 0 4px 4px 0;
-    color: $teal;
+    /*color: $teal;*/ /* too faint for WCAG AAA */
+    color: #16837f; /* increased contrast by lowering luminance */
+    background: transparent;
     &:hover {
       background-color: #1FBAB4;
       color: white;
@@ -366,6 +372,9 @@
     }
     & li {
       display: inline-block;
+    }
+    & button {
+      line-height: 20px;
     }
   }
   a.navbar-brand {
@@ -425,11 +434,13 @@
     max-height: 100vh;
 
     .text-teal {
-      color: $teal;
+      /*color: $teal;*/ /* too faint for WCAG AAA */
+      color: #16837f; /* increased contrast by lowering luminance */
+      font-weight: 600;  /* increased contrast by increasing weight */
     }
   }
 
-  .nav > li > a {
+  .nav > li > a, .nav > li > button {
     // TODO: Move this to bootstrap variables for navbars
 
     // TODO: getting overridden by .navbar .nav > li > a for some reason
@@ -446,7 +457,7 @@
     }
   }
   // TODO: what is this for?
-  .nav > li.disabled > a {
+  .nav > li.disabled > a, .nav > li.disabled > button {
     color: black;
     &:hover {
       background: white;
@@ -485,7 +496,7 @@
   }
 
   @media (max-width: $grid-float-breakpoint) {
-    .nav > li > a {
+    .nav > li > a, .nav > li > button {
       padding: 10px 20px;
       height: 45px;
     }
@@ -557,6 +568,56 @@
 
     .show-divider:not(:last-child) {
       border-right: 1px solid #131b25;
+    }
+  }
+}
+
+nav#main-nav.navbar.dark-mode {
+  background-color: #0C1016;
+
+  .nav > li > a {
+    color: #FCBB00;
+
+    &:hover {
+      color: #FF39A6;
+    }
+  }
+
+  .dashboard-toggle {
+    border: 1px solid #FCBB00;
+
+    & > .show-divider {
+      border-right: 1px solid #FCBB00 !important;
+    }
+  }
+
+  .dashboard-toggle .dashboard-button a {
+    color: #FCBB00;
+  }
+
+  .dropdown-menu {
+    background-color: white;
+  }
+
+  #create-account-link {
+    background-color: #FCBB00;
+    border: 1px solid #FCBB00;
+    color: #0C1016;
+
+    &:hover {
+      background-color: #FF39A6;
+      border: 1px solid #FF39A6;
+    }
+  }
+
+  #login-link {
+    color: #FCBB00;
+    border: 1px solid #FCBB00;
+
+    &:hover {
+      background-color: #FF39A6;
+      border: 1px solid #FF39A6;
+      color: #0C1016;
     }
   }
 }

--- a/app/components/common/Navigation.ozar.vue
+++ b/app/components/common/Navigation.ozar.vue
@@ -170,8 +170,8 @@
                   li
                     a.text-p(data-event-action="Header Request Quote CTA", href="/contact-cn") {{ $t('new_home.request_quote') }}
 
-                li
-                  ul.nav.navbar-nav(v-if="me.isAnonymous()")
+                li(v-if="me.isAnonymous()")
+                  ul.nav.navbar-nav
                     li.dropdown.dropdown-hover
                       a.text-p(:href="isCodeCombat ? '/impact' : '#'", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" :class="isOzaria && 'text-teal'")
                         span {{ $t('nav.educators') }}
@@ -192,8 +192,8 @@
                 li
                   a.text-p(:class="checkLocation('/league') && 'text-teal'" :href="cocoPath('/league')") {{ $t('nav.esports') }}
 
-                li
-                  ul.nav.navbar-nav(v-if="me.isTeacher()")
+                li(v-if="me.isTeacher()")
+                  ul.nav.navbar-nav
                     li.dropdown.dropdown-hover
                       a.dropdown-toggle.text-p(href="/teachers/classes", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false")
                         span {{ $t('nav.educators') }}
@@ -208,8 +208,8 @@
                           a.text-p(:href="ozPath('/professional-development')")
                             span(:class="checkLocation('/professional-development') && 'text-teal'") {{ $t('nav.professional_development') }}
 
-                li
-                  ul.nav.navbar-nav(v-else-if="me.isStudent()")
+                li(v-else-if="me.isStudent()")
+                  ul.nav.navbar-nav
                     li.dropdown.dropdown-hover
                       a.dropdown-toggle.text-p(href="#", data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false")
                         span {{ $t('nav.my_courses') }}

--- a/app/styles/bootstrap/_navbar.scss
+++ b/app/styles/bootstrap/_navbar.scss
@@ -213,7 +213,8 @@
 .navbar-nav {
   margin: math.div($navbar-padding-vertical, 2) (-$navbar-padding-horizontal);
 
-  > li > a {
+  > li > a,
+  > li > button {
     padding-top:    10px;
     padding-bottom: 10px;
     line-height: $line-height-computed;
@@ -230,10 +231,12 @@
       border: 0;
       box-shadow: none;
       > li > a,
+      > li > button,
       .dropdown-header {
         padding: 5px 15px 5px 25px;
       }
-      > li > a {
+      > li > a,
+      > li > button {
         line-height: $line-height-computed;
         &:hover,
         &:focus {
@@ -250,7 +253,8 @@
 
     > li {
       float: left;
-      > a {
+      > a,
+      > button {
         padding-top:    $navbar-padding-vertical;
         padding-bottom: $navbar-padding-vertical;
       }
@@ -399,7 +403,8 @@
   }
 
   .navbar-nav {
-    > li > a {
+    > li > a,
+    > li > button {
       color: $navbar-default-link-color;
 
       &:hover,
@@ -408,7 +413,8 @@
         background-color: $navbar-default-link-hover-bg;
       }
     }
-    > .active > a {
+    > .active > a,
+    > .active > button {
       &,
       &:hover,
       &:focus {
@@ -416,7 +422,8 @@
         background-color: $navbar-default-link-active-bg;
       }
     }
-    > .disabled > a {
+    > .disabled > a,
+    > .disabled > button {
       &,
       &:hover,
       &:focus {
@@ -445,7 +452,8 @@
   // Dropdown menu items
   .navbar-nav {
     // Remove background color from open dropdown
-    > .open > a {
+    > .open > a,
+    > .open > button {
       &,
       &:hover,
       &:focus {
@@ -457,7 +465,8 @@
     @media (max-width: $grid-float-breakpoint-max) {
       // Dropdowns get custom display when collapsed
       .open .dropdown-menu {
-        > li > a {
+        > li > a,
+        > li > button {
           color: $navbar-default-link-color;
           &:hover,
           &:focus {
@@ -465,7 +474,8 @@
             background-color: $navbar-default-link-hover-bg;
           }
         }
-        > .active > a {
+        > .active > a,
+        > .active > button {
           &,
           &:hover,
           &:focus {
@@ -473,7 +483,8 @@
             background-color: $navbar-default-link-active-bg;
           }
         }
-        > .disabled > a {
+        > .disabled > a,
+        > .disabled > button {
           &,
           &:hover,
           &:focus {
@@ -519,7 +530,8 @@
   }
 
   .navbar-nav {
-    > li > a {
+    > li > a,
+    > li > button {
       color: $navbar-inverse-link-color;
 
       &:hover,
@@ -528,7 +540,8 @@
         background-color: $navbar-inverse-link-hover-bg;
       }
     }
-    > .active > a {
+    > .active > a,
+    > .active > button {
       &,
       &:hover,
       &:focus {
@@ -536,7 +549,8 @@
         background-color: $navbar-inverse-link-active-bg;
       }
     }
-    > .disabled > a {
+    > .disabled > a,
+    > .disabled > button {
       &,
       &:hover,
       &:focus {
@@ -565,7 +579,8 @@
 
   // Dropdowns
   .navbar-nav {
-    > .open > a {
+    > .open > a,
+    > .open > button {
       &,
       &:hover,
       &:focus {
@@ -583,7 +598,8 @@
         .divider {
           background-color: $navbar-inverse-border;
         }
-        > li > a {
+        > li > a,
+        > li > button {
           color: $navbar-inverse-link-color;
           &:hover,
           &:focus {
@@ -591,7 +607,8 @@
             background-color: $navbar-inverse-link-hover-bg;
           }
         }
-        > .active > a {
+        > .active > a,
+        > .active > button {
           &,
           &:hover,
           &:focus {
@@ -599,7 +616,8 @@
             background-color: $navbar-inverse-link-active-bg;
           }
         }
-        > .disabled > a {
+        > .disabled > a,
+        > .disabled > button {
           &,
           &:hover,
           &:focus {

--- a/app/styles/home-view.scss
+++ b/app/styles/home-view.scss
@@ -329,7 +329,7 @@
       margin-bottom: 40px;
       font-weight: 400;
     }
-    p, a {
+    p, a, button {
       margin-bottom: 20px;
     }
     @media screen and (max-width: 768px) {

--- a/app/templates/base-flat.coco.pug
+++ b/app/templates/base-flat.coco.pug
@@ -39,7 +39,7 @@
         p If this is showing, you dun goofed
 
   block footer
-    #footer.small
+    #footer.small(role='contentinfo')
       if !me.hideFooter()
         if !getQueryVariable('landing', false)
           .container

--- a/app/templates/base-flat.ozar.pug
+++ b/app/templates/base-flat.ozar.pug
@@ -1,6 +1,6 @@
 .style-flat
   block header
-    nav#main-nav.navbar.navbar-default.navbar-fixed-top.text-center
+    nav#main-nav.navbar.navbar-default.navbar-fixed-top.text-center(class=!serverConfig.static && /^\/(league|play\/ladder)/.test(document.location.pathname) ? "dark-mode" : '')
       .container-fluid
         .row
           .col-md-12
@@ -28,7 +28,7 @@
 
   block footer
     if !me.hideFooter()
-      .container-fluid.style-ozaria
+      .container-fluid.style-ozaria(role='contentinfo')
         #footer
           .container
             .row
@@ -42,7 +42,7 @@
                       ul.list-unstyled
                         if !me.showChinaResourceInfo()
                           li
-                            a.contact-modal(tabindex=-1, data-i18n="nav.contact")
+                            a.contact-modal(href="#", data-i18n="nav.contact")
                         li
                           - var aboutURL = me.showChinaResourceInfo() ? 'https://koudashijie.com/about' : 'https://codecombat.com/about';
                           a(href=aboutURL, data-i18n="nav.about", data-event-action="Click: Footer About")
@@ -83,11 +83,11 @@
                           a(href="https://www.instagram.com/playozaria/", target="_blank", data-event-action="Click: Footer Instagram" rel="noreferrer")
                             img(src="/images/pages/base/instagram-logo.png", width="40" alt="Instagram")
 
-      #final-footer
-        if me.showChinaResourceInfo()
-          a.small 商务合作：bill@codecombat.com
-          a.small 业务咨询：13810906731 &nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp
-        span= ' © 2022 CodeCombat Inc. '
-        span.spl(data-i18n="nav.copyright_suffix")
-        a.small(href="http://codecombat.com/legal", data-i18n="nav.term_of_service")
-        a.small(href="http://codecombat.com/privacy", data-i18n="nav.privacy")
+        #final-footer
+          if me.showChinaResourceInfo()
+            a.small 商务合作：bill@codecombat.com
+            a.small 业务咨询：13810906731 &nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp
+          span= ' © 2022 CodeCombat Inc. '
+          span.spl(data-i18n="nav.copyright_suffix")
+          a.small(href="http://codecombat.com/legal", data-i18n="nav.term_of_service")
+          a.small(href="http://codecombat.com/privacy", data-i18n="nav.privacy")

--- a/app/templates/core/auth-modal.ozar.pug
+++ b/app/templates/core/auth-modal.ozar.pug
@@ -13,11 +13,11 @@
         //- TODO: Disabled until login works on ozaria.
         //- button#facebook-login-btn.btn.btn-primary.btn-lg(disabled=true)
         //-   span.sign-in-blurb#facebook-blurb(data-i18n="login.sign_in_with_facebook")
-        a#gplus-login-btn(disabled=true)
+        a#gplus-login-btn(disabled=true, href="#")
           img(src="/images/ozaria/common/log-in-google-sso.svg" draggable="false")
           .gplus-login-wrapper
             .gplus-login-button
-        a#clever-login-btn
+        a#clever-login-btn(href="#")
           img(src="/images/pages/modal/auth/clever_sso_button@2x.png" draggable="false")
       .row.or-row
         .line
@@ -56,6 +56,7 @@
               data-toggle="coco-modal"
               data-target="core/RecoverModal"
               data-i18n="login.forgot_password"
+              href="#"
             )
         input#login-btn.btn.btn-block.btn-success(
           value=translate("login.sign_in")
@@ -66,6 +67,6 @@
         h3(data-i18n="login.logging_in")
 
     .extra-pane
-      a#switch-to-signup-btn(data-i18n="login.auth_sign_up")
+      a#switch-to-signup-btn(data-i18n="login.auth_sign_up", href="#")
       p(data-i18n="login.already_have_account1")
       p(data-i18n="login.already_have_account2")

--- a/app/templates/core/create-account-modal/create-account-modal.coco.pug
+++ b/app/templates/core/create-account-modal/create-account-modal.coco.pug
@@ -83,5 +83,5 @@ mixin modal-footer-content
     .modal-footer-content
       .small-details.rtl-allowed
         span.spr(data-i18n="signup.login_switch")
-        a.login-link
+        a.login-link(href="#")
           span(data-i18n="signup.sign_in")

--- a/app/templates/core/create-account-modal/create-account-modal.ozar.pug
+++ b/app/templates/core/create-account-modal/create-account-modal.ozar.pug
@@ -59,4 +59,4 @@ mixin modal-footer-content
     .modal-footer-content
       .small-details.rtl-allowed
         span.spr(data-i18n="login.already_have_account1")
-        a.login-link(data-i18n="signup.sign_in")
+        a.login-link(data-i18n="signup.sign_in" href="#")

--- a/app/templates/home-view.ozar.pug
+++ b/app/templates/home-view.ozar.pug
@@ -26,9 +26,9 @@ block content
         else
           p(data-i18n="ozaria_home.item_list_p")
           div
-            a.btn.btn-primary.btn-large.btn-moon.teacher-btn(data-i18n="ozaria_home.im_an_educator" data-event-action="Click: I'm an Educator")
+            button.btn.btn-primary.btn-large.btn-moon.teacher-btn(data-i18n="ozaria_home.im_an_educator" data-event-action="Click: I'm an Educator")
           div
-            a.btn.btn-primary.btn-large.btn-moon.student-btn(data-i18n="ozaria_home.im_a_student" data-event-action="Click: I'm a Student")
+            button.btn.btn-primary.btn-large.btn-moon.student-btn(data-i18n="ozaria_home.im_a_student" data-event-action="Click: I'm a Student")
 
     section#graphics-1
       .move-image
@@ -71,7 +71,7 @@ block content
           p(data-i18n="[html]ozaria_home.pd_blurb", data-i18n-options=JSON.stringify(i18nData))
 
     section.full-width.section-spacer#back_cta_1
-      a.btn.btn-primary.btn-large.btn-moon.try-chapter-1(data-i18n="ozaria_home.back_cta_1_a" data-event-action="Click: Try Chapter 1 CTA 1")
+      button.btn.btn-primary.btn-large.btn-moon.try-chapter-1(data-i18n="ozaria_home.back_cta_1_a" data-event-action="Click: Try Chapter 1 CTA 1")
 
     section.section-spacer#speech-bubble-testimonial-1(style="padding-top:130px;")
       .row.xs-marg-15
@@ -182,7 +182,7 @@ block content
           p(data-i18n="ozaria_home.admin_dashboard_row2_p")
 
       .row.flex-row.text-center(style="width: 100%;")
-        a.btn.btn-primary.btn-large.btn-moon.request-quote(data-i18n="ozaria_home.admin_dashboard_row3_a" data-event-action="Click: Request a Quote")
+        button.btn.btn-primary.btn-large.btn-moon.request-quote(data-i18n="ozaria_home.admin_dashboard_row3_a" data-event-action="Click: Request a Quote")
 
     section#acodus-awards
       .row
@@ -199,7 +199,7 @@ block content
             .col-md-4
               img(src="/images/ozaria/home/award_3.png" class="img-responsive" alt="Member CS for All consortium")
       .row.flex-row(style="margin: 85px 0 130px;")
-        a.btn.btn-primary.btn-large.btn-moon.try-chapter-1(data-i18n="ozaria_home.acodus_awards_a" data-event-action="Click: Try Chapter 1 CTA 2")
+        button.btn.btn-primary.btn-large.btn-moon.try-chapter-1(data-i18n="ozaria_home.acodus_awards_a" data-event-action="Click: Try Chapter 1 CTA 2")
 
 
     section#speech-bubble-testimonial-2
@@ -225,7 +225,7 @@ block content
         a.btn.btn-primary.btn-large.btn-moon(data-i18n="ozaria_home.shareable_resources_a" data-event-action="Click: Download Flyer" style="margin: 20px;" href="https://drive.google.com/file/d/1T_UNIAN7v3gMJzOyyYAdbBoRTea1wkRp/view" target="_blank" rel="noopener")
 
     section.full-width#back_cta_2
-      a.btn.btn-primary.btn-large.btn-moon.try-chapter-1(data-i18n="ozaria_home.back_cta_2_a" data-event-action="Click: Try Chapter 1 CTA 3")
+      button.btn.btn-primary.btn-large.btn-moon.try-chapter-1(data-i18n="ozaria_home.back_cta_2_a" data-event-action="Click: Try Chapter 1 CTA 3")
 
     section#faq(style="padding-top: 130px;")
       h1.heading-corner(data-i18n="ozaria_home.faq_header" style="margin-bottom: 60px;")
@@ -240,7 +240,7 @@ block content
           h2(data-i18n="ozaria_home.faq_row3_header")
           p
             span(data-i18n="ozaria_home.faq_row3_p_part1")
-            a.contact-us(data-i18n="general.contact_us")
+            a.contact-us(data-i18n="general.contact_us", href="#")
             span(data-i18n="ozaria_home.faq_row3_p_part2")
             a(href="/funding" data-i18n="nav.funding_resources_guide")
             span(data-i18n="ozaria_home.faq_row3_p_part4")
@@ -258,5 +258,5 @@ block content
           span(data-i18n="ozaria_home.see_faq_suffix")
         p
           span(data-i18n="ozaria_home.faq_row6_p_part1")
-          a.contact-us(data-i18n="general.contact_us")
+          a.contact-us(data-i18n="general.contact_us", href="#")
           | .

--- a/app/views/core/ModalView.coffee
+++ b/app/views/core/ModalView.coffee
@@ -1,4 +1,5 @@
 CocoView = require './CocoView'
+focusTrap = require 'focus-trap'
 
 module.exports = class ModalView extends CocoView
   className: 'modal fade'
@@ -27,6 +28,12 @@ module.exports = class ModalView extends CocoView
 
   subscriptions:
     {}
+
+  render: ->
+    @focusTrap?.deactivate?()
+    super()
+    @focusTrap ?= focusTrap.createFocusTrap @el
+    @focusTrap?.activate()
 
   afterRender: ->
     super()
@@ -71,4 +78,5 @@ module.exports = class ModalView extends CocoView
   destroy: ->
     @hide() unless @hidden
     @$el.off 'hide.bs.modal' if @$el
+    @focusTrap?.deactivate?()
     super()

--- a/app/views/core/ModalView.coffee
+++ b/app/views/core/ModalView.coffee
@@ -33,7 +33,10 @@ module.exports = class ModalView extends CocoView
     @focusTrap?.deactivate?()
     super()
     @focusTrap ?= focusTrap.createFocusTrap @el
-    @focusTrap?.activate()
+    try
+      @focusTrap?.activate()
+    catch e
+      console.log 'No focus trap for modal with no focusable elements'
 
   afterRender: ->
     super()

--- a/app/views/core/RootView.coco.coffee
+++ b/app/views/core/RootView.coco.coffee
@@ -175,7 +175,7 @@ module.exports = class RootView extends CocoView
     for code, localeInfo of locale when (not (code in genericCodes) or code is initialVal)
       if $select.is('ul') # base-flat template
         $select.append(
-          $('<li data-code="' + code + '"><a class="language-dropdown-item">' + localeInfo.nativeDescription + '</a></li>'))
+          $('<li data-code="' + code + '"><a class="language-dropdown-item" href="#">' + localeInfo.nativeDescription + '</a></li>'))
         if code is 'pt-BR'
           $select.append($('<li role="separator" class="divider"</li>'))
       else # base template

--- a/app/views/core/RootView.ozar.coffee
+++ b/app/views/core/RootView.ozar.coffee
@@ -176,7 +176,7 @@ module.exports = class RootView extends CocoView
     for code, localeInfo of filteredLocale when (not (code in genericCodes) or code is initialVal)
       if $select.is('ul') # base-flat template
         $select.append(
-          $('<li data-code="' + code + '"><a class="language-dropdown-item">' + localeInfo.nativeDescription + '</a></li>'))
+          $('<li data-code="' + code + '"><a class="language-dropdown-item" href="#">' + localeInfo.nativeDescription + '</a></li>'))
         #if code is 'pt-BR'
         #  $select.append($('<li role="separator" class="divider"</li>'))
       else # base template
@@ -267,9 +267,7 @@ module.exports = class RootView extends CocoView
     })
 
     # Hack - It would be better for the Navigation component to manage the language dropdown.
-    setTimeout(() =>
-      @buildLanguages()
-    , 0)
+    _.defer => @buildLanguages?()
 
   # Set the page title when the view is loaded.  This value is merged into the
   # result of getMeta.  It will override any title specified in getMeta.  Kept

--- a/ozaria/site/components/play/PageUnitMap/common/UnitMapLevelDot.vue
+++ b/ozaria/site/components/play/PageUnitMap/common/UnitMapLevelDot.vue
@@ -151,11 +151,14 @@
       <a
         class="level-dot-link"
         :href="playLevelLink"
+        :title="`${displayName} - ${levelStatus}`"
+        :tabindex="levelData.locked ? '-1' : '0'"
       >
         <img
           class="level-dot-image"
           :class="levelDotClasses"
           :src="levelIcon[levelStatus]"
+          alt=""
         >
       </a>
 

--- a/ozaria/site/components/play/PageUnitMap/hoc2019modal/ModalSignIn.vue
+++ b/ozaria/site/components/play/PageUnitMap/hoc2019modal/ModalSignIn.vue
@@ -177,11 +177,11 @@ export default {
 
     .socialSignOn(v-if="useSocialSignOn")
       .auth-network-logins()
-        a#gplus-login-btn(:disabled="!gplusLoaded" @click="onClickGPlusLoginButton")
+        a#gplus-login-btn(:disabled="!gplusLoaded" @click="onClickGPlusLoginButton" href="#")
           img(src="/images/ozaria/common/log-in-google-sso.svg" draggable="false")
           .gplus-login-wrapper
             .gplus-login-button
-        a#clever-login-btn(@click="onClickCleverLoginButton")
+        a#clever-login-btn(@click="onClickCleverLoginButton" href="#")
           img(src="/images/pages/modal/auth/clever_sso_button@2x.png" draggable="false")
       .row.or-row
         .line
@@ -218,6 +218,7 @@ export default {
           #recover-account-wrapper
             a#link-to-recover(
               @click="$emit('clickRecoverModal')"
+              href="#"
             ) {{ $t("login.forgot_password") }}
         input#login-btn.btn.btn-block.btn-success(
           :value="$t('login.sign_in')"
@@ -228,7 +229,7 @@ export default {
         h3 {{ $t("login.logging_in") }}
 
     .extra-pane
-      a#switch-to-signup-btn(@click="$emit('switchToSignup')") {{ $t("login.auth_sign_up") }}
+      a#switch-to-signup-btn(@click="$emit('switchToSignup')" href="#") {{ $t("login.auth_sign_up") }}
       p {{ $t("login.already_have_account1") }}
       p {{ $t("login.already_have_account2") }}
 </template>

--- a/ozaria/site/components/play/PageUnitMap/hoc2019modal/ModalStartJourney.vue
+++ b/ozaria/site/components/play/PageUnitMap/hoc2019modal/ModalStartJourney.vue
@@ -1,10 +1,38 @@
 <script>
 import CloseModalBar from './layout/CloseModalBar'
-export default {
+import * as focusTrap from 'focus-trap'
+
+export default Vue.extend({
   components: {
     CloseModalBar
+  },
+  data: () => ({
+    focusTrapDeactivated: false,
+    focusTrap: null
+  }),
+  mounted () {
+    // TODO: do this generally for all modals
+    this.focusTrap = focusTrap.createFocusTrap(this.$el, {
+      initialFocus: '.btn-primary',
+      onDeactivate: () => {
+        this.focusTrapDeactivated = true
+      }
+    })
+    this.focusTrap.activate()
+    // fallback
+    if (this.focusTrapDeactivated) this.deactivateFocusTrap()
+  },
+  beforeDestroy () {
+    // seems not work when this component is destroyed by parent conditional-render
+    this.deactivateFocusTrap()
+  },
+  methods: {
+    deactivateFocusTrap () {
+      this.focusTrapDeactivated = true
+      this.focusTrap?.deactivate()
+    }
   }
-}
+})
 </script>
 
 <template>

--- a/ozaria/site/components/play/PageUnitMap/hoc2019modal/StudentSignup/ModalStudentClassCode.vue
+++ b/ozaria/site/components/play/PageUnitMap/hoc2019modal/StudentSignup/ModalStudentClassCode.vue
@@ -2,6 +2,7 @@
   import { mapMutations } from 'vuex'
   import LayoutSplit from '../layout/LayoutSplit'
   import CloseModalBar from '../layout/CloseModalBar'
+  import * as focusTrap from 'focus-trap'
 
   const Classroom = require('models/Classroom')
   const utils = require('core/utils')
@@ -10,7 +11,9 @@
     data: () => ({
       classCode: '',
       classroom: {},
-      validClassCodes: new Set()
+      validClassCodes: new Set(),
+      focusTrapDeactivated: false,
+      focusTrap: null
     }),
 
     components: {
@@ -21,6 +24,22 @@
     mounted() {
       const { _cc } = utils.getQueryVariables()
       this.classCode = _cc
+      // TODO: do this generally for all modals
+      // TODO: do it on parent? Can't get to back button this way
+      this.focusTrap = focusTrap.createFocusTrap(this.$el, {
+        initialFocus: 'input',
+        onDeactivate: () => {
+          this.focusTrapDeactivated = true
+        }
+      })
+      this.focusTrap.activate()
+      // fallback
+      if (this.focusTrapDeactivated) this.deactivateFocusTrap()
+    },
+
+    beforeDestroy () {
+      // seems not work when this component is destroyed by parent conditional-render
+      this.deactivateFocusTrap()
     },
 
     methods: {
@@ -56,6 +75,11 @@
           console.error('Error in validating class code', err)
           return false
         }
+      },
+
+      deactivateFocusTrap () {
+        this.focusTrapDeactivated = true
+        this.focusTrap?.deactivate()
       }
     }
   }

--- a/ozaria/site/components/play/PageUnitMap/index.vue
+++ b/ozaria/site/components/play/PageUnitMap/index.vue
@@ -206,6 +206,9 @@
       closeHocModal () {
         this.openHoC2019Modal = false
         this.registerHocProgressModalCheck()
+        _.defer(() => {
+          $(this.$el).find('img.level-dot-image.next').parent().focus()
+        })
       },
 
       async loadCampaign () {

--- a/ozaria/site/components/sign-up/PageEducatorSignup/PageStartSignup.vue
+++ b/ozaria/site/components/sign-up/PageEducatorSignup/PageStartSignup.vue
@@ -111,15 +111,15 @@
           span.li-title {{ $t("signup.educator_signup_list_3_title") }}!{' '}
           span.li-desc {{ $t("signup.educator_signup_list_3_desc") }}
       .social-sign-in(v-if="useSocialSignOn")
-        a(@click="clickGoogleSignup")
+        a(@click="clickGoogleSignup" href="#")
           img(src="/images/ozaria/common/google_signin_classroom.png")
         span.error(v-if="errorMessage") {{ $t(errorMessage) }}
       .email-sign-up
         span {{ $t("general.or") }}!{' '}
-        a(@click="clickEmailSignup") {{ $t("signup.signup_with_email") }}
+        a(@click="clickEmailSignup" href="#") {{ $t("signup.signup_with_email") }}
     .log-in
       span {{ $t("signup.already_have_account") }}!{'? '}
-        a(@click="$emit('signIn')") {{ $t("signup.sign_in") }}
+        a(@click="$emit('signIn')" href="#") {{ $t("signup.sign_in") }}
 </template>
 
 <style lang="sass" scoped>

--- a/ozaria/site/components/sign-up/PageEducatorSignup/PageStartSignup.vue
+++ b/ozaria/site/components/sign-up/PageEducatorSignup/PageStartSignup.vue
@@ -39,7 +39,8 @@
         return false
       },
 
-      async clickGoogleSignup () {
+      async clickGoogleSignup (e) {
+        e.preventDefault()
         try {
           this.errorMessage = ''
           await new Promise((resolve, reject) =>
@@ -87,7 +88,8 @@
         this.$emit('startSignup', 'gplus')
       },
 
-      clickEmailSignup () {
+      clickEmailSignup (e) {
+        e.preventDefault()
         this.errorMessage = ''
         this.resetState()
         this.$emit('startSignup', 'email')

--- a/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
+++ b/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
@@ -179,7 +179,7 @@
     <li>
       <router-link to="/teachers/professional-development" id="PDAnchor" :class="{ 'current-route': pdSelected }" @click.native="trackEvent" data-action="PD: Nav Clicked">
         <div id="IconPD" />
-        <div id="IconNew">New!</div>
+        <!-- <div id="IconNew">New!</div> -->
         {{ $t('teacher_dashboard.pd_short') }}
       </router-link>
     </li>


### PR DESCRIPTION
Make all Backbone modals activate focus trap by default, and add Vue modal focus trap code to several modals.

Fix some button and link roles, hrefs, etc. to allow them to be keyboard navigable.

Couple minor line-level merges in here, too, as well as removing PD "new" label while I was at it.