### PR TITLE
don't put hero-placeholder-1

### DIFF
--- a/app/lib/LevelBus.coffee
+++ b/app/lib/LevelBus.coffee
@@ -116,7 +116,8 @@ module.exports = class LevelBus extends Bus
 
     @changedSessionProperties.code = true
     @changedSessionProperties.heroCode = undefined
-    if e.spell.level.isType('ladder') and e.spell.team is 'ogres'
+    if e.spell.level.isType('ladder')
+      # lets always set heroCode for ladder so that we don't save hero-placeholder-1 anyway
       @changedSessionProperties.heroCode = e.spell.getSource()
     @session.set({'code': code})
     @saveSession()
@@ -282,11 +283,12 @@ module.exports = class LevelBus extends Bus
       delete @changedSessionProperties.heroCode
     Backbone.Mediator.publish 'level:session-will-save', session: @session
     patch = {}
-    patch[prop] = @session.get(prop) for prop of @changedSessionProperties
-    if heroCode # let's only update trueSpell of session
+    # clone objects so we won't update session
+    patch[prop] = _.cloneDeep(@session.get(prop)) for prop of @changedSessionProperties
+    if heroCode # let's only update trueSpell of session(hero-placeholder for all ladders)
       patch.code ?= {}
       delete patch.code['hero-placeholder-1']
-      patch.code['hero-placeholder'] = heroCode
+      patch.code['hero-placeholder'] = { plan: heroCode }
     delete patch.code if _.isEmpty(patch.code) # don't update empty code
     @changedSessionProperties = {}
 

--- a/app/lib/LevelBus.coffee
+++ b/app/lib/LevelBus.coffee
@@ -283,12 +283,9 @@ module.exports = class LevelBus extends Bus
       delete @changedSessionProperties.heroCode
     Backbone.Mediator.publish 'level:session-will-save', session: @session
     patch = {}
-    # clone objects so we won't update session
-    patch[prop] = _.cloneDeep(@session.get(prop)) for prop of @changedSessionProperties
+    patch[prop] = @session.get(prop) for prop of @changedSessionProperties
     if heroCode # let's only update trueSpell of session(hero-placeholder for all ladders)
-      patch.code ?= {}
-      delete patch.code['hero-placeholder-1']
-      patch.code['hero-placeholder'] = { plan: heroCode }
+      patch.code = { 'hero-placeholder' : { plan: heroCode } }
     delete patch.code if _.isEmpty(patch.code) # don't update empty code
     @changedSessionProperties = {}
 

--- a/app/lib/LevelBus.coffee
+++ b/app/lib/LevelBus.coffee
@@ -285,7 +285,7 @@ module.exports = class LevelBus extends Bus
     patch = {}
     patch[prop] = @session.get(prop) for prop of @changedSessionProperties
     if heroCode # let's only update trueSpell of session(hero-placeholder for all ladders)
-      patch.code = { 'hero-placeholder' : { plan: heroCode } }
+      patch.code = { 'hero-placeholder': { plan: heroCode }, 'hero-placeholder-1': { plan: '' } }
     delete patch.code if _.isEmpty(patch.code) # don't update empty code
     @changedSessionProperties = {}
 


### PR DESCRIPTION
since this code is based on part of play-blue logic so the changes may seems little strange. let me describe something here.
1. when play against another player in arena, we load opponent's code into `session.code['hero-placeholder-1'].plan` so the session has both plan for red and blue team so that the level can play normal with two players. i.e. we laod opponent's code in `levelLoader`
2. we would put the session at the beginning of spellview to update code and spells in `levelBus` so we update the `hero-placeholder-1` too.
-- that's the reason of some bugs, like when opponent uses cpp, since cpp code loaded in frontend is an AST tree encoded with UTF-16, so it's longer than our string length limitation for sessions. Also when i want to introduce play blue feature in arenas, red and blue codes always messed up
idealy we only need to update red code to players' session for `ladder` type arenas, So we can fetch the code from spell (which comes from player's code editor) and only set this correct code to hero-placeholder and save to server, and keep the frontend session still having origin code to run.

-- 
testing: 
can easily test that play against others in ladder still working normal. 
for simulation which is not so easy to test, but simulation also uses levelLoader to prepare session and run code, and simulation never update sessions, so i believe it would work good.