### PR TITLE
allow additional propeties so that we can add new products without sc…

### DIFF
--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -429,7 +429,7 @@ _.extend UserSchema.properties,
       prepaid: c.objectId(links: [ {rel: 'db', href: '/db/prepaid/{($)}'} ])  # required for type: “course” for legacy compatibility, optional for other types
       productOptions:
         anyOf: [
-          c.object({}, { # course
+          c.object({additionalProperties: true}, { # course
             includedCourseIDs: {
               type: ['array', 'null']
               }


### PR DESCRIPTION
…hema error easily

--- 
Currently we change our user.products schema a little frequent. so add a allow additional property here so that any `productOption` can match the schema. to Avoid issues on prod server.