### PR TITLE
fix cpp/java function autocomplete fill the types instead of params

### DIFF
--- a/app/core/aceUtils.coffee
+++ b/app/core/aceUtils.coffee
@@ -70,7 +70,7 @@ singleLineCommentRegex = (lang) ->
 parseUserSnippets = (source, lang, session) ->
   replaceParams = (str) ->
     i = 1
-    str = str.replace(/([a-zA-Z-0-9\$\-\u00A2-\uFFFF]+)([^,)]*)/g, "${:$1}")
+    str = str.replace(/(?:[^(,)]+ )?([a-zA-Z-0-9\$\-\u00A2-\uFFFF]+)([^,)]*)/g, "${:$1}") # /(?:[^(,)]+ )?/ part for ignoring the type declaration in cpp/java
     reg = /\$\{:/
     while (reg.test(str))
       str = str.replace(reg, "${#{i}:")


### PR DESCRIPTION
bug: https://codecombat-core.slack.com/archives/C3BBBA01K/p1676513189688549

now: 
![image](https://user-images.githubusercontent.com/11417632/219251565-2764ca9f-d98d-4aba-bd7f-ca5152655997.png)
