### PR TITLE
Add changelog feature via Makelog

### DIFF
--- a/app/core/Tracker2/MakelogTracker.js
+++ b/app/core/Tracker2/MakelogTracker.js
@@ -1,0 +1,32 @@
+import BaseTracker from './BaseTracker'
+
+const makelogOrgId = 'org-2F8P67Q21Vm51O97wEnzbtwrg9W'
+
+export default class MakelogTracker extends BaseTracker {
+  constructor (store) {
+    super()
+    this.store = store
+  }
+
+  async _initializeTracker () {
+    //if (this.store.state.me.isAdmin) {  // Why doesn't this work? this.store.state.me.isAdmin is undefined
+    if (me.isAdmin()) {
+      const script = document.createElement('script')
+      script.src = 'https://unpkg.com/@mklog/widgets@latest'
+      script.async = true
+      script.type = 'module'
+      document.head.appendChild(script);
+
+      // We don't need to create the widget here; we'Ll create it wherever we want it to live (footer, etc.)
+      // TODO: unhide those mklog-ledger and mk-since-last-viewed elements with CSS if we are actually going to show them
+      //const widget = document.createElement('mklog-ledger')
+      //widget.setAttribute('organization', makelogOrgId)
+      //widget.setAttribute('kind', 'popper')
+      //document.body.appendChild(widget)
+
+      this.enabled = true
+    }
+
+    this.onInitializeSuccess()
+  }
+}

--- a/app/core/Tracker2/index.js
+++ b/app/core/Tracker2/index.js
@@ -8,6 +8,7 @@ import FullStoryTracker from './FullStoryTracker'
 import GoogleOptimizeTracker from './GoogleOptimizeTracker'
 import FacebookPixelTracker from './FacebookPixelTracker'
 import ProfitWellTracker from './ProfitWellTracker'
+import MakelogTracker from './MakelogTracker'
 
 const SESSION_STORAGE_IDENTIFIED_AT_SESSION_START_KEY = 'coco.tracker.identifiedAtSessionStart'
 const SESSION_STORAGE_IDENTIFY_ON_NEXT_PAGE_LOAD = 'coco.tracker.identifyOnNextPageLoad'
@@ -37,9 +38,11 @@ export default class Tracker2 extends BaseTracker {
     this.googleOptimizeTracker = new GoogleOptimizeTracker(this.store)
     this.facebookPixelTracker = new FacebookPixelTracker(this.store)
     this.profitWellTracker = new ProfitWellTracker(this.store)
+    this.makelogTracker = new MakelogTracker(this.store)
 
     this.trackers = [
-      this.internalTracker
+      this.internalTracker,
+      this.makelogTracker
     ]
 
     const isGlobal = !(window.features || {}).china

--- a/app/styles/style-flat.coco.sass
+++ b/app/styles/style-flat.coco.sass
@@ -612,3 +612,11 @@ body[lang='ru'], body[lang='uk'], body[lang='bg'], body[lang^='mk'], body[lang='
     position: absolute
     top: 10px
     right: 10px
+
+  mklog-ledger
+    --mklog-color-brand-background: #0E4C60
+    --mklog-color-brand-text: #1FBAB4
+
+  mklog-since-last-viewed
+    margin-left: 5px
+

--- a/app/styles/style-flat.ozar.sass
+++ b/app/styles/style-flat.ozar.sass
@@ -454,3 +454,11 @@ body[lang='ru'], body[lang='uk'], body[lang='bg'], body[lang^='mk'], body[lang='
     position: absolute
     top: 10px
     right: 10px
+
+  mklog-ledger
+    --mklog-color-brand-background: #0E4C60
+    --mklog-color-brand-text: #1FBAB4
+
+  mklog-since-last-viewed
+    margin-left: 5px
+

--- a/app/templates/base-flat.coco.pug
+++ b/app/templates/base-flat.coco.pug
@@ -116,6 +116,12 @@
                           a(href="/parents", data-i18n="nav.parent")
                         li
                           a(href="https://blog.codecombat.com/", data-i18n="nav.blog", target="_blank")
+                        if me.isAdmin()
+                          li
+                            mklog-ledger(organization='org-2F8P67Q21Vm51O97wEnzbtwrg9W', kind='popper')
+                              a(href="#changelog")
+                                span Changelog
+                                mklog-since-last-viewed(organization='org-2F8P67Q21Vm51O97wEnzbtwrg9W', color="candy")
                     .col-lg-3
                       if !me.isStudent()
                         h3(data-i18n="nav.educators")

--- a/app/templates/base-flat.ozar.pug
+++ b/app/templates/base-flat.ozar.pug
@@ -59,6 +59,12 @@
                           a(href=faqURL data-i18n="nav.faq", data-event-action="Click: Footer FAQ")
                         li
                           a(href="http://press.ozaria.com" data-i18n="nav.press" data-event-action="Click: Footer Press")
+                        if me.isAdmin()
+                          li
+                            mklog-ledger(organization='org-2F8P67Q21Vm51O97wEnzbtwrg9W', kind='popper')
+                              a(href="#")
+                                span Changelog
+                                mklog-since-last-viewed(organization='org-2F8P67Q21Vm51O97wEnzbtwrg9W', color="candy")
                         if me.showChinaResourceInfo()
                           li
                             a(href="https://ozaria.com") 奥佳睿全球官网


### PR DESCRIPTION
Add a changelog link to the footer that can display our public changelog in a widget, as well as a number count of unread changelog updates next to it for this site visitor.

This is gated to CoCo admin-only for now until we decide to do more with it.

<img width="534" alt="Screen Shot 2022-09-22 at 14 21 07" src="https://user-images.githubusercontent.com/99704/191861277-7d7a6ad7-a1ab-4b57-a5e9-aa9bb2ad550e.png">
