### PR TITLE
Fix issue with class selection drop-down menu not working correctly

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
@@ -396,7 +396,8 @@ function getLearningGoalsDocumentation (content) {
         setClassroomId: 'teacherDashboard/setClassroomId',
         setSelectedCourseId: 'teacherDashboard/setSelectedCourseIdCurrentClassroom',
         setSelectableStudentIds: 'baseSingleClass/setSelectableStudentIds',
-        setSelectableOriginals: 'baseSingleClass/setSelectableOriginals'
+        setSelectableOriginals: 'baseSingleClass/setSelectableOriginals',
+        closePanel: 'teacherDashboardPanel/closePanel'
       }),
 
       async fetchClassroomData (classroomId) {


### PR DESCRIPTION
The `closePanel` function was previously removed by mistake. 
Now it's added back.

`beforeRoute` hooks were failing, since they were calling it: 
https://github.com/codecombat/codecombat/blob/a93ebbd5f9978a0569d364fb36acf843cf57b3a3/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue#L367