### PR TITLE
Support Team OOO message for Team Week

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1776,6 +1776,8 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     screenshot_included: "Screenshot included."
     where_reply: "Where should we reply?"
     send: "Send Feedback"
+    ooo_blurb: "The CodeCombat team will be out of the office from June 5th to June 9th, and during this time will have limited access to emails. We will respond to your inquiry as soon as possible, please be aware of the anticipated wait time."
+
 
   account_settings:
     title: "Account Settings"

--- a/app/views/core/CocoView.coffee
+++ b/app/views/core/CocoView.coffee
@@ -283,7 +283,7 @@ module.exports = class CocoView extends Backbone.View
       @openModalView(new ContactModal())
 
     confirmOOOMessage = (afterConfirm) =>
-      oooStart = new Date('2023-05-05T00:00:00Z')
+      oooStart = new Date('2023-06-05T00:00:00Z')
       oooEnd = new Date('2023-06-09T23:59:59Z')
       
       storageKey = "contact-modal-confirm-seen-#{me.id}-#{oooStart.getTime()}-#{oooEnd.getTime()}"

--- a/app/views/core/CocoView.coffee
+++ b/app/views/core/CocoView.coffee
@@ -282,11 +282,36 @@ module.exports = class CocoView extends Backbone.View
 
       @openModalView(new ContactModal())
 
+    confirmOOOMessage = (afterConfirm) =>
+      oooStart = new Date('2023-05-05T00:00:00Z')
+      oooEnd = new Date('2023-06-09T23:59:59Z')
       
-    if (me.isTeacher(true) and zE) or me.showChinaResourceInfo()
-      openDirectContactModal()
-    else
-      openContactModal()
+      storageKey = "contact-modal-confirm-seen-#{me.id}-#{oooStart.getTime()}-#{oooEnd.getTime()}"
+      seen = storage.load(storageKey)
+
+      isOoo = new Date() > oooStart and new Date() < oooEnd
+
+      if (not isOoo) or seen
+        afterConfirm()
+        return
+      
+      renderData =
+        body: $.i18n.t 'contact.ooo_blurb'
+        decline: $.i18n.t 'modal.cancel'
+        confirm: $.i18n.t 'modal.okay'
+      ConfirmModal = require 'views/core/ConfirmModal'
+      confirmModal = new ConfirmModal renderData
+      confirmModal.on 'confirm', ->
+        storage.save(storageKey, true)
+        afterConfirm()
+        
+      @openModalView confirmModal      
+
+    confirmOOOMessage =>
+      if (me.isTeacher(true) and zE) or me.showChinaResourceInfo()
+        openDirectContactModal()
+      else
+        openContactModal()
 
   onClickLoadingErrorLoginButton: (e) ->
     e.stopPropagation() # Backbone subviews and superviews will handle this call repeatedly otherwise


### PR DESCRIPTION
OOO message is shown after `Contact` link is clicked. Normal functionality continues after user seen the popup.
We use localStorage to show message only once for the user.

![contact-ooo-teamweek](https://github.com/codecombat/codecombat/assets/11805970/bf5dd4a8-5314-4819-a7d1-0a689b9681e9)
