### PR TITLE
game dev levels cannot 100% canvas

### DIFF
--- a/app/styles/play/play-level-view.sass
+++ b/app/styles/play/play-level-view.sass
@@ -24,7 +24,7 @@ body.is-playing
         width: 80%
 
     #canvas-wrapper
-      width: 100% !important
+      width: 100%
       canvas
         margin: 0 auto
       #normal-surface


### PR DESCRIPTION
i add `important` here: https://github.com/codecombat/codecombat/pull/6850
but it makes gd levels breaking 
![image](https://user-images.githubusercontent.com/11417632/230851199-17d683c5-a802-4f2a-a15e-fcc143d29cca.png)

while this time i remove the `important`, both level works fine :joy: