### PR TITLE
Remove Ned Fulmer

### DIFF
--- a/app/core/utils.coco.coffee
+++ b/app/core/utils.coco.coffee
@@ -1081,7 +1081,7 @@ teamSpells = humans: ['hero-placeholder/plan'], ogres: ['hero-placeholder-1/plan
 
 clanHeroes = [
   {clanId: '601351bb4b79b4013e198fbe', clanSlug: 'team-derbezt', thangTypeOriginal: '6037ed81ad0ac000f5e9f0b5', thangTypeSlug: 'armando-hoyos'}
-  {clanId: '6137aab4e0bae40025bed266', clanSlug: 'team-ned', thangTypeOriginal: '6136fe7e9f1147002c1316b4', thangTypeSlug: 'ned-fulmer'}
+  #{clanId: '6137aab4e0bae40025bed266', clanSlug: 'team-ned', thangTypeOriginal: '6136fe7e9f1147002c1316b4', thangTypeSlug: 'ned-fulmer'} Disabled for now
 ]
 
 freeAccessLevels = [

--- a/app/core/utils.coco.coffee
+++ b/app/core/utils.coco.coffee
@@ -1081,7 +1081,6 @@ teamSpells = humans: ['hero-placeholder/plan'], ogres: ['hero-placeholder-1/plan
 
 clanHeroes = [
   {clanId: '601351bb4b79b4013e198fbe', clanSlug: 'team-derbezt', thangTypeOriginal: '6037ed81ad0ac000f5e9f0b5', thangTypeSlug: 'armando-hoyos'}
-  #{clanId: '6137aab4e0bae40025bed266', clanSlug: 'team-ned', thangTypeOriginal: '6136fe7e9f1147002c1316b4', thangTypeSlug: 'ned-fulmer'} Disabled for now
 ]
 
 freeAccessLevels = [

--- a/app/core/utils.ozar.coffee
+++ b/app/core/utils.ozar.coffee
@@ -1049,7 +1049,7 @@ teamSpells = humans: ['hero-placeholder/plan'], ogres: ['hero-placeholder-1/plan
 
 clanHeroes = [
   {clanId: '601351bb4b79b4013e198fbe', clanSlug: 'team-derbezt', thangTypeOriginal: '6037ed81ad0ac000f5e9f0b5', thangTypeSlug: 'armando-hoyos'}
-  {clanId: '6137aab4e0bae40025bed266', clanSlug: 'team-ned', thangTypeOriginal: '6136fe7e9f1147002c1316b4', thangTypeSlug: 'ned-fulmer'}
+  #{clanId: '6137aab4e0bae40025bed266', clanSlug: 'team-ned', thangTypeOriginal: '6136fe7e9f1147002c1316b4', thangTypeSlug: 'ned-fulmer'} Disable for now
 ]
 
 freeAccessLevels = [

--- a/app/core/utils.ozar.coffee
+++ b/app/core/utils.ozar.coffee
@@ -1049,7 +1049,6 @@ teamSpells = humans: ['hero-placeholder/plan'], ogres: ['hero-placeholder-1/plan
 
 clanHeroes = [
   {clanId: '601351bb4b79b4013e198fbe', clanSlug: 'team-derbezt', thangTypeOriginal: '6037ed81ad0ac000f5e9f0b5', thangTypeSlug: 'armando-hoyos'}
-  #{clanId: '6137aab4e0bae40025bed266', clanSlug: 'team-ned', thangTypeOriginal: '6136fe7e9f1147002c1316b4', thangTypeSlug: 'ned-fulmer'} Disable for now
 ]
 
 freeAccessLevels = [

--- a/app/views/ladder/LadderView.coco.coffee
+++ b/app/views/ladder/LadderView.coco.coffee
@@ -354,7 +354,7 @@ module.exports = class LadderView extends RootView
   isAILeagueArena: -> _.find utils.arenas, slug: @levelID
 
   teamOffers: [
-    {slug: 'ned', clanId: '6137aab4e0bae40025bed266', name: 'Team Ned', clanSlug: 'team-ned'}
+    #{slug: 'ned', clanId: '6137aab4e0bae40025bed266', name: 'Team Ned', clanSlug: 'team-ned'} Remove Ned for now
     {slug: 'hyperx', clanId: '60a4378875b540004c78f121', name: 'Team HyperX', clanSlug: 'hyperx'}
     {slug: 'derbezt', clanId: '601351bb4b79b4013e198fbe', name: 'Team DerBezt', clanSlug: 'team-derbezt'}
   ]

--- a/app/views/ladder/LadderView.coco.coffee
+++ b/app/views/ladder/LadderView.coco.coffee
@@ -354,7 +354,6 @@ module.exports = class LadderView extends RootView
   isAILeagueArena: -> _.find utils.arenas, slug: @levelID
 
   teamOffers: [
-    #{slug: 'ned', clanId: '6137aab4e0bae40025bed266', name: 'Team Ned', clanSlug: 'team-ned'} Remove Ned for now
     {slug: 'hyperx', clanId: '60a4378875b540004c78f121', name: 'Team HyperX', clanSlug: 'hyperx'}
     {slug: 'derbezt', clanId: '601351bb4b79b4013e198fbe', name: 'Team DerBezt', clanSlug: 'team-derbezt'}
   ]

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -535,7 +535,7 @@ export default {
       </div>
       <div class="col-sm-7">
         <img v-if="currentSelectedClanName === 'Team DerBezt'" class="custom-esports-image-2" alt="" src="/file/db/thang.type/6037ed81ad0ac000f5e9f0b5/armando-pose.png">
-        <img v-if="currentSelectedClanName === 'Team Ned'" class="custom-esports-image-2 flip-horizontally" alt="" src="/file/db/thang.type/6136fe7e9f1147002c1316b4/Ned-Fulmer-Pose.png">
+        <!-- <img v-if="currentSelectedClanName === 'Team Ned'" class="custom-esports-image-2 flip-horizontally" alt="" src="/file/db/thang.type/6136fe7e9f1147002c1316b4/Ned-Fulmer-Pose.png"> -->
         <h1><span class="esports-aqua">{{ currentSelectedClanName }}</span></h1>
         <div class="clan-description" style="margin-bottom: 40px;" v-html="currentSelectedClanDescription"></div>
         <p v-if="currentSelectedClanName === 'Team DerBezt'">{{ $t('league.team_derbezt') }}</p>

--- a/app/views/landing-pages/league/PageLeagueGlobal.vue
+++ b/app/views/landing-pages/league/PageLeagueGlobal.vue
@@ -535,7 +535,6 @@ export default {
       </div>
       <div class="col-sm-7">
         <img v-if="currentSelectedClanName === 'Team DerBezt'" class="custom-esports-image-2" alt="" src="/file/db/thang.type/6037ed81ad0ac000f5e9f0b5/armando-pose.png">
-        <!-- <img v-if="currentSelectedClanName === 'Team Ned'" class="custom-esports-image-2 flip-horizontally" alt="" src="/file/db/thang.type/6136fe7e9f1147002c1316b4/Ned-Fulmer-Pose.png"> -->
         <h1><span class="esports-aqua">{{ currentSelectedClanName }}</span></h1>
         <div class="clan-description" style="margin-bottom: 40px;" v-html="currentSelectedClanDescription"></div>
         <p v-if="currentSelectedClanName === 'Team DerBezt'">{{ $t('league.team_derbezt') }}</p>


### PR DESCRIPTION
This PR removes the ability to obtain Ned Fulmer. We still need to figure out how we should change/remove the custom pages for Ned. Also, upon pushing this PR, we need to set Ned Fulmer's releasePhase property to "beta" so it doesn't show up on the hero selection page.

What it does:
* Simple change so joining the clan no longer grants the Ned Fulmer hero
* Remove Ned's team offer in ladder page.

What needs to be worked on later:
- [x] Change release phase to "beta" from "released" for his Thang
- [ ] Do something with the [Team Page](https://direct.codecombat.com/league/team-ned)
- [ ] Possibly remove any other references in-game?
- [ ] Change the description in the [clan page](https://direct.codecombat.com/clans/team-ned) to remove any references to clan hero.
- [ ] Edit the DB to remove the Ned clan-image in Team-Ned clan.