### PR TITLE
Fix: CodeCombat Level Lock Feature Not Working Correctly

### DIFF
--- a/app/templates/courses/teacher-class-view.pug
+++ b/app/templates/courses/teacher-class-view.pug
@@ -217,6 +217,7 @@ mixin courseOverview(course)
         - var courseInstance = view.getSelectedCourseInstance();
         each level, index in levels
           - if (level.get('assessment')) continue;
+          - if (courseInstance && level.get('slug') === courseInstance.get('startLockedLevel')) lockedFromHere = true;          
           - var progress = state.get('progressData').get({ classroom: view.classroom, course: course, level: level })
           - var levelNumber = view.classroom.getLevelNumber(level.get('original'), index + 1)
           +allStudentsLevelProgressDot(progress, level, levelNumber, lockedFromHere)
@@ -236,12 +237,12 @@ mixin studentLevelsRow(student)
           - var courseInstance = view.getSelectedCourseInstance();
           each level, index in levels
             - if (level.get('assessment')) continue;
-            - if (courseInstance && courseInstance.get('lockedLevels') && courseInstance.get('lockedLevels').includes(level.get('slug'))) locked = true;
+            - if (courseInstance && level.get('slug') === courseInstance.get('startLockedLevel')) lockedFromHere = true;
             - var progress = state.get('progressData').get({ classroom: view.classroom, course: course, level: level, user: student })
             - var levelNumber = view.classroom.getLevelNumber(level.get('original'), index + 1)
             - if (!level.get('practice'))
               - courseFinished = progress.completed;
-            +studentLevelProgressDot(progress, level, levelNumber, student, locked)
+            +studentLevelProgressDot(progress, level, levelNumber, student, lockedFromHere)
       div
         if courseFinished
           a.certificate-link.open-certificate-btn(target='_blank', href='/certificates/' + student.id + '?class=' + view.classroom.id + '&course=' + course.id + '&course-instance=' + state.get('selectedCourseInstance').id, data-event-action="Teachers Click Certificates - Progress tab")

--- a/app/views/play/CampaignView.coco.coffee
+++ b/app/views/play/CampaignView.coco.coffee
@@ -1510,7 +1510,7 @@ module.exports = class CampaignView extends RootView
 
       level.noFlag = !level.next
 
-      if this.courseInstance.get('lockedLevels')?.includes level.slug
+      if level.slug == @courseInstance.get('startLockedLevel') # lock level begin from startLockedLevel
         lockedByTeacher = true
       if lockedByTeacher
         level.locked = true


### PR DESCRIPTION
It seems that by mistake the new Ozaria locking logic was also implemented in some codecombat files.
Change reverted, and seems to be working as expected: 

<img width="1909" alt="Students___CodeCombat_and_Play_CodeCombat_Levels_-_Learn_Python__JavaScript__and_HTML___CodeCombat_🔊_and_CodeCombat_Level_Lock_Feature_Not_Working_Correctly_-_Asana_and_SendUserPodcastSubscriptionEmailJob_ts_—_background-processor" src="https://user-images.githubusercontent.com/11805970/236274337-00883b34-0afe-461f-9cfb-e0d15e3c4ce1.png">

<img width="2381" alt="My_Classes___CodeCombat_and_My_Classes___CodeCombat_and_Students___CodeCombat" src="https://user-images.githubusercontent.com/11805970/236277367-2a712de0-4ef4-49ac-bf9f-4a3390646af1.png">

