### PR TITLE
Track mobile signup event & Encode prefill data

### DIFF
--- a/app/views/core/CreateAccountModal/BasicInfoView.coffee
+++ b/app/views/core/CreateAccountModal/BasicInfoView.coffee
@@ -62,8 +62,18 @@ module.exports = class BasicInfoView extends CocoView
 
     # Prefill form by url params
     url = new URLSearchParams window.location.search
-    ['firstName', 'lastName', 'email'].forEach (param) =>
-      @signupState.get('signupForm')[param]= url.get param
+
+    if url.get 'prefill'
+      prefillData = JSON.parse(Buffer.from(url.get('prefill'), 'base64').toString('ascii'))
+    else
+      prefillData = ['firstName', 'lastName', 'email'].reduce (data = {}, param) =>
+        value = url.get param
+        if value then data[param] = url.get param
+        data
+      , {}
+
+    Object.entries(prefillData).forEach ([param,value]) =>
+      @signupState.get('signupForm')[param]= value
 
     @hideEmail = if isCodeCombat then userUtils.shouldHideEmail() else false
 

--- a/app/views/landing-pages/mobile/PageMobileView.vue
+++ b/app/views/landing-pages/mobile/PageMobileView.vue
@@ -251,6 +251,7 @@ export default Vue.extend({
       }).then(() => {
         this.registrationSucceeded = true
         this.setActiveStep(this.STEP_DONE)
+        window.tracker.trackEvent(`${utils.getProduct()}MobileSignup`, { category: 'Teachers', product: utils.getProduct() })
       }).catch((err) => {
         noty({
           text: 'Failed to contact server: ' + err.message,


### PR DESCRIPTION
Call `trackEvent` when `/mobile` signup is done.
The event name is `codecobatMobileSignup` or `ozariaMobileSignup` depending on product.

Also ability added for _Create Teacher Account_ from to be prefilled by base64 encoded `prefill` data param instead of `firstName`, `lastName` and `email`:
![CodeCombat_-_Coding_games_to_learn_Python_and_JavaScript___CodeCombat_and_CodeCombat_-_Coding_games_to_learn_Python_and_JavaScript___CodeCombat](https://user-images.githubusercontent.com/11805970/217779047-5f98248d-ceb2-4b40-9dbb-0020fb97730e.png)

Pls also check: https://github.com/codecombat/codecombat-server/pull/556
