### PR TITLE
simply add clan column in league leaderboard

### DIFF
--- a/app/templates/play/ladder/my_matches_tab.coco.pug
+++ b/app/templates/play/ladder/my_matches_tab.coco.pug
@@ -1,6 +1,6 @@
 .row
   for team in view.teams
-    div.matches-column.col-md-6
+    div.matches-column.col-md-5
       table.table.table-bordered.table-condensed.my-matches-table
 
         tr

--- a/app/views/ladder/components/Leaderboard.coffee
+++ b/app/views/ladder/components/Leaderboard.coffee
@@ -41,10 +41,11 @@ module.exports = class LeaderboardView extends CocoView
         {slug: 'creator', col: 0, title: ''},
         {slug: 'language', col: 1, title: ''},
         {slug: 'rank', col: 1, title: ''},
-        {slug: 'name', col: 3, title: $.i18n.t('general.name')},
+        {slug: 'name', col: 2, title: $.i18n.t('general.name')},
         {slug: 'score', col: 2, title: $.i18n.t('general.score')},
+        {slug: 'clan', col: 2, title: $.i18n.t('league.team')},
         {slug: 'age', col: 1, title: $.i18n.t('ladder.age')},
-        {slug: 'when', col: 2, title: $.i18n.t('general.when')}
+        {slug: 'when', col: 1, title: $.i18n.t('general.when')}
         {slug: 'fight', col: 1, title: ''}
       ]
       @propsData.scoreType = 'arena'
@@ -155,6 +156,7 @@ module.exports = class LeaderboardView extends CocoView
           model.rank || index+1,
           (@mapFullName(model.get('fullName')) || model.get('creatorName') || $.i18n.t("play.anonymous")),
           @correctScore(model),
+          @getClanName(model),
           @getAgeBracket(model),
           moment(model.get('submitDate')).fromNow().replace('a few ', ''),
           model.get('_id')

--- a/app/views/ladder/components/Leaderboard.vue
+++ b/app/views/ladder/components/Leaderboard.vue
@@ -195,7 +195,7 @@ export default Vue.extend({
       if (slug === 'name') {
         return { 'name-col-cell': 1, ai: /(Bronze|Silver|Gold|Platinum|Diamond) AI/.test(item) }
       }
-      if (slug === 'team') {
+      if (slug === 'team' || slug === 'clan') {
         return { capitalize: 1, 'clan-col-cell': 1 }
       }
       if (slug === 'language') {

--- a/app/views/ladder/components/Leaderboard.vue
+++ b/app/views/ladder/components/Leaderboard.vue
@@ -280,7 +280,7 @@ export default Vue.extend({
 </script>
 
 <template lang="pug">
-  .table-responsive(:class="{'col-md-6': scoreType=='arena'}")
+  .table-responsive(:class="{'col-md-7': scoreType=='arena'}")
     div(v-if="scoreType == 'arena'")
       div(:class="{hide: !showContactUs}" id="contact-us-info")
         if dateBeforeSep


### PR DESCRIPTION
simply add team column in leaderboard. 
in future, we can try to drop the `my-matches` tab when user doesn't have matches. and better to have a better `team name` selector (currently we select team from user clan in a not so stable order)

![image](https://user-images.githubusercontent.com/11417632/204952967-0f82a501-6811-4339-b27f-0953e96172e4.png)
