### PR TITLE
Use another method to initialize/remove fbq to avoid errors

### DIFF
--- a/app/core/Tracker2/FacebookPixelTracker.js
+++ b/app/core/Tracker2/FacebookPixelTracker.js
@@ -38,11 +38,22 @@ export default class FacebookPixelTracker extends BaseTracker {
     // double enable it for teachers
     const isStudent = this.store.getters['me/isStudent']
     const isChina = (window.features || {}).china
+    const isRegisteredHomeUser = this.store.getters['me/isHomePlayer'] // Includes anonymous: false check
 
-    if (!this.disableAllTracking && !isStudent && !isChina) {
+    if (!this.disableAllTracking && !isStudent && !isChina && !isRegisteredHomeUser && window.fbq && !window.fbq.doNotTrack) {
       this.enabled = true
+      // Moved this from layout.static, since we need to first know if we are using FB for these
+      window.fbq('init', '514962702046652')
+      window.fbq('track', 'PageView')
     } else {
       this.enabled = false
+      const fbqTrackingScript = document.getElementById('analytics-fbq')
+      if (fbqTrackingScript) {
+        fbqTrackingScript.remove()
+        if (window.fbq) {
+          window.fbq.doNotTrack = true
+        }
+      }
     }
 
     this.onInitializeSuccess()

--- a/app/core/application.coffee
+++ b/app/core/application.coffee
@@ -121,7 +121,6 @@ Application =
       awayTimeout: 5 * 60 * 1000
     @idleTracker.start()
     @trackProductVisit()
-    @handleTracking()
     @setReferrerTracking()
 
   checkForNewAchievement: ->
@@ -174,14 +173,6 @@ Application =
     last = me.get('activity')?[activity]?.last
     return if last and moment(last).isAfter(moment().subtract(12, 'hour'))
     me.trackActivity activity
-
-  handleTracking: ->
-    if me.isStudent() || (me.isHomeUser() && !me.isAnonymous())
-      fbqTrackingScript = document.getElementById('analytics-fbq')
-      if fbqTrackingScript
-        console.log('removing fbq tracking')
-        fbqTrackingScript.remove()
-        window.fbq = { doNotTrack: true }
 
   setReferrerTracking: ->
     return if window.serverSession?.amActually

--- a/app/templates/static/layout.static.coco.pug
+++ b/app/templates/static/layout.static.coco.pug
@@ -123,8 +123,9 @@ html(lang='en')
         }(window, document, 'script',
                 'https://connect.facebook.net/en_US/fbevents.js');
 
-        fbq('init', '514962702046652')
-        fbq('track', 'PageView')
+        // Moved to dynamic tracker code to only apply to relevant user types
+        //fbq('init', '514962702046652')
+        //fbq('track', 'PageView')
     else
       // Baidu Analytics
       script.

--- a/app/templates/static/layout.static.ozar.pug
+++ b/app/templates/static/layout.static.ozar.pug
@@ -121,8 +121,9 @@ html(lang='en')
         }(window, document, 'script',
                 'https://connect.facebook.net/en_US/fbevents.js');
 
-        fbq('init', '514962702046652')
-        fbq('track', 'PageView')
+        // Moved to dynamic tracker code to only apply to relevant user types
+        //fbq('init', '514962702046652')
+        //fbq('track', 'PageView')
     else
       // Baidu Analytics
       script.


### PR DESCRIPTION
Previously, we always loaded and initialized it, but sometimes removed it while it was initializing, leading to errors when we removed `window.fbq` mid-load. Now we wait to initialize it until we have loaded the user and know whether we want to initialize it, and also wait to remove it at that time.