### PR TITLE
COD-Q123-7 - Current Password Not Required When Performing A Password Change

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1786,6 +1786,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     emails_tab: "Emails"
     admin: "Admin"
     manage_subscription: "Click here to manage your subscription."
+    current_password: "Current Password"
     new_password: "New Password"
     new_password_verify: "Verify"
     type_in_email: "Type in your email or username to confirm account deletion."

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -95,7 +95,8 @@ module.exports = class User extends CocoModel
 
   currentPasswordRequired: ->
     # Return true if current password should be given for password change
-    return !@get('newPasswordRequired') && !@hasNoPasswordLoginMethod()
+    spying = window.serverSession?.amActually
+    return !spying && !@get('newPasswordRequired') && !@hasNoPasswordLoginMethod()
 
   @getUnconflictedName: (name, done) ->
     # deprecate in favor of @checkNameConflicts, which uses Promises and returns the whole response

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -89,6 +89,14 @@ module.exports = class User extends CocoModel
 
   getSlugOrID: -> @get('slug') or @get('_id')
 
+  hasNoPasswordLoginMethod: ->
+    # Return true if user has any login method that doesn't require a password
+    return Boolean(@get('facebookID') || @get('gplusID') || @get('githubID') || @get('cleverID'))
+
+  currentPasswordRequired: ->
+    # Return true if current password should be given for password change
+    return !@get('newPasswordRequired') && !@hasNoPasswordLoginMethod()
+
   @getUnconflictedName: (name, done) ->
     # deprecate in favor of @checkNameConflicts, which uses Promises and returns the whole response
     $.ajax "/auth/name/#{encodeURIComponent(name)}",
@@ -376,6 +384,17 @@ module.exports = class User extends CocoModel
         @trigger 'user-keep-me-updated-success'
       error: =>
         @trigger 'user-keep-me-updated-error'
+    })
+
+  updatePassword: (currentPassword, newPassword, success, error) ->
+    $.ajax({
+      method: 'PUT'
+      url: "/db/user/#{@id}/update-user-password"
+      data: { currentPassword, newPassword }
+      success: (attributes) => 
+        this.set attributes
+        success()
+      error: error
     })
 
   sendNoDeleteEUVerificationCode: (code) ->

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -72,6 +72,7 @@ _.extend UserSchema.properties,
   password: c.passwordString
   passwordReset: {type: 'string'}
   passwordResetExpires: c.date()
+  newPasswordRequired: { type: 'boolean' } # Whether the user needs to set a new password 
   photoURL: {type: 'string', format: 'image-file', title: 'Profile Picture', description: 'Upload a 256x256px or larger image to serve as your profile picture.'}
 
   facebookID: c.shortString({title: 'Facebook ID'})

--- a/app/templates/account/account-settings-view.coco.pug
+++ b/app/templates/account/account-settings-view.coco.pug
@@ -79,13 +79,17 @@ else
             .panel-title(data-i18n="general.password")
           .panel-body
             .form
+              if me.currentPasswordRequired()
+                .form-group
+                  label.control-label(for="current-password", data-i18n="account_settings.current_password") 
+                  input#current-password.form-control(name="current-password", type="password")            
               .form-group
                 label.control-label(for="password", data-i18n="account_settings.new_password") New Password
                 input#password.form-control(name="password", type="password")
               .form-group
                 label.control-label(for="password2", data-i18n="account_settings.new_password_verify") Verify
                 input#password2.form-control(name="password2", type="password")
-            button.save-button.passwd-btn.btn.btn-primary.form-control.disabled(data-i18n="delta.no_changes" disabled="true")
+            button.save-password-button.passwd-btn.btn.btn-primary.form-control.disabled(data-i18n="delta.no_changes" disabled="true")
 
       .panel.panel-default.related-account
         .panel-heading

--- a/app/templates/account/account-settings-view.ozar.pug
+++ b/app/templates/account/account-settings-view.ozar.pug
@@ -82,6 +82,10 @@ block content
                 .panel-title(data-i18n="general.password")
               .panel-body
                 .form
+                  if me.currentPasswordRequired()
+                    .form-group
+                      label.control-label(for="current-password", data-i18n="account_settings.current_password")
+                      input#current-password.form-control(name="current-password", type="password")                
                   .form-group
                     label.control-label(for="password", data-i18n="account_settings.new_password") New Password
                     input#password.form-control(name="password", type="password")


### PR DESCRIPTION
"Current Password" field added to Account Settings page.

The new field is NOT shown - and required - if:
 - user has facebook / google / etc login method - since in these cases they could login even without a password, maybe they don't even have one
 - user just logged in with temporary password requested by "forgotten password" button. In this case we set the `newPasswordRequired` flag on the user to know that they won't need the old password for setting a new one.
 
![Ozaria_-_Computer_science_that_captivates](https://user-images.githubusercontent.com/11805970/235151623-1aa84251-a044-4718-9703-d35548fa0c0f.png)
