### PR TITLE
Add level editor tabs for key thangs like Hero and Referee

### DIFF
--- a/app/schemas/subscriptions/editor.coffee
+++ b/app/schemas/subscriptions/editor.coffee
@@ -31,8 +31,14 @@ module.exports =
     thangData: {type: 'object'}
     oldPath: {type: 'string'}
 
-  'editor:thangs-edited': c.object {required: ['thangs']},
+  'editor:level-thangs-changed': c.object {required: ['thangs'], description: 'Something has changed the list of thangs in the level config'},
     thangs: c.array {}, {type: 'object'}
+
+  'editor:thangs-edited': c.object {required: ['thangs'], description: 'Something has edited the fully built thangs in the world'},
+    thangs: c.array {}, {type: 'object'}
+
+  'editor:thang-deleted': c.object {required: ['thangID'], description: 'We have deleted a Thang'},
+    thangID: {type: 'string'}
 
   'editor:level-loaded': c.object {required: ['level']},
     level: {type: 'object'}

--- a/app/styles/editor/editor.sass
+++ b/app/styles/editor/editor.sass
@@ -127,7 +127,7 @@
     margin-top: -10px
     padding-top: 10px
   
-  #level-editor-tabs, &#thang-type-edit-view .tab-content
+  #level-editor-tabs, &#thang-type-edit-view .tab-content, &.key-thang-tab-view .tab-content
     position: absolute
     left: 15px
     right: 15px

--- a/app/styles/editor/level/thang/level-thang-edit-view.sass
+++ b/app/styles/editor/level/thang/level-thang-edit-view.sass
@@ -1,4 +1,4 @@
-#level-thang-edit-view
+#level-thang-edit-view, .key-thang-tab-view
   color: black
 
   .well
@@ -14,7 +14,7 @@
     float: left
     cursor: pointer
 
-  #thang-components-edit-view
+  div#thang-components-edit-view
     top: 50px
 
   .thang-navigation-link

--- a/app/styles/editor/level/thangs-tab-view.sass
+++ b/app/styles/editor/level/thangs-tab-view.sass
@@ -1,6 +1,6 @@
 @import "app/styles/mixins"
    
-#thangs-tab-view
+#thangs-tab-view, .key-thang-tab-view
   $extantThangsWidth: 250px
   position: absolute
   top: 0

--- a/app/styles/editor/thang/thang-type-edit-view.sass
+++ b/app/styles/editor/thang/thang-type-edit-view.sass
@@ -1,4 +1,4 @@
-#thang-type-edit-view
+#thang-type-edit-view, .key-thang-tab-view
   #portrait
     float: left
     margin: 5px

--- a/app/templates/editor/level/level-edit-view.pug
+++ b/app/templates/editor/level/level-edit-view.pug
@@ -18,27 +18,27 @@ block header
 
       ul.nav.navbar-nav.nav-tabs
         li.active
-          a(href="#thangs-tab-view", data-toggle="tab", data-i18n="editor.level_tab_thangs") Thangs
+          a(href="#thangs-tab-view", data-toggle="tab", data-i18n="editor.level_tab_thangs")
         li
-          a(href="#editor-level-scripts-tab-view", data-toggle="tab", data-i18n="editor.level_tab_scripts") Scripts
+          a(href="#editor-level-scripts-tab-view", data-toggle="tab", data-i18n="editor.level_tab_scripts")
         li
-          a(href="#editor-level-settings-tab-view", data-toggle="tab", data-i18n="play.settings") Settings
+          a(href="#editor-level-settings-tab-view", data-toggle="tab", data-i18n="play.settings")
         li
-          a(href="#editor-level-components-tab-view", data-toggle="tab", data-i18n="editor.level_tab_components")#components-tab Components
+          a(href="#editor-level-components-tab-view", data-toggle="tab", data-i18n="editor.level_tab_components")#components-tab
         li
-          a(href="#systems-tab-view", data-toggle="tab", data-i18n="editor.level_tab_systems") Systems
+          a(href="#systems-tab-view", data-toggle="tab", data-i18n="editor.level_tab_systems")
         li
           a(href="#editor-level-tasks-tab-view", data-toggle="tab", data-i18n="editor.level_tab_tasks")#tasks-tab= "Tasks" + " " + view.getTaskCompletionRatio()
         li
           a(href="#editor-level-patches", data-toggle="tab")#patches-tab
-            span(data-i18n="resources.patches").spr Patches
+            span(data-i18n="resources.patches").spr
             - var patches = level.get('patches')
             if patches && patches.length
               span.badge= patches.length
         li
-          a(href="#related-achievements-view", data-toggle="tab", data-i18n="user.achievements_title") Achievements
+          a(href="#related-achievements-view", data-toggle="tab", data-i18n="user.achievements_title")
         li
-          a(href="#editor-level-documentation", data-toggle="tab", data-i18n="editor.level_tab_docs") Documentation
+          a(href="#editor-level-documentation", data-toggle="tab", data-i18n="editor.level_tab_docs")
         li
           a(href="#level-feedback-view", data-toggle="tab")
             .glyphicon.glyphicon-star
@@ -157,6 +157,10 @@ block outer_content
       div.tab-pane#editor-level-components-tab-view
 
       div.tab-pane#systems-tab-view
+
+      div.tab-pane#editor-hero-tab-view
+
+      div.tab-pane#editor-manager-tab-view
 
       div.tab-pane#editor-level-tasks-tab-view
 

--- a/app/templates/editor/level/thang/key-thang-tab-view.pug
+++ b/app/templates/editor/level/thang/key-thang-tab-view.pug
@@ -1,0 +1,14 @@
+div.well
+  span#thang-props
+    a#thang-name-link
+      span= view.thangData.id
+      input.secret(value=view.thangData.id)
+    |  ( 
+    span(data-i18n="editor.level_components_type") Type
+    | : 
+    a#thang-type-link
+      span= view.thangData.thangType
+      input.secret(value=view.thangData.thangType)
+    |  ) 
+
+#thang-components-edit-view

--- a/app/views/editor/component/ThangComponentConfigView.coffee
+++ b/app/views/editor/component/ThangComponentConfigView.coffee
@@ -27,8 +27,9 @@ module.exports = class ThangComponentConfigView extends CocoView
     @buildTreema()
 
   setConfig: (config) ->
+    @config = config
     @handlingChange = true
-    @editThangTreema.set('/', config)
+    @editThangTreema.set('/', @config)
     @handlingChange = false
 
   setIsDefaultComponent: (isDefaultComponent) ->
@@ -79,6 +80,7 @@ module.exports = class ThangComponentConfigView extends CocoView
     @editThangTreema = @$el.find('.treema').treema treemaOptions
     @editThangTreema.build()
     @editThangTreema.open(2)
+    @openTastyTreemas()
     if _.isEqual(@editThangTreema.data, {}) and not @editThangTreema.canAddChild()
       @$el.find('.panel-body').hide()
 
@@ -93,6 +95,18 @@ module.exports = class ThangComponentConfigView extends CocoView
   destroy: ->
     @editThangTreema?.destroy()
     super()
+
+  openTastyTreemas: ->
+    # To save on quick inspection, let's auto-open the properties we're most likely to want to see.
+    delicacies = [
+      ['programmableMethods', 'plan', 'languages']
+    ]
+    for dish in delicacies
+      node = @editThangTreema
+      for ingredient in dish
+        continue unless child = node.childrenTreemas?[ingredient]
+        child.open()
+        node = child
 
 class ComponentConfigNode extends TreemaObjectNode
   nodeDescription: 'Component Property'

--- a/app/views/editor/component/ThangComponentsEditView.coffee
+++ b/app/views/editor/component/ThangComponentsEditView.coffee
@@ -85,6 +85,7 @@ module.exports = class ThangComponentsEditView extends CocoView
     return unless @supermodel.finished()
     @buildComponentsTreema()
     @addThangComponentConfigViews()
+    @selectKeyComponent()
 
   buildComponentsTreema: ->
     components = _.zipObject((c.original for c in @components), @components)
@@ -255,6 +256,8 @@ module.exports = class ThangComponentsEditView extends CocoView
         subview = @makeThangComponentConfigView(componentRef)
         continue unless subview
         @registerSubView(subview)
+      else unless _.isEqual componentRef.config, subview.config
+        subview.setConfig componentRef.config ? {}
       subview.setIsDefaultComponent(not @componentsTreema.data[componentRef.original])
       configsEl.append(subview.$el)
 
@@ -297,6 +300,12 @@ module.exports = class ThangComponentsEditView extends CocoView
 
     @updateComponentsList()
     @reportChanges()
+
+  selectKeyComponent: ->
+    for child in _.values(@componentsTreema.childrenTreemas)
+      if child.keyForParent in [LevelComponent.RefereeID].concat(LevelComponent.ProgrammableIDs)
+        @onSelectComponent null, [child]
+        break
 
   onSelectComponent: (e, nodes) =>
     @componentsTreema.$el.find('.dependent').removeClass('dependent')

--- a/app/views/editor/level/thangs/KeyThangTabView.coffee
+++ b/app/views/editor/level/thangs/KeyThangTabView.coffee
@@ -1,0 +1,16 @@
+LevelThangEditView = require 'views/editor/level/thangs/LevelThangEditView'
+template = require 'app/templates/editor/level/thang/key-thang-tab-view'
+
+module.exports = class KeyThangTabView extends LevelThangEditView
+  id: null
+  className: 'key-thang-tab-view tab-pane'
+  template: template
+
+  constructor: (options) ->
+    super options
+    @id = options.id
+    @interval = setInterval @reportChanges, 750
+
+  destroy: ->
+    clearInterval @interval
+    super()

--- a/app/views/editor/level/thangs/ThangsTabView.ozar.coffee
+++ b/app/views/editor/level/thangs/ThangsTabView.ozar.coffee
@@ -565,6 +565,7 @@ module.exports = class ThangsTabView extends CocoView
       @thangsTreema.delete(@pathForThang(thang))
       @deleteEmptyTreema(thang)
       Thang.resetThangIDs()  # TODO: find some way to do this when we delete from treema, too
+      Backbone.Mediator.publish 'editor:thang-deleted', {thangID: thang.id}
     @gameUIState.set('selected', [])
 
   deleteEmptyTreema: (thang)->
@@ -630,6 +631,7 @@ module.exports = class ThangsTabView extends CocoView
     delete thang.index for thang in thangs
 
     @level.set 'thangs', thangs
+    Backbone.Mediator.publish 'editor:level-thangs-changed', thangs: thangs
     return if @editThangView
     return if skipSerialization
     serializedLevel = @level.serialize {@supermodel, session: null, otherSession: null, headless: false, sessionless: true, cached: true}
@@ -715,6 +717,8 @@ module.exports = class ThangsTabView extends CocoView
     @updateEditedThang e.thangData, e.oldPath
 
   updateEditedThang: (newThang, oldPath) ->
+    return unless @thangsTreema
+    return if _.isEqual(@thangsTreema.get(oldPath), newThang)
     @hush = true
     @thangsTreema.delete oldPath
     @populateFoldersForThang(newThang)


### PR DESCRIPTION
When the level editor starts, if there is already a Hero Placeholder, Hero Placeholder 1, Referee, Level Manager JS, etc., then this adds a new convenience tab to edit that Thang, so it's easier to directly jump to its configuration and to keep persistent code editor windows open for use of external tooling.

This also adds a convenience function for automatically opening Programmable Components to the code and merges a couple minor coco/ozar differences (like not loading archived ThangTypes).

![level-editor-tabs](https://user-images.githubusercontent.com/99704/192344449-a189ec06-232c-4bea-b1ad-1f5b12f2296a.gif)
