### PR TITLE
show license_stats button for japan school admin

### DIFF
--- a/app/components/license/LicenseDataPerUser.vue
+++ b/app/components/license/LicenseDataPerUser.vue
@@ -165,6 +165,9 @@ export default {
         remap(re, true)
       });
       (prepaid.removedRedeemers || []).forEach((re) => {
+        if (!re.teacherID) {
+          re.teacherID = prepaid.creator // fall back to creator as revoke teacher
+        }
         remap(re, false)
       })
 

--- a/app/views/school-administrator/teachers/SchoolAdminTeacherListView.vue
+++ b/app/views/school-administrator/teachers/SchoolAdminTeacherListView.vue
@@ -76,6 +76,9 @@ import { mapActions, mapGetters, mapState } from 'vuex'
             });
           }
           return groupNameTeacherArr;
+        },
+        me () {
+          return me
         }
       }
     ),
@@ -179,6 +182,9 @@ import { mapActions, mapGetters, mapState } from 'vuex'
 
 <template>
   <div>
+    <h3 style="text-align: right"  v-if="me.get('_id').toString() === '63034d47767a600023e3b879'">
+      <a :href="'/school-administrator/licenses/stats'"> {{ $t('teacher.license_stats') }}</a>
+    </h3>
     <h3>
       <span>{{ $t('school_administrator.my_teachers') }}</span>
       <a class="pull-right" :href="'/outcomes-report/school-admin/' + myId" target="_blank"> {{ $t('outcomes.view_outcomes_report') }}</a>


### PR DESCRIPTION
add a simple button to japan school admin `CodeCombat@fce-hd.co.jp` since they really like it.
![image](https://user-images.githubusercontent.com/11417632/200724081-84853686-47bb-4501-b312-eaae19864fd2.png)

also add a fall back teacherID for removedMembers. see https://github.com/codecombat/codecombat-server/compare/yuqiang/JapanSchoolDashboardUpdates?expand=1 also
