### PR TITLE
Fix: ensure the capstone stage order in getNextLevel logic

### DIFF
--- a/ozaria/site/common/ozariaUtils.js
+++ b/ozaria/site/common/ozariaUtils.js
@@ -147,7 +147,13 @@ export const getNextLevelForLevel = (level, capstoneStage = 1) => {
   if (capstoneStage && level.isPlayedInStages) {
     nextLevel = Object.values(nextLevels).filter((n) => (n.conditions || {}).afterCapstoneStage === capstoneStage)
   } else {
-    nextLevel = Object.values(nextLevels)
+    // Ensure that the next level is sorted by afterCapstoneStage
+    nextLevel = Object.values(nextLevels).sort((a, b) => {
+      const afterCapstoneStageA = a.conditions?.afterCapstoneStage ?? 0;
+      const afterCapstoneStageB = b.conditions?.afterCapstoneStage ?? 0;
+  
+      return afterCapstoneStageA - afterCapstoneStageB;
+    });
   }
   return nextLevel[0] // assuming there can only be one next level for a given level and/or capstone stage
 }


### PR DESCRIPTION
It was not 100% sure that `Object.values()` returns the levels always in the same order. 
Now it is sure that the first stage will come first to prevent issues caused by skipping a level unintetionally.