### PR TITLE
Some routes made case insensitive

### DIFF
--- a/app/core/Router.coco.coffee
+++ b/app/core/Router.coco.coffee
@@ -14,6 +14,9 @@ paymentUtils = require 'lib/paymentUtils'
 
 module.exports = class CocoRouter extends Backbone.Router
 
+  _routeToRegExp: (route) ->
+    new RegExp(super(route), 'i') # make all routes case insensitive
+
   initialize: ->
     # http://nerds.airbnb.com/how-to-add-google-analytics-page-tracking-to-57536
     @bind 'route', @_trackPageView

--- a/app/core/Router.coco.coffee
+++ b/app/core/Router.coco.coffee
@@ -117,7 +117,6 @@ module.exports = class CocoRouter extends Backbone.Router
     'artisans/arena-balancer(/:levelSlug)': go('artisans/ArenaBalancerView')
 
     'careers': => window.location.href = 'https://jobs.lever.co/codecombat'
-    'Careers': => window.location.href = 'https://jobs.lever.co/codecombat'
 
     'cla': go('CLAView')
 
@@ -249,7 +248,6 @@ module.exports = class CocoRouter extends Backbone.Router
     'play/:map': go('play/CampaignView')
 
     'premium': go('PremiumFeaturesView', { redirectStudents: true, redirectTeachers: true })
-    'Premium': go('PremiumFeaturesView', { redirectStudents: true, redirectTeachers: true })
 
     'preview': if me.useChinaHomeView() then go('HomeCNView') else go('HomeView')
 
@@ -259,7 +257,6 @@ module.exports = class CocoRouter extends Backbone.Router
 
     'schools': if me.useChinaHomeView() then go('HomeCNView') else go('HomeView')
     'seen': if me.useChinaHomeView() then go('HomeCNView') else go('HomeView')
-    'SEEN': if me.useChinaHomeView() then go('HomeCNView') else go('HomeView')
 
     'students': go('courses/CoursesView', { redirectTeachers: true })
     'students/update-account': go('courses/CoursesUpdateAccountView', { redirectTeachers: true })

--- a/app/core/Router.ozar.coffee
+++ b/app/core/Router.ozar.coffee
@@ -20,6 +20,9 @@ ViewLoadTimer = require 'core/ViewLoadTimer'
 
 module.exports = class CocoRouter extends Backbone.Router
 
+  _routeToRegExp: (route) ->
+    new RegExp(super(route), 'i') # make all routes case insensitive
+
   initialize: ->
     # http://nerds.airbnb.com/how-to-add-google-analytics-page-tracking-to-57536
     @bind 'route', @_trackPageView

--- a/app/core/Router.ozar.coffee
+++ b/app/core/Router.ozar.coffee
@@ -108,7 +108,6 @@ module.exports = class CocoRouter extends Backbone.Router
     'artisans/bulk-level-editor/:campaign': go('artisans/BulkLevelEditView')
 
     'careers': => window.location.href = 'https://jobs.lever.co/codecombat'
-    'Careers': => window.location.href = 'https://jobs.lever.co/codecombat'
 
     'cla': go('CLAView')
 
@@ -290,7 +289,6 @@ module.exports = class CocoRouter extends Backbone.Router
     'social-and-emotional-learning': go('core/SingletonAppVueComponentView')
     'schools': go('HomeView')
     'seen': go('HomeView')
-    'SEEN': go('HomeView')
 
     'students': go('courses/CoursesView', { redirectTeachers: true })
     'students/update-account': go('courses/CoursesUpdateAccountView', { redirectTeachers: true })


### PR DESCRIPTION
`codecombat.com/Roblox` or `codecombat.com/roblox` was requested to work regardless of letter cases.
Other two routes moved to new logic to avoid duplications.

Now the router works case insensitively for the routes `/roblox`, `/careers` and `/premium`