### PR TITLE
distinguish oldbrowser and chinaoldbrowser | fallback to old styles i…

### DIFF
--- a/app/components/common/Navigation.vue
+++ b/app/components/common/Navigation.vue
@@ -5,6 +5,7 @@
     OZARIA,
     OZARIA_CHINA,
     isOldBrowser,
+    isChinaOldBrowser,
     isCodeCombat,
     isOzaria,
     getQueryVariable
@@ -24,8 +25,8 @@
         'announcementModalOpen',
         'announcementDisplay',
       ]),
-      isOldBrowser () {
-        return isOldBrowser()
+      isChinaOldBrowser () {
+        return isChinaOldBrowser()
       },
 
       isCodeCombat () {
@@ -191,7 +192,7 @@
               a.navbar-brand(v-else :href="hideNav ? '#' : '/home'")
                 img#logo-img(src="/images/pages/base/logo.png" alt="CodeCombat logo")
 
-            .navbar-browser-recommendation.navbar-header(v-if="isOldBrowser")
+            .navbar-browser-recommendation.navbar-header(v-if="isChinaOldBrowser")
               .nav-spacer
                 .navbar-nav
                   a.text-p(href="https://www.google.cn/intl/zh-CN/chrome/") {{ $t('nav.browser_recommendation') }}

--- a/app/core/utils.coco.coffee
+++ b/app/core/utils.coco.coffee
@@ -1026,12 +1026,18 @@ OZARIA = 'ozaria'
 OZARIA_CHINA = 'aojiarui'
 
 isOldBrowser = () ->
-  if features.china and $.browser
+  if $.browser
     return true if not ($.browser.webkit or $.browser.mozilla or $.browser.msedge)
     majorVersion = $.browser.versionNumber
-    return true if $.browser.mozilla && majorVersion < 25
-    return true if $.browser.chrome && majorVersion < 72  # forbid some chinese browser
-    return true if $.browser.safari && majorVersion < 6  # 6 might have problems with Aether, or maybe just old minors of 6: https://errorception.com/projects/51a79585ee207206390002a2/errors/547a202e1ead63ba4e4ac9fd
+    # css math function supports
+    return true if $.browser.mozilla && majorVersion < 75
+    return true if $.browser.chrome && majorVersion < 79
+    return true if $.browser.safari && majorVersion < 11.1
+  return false
+
+isChinaOldBrowser = () ->
+  if features.china && isOldBrowser()
+    return true
   return false
 
 # AI League arenas
@@ -1222,6 +1228,7 @@ module.exports = {
   CODECOMBAT_CHINA
   OZARIA_CHINA
   isOldBrowser
+  isChinaOldBrowser
   isCodeCombat
   isOzaria
   supportEmail

--- a/app/core/utils.ozar.coffee
+++ b/app/core/utils.ozar.coffee
@@ -994,12 +994,18 @@ OZARIA = 'ozaria'
 OZARIA_CHINA = 'aojiarui'
 
 isOldBrowser = () ->
-  if features.china and $.browser
+  if $.browser
     return true if not ($.browser.webkit or $.browser.mozilla or $.browser.msedge)
     majorVersion = $.browser.versionNumber
-    return true if $.browser.mozilla && majorVersion < 25
-    return true if $.browser.chrome && majorVersion < 72  # forbid some chinese browser
-    return true if $.browser.safari && majorVersion < 6  # 6 might have problems with Aether, or maybe just old minors of 6: https://errorception.com/projects/51a79585ee207206390002a2/errors/547a202e1ead63ba4e4ac9fd
+    # css math function supports
+    return true if $.browser.mozilla && majorVersion < 75
+    return true if $.browser.chrome && majorVersion < 79
+    return true if $.browser.safari && majorVersion < 11.1
+  return false
+
+isChinaOldBrowser = () ->
+  if features.china && isOldBrowser()
+    return true
   return false
 
 # AI League arenas
@@ -1167,6 +1173,7 @@ module.exports = {
   CODECOMBAT_CHINA
   OZARIA_CHINA
   isOldBrowser
+  isChinaOldBrowser
   isCodeCombat
   isOzaria
   supportEmail

--- a/app/styles/play/level/tome/spell-palette-view.sass
+++ b/app/styles/play/level/tome/spell-palette-view.sass
@@ -30,7 +30,7 @@
       text-align: right
 
 #spell-palette-view-mid
-  right: 200px
+  right: 43.5%
   right: $spell-palette-right
   width: $api-bar-width
   bottom: 0px

--- a/app/views/core/RootView.coco.coffee
+++ b/app/views/core/RootView.coco.coffee
@@ -215,6 +215,8 @@ module.exports = class RootView extends CocoView
 
   isOldBrowser: utils.isOldBrowser
 
+  isChinaOldBrowser: utils.isChinaOldBrowser
+
   logoutRedirectURL: '/'
 
   navigateToAdmin: ->

--- a/app/views/play/CampaignView.coco.coffee
+++ b/app/views/play/CampaignView.coco.coffee
@@ -423,7 +423,7 @@ module.exports = class CampaignView extends RootView
     levelPlayCountsRequest.load()
 
   onLoaded: ->
-    if @isOldBrowser()
+    if @isChinaOldBrowser()
       unless storage.load('hideBrowserRecommendation')
         BrowserRecommendationModal = require 'views/core/BrowserRecommendationModal'
         @openModalView(new BrowserRecommendationModal())

--- a/app/views/play/level/tome/SpellPaletteView.coffee
+++ b/app/views/play/level/tome/SpellPaletteView.coffee
@@ -10,6 +10,7 @@ GameMenuModal = require 'views/play/menu/GameMenuModal'
 LevelSetupManager = require 'lib/LevelSetupManager'
 ace = require('lib/aceContainer')
 aceUtils = require 'core/aceUtils'
+utils = require 'core/utils'
 
 N_ROWS = 4
 
@@ -37,6 +38,8 @@ module.exports = class SpellPaletteView extends CocoView
     docs = @options.level.get('documentation') ? {}
     @createPalette()
     $(window).on 'resize', @onResize
+
+  isOldBrowser: utils.isOldBrowser
 
   getRenderData: ->
     c = super()
@@ -125,6 +128,11 @@ module.exports = class SpellPaletteView extends CocoView
   afterInsert: ->
     super()
     _.delay => @$el?.css('bottom', 0) unless $('#spell-view').is('.shown')
+    if @isOldBrowser() and @position is 'mid'
+      # fallback in old browsers that doesn't support css math function
+      vw = window.innerWidth
+      @$el?.css('right', 0.435*vw)
+
 
   updateCodeLanguage: (language) ->
     @options.language = language

--- a/app/views/play/level/tome/SpellPaletteView.coffee
+++ b/app/views/play/level/tome/SpellPaletteView.coffee
@@ -10,7 +10,6 @@ GameMenuModal = require 'views/play/menu/GameMenuModal'
 LevelSetupManager = require 'lib/LevelSetupManager'
 ace = require('lib/aceContainer')
 aceUtils = require 'core/aceUtils'
-utils = require 'core/utils'
 
 N_ROWS = 4
 
@@ -38,8 +37,6 @@ module.exports = class SpellPaletteView extends CocoView
     docs = @options.level.get('documentation') ? {}
     @createPalette()
     $(window).on 'resize', @onResize
-
-  isOldBrowser: utils.isOldBrowser
 
   getRenderData: ->
     c = super()
@@ -128,11 +125,6 @@ module.exports = class SpellPaletteView extends CocoView
   afterInsert: ->
     super()
     _.delay => @$el?.css('bottom', 0) unless $('#spell-view').is('.shown')
-    if @isOldBrowser() and @position is 'mid'
-      # fallback in old browsers that doesn't support css math function
-      vw = window.innerWidth
-      @$el?.css('right', 0.435*vw)
-
 
   updateCodeLanguage: (language) ->
     @options.language = language

--- a/static-mock.coffee
+++ b/static-mock.coffee
@@ -48,6 +48,7 @@ exports.view =
   forumLink: () -> 'http://discourse.codecombat.com/'
   isMobile: () -> false
   isOldBrowser: () -> false
+  isChinaOldBrowser: () -> false
   isIPadBrowser: () -> false
 
 exports.getQueryVariable = -> null


### PR DESCRIPTION
…n playlevelview in oldbrowsers that doesn't support css math
before: 
![image](https://user-images.githubusercontent.com/11417632/195743834-5fe1aaef-3532-4ebd-88b9-62cd852b43d0.png)

after:
![1665712049963](https://user-images.githubusercontent.com/11417632/195743466-9f028805-fbcb-475c-9121-ae2e6c3947b2.jpg)

new SpellPaletteView has two types : `mid` and `bot`
both uses css math functions like `calc`, `max`, `min`. which [is not supported in oldBrowsers ](https://developer.mozilla.org/en-US/docs/Web/CSS/min#browser_compatibility)
the bot view still seem not so bad so haven't fix in this pr. while `mid` view stop user to see their codes, so fix here.