### PR TITLE
Add ability to run CodeCombat and Ozaria simultaneously.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ tmp/
 
 # Brunch output
 public/
+public_coco/
+public_ozar/
 
 # Redis?
 dump.rdb

--- a/compile-static-templates.coffee
+++ b/compile-static-templates.coffee
@@ -7,12 +7,13 @@ basePath = path.resolve('./app')
 _ = require 'lodash'
 fs = require('fs')
 load = require 'pug-load'
+devUtils = require './development/utils'
 
 # TODO: stop webpack build on error (e.g. http://dev.topheman.com/how-to-fail-webpack-build-on-error/)
 
-product = process.env.COCO_PRODUCT or 'codecombat'
-productSuffix = { codecombat: 'coco', ozaria: 'ozar' }[product]
-publicFolderName = 'public_'+productSuffix
+product = devUtils.product
+productSuffix = devUtils.productSuffix
+publicFolderName = devUtils.publicFolderName
 
 
 productFallbackPlugin =

--- a/compile-static-templates.coffee
+++ b/compile-static-templates.coffee
@@ -12,6 +12,8 @@ load = require 'pug-load'
 
 product = process.env.COCO_PRODUCT or 'codecombat'
 productSuffix = { codecombat: 'coco', ozaria: 'ozar' }[product]
+publicFolderName = 'public_'+productSuffix
+
 
 productFallbackPlugin =
   read: (path) ->
@@ -98,13 +100,13 @@ compile = (contents, locals, filename, cb) ->
 
   # console.log {outFile}
 
-  if not fs.existsSync(path.resolve('./public'))
-    fs.mkdirSync(path.resolve('./public'))
-  if not fs.existsSync(path.resolve('./public/templates'))
-    fs.mkdirSync(path.resolve('./public/templates'))
-  if not fs.existsSync(path.resolve('./public/templates/static'))
-    fs.mkdirSync(path.resolve('./public/templates/static'))
-  fs.writeFileSync(path.join(path.resolve('./public/templates/static'), outFile), c.html())
+  if not fs.existsSync(path.resolve("./#{publicFolderName}"))
+    fs.mkdirSync(path.resolve("./#{publicFolderName}"))
+  if not fs.existsSync(path.resolve("./#{publicFolderName}/templates"))
+    fs.mkdirSync(path.resolve("./#{publicFolderName}/templates"))
+  if not fs.existsSync(path.resolve("./#{publicFolderName}/templates/static"))
+    fs.mkdirSync(path.resolve("./#{publicFolderName}/templates/static"))
+  fs.writeFileSync(path.join(path.resolve("./#{publicFolderName}/templates/static"), outFile), c.html())
   cb()
   # cb(null, [{filename: outFile, content: c.html()}], deps) # old brunch callback
 

--- a/development/utils.js
+++ b/development/utils.js
@@ -1,0 +1,9 @@
+const product = process.env.COCO_PRODUCT || 'codecombat'
+const productSuffix = { codecombat: 'coco', ozaria: 'ozar' }[product]
+const publicFolderName = 'public_' + productSuffix
+
+module.exports = {
+  product,
+  productSuffix,
+  publicFolderName
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,8 @@
 const product = process.env.COCO_PRODUCT || 'codecombat'
 const productSuffix = { codecombat: 'coco', ozaria: 'ozar' }[product]
 const otherProductSuffix = { codecombat: 'ozar', ozaria: 'coco' }[product]
+const publicFolderName = 'public_'+productSuffix;
+
 
 module.exports = function(config) {
 
@@ -12,11 +14,11 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files : [
-      'public/javascripts/esper.modern.js', // Doesn't load properly from vendor.js.
-      'public/javascripts/app/vendor/aether-python.modern.js',
-      'public/javascripts/app/vendor/aether-coffeescript.modern.js',
-      'public/javascripts/app/vendor/aether-lua.modern.js',
-      'public/javascripts/test.js',
+      `${publicFolderName}/javascripts/esper.modern.js`, // Doesn't load properly from vendor.js.
+      `${publicFolderName}/javascripts/app/vendor/aether-python.modern.js`,
+      `${publicFolderName}/javascripts/app/vendor/aether-coffeescript.modern.js`,
+      `${publicFolderName}/javascripts/app/vendor/aether-lua.modern.js`,
+      `${publicFolderName}/javascripts/test.js`,
       // 'public/javascripts/chunks/TestView.bundle.js',
       // 'public/javascripts/vendor.js', // need for jade definition...
       // 'public/javascripts/whole-vendor.js',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,8 +1,7 @@
 const product = process.env.COCO_PRODUCT || 'codecombat'
 const productSuffix = { codecombat: 'coco', ozaria: 'ozar' }[product]
 const otherProductSuffix = { codecombat: 'ozar', ozaria: 'coco' }[product]
-const publicFolderName = 'public_'+productSuffix;
-
+const { publicFolderName } = require('./development/utils')
 
 module.exports = function(config) {
 

--- a/package.json
+++ b/package.json
@@ -41,8 +41,10 @@
     "webpack": "NODE_OPTIONS='--max-old-space-size=4096' webpack",
     "bower": "bower",
     "dev": "NODE_OPTIONS='--max-old-space-size=4096' webpack --watch",
+    "dev:ozaria": "COCO_PRODUCT=ozaria npm run dev",
     "dev-container": "DEV_CONTAINER=1 NODE_OPTIONS='--max-old-space-size=4096' webpack --watch",
     "proxy": "COCO_PROXY='true' nodemon",
+    "proxy:ozaria": "COCO_PRODUCT=ozaria COCO_PORT=3001 npm run proxy",
     "proxy-win": "cross-env COCO_PROXY='true' nodemon",
     "analyzer": "COCO_ANALYZER_BUNDLE=1 NODE_OPTIONS='--max-old-space-size=4096' webpack --profile --json > stats.json",
     "lint": "eslint --max-warnings 0 '**/*.{js,vue}'"
@@ -59,6 +61,8 @@
       "vendor/**",
       "spec/**",
       "public/**",
+      "public_coco/**",
+      "public_ozar/**",
       "**/styles/**"
     ]
   },

--- a/server_setup.coffee
+++ b/server_setup.coffee
@@ -14,6 +14,9 @@ wrap = require 'co-express'
 morgan = require 'morgan'
 timeout = require('connect-timeout')
 PWD = process.env.PWD || __dirname
+productSuffix = { codecombat: 'coco', ozaria: 'ozar' }[config.product]
+publicFolderName = 'public_'+productSuffix
+publicPath = path.join(PWD, publicFolderName)
 
 {countries} = require './app/core/utils'
 
@@ -57,21 +60,19 @@ setupExpressMiddleware = (app) ->
     res.header 'X-Cluster-ID', config.clusterID
     next()
 
-  public_path = path.join(PWD, 'public')
-
-  app.use('/', express.static(path.join(public_path, 'templates', 'static')))
+  app.use('/', express.static(path.join(publicPath, 'templates', 'static')))
 
   if config.buildInfo.sha isnt 'dev' and config.isProduction
-    app.use("/#{config.buildInfo.sha}", express.static(public_path, maxAge: '1y'))
+    app.use("/#{config.buildInfo.sha}", express.static(publicPath, maxAge: '1y'))
   else
-    app.use('/dev', express.static(public_path, maxAge: 0))  # CloudFlare overrides maxAge, and we don't want local development caching.
+    app.use('/dev', express.static(publicPath, maxAge: 0))  # CloudFlare overrides maxAge, and we don't want local development caching.
 
-  app.use(express.static(public_path, maxAge: 0))
+  app.use(express.static(publicPath, maxAge: 0))
 
   setupProxyMiddleware app # TODO: Flatten setup into one function. This doesn't fit its function name.
 
-  productSuffix = { codecombat: 'coco', ozaria: 'ozar' }[config.product]
-  app.use require('serve-favicon') path.join(PWD, 'public', 'images', 'favicon', "favicon-#{productSuffix}", 'favicon.ico')
+
+  app.use require('serve-favicon') path.join(publicPath, 'images', 'favicon', "favicon-#{productSuffix}", 'favicon.ico')
   app.use require('cookie-parser')()
   app.use require('body-parser').json limit: '25mb', strict: false
   app.use require('body-parser').urlencoded extended: true, limit: '25mb'
@@ -197,7 +198,7 @@ templates = {}
 getStaticTemplate = (file) ->
   # Don't cache templates in development so you can just edit then.
   return templates[file] if templates[file] and config.isProduction
-  templates[file] = fs.readFileAsync(path.join(PWD, 'public', 'templates', 'static', file), 'utf8')
+  templates[file] = fs.readFileAsync(path.join(publicPath, 'templates', 'static', file), 'utf8')
 
 renderMain = wrap (template, req, res) ->
   template = yield getStaticTemplate(template)

--- a/server_setup.coffee
+++ b/server_setup.coffee
@@ -14,8 +14,9 @@ wrap = require 'co-express'
 morgan = require 'morgan'
 timeout = require('connect-timeout')
 PWD = process.env.PWD || __dirname
-productSuffix = { codecombat: 'coco', ozaria: 'ozar' }[config.product]
-publicFolderName = 'public_'+productSuffix
+devUtils = require './development/utils'
+productSuffix = devUtils.productSuffix
+publicFolderName = devUtils.publicFolderName
 publicPath = path.join(PWD, publicFolderName)
 
 {countries} = require './app/core/utils'

--- a/setup-aether.js
+++ b/setup-aether.js
@@ -11,10 +11,7 @@
 const fs = require("fs-extra");
 const webpack = require("webpack");
 const path = require("path");
-
-const product = process.env.COCO_PRODUCT || 'codecombat';
-const productSuffix = { codecombat: 'coco', ozaria: 'ozar' }[product];
-const publicFolderName = 'public_'+productSuffix;
+const { publicFolderName } = require('./development/utils')
 
 // List of esper langauge plugins we want to move into the public directory.
 const targets = ["lua", "python", "coffeescript"];

--- a/setup-aether.js
+++ b/setup-aether.js
@@ -12,6 +12,10 @@ const fs = require("fs-extra");
 const webpack = require("webpack");
 const path = require("path");
 
+const product = process.env.COCO_PRODUCT || 'codecombat';
+const productSuffix = { codecombat: 'coco', ozaria: 'ozar' }[product];
+const publicFolderName = 'public_'+productSuffix;
+
 // List of esper langauge plugins we want to move into the public directory.
 const targets = ["lua", "python", "coffeescript"];
 
@@ -88,7 +92,7 @@ function copyLanguagesFromEsper(targets) {
         ),
         path.join(
           PWD,
-          "public",
+          publicFolderName,
           "javascripts",
           "app",
           "vendor",
@@ -104,7 +108,7 @@ function copyLanguagesFromEsper(targets) {
         ),
         path.join(
           PWD,
-          "public",
+          publicFolderName,
           "javascripts",
           "app",
           "vendor",
@@ -131,7 +135,7 @@ function copyLanguagesFromEsper(targets) {
   );
   const dest = path.join(
     PWD,
-    "public",
+    publicFolderName,
     "javascripts",
     "app",
     "vendor",

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -79,7 +79,7 @@ module.exports = (env) => {
     output: {
       filename: 'javascripts/[name].js', // TODO: Use chunkhash in layout.static.pug's script tags instead of GIT_SHA
       // chunkFilename is determined by build type
-      path: path.resolve(PWD, 'public'),
+      path: path.resolve(PWD, `public_${productSuffix}`),
       publicPath: '/' // Base URL path webpack tries to load other bundles from
     },
     module: {
@@ -221,7 +221,7 @@ module.exports = (env) => {
         'node_modules' // Or maybe require('foo') for the Node module "foo".
       ],
       extensions: [
-        '.web.coffee', '.web.js', '.coffee', '.js', '.pug', '.sass', '.vue', 
+        '.web.coffee', '.web.js', '.coffee', '.js', '.pug', '.sass', '.vue',
         `.${productSuffix}.coffee`, `.${productSuffix}.js`, `.${productSuffix}.pug`, `.${productSuffix}.sass`, `.${productSuffix}.vue`,  //, `.${productSuffix}.scss` ?
       ],
       alias: { // Replace Backbone's underscore with lodash

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -15,6 +15,7 @@ const CompileStaticTemplatesPlugin = require('./compile-static-templates')
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
 const PWD = process.env.PWD || __dirname
 const fs = require('fs')
+const { publicFolderName } = require('./development/utils')
 
 console.log(`Starting Webpack for product ${product}`)
 
@@ -79,7 +80,7 @@ module.exports = (env) => {
     output: {
       filename: 'javascripts/[name].js', // TODO: Use chunkhash in layout.static.pug's script tags instead of GIT_SHA
       // chunkFilename is determined by build type
-      path: path.resolve(PWD, `public_${productSuffix}`),
+      path: path.resolve(PWD, publicFolderName),
       publicPath: '/' // Base URL path webpack tries to load other bundles from
     },
     module: {


### PR DESCRIPTION
- Webpack output path will be `public_coco` or `public_ozar` based on actual product.
- The proxy server will also serve from either `public_coco` or `public_ozar`.
- new npm  scripts added, you can use `npm run dev:ozaria` and `npm run proxy:ozaria`. ozaria will be served at `localhost:3001` while coco will be accessible at `localhost:3000` as before, but you can use the old `npm run proxy` and `npm run dev` commands and set `COCO_PRODUCT` and `COCO_PORT` env variables manually.
