### PR TITLE
correct way to handle real-time canvas-wrapper

### DIFF
--- a/app/styles/play/play-level-view.sass
+++ b/app/styles/play/play-level-view.sass
@@ -433,6 +433,10 @@ body.is-playing
       width: 57%
       width: $game-view-width-no-api
 
+    &.real-time
+      #canvas-wrapper
+        width: 100%
+
   &.web-dev
     position: absolute
     top: 0


### PR DESCRIPTION
prior wrong pr.
https://github.com/codecombat/codecombat/pull/6956
https://github.com/codecombat/codecombat/pull/6850

important is not correct way to handle canvas-wrapper, but we need handle `real-time` after the `no-api` since real-time should have higher priority. 