### PR TITLE
Add goblins HoC activity and teacher solutions for campaigns

### DIFF
--- a/app/core/Router.coco.coffee
+++ b/app/core/Router.coco.coffee
@@ -262,6 +262,7 @@ module.exports = class CocoRouter extends Backbone.Router
     'teachers/classes/:classroomID': go('courses/TeacherClassView', { redirectStudents: true, teachersOnly: true })
     'teachers/courses': go('courses/TeacherCoursesView', { redirectStudents: true })
     'teachers/course-solution/:courseID/:language': go('teachers/TeacherCourseSolutionView', { redirectStudents: true })
+    'teachers/campaign-solution/:courseID/:language': go('teachers/TeacherCourseSolutionView', { redirectStudents: true, campaignMode: true })
     'teachers/demo': redirect('/teachers/quote')
     'teachers/enrollments': redirect('/teachers/licenses')
     'teachers/hour-of-code': go('special_event/HoC2018View')

--- a/app/core/Router.ozar.coffee
+++ b/app/core/Router.ozar.coffee
@@ -300,6 +300,7 @@ module.exports = class CocoRouter extends Backbone.Router
     'teachers/courses': redirect('/teachers') # Redirected 8/20/2019
     'teachers/units': redirect('/teachers') # Redirected 9/10/2020
     'teachers/course-solution/:courseID/:language': go('teachers/TeacherCourseSolutionView', { redirectStudents: true })
+    'teachers/campaign-solution/:courseID/:language': go('teachers/TeacherCourseSolutionView', { redirectStudents: true, campaignMode: true })
     'teachers/demo': redirect('/teachers/quote')
     'teachers/enrollments': redirect('/teachers/licenses')
     'teachers/hour-of-code': => window.location.href = 'https://docs.google.com/presentation/d/1KgFOg2tqbKEH8qNwIBdmK2QbHvTsxnW_Xo7LvjPsxwE/edit?usp=sharing'

--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -3709,6 +3709,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     step_3: "Step 3: Download Lesson Plan"
     try_activity: "Try Activity"
     download_pdf: "Download PDF"
+    solutions: "Solutions"
     teacher_signup_heading: "Turn Hour of Code into a Year of Code"
     teacher_signup_blurb: "Everything you need to teach computer science, no prior experience needed."
     teacher_signup_input_blurb: "Get first course free:"

--- a/app/templates/teachers/teacher-course-solution-view.coco.pug
+++ b/app/templates/teachers/teacher-course-solution-view.coco.pug
@@ -8,7 +8,7 @@ block page_nav
         |&lt;
         span= ' '
         spna(data-i18n="teacher.back_to_course_guides")
-    if view.paidTeacher || view.course.get('free')
+    if view.paidTeacher || (view.course && view.course.get('free') || view.campaign && view.campaign.get('type') == 'hoc')
       .quick-actions-container
         a.print-btn.btn.btn-md.btn-navy(href='javascript:window.print()')
           span.glyphicon.glyphicon-print &#160;
@@ -24,15 +24,19 @@ block content
     a(href="/")
       img#nav-logo(src="/images/pages/base/logo.png", title="CodeCombat - Learn how to code by playing a game", alt="CodeCombat")
     h2.text-center(data-i18n="teacher.teacher_account_required")
-  else if !view.paidTeacher && !view.course.get('free')
+  else if !view.paidTeacher && (view.course && !view.course.get('free') || view.campaign && view.campaign.get('type') != 'hoc')
     h2.text-center(data-i18n="courses.solutions_require_licenses")
   else
     .text-center
       img(src="http://direct.codecombat.com/images/pages/base/logo.png")
-      if view.course.loaded
-        h1 #{i18n(view.course.attributes, 'name')}
+      if (view.course && view.course.loaded || view.campaign && view.campaign.loaded)
+        if view.course
+          h1 #{i18n(view.course.attributes, 'name')}
+        else
+          h1 #{i18n(view.campaign.attributes, 'fullName')}
         h3 #{view.prettyLanguage}
-        i= i18n(view.course.attributes, 'description')
+        if view.course
+          i= i18n(view.course.attributes, 'description')
     br
 
     if view.levels

--- a/app/templates/teachers/teacher-course-solution-view.ozar.pug
+++ b/app/templates/teachers/teacher-course-solution-view.ozar.pug
@@ -13,7 +13,7 @@ block page_nav
     else
       //- Create space when the backlink is missing.
       div(style="height: 40px;")
-    if view.paidTeacher || view.course.get('free')
+    if view.paidTeacher || (view.course && view.course.get('free') || view.campaign && view.campaign.get('type') == 'hoc')
       .print
         .btn.btn-md.btn-navy
           a.print-btn(href='javascript:window.print()')
@@ -26,14 +26,18 @@ block content
     a(href="/")
       img#nav-logo(src="/images/ozaria/home/ozaria-logo.png", title="Ozaria - Computer Science that Captivates", alt="Ozaria")
     h2.text-center(data-i18n="teacher.teacher_account_required")
-  else if !view.paidTeacher && !view.course.get('free')
+  else if !view.paidTeacher && (view.course && !view.course.get('free') || view.campaign && view.campaign.get('type') != 'hoc')
     h2.text-center(data-i18n="courses.solutions_require_licenses")
   else
     .text-center
-      if view.course.loaded
-        h1 #{i18n(view.course.attributes, 'name')}
+      if (view.course && view.course.loaded || view.campaign && view.campaign.loaded)
+        if view.course
+          h1 #{i18n(view.course.attributes, 'name')}
+        else
+          h1 #{i18n(view.campaign.attributes, 'fullName')}
         h3 #{view.prettyLanguage}
-        i= i18n(view.course.attributes, 'description')
+        if view.course
+          i= i18n(view.course.attributes, 'description')
     br
 
     if view.levels

--- a/app/views/special_event/HoC2018Component.coco.vue
+++ b/app/views/special_event/HoC2018Component.coco.vue
@@ -25,6 +25,7 @@
             a.btn.btn-primary.btn-lg(href="/play/hoc-2018" data-i18n="hoc_2018.try_activity")
           .col-md-4
             a.btn.btn-primary.btn-lg(href="https://files.codecombat.com/docs/resources/hourofcode/HourofCodeCodeCombatLessonPlan2020.pdf" target="_blank" data-i18n="hoc_2018.download_pdf")
+            a.btn.btn-primary.btn-lg(v-if="isTeacher" href="/teachers/campaign-solution/hoc-2018/python" target="_blank" data-i18n="courses.view_guide_online")
 
       else if activity() == 'goblins'
         .row
@@ -47,6 +48,7 @@
             a.btn.btn-primary.btn-lg(href="/play/goblins-hoc?hour_of_code=true" data-i18n="hoc_2018.try_activity")
           .col-md-4
             a.btn.btn-primary.btn-lg(href="/teachers/resources/hoc-goblins" target="_blank" data-i18n="hoc_2018.download_pdf")
+            a.btn.btn-primary.btn-lg(v-if="isTeacher" href="/teachers/campaign-solution/goblins-hoc/python" target="_blank" data-i18n="courses.view_guide_online")
 
       else
         .row
@@ -63,14 +65,19 @@
             h4.bold-header(data-i18n="hoc_2018.step_3")
             .glyphicon.glyphicon-download-alt.download-icon
 
+          .col-md-4(v-if="isTeacher")
+            h4.bold-header(data-i18n="courses.view_guide_online")
+            .glyphicon.glyphicon-download-alt.download-icon
+
         .row.get-started
           .col-md-4
           .col-md-4
             a.btn.btn-primary.btn-lg(href="/play/ai-league-hoc?hour_of_code=true" data-i18n="hoc_2018.try_activity")
           .col-md-4
             a.btn.btn-primary.btn-lg(href="/teachers/resources/hoc-ai-league" target="_blank" data-i18n="hoc_2018.download_pdf")
+            a.btn.btn-primary.btn-lg(v-if="isTeacher" href="/teachers/campaign-solution/ai-league-hoc/python" target="_blank" data-i18n="courses.view_guide_online")
 
-      .row
+      .row(v-if="isAnonymous")
         br
         h1.page-heading(data-i18n="hoc_2018.teacher_signup_heading")
         h4(data-i18n="hoc_2018.teacher_signup_blurb")
@@ -94,8 +101,8 @@
             h6(data-i18n="hoc_2018.activity_label_ai_league")
             div
               a.btn.btn-primary.btn-md(href="/play/ai-league-hoc?hour_of_code=true" data-i18n="hoc_2018.try_activity")
-            div
               a.btn.btn-primary.btn-md(href="/teachers/hour-of-code" data-i18n="hoc_2018.activity_button_1")
+              a.btn.btn-primary.btn-md(v-if="isTeacher" href="/teachers/campaign-solution/ai-league-hoc/python" target="_blank" data-i18n="hoc_2018.solutions")
         if activity() != 'goblins' && isAdmin
           .col-md-4
             // TODO: image
@@ -103,20 +110,22 @@
             h6(data-i18n="hoc_2018.activity_label_goblins")
             div
               a.btn.btn-primary.btn-md(href="/play/goblins-hoc?hour_of_code=true" data-i18n="hoc_2018.try_activity")
-            div
               a.btn.btn-primary.btn-md(href="/teachers/hour-of-code" data-i18n="hoc_2018.activity_button_1")
+              a.btn.btn-primary.btn-md(v-if="isTeacher" href="/teachers/campaign-solution/goblins-hoc/python" target="_blank" data-i18n="hoc_2018.solutions")
         .col-md-4
           img(src='/images/pages/teachers/hour-of-code/escape_the_dungeon.png' alt="")
           h6(data-i18n="hoc_2018.activity_label_1")
           div
             a.btn.btn-primary.btn-md(href="/play/dungeon?hour_of_code=true" data-i18n="hoc_2018.try_activity")
-          div
             a.btn.btn-primary.btn-md(href="/teachers/resources/hoc" data-i18n="hoc_2018.activity_button_1")
+            a.btn.btn-primary.btn-md(v-if="isTeacher" href="/teachers/campaign-solution/dungeon/python" target="_blank" data-i18n="hoc_2018.solutions")
 
         .col-md-4
           img(src='/images/pages/teachers/hour-of-code/beginner_buildagame.png' alt="")
           h6(data-i18n="hoc_2018.activity_label_2")
-          a.btn.btn-primary.btn-md(href="/play/game-dev-hoc?hour_of_code=true" data-i18n="hoc_2018.try_activity")
+          div
+            a.btn.btn-primary.btn-md(href="/play/game-dev-hoc?hour_of_code=true" data-i18n="hoc_2018.try_activity")
+            a.btn.btn-primary.btn-md(v-if="isTeacher" href="/teachers/campaign-solution/game-dev-hoc/python" target="_blank" data-i18n="hoc_2018.solutions")
 
         if activity() != 'teacher-gd'
           .col-md-4
@@ -125,13 +134,15 @@
             h6(data-i18n="hoc_2018.activity_label_hoc_2018") 
             div
               a.btn.btn-primary.btn-md(href="/play/hoc-2018?hour_of_code=true" data-i18n="hoc_2018.try_activity")
-            div
               a.btn.btn-primary.btn-md(href="/teachers/hour-of-code?activity=teacher-gd" data-i18n="hoc_2018.activity_button_1")
+              a.btn.btn-primary.btn-md(v-if="isTeacher" href="/teachers/campaign-solution/hoc-2018/python" target="_blank" data-i18n="hoc_2018.solutions")
 
         .col-md-4
           img(src='/images/pages/teachers/hour-of-code/advanced_buildagame.png' alt="")
           h6(data-i18n="hoc_2018.activity_label_3")
-          a.btn.btn-primary.btn-md(href="/play/game-dev-hoc-2?hour_of_code=true" data-i18n="hoc_2018.try_activity")
+          div
+            a.btn.btn-primary.btn-md(href="/play/game-dev-hoc-2?hour_of_code=true" data-i18n="hoc_2018.try_activity")
+            a.btn.btn-primary.btn-md(v-if="isTeacher" href="/teachers/campaign-solution/game-dev-hoc-2/python" target="_blank" data-i18n="hoc_2018.solutions")
 
       .row
         br
@@ -176,7 +187,9 @@ module.exports = Vue.extend({
   data: function() {
     return {
       teacherEmail: '',
-      isAdmin: me.isAdmin()
+      isAdmin: me.isAdmin(),
+      isTeacher: me.isTeacher(),
+      isAnonymous: me.isAnonymous(),
     }
   },
   props: {

--- a/app/views/special_event/HoC2018Component.ozar.vue
+++ b/app/views/special_event/HoC2018Component.ozar.vue
@@ -1,32 +1,83 @@
 <template lang="pug">
   #hoc-2018-page
     .hoc-header
-      h4(data-i18n="hoc_2018.banner_ozar")
+      h4(data-i18n="hoc_2018.banner_coco")
 
     .container
 
-      .row
-        h1.page-heading(data-i18n="hoc_2018.page_heading")
+      if activity() == 'teacher-gd'
+        .row
+          h1.page-heading(data-i18n="hoc_2018.page_heading")
+        .row.get-started
+          .col-md-4
+            h4.bold-header(data-i18n="hoc_2018.step_1")
+            <iframe src="https://www.youtube.com/embed/k965LUC7oww" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          .col-md-4
+            h4.bold-header(data-i18n="hoc_2018.step_2")
+            img(src='/images/pages/teachers/hour-of-code/code_play_share.png' alt="")
+          .col-md-4
+            h4.bold-header(data-i18n="hoc_2018.step_3")
+            .glyphicon.glyphicon-download-alt.download-icon
 
-      .row.get-started
-        .col-md-4
-          h4.bold-header(data-i18n="hoc_2018.step_1")
-          <iframe src="https://www.youtube.com/embed/k965LUC7oww" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        .col-md-4
-          h4.bold-header(data-i18n="hoc_2018.step_2")
-          img(src='/images/pages/teachers/hour-of-code/code_play_share.png')
-        .col-md-4
-          h4.bold-header(data-i18n="hoc_2018.step_3")
-          .glyphicon.glyphicon-download-alt.download-icon
+        .row.get-started
+          .col-md-4
+          .col-md-4
+            a.btn.btn-primary.btn-lg(href="/play/hoc-2018" data-i18n="hoc_2018.try_activity")
+          .col-md-4
+            a.btn.btn-primary.btn-lg(href="https://files.codecombat.com/docs/resources/hourofcode/HourofCodeCodeCombatLessonPlan2020.pdf" target="_blank" data-i18n="hoc_2018.download_pdf")
+            a.btn.btn-primary.btn-lg(v-if="isTeacher" href="/teachers/campaign-solution/hoc-2018/python" target="_blank" data-i18n="courses.view_guide_online")
 
-      .row.get-started
-        .col-md-4
-        .col-md-4
-          a.btn.btn-primary.btn-lg(href="/play/hoc-2018" data-i18n="hoc_2018.try_activity")
-        .col-md-4
-          a.btn.btn-primary.btn-lg(href="http://files.codecombat.com/docs/resources/hourofcode/HourofCodeCodeCombatLessonPlan2018.pdf" target="_blank" data-i18n="hoc_2018.download_pdf")
+      else if activity() == 'goblins'
+        .row
+          h1.page-heading(data-i18n="hoc_2018.page_heading_goblins")
+        .row.get-started
+          .col-md-4
+            h4.bold-header(data-i18n="hoc_2018.step_1")
+            <iframe src="https://www.youtube.com/embed/niKXOofTckE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          .col-md-4
+            h4.bold-header(data-i18n="hoc_2018.step_2")
+            // TODO: image
+            img.activity-tile(src='/images/pages/play/ladder/multiplayer_notext.jpg' alt="")
+          .col-md-4
+            h4.bold-header(data-i18n="hoc_2018.step_3")
+            .glyphicon.glyphicon-download-alt.download-icon
 
-      .row
+        .row.get-started
+          .col-md-4
+          .col-md-4
+            a.btn.btn-primary.btn-lg(href="/play/goblins-hoc?hour_of_code=true" data-i18n="hoc_2018.try_activity")
+          .col-md-4
+            a.btn.btn-primary.btn-lg(href="/teachers/resources/hoc-goblins" target="_blank" data-i18n="hoc_2018.download_pdf")
+            a.btn.btn-primary.btn-lg(v-if="isTeacher" href="/teachers/campaign-solution/goblins-hoc/python" target="_blank" data-i18n="courses.view_guide_online")
+
+      else
+        .row
+          h1.page-heading(data-i18n="hoc_2018.page_heading_ai_league")
+        .row.get-started
+          .col-md-4
+            h4.bold-header(data-i18n="hoc_2018.step_1")
+            <iframe src="https://www.youtube.com/embed/niKXOofTckE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          .col-md-4
+            h4.bold-header(data-i18n="hoc_2018.step_2")
+            // TODO: image
+            img.activity-tile(src='/images/pages/play/ladder/multiplayer_notext.jpg' alt="")
+          .col-md-4
+            h4.bold-header(data-i18n="hoc_2018.step_3")
+            .glyphicon.glyphicon-download-alt.download-icon
+
+          .col-md-4(v-if="isTeacher")
+            h4.bold-header(data-i18n="courses.view_guide_online")
+            .glyphicon.glyphicon-download-alt.download-icon
+
+        .row.get-started
+          .col-md-4
+          .col-md-4
+            a.btn.btn-primary.btn-lg(href="/play/ai-league-hoc?hour_of_code=true" data-i18n="hoc_2018.try_activity")
+          .col-md-4
+            a.btn.btn-primary.btn-lg(href="/teachers/resources/hoc-ai-league" target="_blank" data-i18n="hoc_2018.download_pdf")
+            a.btn.btn-primary.btn-lg(v-if="isTeacher" href="/teachers/campaign-solution/ai-league-hoc/python" target="_blank" data-i18n="courses.view_guide_online")
+
+      .row(v-if="isAnonymous")
         br
         h1.page-heading(data-i18n="hoc_2018.teacher_signup_heading")
         h4(data-i18n="hoc_2018.teacher_signup_blurb")
@@ -43,23 +94,55 @@
         h3(data-i18n="hoc_2018.activities_header")
 
       .row.overline.activities-row
+        if activity() != 'ai-league'
+          .col-md-4
+            // TODO: image
+            img.activity-tile(src='/images/pages/play/ladder/multiplayer_notext.jpg' alt="")
+            h6(data-i18n="hoc_2018.activity_label_ai_league")
+            div
+              a.btn.btn-primary.btn-md(href="/play/ai-league-hoc?hour_of_code=true" data-i18n="hoc_2018.try_activity")
+              a.btn.btn-primary.btn-md(href="/teachers/hour-of-code" data-i18n="hoc_2018.activity_button_1")
+              a.btn.btn-primary.btn-md(v-if="isTeacher" href="/teachers/campaign-solution/ai-league-hoc/python" target="_blank" data-i18n="hoc_2018.solutions")
+        if activity() != 'goblins' && isAdmin
+          .col-md-4
+            // TODO: image
+            img.activity-tile(src='/images/pages/play/ladder/multiplayer_notext.jpg' alt="")
+            h6(data-i18n="hoc_2018.activity_label_goblins")
+            div
+              a.btn.btn-primary.btn-md(href="/play/goblins-hoc?hour_of_code=true" data-i18n="hoc_2018.try_activity")
+              a.btn.btn-primary.btn-md(href="/teachers/hour-of-code" data-i18n="hoc_2018.activity_button_1")
+              a.btn.btn-primary.btn-md(v-if="isTeacher" href="/teachers/campaign-solution/goblins-hoc/python" target="_blank" data-i18n="hoc_2018.solutions")
         .col-md-4
-          img(src='/images/pages/teachers/hour-of-code/escape_the_dungeon.png')
+          img(src='/images/pages/teachers/hour-of-code/escape_the_dungeon.png' alt="")
           h6(data-i18n="hoc_2018.activity_label_1")
           div
             a.btn.btn-primary.btn-md(href="/play/dungeon?hour_of_code=true" data-i18n="hoc_2018.try_activity")
-          div
             a.btn.btn-primary.btn-md(href="/teachers/resources/hoc" data-i18n="hoc_2018.activity_button_1")
+            a.btn.btn-primary.btn-md(v-if="isTeacher" href="/teachers/campaign-solution/dungeon/python" target="_blank" data-i18n="hoc_2018.solutions")
 
         .col-md-4
-          img(src='/images/pages/teachers/hour-of-code/beginner_buildagame.png')
+          img(src='/images/pages/teachers/hour-of-code/beginner_buildagame.png' alt="")
           h6(data-i18n="hoc_2018.activity_label_2")
-          a.btn.btn-primary.btn-md(href="/play/game-dev-hoc?hour_of_code=true" data-i18n="hoc_2018.try_activity")
+          div
+            a.btn.btn-primary.btn-md(href="/play/game-dev-hoc?hour_of_code=true" data-i18n="hoc_2018.try_activity")
+            a.btn.btn-primary.btn-md(v-if="isTeacher" href="/teachers/campaign-solution/game-dev-hoc/python" target="_blank" data-i18n="hoc_2018.solutions")
+
+        if activity() != 'teacher-gd'
+          .col-md-4
+            // TODO: image
+            img(src='/images/pages/teachers/hour-of-code/code_play_share.png' alt="")
+            h6(data-i18n="hoc_2018.activity_label_hoc_2018") 
+            div
+              a.btn.btn-primary.btn-md(href="/play/hoc-2018?hour_of_code=true" data-i18n="hoc_2018.try_activity")
+              a.btn.btn-primary.btn-md(href="/teachers/hour-of-code?activity=teacher-gd" data-i18n="hoc_2018.activity_button_1")
+              a.btn.btn-primary.btn-md(v-if="isTeacher" href="/teachers/campaign-solution/hoc-2018/python" target="_blank" data-i18n="hoc_2018.solutions")
 
         .col-md-4
-          img(src='/images/pages/teachers/hour-of-code/advanced_buildagame.png')
+          img(src='/images/pages/teachers/hour-of-code/advanced_buildagame.png' alt="")
           h6(data-i18n="hoc_2018.activity_label_3")
-          a.btn.btn-primary.btn-md(href="/play/game-dev-hoc-2?hour_of_code=true" data-i18n="hoc_2018.try_activity")
+          div
+            a.btn.btn-primary.btn-md(href="/play/game-dev-hoc-2?hour_of_code=true" data-i18n="hoc_2018.try_activity")
+            a.btn.btn-primary.btn-md(v-if="isTeacher" href="/teachers/campaign-solution/game-dev-hoc-2/python" target="_blank" data-i18n="hoc_2018.solutions")
 
       .row
         br
@@ -86,7 +169,7 @@
 
       .row
         br
-        a.btn.btn-primary.btn-lg(href="/demo" data-i18n="signup.sign_up")
+        a.btn.btn-primary.btn-lg(href="/home#create-account-teacher" data-i18n="signup.sign_up")
 
 </template>
 
@@ -103,11 +186,18 @@ module.exports = Vue.extend({
 
   data: function() {
     return {
-      teacherEmail: ''
+      teacherEmail: '',
+      isAdmin: me.isAdmin(),
+      isTeacher: me.isTeacher(),
+      isAnonymous: me.isAnonymous(),
     }
   },
   props: {
     onGetCS1Free: {
+      type: Function,
+      required: true
+    },
+    activity: {
       type: Function,
       required: true
     }
@@ -115,7 +205,7 @@ module.exports = Vue.extend({
 });
 </script>
 
-<style lang="sass" scoped>
+<style lang="sass">
 @import "../../styles/style-flat-variables"
 
 #hoc-2018-page
@@ -199,4 +289,12 @@ module.exports = Vue.extend({
   .activities-row
     .btn
       width: 120px
+
+    .col-md-4
+      min-height: 345px
+
+  .activity-tile
+    height: 212px
+    object-fit: cover
+
 </style>

--- a/app/views/teachers/TeacherCourseSolutionView.coffee
+++ b/app/views/teachers/TeacherCourseSolutionView.coffee
@@ -2,6 +2,7 @@ require('app/styles/teachers/teacher-course-solution-view.sass')
 utils = require 'core/utils'
 RootView = require 'views/core/RootView'
 Course = require 'models/Course'
+Campaign = require 'models/Campaign'
 Level = require 'models/Level'
 LevelComponent = require 'models/LevelComponent'
 Prepaids = require 'collections/Prepaids'
@@ -30,7 +31,7 @@ module.exports = class TeacherCourseSolutionView extends RootView
 
   getTitle: ->
     title = $.i18n.t('teacher.course_solution')
-    title += " " + @course.acronym()
+    title += " " + @course.acronym() if @course
     if @language != "html"
       title +=  " " + utils.capitalLanguages[@language]
     title
@@ -46,9 +47,15 @@ module.exports = class TeacherCourseSolutionView extends RootView
     @isWebDev = @courseID in [utils.courseIDs.WEB_DEVELOPMENT_2]
     if me.isTeacher() or me.isAdmin()
       @prettyLanguage = @camelCaseLanguage(@language)
-      @course = new Course(_id: @courseID)
-      @supermodel.trackRequest(@course.fetch())
-      @levels = new Levels([], { url: "/db/course/#{@courseID}/level-solutions"})
+      if options.campaignMode
+        campaignSlug = @courseID
+        @campaign = new Campaign(_id: campaignSlug)
+        @supermodel.trackRequest(@campaign.fetch())
+        @levels = new Levels([], { url: "/db/campaign/#{campaignSlug}/level-solutions"})
+      else
+        @course = new Course(_id: @courseID)
+        @supermodel.trackRequest(@course.fetch())
+        @levels = new Levels([], { url: "/db/course/#{@courseID}/level-solutions"})
       @supermodel.loadCollection(@levels, 'levels', {cache: false})
 
       @levelNumberMap = {}


### PR DESCRIPTION
Updated the HoC teachers' notes page to add goblins-hoc activity (visible just to admins until we add some more resources for it).

<img width="1357" alt="Screen Shot 2022-09-15 at 18 42 10" src="https://user-images.githubusercontent.com/99704/190538564-d02de0ef-806d-458c-aa83-dcf91b367c10.png">

Also made it so that the TeacherCoursesView can view solutions for campaigns, not just courses.

<img width="1357" alt="Screen Shot 2022-09-15 at 18 42 19" src="https://user-images.githubusercontent.com/99704/190538588-0d8ba0c4-0083-4fc0-b8d6-3ff96939ea43.png">
