### PR TITLE
Subscription page not displaying correctly

### DIFF
--- a/app/templates/account/subscription-view.pug
+++ b/app/templates/account/subscription-view.pug
@@ -116,7 +116,7 @@ block content
             if new Date() < new Date(view.personalSub.free)
               div
                 - date = moment(new Date(view.personalSub.free)).format('l')
-                span.spr(data-i18n="subscribe.currently_free_until", data-i18n-options={date})
+                span.spr(data-i18n="[html]subscribe.currently_free_until", data-i18n-options={date})
             else
               span.spr(data-i18n="subscribe.was_free_until")
               span= moment(new Date(view.personalSub.free)).format('l')


### PR DESCRIPTION
It seems, `data-i18n` will be automatically html encoded. By adding `[html]` prefix it can be switched off: 

<img width="1435" alt="Subscription___CodeCombat_and_Admin___CodeCombat_and_background-processor_–_docker-compose_yml_and_Kellie_Pickler_-_My_Angel" src="https://user-images.githubusercontent.com/11805970/196173315-75543387-9099-49f4-ac8b-448084dbfce8.png">
