### PR TITLE
support use user timezone when admin add prepaid

### DIFF
--- a/app/core/auth.coffee
+++ b/app/core/auth.coffee
@@ -23,6 +23,12 @@ init = ->
       me.set(res)
       setTestGroupNumberUS()
     .catch((e) => console.error("Error in setting country and geo:", e))
+  if not me.get('geo')?.timeZone
+    api.users.setCountryGeo()
+    .then (res) ->
+      me.set(res)
+      setTestGroupNumberUS()
+    .catch((e) => console.error("Error in setting country and geo:", e))
   if me and not me.get('testGroupNumber')?
     # Assign testGroupNumber to returning visitors; new ones in server/routes/auth
     me.set 'testGroupNumber', Math.floor(Math.random() * 256)

--- a/app/schemas/models/user.coffee
+++ b/app/schemas/models/user.coffee
@@ -348,6 +348,7 @@ _.extend UserSchema.properties,
     ll: c.array {}, { description: 'Latitude and longitude of the city'}
     metro: { description: 'Metro code'}
     zip: { description: 'Postal code'}
+    timeZone: { description: 'Timezone' }
   }
 
   clans: c.array {}, c.objectId()

--- a/app/templates/admin/administer-user-modal.pug
+++ b/app/templates/admin/administer-user-modal.pug
@@ -204,6 +204,9 @@ block modal-body-content
         +license-type(view.licenseType, view.licensePresets, view.utils)
         +license-form-group('Start Date')(type="date" name="startDate" value=view.momentTimezone().tz(view.timeZone).format('YYYY-MM-DD'))
         +license-form-group('End Date')(type="date" name="endDate" value=view.momentTimezone().tz(view.timeZone).add(1, 'year').format('YYYY-MM-DD'))
+        - userTimeZone = view.getUserTimeZone()
+        if userTimeZone != view.timeZone
+          +license-form-group('Use User TimeZone? (' + userTimeZone + ')')(type="checkbox" name="userTimeZone" value=false)
         .form-group
           button#add-seats-btn.btn.btn-primary Add Licenses
       hr

--- a/app/views/admin/AdministerUserModal.coffee
+++ b/app/views/admin/AdministerUserModal.coffee
@@ -189,8 +189,11 @@ module.exports = class AdministerUserModal extends ModelModal
     return unless attrs.maxRedeemers > 0
     return unless attrs.endDate and attrs.startDate and attrs.endDate > attrs.startDate
     attrs.endDate = attrs.endDate + " " + "23:59"   # Otherwise, it ends at 12 am by default which does not include the date indicated
-    attrs.startDate = momentTimezone.tz(attrs.startDate, @timeZone).toISOString()
-    attrs.endDate = momentTimezone.tz(attrs.endDate, @timeZone).toISOString()
+    timeZone = @timeZone
+    if attrs.userTimeZone?[0] == 'on'
+      timeZone = @getUserTimeZone()
+    attrs.startDate = momentTimezone.tz(attrs.startDate, timeZone).toISOString()
+    attrs.endDate = momentTimezone.tz(attrs.endDate, timeZone).toISOString()
 
     if attrs.licenseType of @licensePresets
       attrs.includedCourseIDs = @licensePresets[attrs.licenseType]
@@ -665,3 +668,10 @@ module.exports = class AdministerUserModal extends ModelModal
     @user.set 'volume', val
     @user.patch()
     @modelTreemas[@user.id].set 'volume', val
+
+  getUserTimeZone: ->
+    geo = @user.get('geo')
+    if geo?.timeZone
+      return geo.timeZone
+    else
+      return @timeZone


### PR DESCRIPTION
![image](https://github.com/codecombat/codecombat/assets/11417632/c92ab980-12ba-4963-9ea1-e2cedf52c7ca)
display a `useUserTimeZone` option when user timezone is different from server timezone. (the screenshot from china which server timezone is Asia/Shanghai, so  when user timezone is Los angeles it shows) .see https://github.com/codecombat/codecombat-server/pull/625 server changes
