### PR TITLE
Separate ai root & tailwind root(s)

### DIFF
--- a/app/styles/ai/ai.sass
+++ b/app/styles/ai/ai.sass
@@ -1,7 +1,7 @@
 #ai-view
   background: white
 
-  #ai-wrapper
+  #ai-root
     position: relative
     height: calc(100vh - 70px)
 

--- a/app/templates/ai/ai.pug
+++ b/app/templates/ai/ai.pug
@@ -1,7 +1,7 @@
 extends /templates/base-flat
 
 block content
-  #ai-wrapper
+  #ai-root.tailwind-wrapper
     h1 hi AI
 
 

--- a/app/views/ai/AIView.js
+++ b/app/views/ai/AIView.js
@@ -14,7 +14,7 @@ try {
 } catch (e) {
   console.warn('AI import unavailable; /ai will not work')
   console.warn(e)
-  ai = { AI: () => {} }
+  ai = { AI: () => { } }
 }
 
 module.exports = (AIView = (function () {
@@ -27,7 +27,7 @@ module.exports = (AIView = (function () {
     afterInsert() {
       // Undo our 62.5% default HTML font-size here
       $('html').css('font-size', '16px')
-      ai.AI({ domElement: this.$el.find('#ai-wrapper')[0] })
+      ai.AI({ domElement: this.$el.find('#ai-root')[0] })
       return super.afterInsert()
     }
 


### PR DESCRIPTION
Headless UI wants its modal to be a child of `<body>`, which is outside of the old `#ai-wrapper`. The solution is to use a class on both sibling divs (the AI container and the HeadlessUI modal) instead of the `#ai-wrapper` id.

This PR adds a `.tailwind-wrapper` class to the AI Root node since that's now the CSS selector wrapper, and renames `#ai-wrapper` to `#ai-root` just to be more explicit about the difference.