### PR TITLE
Updates for new embed setup

### DIFF
--- a/app/styles/ai/ai.sass
+++ b/app/styles/ai/ai.sass
@@ -1,5 +1,9 @@
 #ai-view
   background: white
 
+  #ai-wrapper
+    position: relative
+    height: calc(100vh - 70px)
+
   #site-footer
     margin-top: 0

--- a/app/templates/ai/ai.pug
+++ b/app/templates/ai/ai.pug
@@ -1,7 +1,7 @@
 extends /templates/base-flat
 
 block content
-  #root
+  #ai-wrapper
     h1 hi AI
 
 

--- a/app/views/ai/AIView.js
+++ b/app/views/ai/AIView.js
@@ -7,10 +7,10 @@ let AIView
 require('app/styles/ai/ai.sass')
 const RootView = require('views/core/RootView')
 const template = require('app/templates/ai/ai')
-const ai = require('../../../node_modules/ai/dist-embed/ai')
-require('../../../node_modules/ai/dist-embed/style.css')
+const ai = require('../../../node_modules/ai/dist/ai.js')
+require('../../../node_modules/ai/dist/style.css')
 
-module.exports = (AIView = (function() {
+module.exports = (AIView = (function () {
   AIView = class AIView extends RootView {
     static initClass() {
       this.prototype.id = 'ai-view'
@@ -20,7 +20,7 @@ module.exports = (AIView = (function() {
     afterInsert() {
       // Undo our 62.5% default HTML font-size here
       $('html').css('font-size', '16px')
-      ai.AI({ domElement: this.$el.find('#root')[0] })
+      ai.AI({ domElement: this.$el.find('#ai-wrapper')[0] })
       return super.afterInsert()
     }
 

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -277,8 +277,8 @@ module.exports = (env) => {
             from: 'vendor/esper-plugin-lang-cpp-modern.js',
             to: 'javascripts/app/vendor/aether-cpp.modern.js'
           }, {
-            // Standalone ai project expects images and other assets in /ai subfolder; we also add one here
-            context: 'node_modules/ai/dist-embed/ai',
+            // Standalone ai project expects images and other assets to be in its public folder, so copy them to AI's new root `/ai`
+            context: 'node_modules/ai/dist',
             from: '**/*',
             to: 'ai'
           }

--- a/webpack.development.config.js
+++ b/webpack.development.config.js
@@ -69,7 +69,7 @@ module.exports = (env) => {
       devtool: 'eval', // Recommended choice for development builds with maximum performance.
       plugins: prePlugins.concat(baseConfig.plugins).concat(plugins),
       watchOptions: {
-        ignored: /node_modules(?!\/ai\/dist-embed)|bower_components|\.#|~$/,
+        ignored: /node_modules(?!\/ai\/dist)|bower_components|\.#|~$/,
       },
       mode: 'development'
     })


### PR DESCRIPTION
I made some slight changes to how embedding works in codecombat/ai#24. This brings your branch inline with those changes:

- Threw out `dist-embed` in favor of just a `dist`
- AI app is now absolutely positioned within a parent container, so it needs to be embedded in a positioned `#ai-wrapper`, so I changed root to match that.
  - I did this to try and make "full screen pages" from within the embedded app, but it looks like that's not exactly working.