### PR TITLE
Update Spade to keep track of UI events

### DIFF
--- a/app/styles/admin/codeplayback-view.sass
+++ b/app/styles/admin/codeplayback-view.sass
@@ -5,6 +5,7 @@
   margin: auto
   background-color: rgba(0,0,0,0.125)
   border-radius: 8px
+  position: relative
   .number, #slider-container
     display: inline-block
   .number
@@ -28,7 +29,7 @@
     min-height: 24px
   .event
     position: absolute
-    background-color: rgba(100, 100, 255, 0.125)
+    background-color: rgba(100, 100, 255, 0.75)
     left: 7px
     top: 0px
     width: 1px
@@ -36,3 +37,20 @@
     pointer-events: none
   .clicked
     background-color: orange
+  #event-container
+    border: 1px black solid
+    background-color: rgba(0,0,0,0.125)
+    border-radius: 8px
+    padding: 8px
+    position: absolute
+    right: -8px
+    top: 0
+    transform: translate(100%, 0)
+    .event-label
+      background-color: rgba(0,0,0,0.125)
+      border: 1px black solid
+      border-radius: 8px
+      text-align: center
+      margin-bottom: 2px
+      padding-left: 8px
+      padding-right: 8px

--- a/app/templates/admin/codeplayback-view.pug
+++ b/app/templates/admin/codeplayback-view.pug
@@ -16,3 +16,11 @@ div
     button.speed-button(data-speed='2') 2x
     button.speed-button(data-speed='4') 4x
     button.speed-button(data-speed='8') 8x
+#event-container
+  .event-label.spade-created spade-created
+  .event-label.code-run code-run
+  .event-label.code-reset code-reset
+  .event-label.code-error code-error
+  .event-label.saving-spade saving-spade
+  .event-label.destroying-view destroying-view
+  .event-label.victory-shown victory-shown

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -137,6 +137,7 @@ module.exports = class SpellView extends CocoView
     # Create a Spade to 'dig' into Ace.
     @spade = new Spade()
     @spade.track(@ace)
+    @spade.createUIEvent "spade-created"
     # If a user is taking longer than 10 minutes, let's log it.
     saveSpadeDelay = 10 * 60 * 1000
     if @options.level.get('releasePhase') is 'beta'
@@ -727,14 +728,15 @@ module.exports = class SpellView extends CocoView
 
   saveSpade: =>
     return if @destroyed or not @spade
+    @spade.createUIEvent "saving-spade"
     spadeEvents = @spade.compile()
-    # Uncomment the below line for a debug panel to display inside the level
-    #@spade.debugPlay(spadeEvents)
     condensedEvents = @spade.condense(spadeEvents)
+    # Uncomment the below lines for a debug panel to display inside the level
+    # uncondensedEvents = @spade.expand(condensedEvents)
+    # @spade.debugPlay(uncondensedEvents)
 
     return unless condensedEvents.length
     compressedEvents = LZString.compressToUTF16(JSON.stringify(condensedEvents))
-
     codeLog = new CodeLog({
       sessionID: @options.session.id
       level:
@@ -748,6 +750,8 @@ module.exports = class SpellView extends CocoView
     codeLog.save()
 
   onShowVictory: (e) ->
+    if @spade?
+      @spade.createUIEvent "victory-shown"
     if @saveSpadeTimeout?
       window.clearTimeout @saveSpadeTimeout
       @saveSpadeTimeout = null
@@ -757,6 +761,8 @@ module.exports = class SpellView extends CocoView
         @saveSpade()
 
   onManualCast: (e) ->
+    if @spade?
+      @spade.createUIEvent "code-run"
     cast = @$el.parent().length
     @recompile cast, e.realTime, false
     @focus() if cast
@@ -775,6 +781,8 @@ module.exports = class SpellView extends CocoView
     @hasSetInitialCursor = false
     @highlightCurrentLine()
     @updateLines()
+    if @spade?
+      @spade.createUIEvent "code-reset"
 
   recompile: (cast=true, realTime=false, cinematic=false) ->
     @fetchTokenForSource().then (source) =>
@@ -960,6 +968,8 @@ module.exports = class SpellView extends CocoView
 
   # Tell ProblemAlertView to display this problem (only)
   displayProblemBanner: (problem) ->
+    if @spade?
+      @spade.createUIEvent "code-error"
     lineOffsetPx = 0
     if problem.row?
       for i in [0...problem.row]
@@ -1490,6 +1500,9 @@ module.exports = class SpellView extends CocoView
     @toolbarView?.destroy()
     @autocomplete?.addSnippets [], @editorLang if @editorLang?
     $(window).off 'resize', @onWindowResize
+    if @spade?
+      @spade.createUIEvent "destroying-view"
+    @saveSpade()
     window.clearTimeout @saveSpadeTimeout
     @saveSpadeTimeout = null
     @autocomplete?.destroy()

--- a/vendor/scripts/spade.js
+++ b/vendor/scripts/spade.js
@@ -1,268 +1,393 @@
 var Spade = function Spade() {
-	this.stack = [];
-	this.playback = [];
-	this.speed = 1;
+  this.stack = [];
+  this.playback = [];
+  this.speed = 1;
+  this.target = null;
 }
+
+var isObject = function isObject(item) {
+  return typeof item === 'object' && !Array.isArray(item);
+}
+
 Spade.prototype = {
-	track: function(_elem) {
-		this.target = _elem;
+  track: function(elem) {
+    this.target = elem;
 
-		var spade = this;
+    keyHook = null;
+    if(elem.textInput && elem.textInput.getElement) {
+      keyHook = elem.textInput.getElement();
+    } else {
+      keyHook = elem;
+    }
 
-		var el = document.createElement("div");
+    keyHook.addEventListener("keydown", this.createEvent.bind(this));
+    //Maybe this is needed depending on Firefox/other browsers? Duplicate non-diff events get compiled down.
+    keyHook.addEventListener("keyup", this.createEvent.bind(this));
+    elem.addEventListener("mouseup", this.createEvent.bind(this));
+  },
+  createEvent: function() {
+    if (this.target.getValue) {
+      this.stack.push({
+        "startPos": this.target.selection.getCursor(),
+        "endPos": this.target.selection.getSelectionAnchor(),
+        "content": this.target.getValue(),
+        "timestamp": (new Date()).getTime(),
+      });
+    } else {
+      this.stack.push({
+        "startPos": this.target.selectionStart,
+        "endPos": this.target.selectionEnd,
+        "content": this.target.value,
+        "timestamp": (new Date()).getTime(),
+      });
+    }
+  },
+  createUIEvent: function(eventName, eventOptions) {
+    if(this.stack.length === 0) {
+      this.createEvent();
+    }
+    if(eventName === "code-reset" || eventName == "saving-spade") {
+      this.createEvent();
+    }
+    this.stack.push({
+      eventName: eventName,
+      eventOptions: eventOptions,
+      timestamp: (new Date()).getTime(),
+    });
+  },
+  compile: function() {
+    let compiledStack = [];
+    if (this.stack.length === 0) {
+      return compiledStack;
+    }
+    let startTime = this.stack[0].timestamp;
+    let sum = 0;
+    let sum2 = 0;
 
-		keyHook = null;
-		if(_elem.textInput && _elem.textInput.getElement) {
-			keyHook = _elem.textInput.getElement();
-		} else {
-			keyHook = _elem;
-		}
-		keyHook.addEventListener("keydown", function(_event) {spade.createEvent(spade.target)});
-		//Maybe this is needed depending on Firefox/other browsers? Duplicate non-diff events get compiled down.
-		keyHook.addEventListener("keyup", function(_event) {spade.createEvent(spade.target)});
-		_elem.addEventListener("mouseup", function(_event) {spade.createEvent(spade.target)});
-	},
-	createEvent: function(_target) {
-		if(_target.getValue) {
-			this.stack.push({
-				"startPos":_target.selection.getCursor(),
-				"endPos":_target.selection.getSelectionAnchor(),
-				"content":_target.getValue(),
-				"timestamp":(new Date()).getTime()
-			});
-		} else {
-			this.stack.push({
-				"startPos":_target.selectionStart,
-				"endPos":_target.selectionEnd,
-				"content":_target.value,
-				"timestamp":(new Date()).getTime()
-			});
-		}
-	},
-	compile: function() {
-		var compiledStack = [];
-		if(this.stack.length > 0) {
-			var startTime = this.stack[0].timestamp;
-			var sum = 0;
-			var sum2 = 0;
-			for(var i = 0; i < this.stack.length; i++) {
-				var c = this.stack[i];
-				var adjustedTimestamp = c.timestamp - startTime;
+    let filteredStack = this.stack.filter(elem => !elem.eventName);
+    let uiEvents = this.stack.filter(elem => elem.eventName);
 
-				var tString = "";	//The changed string.
-				var fIndex = null;	//The first index of changes.
-				var eIndex = null;	//The last index of changes.
-				var dCount = 0;		//Amount of character changes.
-				if(i >= 1) {
-					var p = this.stack[i - 1];
-					var isOkay = false;
-					for(var key in p) {
-						if(key != "timestamp") {
-							if(typeof p[key] === "string") {
-								if(p[key] !== c[key]) {
-									isOkay = true;
-								}
-							} else {
-								for(var key2 in p[key]) {
-									if(c[key][key2] !== undefined) {
-										if(p[key][key2] !== c[key][key2]) {
-											isOkay = true;
-										}
-									} else {
-										console.warn("Warning: c[key][key2] doesn't exist, but p[key][key2] does.");
-										isOkay = true;
-									}
-								}
-							}
-						}
-					}
-					if(!isOkay) {
-						sum2++;
-						continue;
-					}
-					sum++;
-					if(p.content != c.content) {
-						//Check from the start to the end, which characters are different.
-						for(var j = 0; j < Math.max(p.content.length, c.content.length); j++) {
-							if(p.content.charAt(j) === c.content.charAt(j)) {
-								if(fIndex != null) {
-									tString += c.content.charAt(j);
-									dCount++;
-								}
-							} else {
-								tString += c.content.charAt(j);
-								if(fIndex === null) {
-									fIndex = j;
-								}
-								dCount++;
-							}
-						}
-						//Check from the end to the start, which characters are different.
-						for(var j = 0; j < Math.min(p.content.length, c.content.length) - fIndex; j++) {
-							if(p.content.charAt(p.content.length - 1 - j) !== c.content.charAt(c.content.length - 1 - j)) {
-								if(eIndex == null) {
-									eIndex = j;
-									break;	
-								}
-							}
-						}
-						//This accounts for the fact when changing from "aa" to "aaa" (for example).
-						if(eIndex === null) {
-							eIndex = Math.min(p.content.length, c.content.length) - fIndex;
-						}
-						tString = tString.substring(0, tString.length - eIndex);
-					}
-				} else {
-					tString = c.content;
-					fIndex = 0;
-					eIndex = tString.length;
-				}
-				compiledStack.push({
-					"timestamp":adjustedTimestamp,
-					"difContent":tString,
-					"difFIndex":fIndex,
-					"difEIndex":eIndex,
-					"selFIndex":c.startPos,
-					"selEIndex":c.endPos
-				});
-			}
-		} else {
-			//Just return the empty array.
-		}
-		return compiledStack;
-	},
-	renderTime: function(_stack, _elem, _t) {
-		if(_stack.length === 0) {
-			console.warn("SPADE: No events to play.");
-			return
-		}
-		var tTime = _stack[_stack.length - 1].timestamp;
-		//var destinedIndex = Math.floor(_stack.length * _t);
-		var result = _stack[0].difContent;
-		for(var i = 1; i < _stack.length; i++) {
-			if(_t * tTime < _stack[i].timestamp) {
-				break;
-			}
-			var tEvent = _stack[i];
-			var oVal = result;
-			if(tEvent.difFIndex !== null && tEvent.difEIndex !== null) {
-				result = oVal.substring(0, tEvent.difFIndex) + tEvent.difContent + oVal.substring(oVal.length - tEvent.difEIndex, oVal.length);
-			}
-		}
-		var returnObject = {
-			result: result
-		};
-		if(tEvent) {
-			returnObject["selFIndex"] = tEvent.selFIndex;
-			returnObject["selEIndex"] = tEvent.selEIndex;		}
-		return returnObject
-	},
-	play: function(_stack, _elem, _t) {
-		_t = _t || 0;
-		if(_stack.length === 0) {
-			console.warn("SPADE: No events to play.")
-			return
-		}
-		if(_elem.setValue) {
-			_elem.setValue(this.renderTime(_stack, _elem, _t).result);
-		} else {
-			_elem.value = this.renderTime(_stack, _elem, _t).result
-		}
-		_stack = _stack.slice();
-		_stack.shift();
-		var curTime, dTime;
-		var tTime = _stack[_stack.length - 1].timestamp;
-		var elapsedTime = _t * tTime;
-		this.elapsedTime = elapsedTime;
-		var prevTime = (new Date()).getTime();
-		this.playback = playbackInterval = setInterval(function() {
-			//console.log(this);
-			curTime = (new Date()).getTime();
-			dTime = curTime - prevTime;
-			dTime *= this.speed;	//Multiply for faster/slower playback speeds.
-			elapsedTime += dTime;
-			var tArray = _stack.filter(function(_event) {
-				return ((_event.timestamp) >= (elapsedTime - dTime)) && ((_event.timestamp) < (elapsedTime));
-			});
-			this.elapsedTime = elapsedTime;
-			for(var i = 0; i < tArray.length; i++) {
-				var tEvent = tArray[i];
-				var oVal = null;
-				if(_elem.getValue) {
-					oVal = _elem.getValue();
-				} else {
-					oVal = _elem.value;
-				}
-				if(tEvent.difFIndex !== null && tEvent.difEIndex !== null) {
-					if(_elem.setValue) {
-						_elem.setValue(oVal.substring(0, tEvent.difFIndex) + tEvent.difContent + oVal.substring(oVal.length - tEvent.difEIndex, oVal.length));
-					} else {
-						_elem.value = oVal.substring(0, tEvent.difFIndex) + tEvent.difContent + oVal.substring(oVal.length - tEvent.difEIndex, oVal.length)
-					}
-				}
+    for(let i = 0; i < filteredStack.length; i++) {
+      let c = filteredStack[i];
+      let adjustedTimestamp = c.timestamp - startTime;
 
-				if(_elem.selection && _elem.selection.moveCursorToPosition) {
-					_elem.selection.moveCursorToPosition(tEvent.selFIndex);
-					_elem.selection.setSelectionAnchor(tEvent.selEIndex.row, tEvent.selEIndex.column);
-				} else {
-					//Likewise
-					_elem.focus();
-					_elem.setSelectionRange(tEvent.selFIndex, tEvent.selEIndex);
-				}
-			}
-			if(_stack[_stack.length - 1] === undefined || elapsedTime > _stack[_stack.length - 1].timestamp) {
-				clearInterval(playbackInterval);
-			}
-			prevTime = curTime;
-		}.bind(this), 10);
-	},
-	debugPlay: function(_stack) {
-		var area = document.createElement('textarea');
-		area.zIndex = 9999;
-		area.style.width = "512px";
-		area.style.height = "512px";
-		area.style.position = "absolute";
-		area.style.left = "100px";
-		area.style.top = "100px";
-		document.body.appendChild(area);
-		this.play(_stack, area);
-	},
-	condense: function(_stack) {
-		var compressedArray = [];
-		for(var i = 0; i < _stack.length; i++) {
-			var u = _stack[i];
-			compressedArray.push([
-				u.timestamp,
-				u.difContent,
-				u.difFIndex,
-				u.difEIndex,
-				u.selFIndex.row,
-				u.selFIndex.column,
-				u.selEIndex.row,
-				u.selEIndex.column
-			]);
-		}
-		return compressedArray;
-	},
-	expand: function(_array) {
-		var uncompressedArray = [];
-		for(var i = 0 ; i < _array.length; i++) {
-			var c = _array[i];
-			uncompressedArray.push({
-				"timestamp":c[0],
-				"difContent":c[1],
-				"difFIndex":c[2],
-				"difEIndex":c[3],
-				"selFIndex":{
-					"row":c[4],
-					"column":c[5]
-				},
-				"selEIndex":{
-					"row":c[6],
-					"column":c[7]
-				},
-			});
-		}
-		return uncompressedArray;
-	}
+      let tString = "";	//The changed string.
+      let fIndex = null;	//The first index of changes.
+      let eIndex = null;	//The last index of changes.
+      let dCount = 0;		//Amount of character changes.
+      if (i >= 1) {
+        let p = filteredStack[i - 1];
+        let isOkay = false;
+        for (let key in p) {
+          if (key != "timestamp") {
+            if (typeof p[key] === "string") {
+              if (p[key] !== c[key]) {
+                isOkay = true;
+              }
+            } else {
+              for (let key2 in p[key]) {
+                if (c[key][key2] !== undefined) {
+                  if (p[key][key2] !== c[key][key2]) {
+                    isOkay = true;
+                  }
+                } else {
+                  console.warn("Warning: c[key][key2] doesn't exist, but p[key][key2] does.");
+                  isOkay = true;
+                }
+              }
+            }
+          }
+        }
+        if (!isOkay) {
+          sum2++;
+          continue;
+        }
+        sum++;
+        if (p.content != c.content) {
+          //Check from the start to the end, which characters are different.
+          for (let j = 0; j < Math.max(p.content.length, c.content.length); j++) {
+            if (p.content.charAt(j) === c.content.charAt(j)) {
+              if (fIndex != null) {
+                tString += c.content.charAt(j);
+                dCount++;
+              }
+            } else {
+              tString += c.content.charAt(j);
+              if (fIndex === null) {
+                fIndex = j;
+              }
+              dCount++;
+            }
+          }
+          //Check from the end to the start, which characters are different.
+          for (let j = 0; j < Math.min(p.content.length, c.content.length) - fIndex; j++) {
+            if (p.content.charAt(p.content.length - 1 - j) !== c.content.charAt(c.content.length - 1 - j)) {
+              if (eIndex == null) {
+                eIndex = j;
+                break;
+              }
+            }
+          }
+          //This accounts for the fact when changing from "aa" to "aaa" (for example).
+          if (eIndex === null) {
+            eIndex = Math.min(p.content.length, c.content.length) - fIndex;
+          }
+          tString = tString.substring(0, tString.length - eIndex);
+        }
+      } else {
+        tString = c.content;
+        fIndex = 0;
+        eIndex = tString.length;
+      }
+
+      while (uiEvents.length) {
+        const uiAdjustedTime = uiEvents[0].timestamp - startTime;
+        if (uiAdjustedTime < adjustedTimestamp) {
+          const uiEvent = uiEvents.shift();
+          uiEvent.timestamp = uiAdjustedTime;
+          compiledStack.push(uiEvent);
+        } else {
+          break;
+        }
+      }
+
+      compiledStack.push({
+        "timestamp": adjustedTimestamp,
+        "difContent": tString,
+        "difFIndex": fIndex,
+        "difEIndex": eIndex,
+        "selFIndex": c.startPos,
+        "selEIndex": c.endPos
+      });
+    }
+
+    while (uiEvents.length) {
+      const uiAdjustedTime = uiEvents[0].timestamp - startTime;
+      const uiEvent = uiEvents.shift();
+      uiEvent.timestamp = uiAdjustedTime;
+      compiledStack.push(uiEvent);
+    }
+    return compiledStack;
+  },
+  renderTime: function(stack, elem, timeScale) {
+    if(stack.length === 0) {
+      console.warn("SPADE: No events to play.");
+      return
+    }
+    let tTime = stack[stack.length - 1].timestamp;
+    //let destinedIndex = Math.floor(stack.length * timeScale);
+    let result;
+    for(let i = 0; i < stack.length; i++) {
+      if(stack[i].difContent) {
+        result = stack[i].difContent;
+        break;
+      }
+    }
+    let tEvent;
+    for(let i = 1; i < stack.length; i++) {
+      tEvent = stack[i];
+      if (tEvent.eventName) {
+        continue;
+      }
+      if(timeScale * tTime < tEvent.timestamp) {
+        break;
+      }
+      let oVal = result;
+      if(tEvent.difFIndex !== null && tEvent.difEIndex !== null) {
+        result = oVal.substring(0, tEvent.difFIndex) + tEvent.difContent + oVal.substring(oVal.length - tEvent.difEIndex, oVal.length);
+      }
+    }
+    let returnObject = {
+      result: result
+    };
+    if(tEvent) {
+      returnObject["selFIndex"] = tEvent.selFIndex;
+      returnObject["selEIndex"] = tEvent.selEIndex;
+    }
+    return returnObject
+  },
+  renderToElem(stack, elem, timeScale) {
+    timeScale = timeScale || 0;
+    let result = this.renderTime(stack, elem, timeScale);
+    if(result) {
+      if(elem.setValue) {
+        elem.setValue(result.result);
+        if(elem.selection && elem.selection.moveCursorToPosition && result.selFIndex) {
+          elem.selection.moveCursorToPosition(result.selFIndex);
+          elem.selection.setSelectionAnchor(result.selEIndex.row, result.selEIndex.column);
+        }
+      } else {
+        elem.value = result.result
+      }
+    }
+  },
+  play: function(stack, elem, timeScale, eventCallback) {
+    console.log(stack);
+    if(stack.length === 0) {
+      console.warn("SPADE: No events to play.")
+      return
+    }
+
+    timeScale = timeScale || 0;
+    this.renderToElem(stack, elem, timeScale);
+
+    stack = stack.slice();
+    stack.shift();
+    let curTime, dTime;
+    let tTime;
+    if(stack.length >= 1) {
+      tTime = stack[stack.length - 1].timestamp;
+    } else {
+      tTime = 0;
+    }
+    let elapsedTime = timeScale * tTime;
+    this.elapsedTime = elapsedTime;
+    let prevTime = (new Date()).getTime();
+
+    this.playback = playbackInterval = setInterval(function() {
+      curTime = (new Date()).getTime();
+      dTime = curTime - prevTime;
+      dTime *= this.speed;	//Multiply for faster/slower playback speeds.
+      elapsedTime += dTime;
+      let tArray = stack.filter(function(_event) {
+        return ((_event.timestamp) >= (elapsedTime - dTime)) && ((_event.timestamp) < (elapsedTime));
+      });
+      this.elapsedTime = elapsedTime;
+      for(let i = 0; i < tArray.length; i++) {
+        let tEvent = tArray[i];
+        let oVal = null;
+        if(elem.getValue) {
+          oVal = elem.getValue();
+        } else {
+          oVal = elem.value;
+        }
+        if(tEvent.eventName) {
+          if(eventCallback) {
+            eventCallback(tEvent);
+            // const eventDiv = document.createElement('div');
+            // eventDiv.innerText = tEvent.eventName;
+            // eventBox.appendChild(eventDiv);
+          }
+          continue;
+        }
+        if(tEvent.difFIndex !== null && tEvent.difEIndex !== null) {
+          if(elem.setValue) {
+            elem.setValue(oVal.substring(0, tEvent.difFIndex) + tEvent.difContent + oVal.substring(oVal.length - tEvent.difEIndex, oVal.length));
+          } else {
+            elem.value = oVal.substring(0, tEvent.difFIndex) + tEvent.difContent + oVal.substring(oVal.length - tEvent.difEIndex, oVal.length)
+          }
+        }
+
+        if(elem.selection && elem.selection.moveCursorToPosition) {
+          elem.selection.moveCursorToPosition(tEvent.selFIndex);
+          elem.selection.setSelectionAnchor(tEvent.selEIndex.row, tEvent.selEIndex.column);
+        } else {
+          elem.focus();
+
+          let startIndex = 0;
+          let targetRow = tEvent.selFIndex.row;
+          let rows = elem.value.split("\n");
+          while(targetRow > 0) {
+            let row = rows.shift();
+            if (row === undefined) break;
+            startIndex += row.length;
+            startIndex++;
+            targetRow--;
+          }
+          startIndex += tEvent.selFIndex.column;
+
+          let endIndex = 0;
+          targetRow = tEvent.selEIndex.row;
+          rows = elem.value.split("\n");
+          while(targetRow > 0) {
+            let row = rows.shift();
+            if (row === undefined) break;
+            endIndex += row.length;
+            endIndex++;
+            targetRow--;
+          }
+          endIndex += tEvent.selEIndex.column;
+
+          if(startIndex > endIndex) {
+            elem.setSelectionRange(endIndex, startIndex);
+          } else {
+            elem.setSelectionRange(startIndex, endIndex);
+          }
+        }
+      }
+      if(stack[stack.length - 1] === undefined || elapsedTime > stack[stack.length - 1].timestamp) {
+        clearInterval(playbackInterval);
+      }
+      prevTime = curTime;
+    }.bind(this), 10);
+  },
+  debugPlay: function(stack) {
+    let area = document.createElement('textarea');
+    area.zIndex = 9999;
+    area.style.width = "256px";
+    area.style.height = "512px";
+    area.style.position = "absolute";
+    area.style.left = "100px";
+    area.style.top = "100px";
+    document.body.appendChild(area);
+
+    let eventBox = document.createElement('div');
+    eventBox.zIndex = 9999;
+    eventBox.style.width = "256px";
+    eventBox.style.height = "512px";
+    eventBox.style.position = "absolute";
+    eventBox.style.left = "356px";
+    eventBox.style.top = "100px";
+    eventBox.style.border = "1px solid red";
+    eventBox.style.backgroundColor = "rgb(255,255,255)";
+    document.body.appendChild(eventBox);
+
+    this.play(stack, area, 0, eventBox);
+  },
+  condense: function(stack) {
+    let compressedArray = [];
+    for(let i = 0; i < stack.length; i++) {
+      let unit = stack[i];
+      if (unit.eventName) {
+        compressedArray.push(unit);
+      } else {
+        compressedArray.push([
+          unit.timestamp,
+          unit.difContent,
+          unit.difFIndex,
+          unit.difEIndex,
+          unit.selFIndex.row,
+          unit.selFIndex.column,
+          unit.selEIndex.row,
+          unit.selEIndex.column,
+        ]);
+      }
+    }
+    return compressedArray;
+  },
+  expand: function(array) {
+    let uncompressedArray = [];
+    for(let i = 0 ; i < array.length; i++) {
+      let unit = array[i];
+      if(isObject(unit)) {
+        uncompressedArray.push(unit);
+      } else {
+        uncompressedArray.push({
+          "timestamp": unit[0],
+          "difContent": unit[1],
+          "difFIndex": unit[2],
+          "difEIndex": unit[3],
+          "selFIndex":{
+            "row": unit[4],
+            "column": unit[5],
+          },
+          "selEIndex":{
+            "row": unit[6],
+            "column": unit[7],
+          },
+        });
+      }
+    }
+    return uncompressedArray;
+  }
 }

--- a/vendor/scripts/spade.js
+++ b/vendor/scripts/spade.js
@@ -13,7 +13,7 @@ Spade.prototype = {
   track: function(elem) {
     this.target = elem;
 
-    keyHook = null;
+    let keyHook = null;
     if(elem.textInput && elem.textInput.getElement) {
       keyHook = elem.textInput.getElement();
     } else {
@@ -222,7 +222,6 @@ Spade.prototype = {
     }
   },
   play: function(stack, elem, timeScale, eventCallback) {
-    console.log(stack);
     if(stack.length === 0) {
       console.warn("SPADE: No events to play.")
       return
@@ -244,6 +243,7 @@ Spade.prototype = {
     this.elapsedTime = elapsedTime;
     let prevTime = (new Date()).getTime();
 
+    let playbackInterval
     this.playback = playbackInterval = setInterval(function() {
       curTime = (new Date()).getTime();
       dTime = curTime - prevTime;


### PR DESCRIPTION
I dunno how you folks review so I added everyone 🙏.

Backwards compatible Spade/codelogs change to keep track of UI events (like running code or resetting code). Spade was reformatted from tabs to spaces so it bricked the diff... Lemme know if that's a problem.

Updated Codelogs UI w/ flashing text areas indicating when an 'event' occurred during playback.
Red lines in the timeline indicate 'events'

<img width="651" alt="image" src="https://user-images.githubusercontent.com/9985594/222958892-babb7912-7407-4532-b12d-7e7547547224.png">
