### PR TITLE
update jaba runtime

### DIFF
--- a/vendor/esper-plugin-lang-cpp-modern.js
+++ b/vendor/esper-plugin-lang-cpp-modern.js
@@ -1,10 +1,10 @@
 /*!
  * jaba
  * 
- * Compiled: Tue Jan 25 2022 16:49:02 GMT-0800 (Pacific Standard Time)
+ * Compiled: Tue Apr 11 2023 15:28:50 GMT+0800 (China Standard Time)
  * Target  : web (umd)
  * Profile : modern
- * Version : cde3bc8
+ * Version : e0a16a1-dirty
  * 
  * 
  * 
@@ -430,30 +430,37 @@ class JavaCast extends esper.ObjectValue {
 }
 
 function javaifyEngine(ev) {
-	let fpn = Value.fromPrimativeNative.bind(Value);
-	Value.fromPrimativeNative = (v) => {
-		let type = typeof(v)
-		let r = new JavaPrimitiveValue(v);
-		if (type == "int") {
-			r.boundType = "int";
-			return r;
-		}
-		if ( type == "double" ) {
-			r.boundType = "double";
-			return r;
-		}
+	// Value.fromPrimativeNative wont refresh when every call of javaifyEngine
+	if(!(/\[converted function\]/.test(Value.fromPrimativeNative))) {
+		let fpn = Value.fromPrimativeNative.bind(Value);
+		Value.fromPrimativeNative = (v) => {
+			let type = typeof(v)
+			let r = new JavaPrimitiveValue(v);
+			if (type == "int") {
+				r.boundType = "int";
+				return r;
+			}
+			if ( type == "double" ) {
+				r.boundType = "double";
+				return r;
+			}
 
-		if ( type == "string" ) {
-			r.boundType = "string";
-			return r;
-		}
+			if ( type == "string" ) {
+				r.boundType = "string";
+				return r;
+			}
 
-		if ( type == "number" ) {
-			r.boundType = "double";
-			return r;
+			if ( type == "number" ) {
+				r.boundType = "double";
+				return r;
+			}
+			return fpn(v)
 		}
-		return fpn(v)
+		Value.fromPrimativeNative.toString = function () {
+			return '[converted function]'
+		}
 	}
+	// ev.realm.fromNative refreshed when every call of javaifyEngine
 	let rev = ev.realm.fromNative.bind(ev.realm);
 	ev.realm.fromNative = (v,n) => {
 		if(['cpp', 'java'].indexOf(ev.realm.options.language) != -1) {
@@ -472,7 +479,7 @@ function javaifyEngine(ev) {
 				}
 				return r;
 			}
-		
+
 			if ( type == "int" ) {
 				r.boundType = "int";
 				return r;
@@ -491,7 +498,7 @@ function javaifyEngine(ev) {
 			if ( type == "number" ) {
 				r.boundType = "double";
 				return r;
-			}	
+			}
 		}
 		return rev(v);
 	}
@@ -520,24 +527,43 @@ function javaifyEngine(ev) {
 		obj.setImmediate("prototype", ptype);
 		ev.realm.globalScope.add(k, obj);
 	}
+	ev.realm.CPPListProto = new stdlib.p.CPPListProto(ev.realm)
 
-	let amake = ArrayValue.make.bind(ArrayValue);
-	ArrayValue.make = function(vals, realm) {
-		if(realm.options.language == 'cpp') {
-			let av = amake(vals, realm);
-			av.setPrototype(new stdlib.p.CPPListProto(ev.realm));
+	// ArrayValue.make wont refresh when every call of javaifyEngine
+	if(!(/\[converted function\]/.test(ArrayValue.make))) {
+		let amake = ArrayValue.make.bind(ArrayValue);
+		ArrayValue.make = function(vals, realm) {
+			if(realm.options.language == 'cpp') {
+				let av = amake(vals, realm);
+				av.setPrototype(ev.realm.CPPListProto);
 
-			let l = vals.length
-			if(l > 0) {av.setImmediate('x', vals[0]); av.properties.x.enumerable = false;}
-			if(l > 1) {av.setImmediate('y', vals[1]); av.properties.y.enumerable = false;}
-			if(l > 2) {av.setImmediate('z', vals[2]); av.properties.z.enumerable = false;}
-			return av;
+				let l = vals.length
+				if(l > 0) {av.setImmediate('x', vals[0]); av.properties.x.enumerable = false;}
+				if(l > 1) {av.setImmediate('y', vals[1]); av.properties.y.enumerable = false;}
+				if(l > 2) {av.setImmediate('z', vals[2]); av.properties.z.enumerable = false;}
+				return av;
+			}
+			else {
+				return amake(vals, realm);
+			}
 		}
-		else {
-			return amake(vals, realm);
+		ArrayValue.make.toString = function () {
+			return '[converted function]'
 		}
 	}
-	
+
+	ev.addGlobal("tolower", (char) => {
+		if(typeof char !== 'string' || char.length > 1) {
+			throw SyntaxError('arg1 only accept char type.')
+		}
+		return char.toLowerCase()
+	})
+	ev.addGlobal('toupper', (char) => {
+		if(typeof char !== 'string' || char.length > 1) {
+			throw SyntaxError('arg1 only accept char type.')
+		}
+		return char.toUpperCase()
+	})
 }
 
 module.exports = {
@@ -611,6 +637,43 @@ class JavaString extends EasyObjectValue {
 	}
 	static *toString$(thiz, argz, s) { return s.fromNative(thiz.native); }
 
+	static *trim(thiz, argz, s) {
+		return thiz.native.trim();
+	}
+
+	static *replace(thiz, argz, s) {
+		return thiz.native.split(argz[0].toNative()).join(argz[1].toNative())
+	}
+
+	static *split(thiz, argz, s) {
+		let regex = new RegExp(argz[0].toNative(), 'g')
+		let orig = thiz.toNative()
+		if(argz.length > 1) {
+			let limit = argz[1].toNative()
+			if(limit === 0) { return orig.split(regex) }
+			let prev = orig.split(regex, limit - 1)
+			let i = 0;
+			do {
+				i += 1;
+				if(i == limit) {
+					break;
+				}
+			}while(regex.exec(orig) && i < limit);
+			prev.push(orig.slice(regex.lastIndex))
+			return prev
+		} else {
+			return orig.split(regex)
+		}
+	}
+	static *charAt(thiz, argz, s) {
+		return thiz.native[argz[0].toNative()]
+	}
+	static *toLowerCase(thiz, argz, s) {
+		return thiz.native.toLowerCase()
+	}
+	static *toUpperCase(thiz, argz, s) {
+		return thiz.native.toUpperCase()
+	}
 }
 
 class Integer extends EasyObjectValue {

--- a/vendor/esper-plugin-lang-java-modern.js
+++ b/vendor/esper-plugin-lang-java-modern.js
@@ -1,10 +1,10 @@
 /*!
  * jaba
  * 
- * Compiled: Tue Jan 25 2022 16:49:02 GMT-0800 (Pacific Standard Time)
+ * Compiled: Tue Apr 11 2023 15:28:50 GMT+0800 (China Standard Time)
  * Target  : web (umd)
  * Profile : modern
- * Version : cde3bc8
+ * Version : e0a16a1-dirty
  * 
  * 
  * 
@@ -472,30 +472,37 @@ class JavaCast extends esper.ObjectValue {
 }
 
 function javaifyEngine(ev) {
-	let fpn = Value.fromPrimativeNative.bind(Value);
-	Value.fromPrimativeNative = (v) => {
-		let type = typeof(v)
-		let r = new JavaPrimitiveValue(v);
-		if (type == "int") {
-			r.boundType = "int";
-			return r;
-		}
-		if ( type == "double" ) {
-			r.boundType = "double";
-			return r;
-		}
+	// Value.fromPrimativeNative wont refresh when every call of javaifyEngine
+	if(!(/\[converted function\]/.test(Value.fromPrimativeNative))) {
+		let fpn = Value.fromPrimativeNative.bind(Value);
+		Value.fromPrimativeNative = (v) => {
+			let type = typeof(v)
+			let r = new JavaPrimitiveValue(v);
+			if (type == "int") {
+				r.boundType = "int";
+				return r;
+			}
+			if ( type == "double" ) {
+				r.boundType = "double";
+				return r;
+			}
 
-		if ( type == "string" ) {
-			r.boundType = "string";
-			return r;
-		}
+			if ( type == "string" ) {
+				r.boundType = "string";
+				return r;
+			}
 
-		if ( type == "number" ) {
-			r.boundType = "double";
-			return r;
+			if ( type == "number" ) {
+				r.boundType = "double";
+				return r;
+			}
+			return fpn(v)
 		}
-		return fpn(v)
+		Value.fromPrimativeNative.toString = function () {
+			return '[converted function]'
+		}
 	}
+	// ev.realm.fromNative refreshed when every call of javaifyEngine
 	let rev = ev.realm.fromNative.bind(ev.realm);
 	ev.realm.fromNative = (v,n) => {
 		if(['cpp', 'java'].indexOf(ev.realm.options.language) != -1) {
@@ -514,7 +521,7 @@ function javaifyEngine(ev) {
 				}
 				return r;
 			}
-		
+
 			if ( type == "int" ) {
 				r.boundType = "int";
 				return r;
@@ -533,7 +540,7 @@ function javaifyEngine(ev) {
 			if ( type == "number" ) {
 				r.boundType = "double";
 				return r;
-			}	
+			}
 		}
 		return rev(v);
 	}
@@ -562,24 +569,43 @@ function javaifyEngine(ev) {
 		obj.setImmediate("prototype", ptype);
 		ev.realm.globalScope.add(k, obj);
 	}
+	ev.realm.CPPListProto = new stdlib.p.CPPListProto(ev.realm)
 
-	let amake = ArrayValue.make.bind(ArrayValue);
-	ArrayValue.make = function(vals, realm) {
-		if(realm.options.language == 'cpp') {
-			let av = amake(vals, realm);
-			av.setPrototype(new stdlib.p.CPPListProto(ev.realm));
+	// ArrayValue.make wont refresh when every call of javaifyEngine
+	if(!(/\[converted function\]/.test(ArrayValue.make))) {
+		let amake = ArrayValue.make.bind(ArrayValue);
+		ArrayValue.make = function(vals, realm) {
+			if(realm.options.language == 'cpp') {
+				let av = amake(vals, realm);
+				av.setPrototype(ev.realm.CPPListProto);
 
-			let l = vals.length
-			if(l > 0) {av.setImmediate('x', vals[0]); av.properties.x.enumerable = false;}
-			if(l > 1) {av.setImmediate('y', vals[1]); av.properties.y.enumerable = false;}
-			if(l > 2) {av.setImmediate('z', vals[2]); av.properties.z.enumerable = false;}
-			return av;
+				let l = vals.length
+				if(l > 0) {av.setImmediate('x', vals[0]); av.properties.x.enumerable = false;}
+				if(l > 1) {av.setImmediate('y', vals[1]); av.properties.y.enumerable = false;}
+				if(l > 2) {av.setImmediate('z', vals[2]); av.properties.z.enumerable = false;}
+				return av;
+			}
+			else {
+				return amake(vals, realm);
+			}
 		}
-		else {
-			return amake(vals, realm);
+		ArrayValue.make.toString = function () {
+			return '[converted function]'
 		}
 	}
-	
+
+	ev.addGlobal("tolower", (char) => {
+		if(typeof char !== 'string' || char.length > 1) {
+			throw SyntaxError('arg1 only accept char type.')
+		}
+		return char.toLowerCase()
+	})
+	ev.addGlobal('toupper', (char) => {
+		if(typeof char !== 'string' || char.length > 1) {
+			throw SyntaxError('arg1 only accept char type.')
+		}
+		return char.toUpperCase()
+	})
 }
 
 module.exports = {
@@ -653,6 +679,43 @@ class JavaString extends EasyObjectValue {
 	}
 	static *toString$(thiz, argz, s) { return s.fromNative(thiz.native); }
 
+	static *trim(thiz, argz, s) {
+		return thiz.native.trim();
+	}
+
+	static *replace(thiz, argz, s) {
+		return thiz.native.split(argz[0].toNative()).join(argz[1].toNative())
+	}
+
+	static *split(thiz, argz, s) {
+		let regex = new RegExp(argz[0].toNative(), 'g')
+		let orig = thiz.toNative()
+		if(argz.length > 1) {
+			let limit = argz[1].toNative()
+			if(limit === 0) { return orig.split(regex) }
+			let prev = orig.split(regex, limit - 1)
+			let i = 0;
+			do {
+				i += 1;
+				if(i == limit) {
+					break;
+				}
+			}while(regex.exec(orig) && i < limit);
+			prev.push(orig.slice(regex.lastIndex))
+			return prev
+		} else {
+			return orig.split(regex)
+		}
+	}
+	static *charAt(thiz, argz, s) {
+		return thiz.native[argz[0].toNative()]
+	}
+	static *toLowerCase(thiz, argz, s) {
+		return thiz.native.toLowerCase()
+	}
+	static *toUpperCase(thiz, argz, s) {
+		return thiz.native.toUpperCase()
+	}
 }
 
 class Integer extends EasyObjectValue {


### PR DESCRIPTION
update cpp/java runtime so they supports more useful methods. (it's an incidental update)



> i don't know how to get rid of `-dirty` in `version`, but it won't affect runtime anyway.

use `toString` to check if the function already be converted by JavaifyEngine. so that we won't convert those methods again and agian. and finally lead to memory leak.

**to test it**. open a ladder and play against a cpp/java user (or choose cpp/java language by yourself) 

> i think play normal levels with cpp/java langauge should also work but i haven't try

then open chrome devtools - memory , and snapshot once when level is loaded.
then click `run` several times (for example 5), then snapshot again.
then click `run` 5 more times, snapshot again.

checking 3 snapshots, if the `world` increase 5 and 5, that's the bug. (you can try in codecombat.com first to reproduce this bug)
and if the `world` keeps same in second and third snapshot, the bug is fixed.

normally in first snapshot you would see 2 `world`, maybe 3, and if you're lucky, you may see up to 6 `world` in second snapshot (we still have other memory leak issue in esper.js i believe). but at the third snapshot, it should keeps the same `world` as second. or maybe less (the browser GC works). if you're not so lucky, you would see 3 `world` in second and third snapshot. which also sign the bug is fixed anyway.
![image](https://user-images.githubusercontent.com/11417632/231089855-07a402de-ffad-4c5d-bb90-73d4da47b47a.png)
