### PR TITLE
Fix resource hub resource locking

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseResourceHub/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseResourceHub/index.vue
@@ -53,9 +53,10 @@
       }
     },
 
-    mounted () {
+    async mounted () {
       this.setTeacherId(me.get('_id'))
       this.setPageTitle(PAGE_TITLES[this.$options.name])
+      await this.fetchTeacherPrepaids({ teacherId: me.get('_id') })
       this.fetchData({ componentName: this.$options.name, options: { loadedEventName: 'Resource Hub: Loaded' } })
 
       getResourceHubResources().then(allResources => {
@@ -94,7 +95,8 @@
 
     methods: {
       ...mapActions({
-        fetchData: 'teacherDashboard/fetchData'
+        fetchData: 'teacherDashboard/fetchData',
+        'fetchTeacherPrepaids': 'prepaids/fetchPrepaidsForTeacher'
       }),
       ...mapMutations({
         resetLoadingState: 'teacherDashboard/resetLoadingState',


### PR DESCRIPTION
It seems the problem was that we tried to check the prepaids while they were not yet loaded. 
Now, that fetching is added, everything seems to be working correctly. 

Pls check screenshots of a paid teacher account below. All CS2+ resources set to `hidden:"paid-only"`
<img width="2038" alt="Student_Licenses___CodeCombat_and_Student_Licenses___CodeCombat_and_Robo_3T_-_1_4_and_CodeCombat_-_Coding_games_to_learn_Python_and_JavaScript___CodeCombat" src="https://github.com/codecombat/codecombat/assets/11805970/5f574721-14d0-4060-927c-79255b62b010">

(after taking the screenshot I've set all the resources to hidden:false)