### PR TITLE
Fix Contact Link

### DIFF
--- a/app/components/common/DirectContactModal.vue
+++ b/app/components/common/DirectContactModal.vue
@@ -8,7 +8,6 @@
       Modal
     },
     data: () => ({
-      zendeskError: null
     }),
     methods: {
       showError (error) {
@@ -27,7 +26,7 @@
       },
       clickedSalesChat () {
         try {
-          window.tracker.drift.openChat()
+          zE('messenger', 'open')
           this.programaticallyClose()
           window.tracker.trackEvent('Sales chat opened')
         } catch (e) {
@@ -36,29 +35,13 @@
       },
       clickedSupportChat () {
         try {
-          window.tracker.drift.startInteraction({ interactionId: 135698 })
+          zE('messenger', 'open')
           this.programaticallyClose()
           window.tracker.trackEvent('Support chat opened')
         } catch (e) {
           this.showError(e)
         }
       },
-      clickedEmail () {
-        try {
-          zE('webWidget', 'prefill', {
-            email: {
-              value: me.get('email')
-            }
-          })
-          zE('webWidget', 'open')
-          zE('webWidget', 'show')
-          this.programaticallyClose()
-          window.tracker.trackEvent('Support email opened')
-        } catch (e) {
-          this.showError(e)
-          this.zendeskError = true
-        }
-      }
     }
   })
 </script>
@@ -82,12 +65,8 @@
 
       <modal-divider />
 
-      <div v-if="zendeskError">
+      <div>
         {{ $t('general.email_us') }}: <a href="mailto:support@codecombat.com">support@codecombat.com</a>
-      </div>
-      <div v-else class="flex-container column">
-        <p>{{ $t("general.email_us") }}</p>
-        <button @click.prevent="clickedEmail" class="btn btn-large btn-primary btn-moon">{{ $t("general.email") }}</button>
       </div>
     </div>
   </modal>

--- a/app/components/common/Footer.vue
+++ b/app/components/common/Footer.vue
@@ -100,7 +100,8 @@ export default Vue.extend({
             { url: this.cocoPath('/about'), title: 'nav.about', attrs: { 'data-event-action': 'Click: Footer About' } },
             { url: 'https://codecombat.zendesk.com/hc/en-us', title: 'contact.faq', attrs: { target: '_blank', 'data-event-action': 'Click: Footer FAQ' } },
             { url: this.cocoPath('/about#careers'), title: 'nav.careers' },
-            { title: 'nav.contact', attrs: { class: 'contact-modal', tabindex: -1 } },
+            { title: 'nav.contact', attrs: { class: 'contact-modal', tabindex: -1 }, hide: !me.isTeacher() },
+            { title: 'nav.contact', url: 'mailto:support@codecombat.com', attrs: { tabindex: -1 }, hide: me.isTeacher() },
             { url: this.cocoPath('/parents'), title: 'nav.parent' },
             { url: 'https://blog.codecombat.com/', title: 'nav.blog' }
           ]

--- a/app/views/HomeView.coco.coffee
+++ b/app/views/HomeView.coco.coffee
@@ -42,7 +42,7 @@ module.exports = class HomeView extends RootView
     context.i18nData =
       slides: "<a href='https://docs.google.com/presentation/d/1KgFOg2tqbKEH8qNwIBdmK2QbHvTsxnW_Xo7LvjPsxwE/edit?usp=sharing' target='_blank'>#{$.i18n.t('new_home.lesson_slides')}</a>"
       clever: "<a href='/teachers/resources/clever-faq'>#{$.i18n.t('new_home_faq.clever_integration_faq')}</a>"
-      contact: "<a class='contact-modal'>#{$.i18n.t('general.contact_us')}</a>"
+      contact: if me.isTeacher() then "<a class='contact-modal'>#{$.i18n.t('general.contact_us')}</a>" else "<a href=\"mailto:support@codecombat.com\">#{$.i18n.t('general.contact_us')}</a>"
       funding: "<a href='https://www.ozaria.com/funding' target='_blank'>#{$.i18n.t('nav.funding_resources_guide')}</a>"
       maintenanceStartTime: "#{context.maintenanceStartTime.calendar()} (#{context.maintenanceStartTime.fromNow()})"
       interpolation: { escapeValue: false }

--- a/app/views/core/CocoView.coffee
+++ b/app/views/core/CocoView.coffee
@@ -272,15 +272,10 @@ module.exports = class CocoView extends Backbone.View
         DirectContactModal = require('ozaria/site/views/core/DirectContactModal').default
 
       @openModalView(new DirectContactModal())
-
-    if (me.isTeacher(true) and window?.tracker?.drift?.openChat) or me.showChinaResourceInfo()
+    if (me.isTeacher(true) and zE) or me.showChinaResourceInfo()
       openDirectContactModal()
     else
-      # There's an unlikely case where both Drift and Zendesk are unavailable, or Zendesk exists but fails.
-      # Since the modal communicates errors better, and shows the direct support email, we still open it.
-      zendesk.loadZendesk()
-        .then(-> if not zendesk.openZendesk() then openDirectContactModal())
-        .catch(-> openDirectContactModal())
+      location.href = 'mailto:support@codecombat.com'
 
   onClickLoadingErrorLoginButton: (e) ->
     e.stopPropagation() # Backbone subviews and superviews will handle this call repeatedly otherwise

--- a/app/views/core/CocoView.ozar.coffee
+++ b/app/views/core/CocoView.ozar.coffee
@@ -267,14 +267,10 @@ module.exports = class CocoView extends Backbone.View
       DirectContactModal = require('ozaria/site/views/core/DirectContactModal').default
       @openModalView(new DirectContactModal())
 
-    if (me.isTeacher(true) and window?.tracker?.drift?.openChat) or me.showChinaResourceInfo()
+    if (me.isTeacher(true) and zE) or me.showChinaResourceInfo()
       openDirectContactModal()
     else
-      # There's an unlikely case where both Drift and Zendesk are unavailable, or Zendesk exists but fails.
-      # Since the modal communicates errors better, and shows the direct support email, we still open it.
-      zendesk.loadZendesk()
-        .then(-> if not zendesk.openZendesk() then openDirectContactModal())
-        .catch(-> openDirectContactModal())
+      location.href = 'mailto:support@codecombat.com'
 
   onClickLoadingErrorLoginButton: (e) ->
     e.stopPropagation() # Backbone subviews and superviews will handle this call repeatedly otherwise

--- a/ozaria/site/components/common/DirectContactModal.vue
+++ b/ozaria/site/components/common/DirectContactModal.vue
@@ -1,7 +1,6 @@
 <script>
   import ModalDivider from './ModalDivider'
   import Modal from './Modal'
-  const zendesk = require('core/services/zendesk')
 
   export default Vue.extend({
     components: {
@@ -9,7 +8,6 @@
       Modal
     },
     data: () => ({
-      zendeskError: null
     }),
     methods: {
       programaticallyClose () {
@@ -28,7 +26,7 @@
       },
       clickedSalesChat () {
         try {
-          window.tracker.drift.openChat()
+          zE('messenger', 'open')
           this.programaticallyClose()
           window.tracker.trackEvent('Sales chat opened')
         } catch (e) {
@@ -37,32 +35,13 @@
       },
       clickedSupportChat () {
         try {
-          window.tracker.drift.startInteraction({ interactionId: 135698 })
-
+          zE('messenger', 'open')
           this.programaticallyClose()
           window.tracker.trackEvent('Support chat opened')
         } catch (e) {
           this.showError(e)
         }
       },
-      clickedEmail () {
-        zendesk.loadZendesk().then(() => {
-          try {
-            zE('webWidget', 'prefill', {
-              email: {
-                value: me.get('email')
-              }
-            })
-            zE('webWidget', 'open')
-            zE('webWidget', 'show')
-            this.programaticallyClose()
-            window.tracker.trackEvent('Support email opened')
-          } catch (e) {
-            this.showError(e)
-            this.zendeskError = true
-          }
-        })
-      }
     }
   })
 </script>
@@ -86,12 +65,8 @@
 
       <modal-divider />
 
-      <div v-if="zendeskError">
+      <div>
         {{ $t('general.email_us') }}: <a href="mailto:support@ozaria.com">support@ozaria.com</a>
-      </div>
-      <div v-else class="flex-container column">
-        <p>{{ $t("general.email_us") }}</p>
-        <button @click.prevent="clickedEmail" class="btn btn-large btn-primary btn-moon">{{ $t("general.email") }}</button>
       </div>
     </div>
   </modal>


### PR DESCRIPTION
The behavior of "Contact" buttons fixed: 
 - for non-teachers: open 'mailto:support@codecombat.com' link
 - for teachers: open contact modal where they choose either Support or Sales, the Zendesk messenger will be shown

The "Email" button was removed from contact modal, and support email address is shown instead.