### PR TITLE
Remove "Contribute" Column from Footer

### DIFF
--- a/app/components/common/Footer.vue
+++ b/app/components/common/Footer.vue
@@ -39,24 +39,6 @@ export default Vue.extend({
       return getQueryVariable('landing', false)
     },
 
-    forumLink () {
-      let link = 'https://discourse.codecombat.com/'
-      const lang = this.preferredLocale.split('-')[0]
-      if (['zh', 'ru', 'es', 'fr', 'pt', 'de', 'nl', 'lt'].includes(lang)) {
-        link += `c/other-languages/${lang}`
-      }
-      return link
-    },
-
-    apiLink () {
-      let link = 'https://github.com/codecombat/codecombat-api'
-      const lang = this.preferredLocale.split('-')[0]
-      if (['zh'].includes(lang) || features.china) {
-        link = this.cocoPath('/api-docs')
-      }
-      return link
-    },
-
     footerUrls () {
       /* footer url example
          column: {
@@ -105,16 +87,6 @@ export default Vue.extend({
           ]
         },
         {
-          title: 'nav.get_involved',
-          condition: true,
-          lists: [
-            { url: 'https://github.com/codecombat/codecombat', extra: 'GitHub' },
-            { url: this.cocoPath('/community'), title: 'nav.community' },
-            { url: this.cocoPath('/contribute'), title: 'nav.contribute' },
-            { url: this.forumLink, title: 'nav.forum', attrs: { target: '_blank' }, hide: me.isStudent() || !me.showForumLink() },
-            { url: this.apiLink, title: 'nav.api', attrs: { target: '_blank' }, hide: me.isStudent() }
-          ]
-        },{
           title: 'nav.products',
           condition: true,
           lists: [
@@ -144,6 +116,7 @@ export default Vue.extend({
             { url: this.cocoPath('/events'), title: 'nav.events' },
             { url: this.cocoPath('/contact-cn'), title: 'nav.contact', hide: me.isStudent() },
             { url: this.cocoPath('/CoCoStar'), title: 'nav.star' },
+            { url: this.cocoPath('/contribute'), title: 'nav.contribute' },            
           ]
         },
         {

--- a/app/styles/contribute/contribute.sass
+++ b/app/styles/contribute/contribute.sass
@@ -24,3 +24,9 @@
       color: black
       padding-top: 0px
       margin-top: 0px
+
+  .bottom-links
+    margin-top: 15px
+    text-align: center
+    a 
+      padding: 0 10px

--- a/app/templates/contribute/contribute.pug
+++ b/app/templates/contribute/contribute.pug
@@ -84,3 +84,16 @@ block content
           | Tame our forum users and provide direction for those with questions. Our ambassadors represent CodeCombat to the world.
 
   div.clearfix
+
+  div.bottom-links
+    if !me.isStudent()
+      a(href=`${view.apiLink}` data-i18n='nav.api' target='_blank')   
+
+    a(href="https://github.com/codecombat/codecombat" target='_blank') GitHub
+
+    a(href=`${view.communityLink}` data-i18n='nav.community' target='_blank') Community
+
+    if !me.isStudent() || me.showForumLink()
+      a(href=`${view.forumLink}` data-i18n='nav.forum' target='_blank') Forum
+
+  div.clearfix

--- a/app/views/contribute/MainContributeView.coffee
+++ b/app/views/contribute/MainContributeView.coffee
@@ -1,10 +1,37 @@
 require('app/styles/contribute/contribute.sass')
 ContributeClassView = require 'views/contribute/ContributeClassView'
 template = require 'app/templates/contribute/contribute'
+utils = require 'core/utils'
 
 module.exports = class MainContributeView extends ContributeClassView
   id: 'contribute-view'
   template: template
 
+  initialize: ->
+    super()
+    @apiLink = @getApiLink()
+    @communityLink = @getCommunityLink()
+    @forumLink = @getForumLink()
+
   events:
     'change input[type="checkbox"]': 'onCheckboxChanged'
+
+  getLanguage: ->
+    (me.get('preferredLanguage') or 'en').split('-')[0]
+
+  getApiLink: ->
+    link = 'https://github.com/codecombat/codecombat-api'
+    if ['zh'].includes(@getLanguage()) or features.china
+      link = utils.cocoBaseURL() + '/api-docs'
+    return link
+
+  getCommunityLink: ->
+    return utils.cocoBaseURL() + '/community'
+
+  getForumLink: ->
+    link = 'https://discourse.codecombat.com/'
+    if ['zh', 'ru', 'es', 'fr', 'pt', 'de', 'nl', 'lt'].includes(@getLanguage)
+      link += "c/other-languages/#{lang}"
+    return link
+
+


### PR DESCRIPTION
The changes made include:
- Moving the "Contribute" link to the "General" column in the footer
- Moving GitHub / Forum / Community to /contribute page
- Moving the API link to both the /contribute page and the /partners page
- Deleting the now-empty "Get Involved" column

Pls check the screenshots below, since I'm not sure I added the links to the right places, also some description might be useful on the /partners page to clarify what the API is.

![CodeCombat_-_Coding_games_to_learn_Python_and_JavaScript___CodeCombat](https://user-images.githubusercontent.com/11805970/235869254-3cc7a215-e882-4e37-abda-37c8ef993cd1.png)
![Cursor_and_CodeCombat_-_Coding_games_to_learn_Python_and_JavaScript___CodeCombat](https://user-images.githubusercontent.com/11805970/235869553-ebbf0eac-4267-4338-8d12-b8671828dcac.png)


