### PR TITLE
Fix Google signup HTML message

### DIFF
--- a/app/templates/core/create-account-modal/setup-account-panel.coco.pug
+++ b/app/templates/core/create-account-modal/setup-account-panel.coco.pug
@@ -22,7 +22,7 @@
           a(href="/teachers/resources") {{ $t("signup.teacher_list_resource_hub_4") }}
           =" "
           span {{ $t("signup.teacher_list_resource_hub_5") }}
-      span(v-html="$t('signup.teacher_additional_questions', {supportEmail: supportEmail})")
+      span(v-html="$t('signup.teacher_additional_questions', {supportEmail: supportEmail, interpolation: { escapeValue: false }})")
 
     br
     div.text-center


### PR DESCRIPTION
Do not escape html tags in signup message
![CodeCombat_-_Coding_games_to_learn_Python_and_JavaScript___CodeCombat_and_CodeCombat_-_Coding_games_to_learn_Python_and_JavaScript___CodeCombat](https://user-images.githubusercontent.com/11805970/210948119-3ee6d540-02a0-47ee-87a1-5faaaee65fba.png)
