### PR TITLE
HoC Banner fix

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -194,6 +194,8 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     top_banner_blurb_podcast: "NEW: Explore the world of EdTech with our new podcast EdTech Adventures."
     top_banner_blurb_demo_day: "Please join us for a demo day webinar on Thursday, August 25 at 4:00 pm EDT."
     top_banner_blurb_demo_day_10_20: "Join us for a spooktacular demo of CodeCombat & Ozaria on Thursday, October 20 at 4:00 pm CDT."
+    top_banner_blurb_hoc_2022_12_01: "Join us Dec. 1st for our Hour of Code Walkthrough! Everything you need to implement our all new activities __topBannerHereLink__"
+    top_banner_blurb_hoc_2022_12_01_here: "HERE"
     try_the_game: "Try the game"
     classroom_edition: "Classroom Edition:"
     learn_to_code: "Learn to code:"

--- a/app/templates/home-view.coco.pug
+++ b/app/templates/home-view.coco.pug
@@ -12,6 +12,8 @@ block content
           else if me.isTeacher() && new Date() < new Date("2022-10-20T16:30:00.000-05:00")
             span(data-i18n="new_home.top_banner_blurb_demo_day_10_20")
             a(href="https://us06web.zoom.us/webinar/register/WN_NU2XXsQORZ-_lkx7rxUplQ", data-i18n="league.register", data-event-action="Click: Homepage Banner Demo Day")
+          else if me.isTeacher() && new Date() < new Date("2022-12-01T14:30:00.000-05:00")
+            span(data-i18n="[html]new_home.top_banner_blurb_hoc_2022_12_01", data-i18n-options=JSON.stringify(i18nData))
           else
             span(data-i18n="new_home.top_banner_blurb_podcast")
             a(href="/podcast", data-i18n="new_home.learn_more", data-event-action="Click: Homepage Banner Podcast Page")
@@ -19,7 +21,6 @@ block content
     .cloud-wrapper
       .row#jumbotron-container-fluid
         .col-md-8
-          .banner-hoc
           h1(data-i18n="new_home.slogan_power_of_play")
           div.button-section
             if me.isAnonymous()

--- a/app/templates/home-view.ozar.pug
+++ b/app/templates/home-view.ozar.pug
@@ -12,12 +12,13 @@ block content
           else if me.isTeacher() && new Date() < new Date("2022-10-20T16:30:00.000-05:00")
             span(data-i18n="new_home.top_banner_blurb_demo_day_10_20")
             a(href="https://us06web.zoom.us/webinar/register/WN_NU2XXsQORZ-_lkx7rxUplQ", data-i18n="league.register", data-event-action="Click: Homepage Banner Demo Day")
+          else if me.isTeacher() && new Date() < new Date("2022-12-01T14:30:00.000-05:00")
+            span(data-i18n="[html]new_home.top_banner_blurb_hoc_2022_12_01", data-i18n-options=JSON.stringify(i18nData))
           else
             span(data-i18n="new_home.top_banner_blurb_funding")
             a(href="/funding", data-i18n="new_home.learn_more", data-event-action="Click: Homepage Banner Funding Page")
 
     section.row#jumbotron-container-fluid
-      .banner-hoc
       .item-list
         img(src="/images/ozaria/home/ozaria_logo_sun.png" alt="Ozaria branding logo")
         h1(data-i18n="ozaria_home.subtitle" style="margin-bottom:15px;")

--- a/app/views/HomeView.coco.coffee
+++ b/app/views/HomeView.coco.coffee
@@ -10,7 +10,6 @@ GetStartedSignupModal  = require('app/views/teachers/GetStartedSignupModal').def
 paymentUtils = require 'app/lib/paymentUtils'
 fetchJson = require 'core/api/fetch-json'
 DOMPurify = require 'dompurify'
-BannerHoC = require("./courses/BannerHoC").default
 
 module.exports = class HomeView extends RootView
   id: 'home-view'
@@ -47,6 +46,7 @@ module.exports = class HomeView extends RootView
       funding: "<a href='https://www.ozaria.com/funding' target='_blank'>#{$.i18n.t('nav.funding_resources_guide')}</a>"
       maintenanceStartTime: "#{context.maintenanceStartTime.calendar()} (#{context.maintenanceStartTime.fromNow()})"
       interpolation: { escapeValue: false }
+      topBannerHereLink: "<a href='/teachers/hour-of-code' target='_blank'>#{$.i18n.t('new_home.top_banner_blurb_hoc_2022_12_01_here')}</a>"
     context
 
   getMeta: ->
@@ -187,10 +187,6 @@ module.exports = class HomeView extends RootView
       noty({ text: title, type: type, timeout: 10000, killer: true })
       @renderedPaymentNoty = true
     _.delay(@activateCarousels, 1000)
-
-    @bannerHoC = new BannerHoC({
-      el: @$('.banner-hoc')[0]
-    })
     super()
 
   trackPurchase: (event) ->

--- a/app/views/HomeView.ozar.coffee
+++ b/app/views/HomeView.ozar.coffee
@@ -3,7 +3,6 @@ RootView = require 'views/core/RootView'
 template = require 'templates/home-view'
 CocoCollection = require 'collections/CocoCollection'
 CreateAccountModal = require 'views/core/CreateAccountModal/CreateAccountModal'
-BannerHoC = require("./courses/BannerHoC").default
 
 utils = require 'core/utils'
 storage = require 'core/storage'
@@ -36,6 +35,7 @@ module.exports = class HomeView extends RootView
       pd: "<a href='/professional-development'>#{$.i18n.t('nav.professional_development')}</a>"
       maintenanceStartTime: "#{context.maintenanceStartTime.calendar()} (#{context.maintenanceStartTime.fromNow()})"
       interpolation: { escapeValue: false }
+      topBannerHereLink: "<a href='https://codecombat.com/teachers/hour-of-code' target='_blank'>#{$.i18n.t('new_home.top_banner_blurb_hoc_2022_12_01_here')}</a>"
     context
 
   getMeta: ->
@@ -126,10 +126,6 @@ module.exports = class HomeView extends RootView
         $buttons = $('.control-buttons > button')
         $buttons.removeClass 'active'
         $('[data-slide-to=\'' + nextActiveSlide + '\']').addClass('active')
-
-    @bannerHoC = new BannerHoC({
-      el: @$('.banner-hoc')[0]
-    })
 
     super()
 


### PR DESCRIPTION
Remove the separate `HoC banner` from homepages, and display its content in the already existing `top-banner` instead: 
![CodeCombat_-_Coding_games_to_learn_Python_and_JavaScript___CodeCombat_and_CodeCombat_-_Coding_games_to_learn_Python_and_JavaScript___CodeCombat_and_Ozaria_-_Computer_science_that_captivates_and_Ozaria_-_Computer_science_that_captivates](https://user-images.githubusercontent.com/11805970/204303959-12941ec8-7396-416c-9228-c8895a0113d9.png)
