### PR TITLE
WIP: Merge Teacher Dashboard

### DIFF
--- a/app/core/Router.coffee
+++ b/app/core/Router.coffee
@@ -386,25 +386,25 @@ module.exports = class CocoRouter extends Backbone.Router
     'students/:courseID/:courseInstanceID': go('courses/CourseDetailsView', { redirectTeachers: true, studentsOnly: true })
 
     'teachers': ->
-      if utils.isCodeCombat
+      if utils.isCodeCombat and localStorage.getItem('newDT') isnt 'true'
         delete window.alreadyLoadedView
         @navigate('/teachers/classes' + document.location.search, { trigger: true, replace: true })
       else
         @routeDirectly('core/SingletonAppVueComponentView', arguments, {redirectStudents: true, teachersOnly: true})
     'teachers/classes': ->
-      if utils.isCodeCombat
+      if utils.isCodeCombat and localStorage.getItem('newDT') isnt 'true'
         @routeDirectly('courses/TeacherClassesView', [], { redirectStudents: true, teachersOnly: true })
       else
         @routeDirectly('core/SingletonAppVueComponentView', arguments, {redirectStudents: true, teachersOnly: true})
     'teachers/projects/:classroomId': go('core/SingletonAppVueComponentView')
     'teachers/classes/:classroomID/:studentID': go('teachers/TeacherStudentView', { redirectStudents: true, teachersOnly: true })
     'teachers/classes/:classroomID': ->
-      if utils.isCodeCombat
+      if utils.isCodeCombat and localStorage.getItem('newDT') isnt 'true'
         @routeDirectly('courses/TeacherClassView', arguments, { redirectStudents: true, teachersOnly: true })
       else
         @routeDirectly('core/SingletonAppVueComponentView', arguments, {redirectStudents: true, teachersOnly: true})
     'teachers/courses': ->
-      if utils.isCodeCombat
+      if utils.isCodeCombat and localStorage.getItem('newDT') isnt 'true'
         @routeDirectly('courses/TeacherCoursesView', arguments, { redirectStudents: true })
       else
         delete window.alreadyLoadedView

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -188,7 +188,7 @@ export default function getVueRouter () {
         {
           path: '/teachers',
           component: () => {
-            if (utils.isCodeCombat) {
+            if (utils.isCodeCombat &&  localStorage.getItem('newDT')!=='true') {
               return import(/* webpackChunkName: "teachers" */ 'app/components/common/PassThrough')
             }
             return import(/* webpackChunkName: "teachers" */ '../../ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue')
@@ -205,7 +205,7 @@ export default function getVueRouter () {
             {
               path: 'licenses',
               component: () => {
-                if (utils.isCodeCombat) {
+                if (utils.isCodeCombat &&  localStorage.getItem('newDT')!=='true') {
                   return import(/* webpackChunkName: "paymentStudentLicenses" */'app/views/payment/v2/StudentLicensesMainComponent')
                 } else {
                   return import(/* webpackChunkName: "teachers" */ '../../ozaria/site/components/teacher-dashboard/BaseTeacherLicenses/index.vue')
@@ -219,7 +219,7 @@ export default function getVueRouter () {
             {
               path: 'resources',
               component: () => {
-                if (utils.isCodeCombat) {
+                if (utils.isCodeCombat && localStorage.getItem('newDT')!=='true') {
                   return import(/* webpackChunkName: "teachers" */ 'app/views/teachers/teacher-dashboard/BaseResourceHub/index.vue')
                 } else {
                   return import(/* webpackChunkName: "teachers" */ '../../ozaria/site/components/teacher-dashboard/BaseResourceHub/index.vue')

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -1498,7 +1498,7 @@ module.exports = class CampaignView extends RootView
             level.hidden = !prev?.practice
             level.locked = true
           else if prev
-            level.hidden = prev.hidden            
+            level.hidden = prev.hidden
             level.locked = prev.locked and not @classroom.isStudentOnOptionalLevel(me.get('_id'), @course.get('_id'), prev.original)
           else
             level.hidden = true

--- a/app/views/play/CampaignView.coffee
+++ b/app/views/play/CampaignView.coffee
@@ -1498,8 +1498,8 @@ module.exports = class CampaignView extends RootView
             level.hidden = !prev?.practice
             level.locked = true
           else if prev
-            level.hidden = prev.hidden
-            level.locked = prev.locked
+            level.hidden = prev.hidden            
+            level.locked = prev.locked and not @classroom.isStudentOnOptionalLevel(me.get('_id'), @course.get('_id'), prev.original)
           else
             level.hidden = true
             level.locked = true
@@ -1512,9 +1512,15 @@ module.exports = class CampaignView extends RootView
 
       level.noFlag = !level.next
 
-      if level.slug == @courseInstance.get('startLockedLevel') # lock level begin from startLockedLevel
-        lockedByTeacher = true
-      if lockedByTeacher
+      lockSkippedLevel = false
+      if level.slug == @courseInstance.get('startLockedLevel') or # lock level begin from startLockedLevel
+      @classroom.isStudentOnLockedLevel(me.get('_id'), @course.get('_id'), level.original, @courseInstance.get('startLockedLevel'))
+        if not @classroom.isStudentOnOptionalLevel(me.get('_id'), @course.get('_id'), level.original)
+          lockedByTeacher = true
+        else
+          lockSkippedLevel = true
+
+      if lockedByTeacher or lockSkippedLevel
         level.locked = true
         level.lockedByTeacher = true
 
@@ -1529,7 +1535,7 @@ module.exports = class CampaignView extends RootView
       level.unlocksHero = false
       level.unlocksItem = false
       prev = level
-      if not @campaign.levelIsPractice(level) and not @campaign.levelIsAssessment(level)
+      if not @campaign.levelIsPractice(level) and not @campaign.levelIsAssessment(level) and not @classroom.isStudentOnOptionalLevel(me.get('_id'), @course.get('_id'), level.original)
         lastNormalLevel = level
 
     return true

--- a/ozaria/site/common/ozariaUtils.js
+++ b/ozaria/site/common/ozariaUtils.js
@@ -308,9 +308,9 @@ export function internationalizeContentType(type){
     case 'cinematic':
       return $.i18n.t('play_level.content_type_cinematic')
     case 'interactive':
-      return $.i18n.t('play_level.content_type_interactive')
+      return $.i18n.t('play_level.content_type_interactive')    
     default:
-      return this.currentContent.contentType
+      return $.i18n.t('play_level.level_type_challenge') // show everything else as "challenge" for now
   }
 }
 
@@ -361,6 +361,9 @@ export function getGameContentDisplayNameWithType (contentData, withLevelSuffix 
 // `withLevelSuffix` will append 'Level' to the names for practice/capstone/challenge levels
 // `withProjectSuffix` will append 'Project' to the capstone name
 export function getGameContentDisplayType (contentType, withLevelSuffix = true, withProjectSuffix = false) {
+  if (!contentType) {
+    contentType = 'hero'
+  }
   if (contentType.startsWith('practice')) {
     return internationalizeLevelType('practice', withLevelSuffix, withProjectSuffix)
   } else if (contentType.startsWith('capstone')) {

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/IntroModuleRow.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/IntroModuleRow.vue
@@ -10,7 +10,7 @@
       iconType: {
         type: String,
         required: true,
-        validator: value => ['cutscene', 'cinematic', 'capstone', 'interactive', 'practicelvl', 'challengelvl', 'intro'].indexOf(value) !== -1
+        validator: value => ['cutscene', 'cinematic', 'capstone', 'interactive', 'practicelvl', 'challengelvl', 'intro', 'hero', 'course-ladder', 'game-dev', 'web-dev'].indexOf(value) !== -1
       },
 
       displayName: {

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleRow.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleRow.vue
@@ -12,7 +12,7 @@
       iconType: {
         type: String,
         required: true,
-        validator: value => ['cutscene', 'cinematic', 'capstone', 'interactive', 'practicelvl', 'challengelvl'].indexOf(value) !== -1
+        validator: value => ['cutscene', 'cinematic', 'capstone', 'interactive', 'practicelvl', 'challengelvl', 'intro', 'hero', 'course-ladder', 'game-dev', 'web-dev'].indexOf(value) !== -1
       },
 
       displayName: {

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
@@ -67,6 +67,7 @@ function getLearningGoalsDocumentation (content) {
         getActiveClassrooms: 'teacherDashboard/getActiveClassrooms',
         selectableStudentIds: 'baseSingleClass/selectableStudentIds',
         getSelectableOriginals: 'baseSingleClass/getSelectableOriginals',
+        classroomCourses: 'teacherDashboard/getCoursesCurrentClassroom'
       }),
 
       modules () {
@@ -97,8 +98,15 @@ function getLearningGoalsDocumentation (content) {
             }
           })
 
-          // Todo: Ozaria-i18n
-          const moduleDisplayName = `${this.$t(`teacher.module${moduleNum}`)}${utils.courseModules[this.selectedCourseId]?.[moduleNum]}`
+          let moduleDisplayName
+          if (utils.isCodeCombat) { // CodeCombat only has one module per course.
+            const course = this.classroomCourses.find(({ _id }) => _id === this.selectedCourseId)
+            moduleDisplayName = course.name
+          } else {
+            // Todo: Ozaria-i18n
+            moduleDisplayName = `${this.$t(`teacher.module${moduleNum}`)}${utils.courseModules[this.selectedCourseId]?.[moduleNum]}`
+          }
+
           const moduleStatsForTable = this.createModuleStatsTable(moduleDisplayName, translatedModuleContent, intros, moduleNum)
 
           // Track summary stats to display in the header of the table

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
@@ -447,7 +447,12 @@ function getLearningGoalsDocumentation (content) {
               normalizedType = type
             }
 
-            if (!['cutscene', 'cinematic', 'capstone', 'interactive', 'practicelvl', 'challengelvl'].includes(normalizedType)) {
+            
+            if(!normalizedType){ // TODO: show all levels as Challenge Levels for now
+              normalizedType = 'challengelvl'
+            }
+
+            if (!['cutscene', 'cinematic', 'capstone', 'interactive', 'practicelvl', 'challengelvl', 'intro', 'hero', 'course-ladder', 'game-dev', 'web-dev'].includes(normalizedType)) {
               throw new Error(`Didn't handle normalized content type: '${normalizedType}'`)
             }
 

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/TableModuleHeader.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/TableModuleHeader.vue
@@ -41,7 +41,7 @@ export default {
       return {
         lockOrSkipShown: false,
         hoveredOriginal: null,
-        userSelectedOriginals: [],
+        userSelectedOriginals: []
       }
     },
 
@@ -116,10 +116,7 @@ export default {
 </script>
 
 <template>
-  <div
-      class="moduleHeading"
-      :style="cssVariables"
-  >
+  <div class="moduleHeading" :style="cssVariables">
     <div class="title">
       <h3>{{ moduleHeading }}</h3>
       <v-popover
@@ -127,8 +124,8 @@ export default {
         placement="top"
         popover-class="teacher-dashboard-tooltip lighter-p lock-tooltip"
         trigger="click"
-        @show="lockOrSkipShown=true"
-        @hide="lockOrSkipShown=false"
+        @show="lockOrSkipShown = true"
+        @hide="lockOrSkipShown = false"
       >
         <!-- Triggers the tooltip -->
         <div v-if="!displayOnly">
@@ -142,12 +139,8 @@ export default {
       </v-popover>
 
     </div>
-    <div
-      v-for="({ type, tooltipName, description, normalizedOriginal }, idx) of listOfContent"
-      :key="`${idx}-${type}`"
-
-      class="content-icons"
-    >
+    <div v-for="({ type, isPractice, tooltipName, description, normalizedOriginal }, idx) of listOfContent" :key="`${idx}-${type}`"
+      class="content-icons">
       <v-popover
         popover-class="teacher-dashboard-tooltip lighter-p lock-tooltip"
         trigger="hover"
@@ -163,14 +156,12 @@ export default {
             @mouseleave="setHoveredOriginal(null)"
             :class="classForContentIconHover(normalizedOriginal)"
         >
-          <ContentIcon
-              class="content-icon"
-              :icon="type"
-          />
+          <ContentIcon class="content-icon" :icon="type" />
         </div>
         <!-- The tooltip -->
         <template slot="popover">
           <div class="level-popover-locking">
+            <span v-if="isPractice">{{ $t('play_level.level_type_practice') }}</span>
             <h3
               v-if="type !== 'cutscene'"
               style="margin-bottom: 15px;"
@@ -178,16 +169,13 @@ export default {
             >
               {{ tooltipName }}
             </h3>
-            <p
-              style="margin-bottom: 15px;"
-              v-html="description"
-            />
+            <p style="margin-bottom: 15px;" v-html="description" />
           </div>
         </template>
       </v-popover>
     </div>
     <div class="golden-backer" v-for="({ status, border }, idx) of classSummaryProgress" :key="idx">
-      <ProgressDot :status="status" :border="border"/>
+      <ProgressDot :status="status" :border="border" />
     </div>
   </div>
 </template>

--- a/ozaria/site/components/teacher-dashboard/common/icons/ContentIcon.vue
+++ b/ozaria/site/components/teacher-dashboard/common/icons/ContentIcon.vue
@@ -22,7 +22,7 @@
       icon: {
         type: String,
         required: true,
-        validator: value => ['cutscene', 'cinematic', 'capstone', 'interactive', 'practicelvl', 'challengelvl', 'intro'].indexOf(value) !== -1
+        validator: value => { return ['cutscene', 'cinematic', 'capstone', 'interactive', 'practicelvl', 'challengelvl', 'intro', 'hero', 'course-ladder', 'game-dev', 'web-dev'].indexOf(value) !== -1}
       }
     }
   }
@@ -31,12 +31,13 @@
 <template>
   <div class="flex-content" :class="icon">
     <IconCutscene v-if="icon=='cutscene'" />
-    <IconCinematic v-if="icon=='cinematic'" />
-    <IconCapstone v-if="icon=='capstone'" />
-    <IconInteractive v-if="icon=='interactive'" />
-    <IconPracticeLevel v-if="icon=='practicelvl'" />
-    <IconChallengeLevel v-if="icon=='challengelvl'" />
-    <IconIntro v-if="icon=='intro'" />
+    <IconCinematic v-else-if="icon=='cinematic'" />
+    <IconCapstone v-else-if="icon=='capstone'" />
+    <IconInteractive v-else-if="icon=='interactive'" />
+    <IconPracticeLevel v-else-if="icon=='practicelvl'" />
+    <IconChallengeLevel v-else-if="icon=='challengelvl'" />
+    <IconIntro v-else-if="icon=='intro'" />
+    <IconIntro v-else />
   </div>
 </template>
 

--- a/ozaria/site/styles/common/variables.scss
+++ b/ozaria/site/styles/common/variables.scss
@@ -16,9 +16,6 @@
   // Used in the signup modals
   $authGray: #a4a4a4 !global;
 
-  // Used in Single class table
-  $studentNameWidth: 260px !global;
-
   // Following Ozaria marketing guide
   $white: #ffffff !global;
   $mist: #eeeced !global;
@@ -38,4 +35,26 @@
   // For the single progress table
   $tooltip-spacing: 200px !global;
   $anti-tooltip-spacing: -200px !global;
+} else {
+  // Used in the signup modals
+  $authGray: #a4a4a4 !global;
+
+  // Following Ozaria marketing guide
+  $white: #ffffff !global;
+  $mist: #eeeced !global;
+  $moon: #f7d047 !global;
+  $goldenlight: #d1b147 !global;
+  $sun: #ff8600 !global;
+  $dawn: #532e4b !global;
+  $dusk: #5db9ac !global;
+  $dusk-dark: #379b8d !global;
+  $fog: #6bd7ef !global;
+  $twilight: #476fb1 !global;
+  $eve: #2d5859 !global;
+  $pitch: #131b25 !global;
+  $haze: #6d8594 !global;
+  $acodus-glow: #40f3e4 !global;
 }
+
+  // Used in Single class table
+  $studentNameWidth: 260px !global;

--- a/ozaria/site/styles/common/variables.scss
+++ b/ozaria/site/styles/common/variables.scss
@@ -13,48 +13,29 @@
   $chromeBottomPadding: 4vh !global;
   $chromeLeftPadding: 2vw !global;
 
-  // Used in the signup modals
-  $authGray: #a4a4a4 !global;
-
-  // Following Ozaria marketing guide
-  $white: #ffffff !global;
-  $mist: #eeeced !global;
-  $moon: #f7d047 !global;
-  $goldenlight: #d1b147 !global;
-  $sun: #ff8600 !global;
-  $dawn: #532e4b !global;
-  $dusk: #5db9ac !global;
-  $dusk-dark: #379b8d !global;
-  $fog: #6bd7ef !global;
-  $twilight: #476fb1 !global;
-  $eve: #2d5859 !global;
-  $pitch: #131b25 !global;
-  $haze: #6d8594 !global;
-  $acodus-glow: #40f3e4 !global;
-
   // For the single progress table
   $tooltip-spacing: 200px !global;
   $anti-tooltip-spacing: -200px !global;
-} else {
-  // Used in the signup modals
-  $authGray: #a4a4a4 !global;
-
-  // Following Ozaria marketing guide
-  $white: #ffffff !global;
-  $mist: #eeeced !global;
-  $moon: #f7d047 !global;
-  $goldenlight: #d1b147 !global;
-  $sun: #ff8600 !global;
-  $dawn: #532e4b !global;
-  $dusk: #5db9ac !global;
-  $dusk-dark: #379b8d !global;
-  $fog: #6bd7ef !global;
-  $twilight: #476fb1 !global;
-  $eve: #2d5859 !global;
-  $pitch: #131b25 !global;
-  $haze: #6d8594 !global;
-  $acodus-glow: #40f3e4 !global;
 }
+// Used in the signup modals
+$authGray: #a4a4a4 !global;
 
-  // Used in Single class table
-  $studentNameWidth: 260px !global;
+// Following Ozaria marketing guide
+$white: #ffffff !global;
+$mist: #eeeced !global;
+$moon: #f7d047 !global;
+$goldenlight: #d1b147 !global;
+$sun: #ff8600 !global;
+$dawn: #532e4b !global;
+$dusk: #5db9ac !global;
+$dusk-dark: #379b8d !global;
+$fog: #6bd7ef !global;
+$twilight: #476fb1 !global;
+$eve: #2d5859 !global;
+$pitch: #131b25 !global;
+$haze: #6d8594 !global;
+$acodus-glow: #40f3e4 !global;
+
+
+// Used in Single class table
+$studentNameWidth: 260px !global;

--- a/test/app/core/utils.spec.coco.coffee
+++ b/test/app/core/utils.spec.coco.coffee
@@ -430,6 +430,85 @@ describe 'Utility library', ->
 
     describe 'when no practice needed', ->
       needsPractice = false
+      it 'returns correct next levels when rc* p optional locked', ->
+        levels = [
+          { practice: false, complete: true }
+          { practice: true, complete: false, optional: true, locked: true }
+        ]
+        expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(2)
+        expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
+
+      it 'returns correct next levels when pc* p r optional locked', ->
+        levels = [
+          { practice: true, complete: true }
+          { practice: true, complete: false, optional: true, locked: true }
+          { practice: false, complete: false }
+        ]
+        expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(2)
+        expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
+
+      it 'returns correct next levels when pc* p p optional not locked', ->
+        levels = [
+          { practice: true, complete: true }
+          { practice: true, complete: false, optional: true, locked: false }
+          { practice: true, complete: false }
+        ]
+        expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(3)
+        expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
+
+      it 'returns correct next levels when rc* p rc optional locked', ->
+        levels = [
+          { practice: false, complete: true }
+          { practice: true, complete: false, optional: true, locked: true }
+          { practice: false, complete: true }
+        ]
+        expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(3)
+        expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
+
+      it 'returns correct next levels when rc rc rc* a r optional not locked', ->
+        levels = [
+          { practice: false, complete: true }
+          { practice: false, complete: true }
+          { practice: false, complete: true, optional: true, locked: false }
+          { practice: false, complete: false, assessment: true }
+          { practice: false, complete: false }
+        ]
+        expect(utils.findNextLevel(levels, 2, needsPractice)).toEqual(4)
+        expect(utils.findNextAssessmentForLevel(levels, 2, needsPractice)).toEqual(3)    
+      it 'returns correct next levels when not nl nl l nl nl nl', ->
+        levels = [
+          { practice: false, complete: true }
+          { practice: false, complete: true }
+          { practice: false, complete: true, locked: true }
+          { practice: false, complete: true }
+          { practice: false, complete: true }
+          { practice: false, complete: true }
+        ]
+        expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(-1)
+        expect(utils.findNextAssessmentForLevel(levels, 2, needsPractice)).toEqual(-1)   
+      it 'returns correct next levels when not nl nl l/o nl nl nl', ->
+        levels = [
+          { practice: false, complete: true }
+          { practice: false, complete: true }
+          { practice: false, complete: true, locked: true, optional: true }
+          { practice: false, complete: true }
+          { practice: false, complete: false }
+          { practice: false, complete: false }
+        ]
+        expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(4)
+        expect(utils.findNextAssessmentForLevel(levels, 2, needsPractice)).toEqual(-1)
+      it 'returns correct next levels when not nl/c nl/c l/o nl/c nl/c nl/c', ->
+        levels = [
+          { practice: false, complete: true }
+          { practice: false, complete: true }
+          { practice: false, complete: true, locked: false, optional: true }
+          { practice: false, complete: true }
+          { practice: false, complete: true }
+          { practice: false, complete: true }
+        ]
+        expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(6)
+        expect(utils.findNextAssessmentForLevel(levels, 2, needsPractice)).toEqual(-1)
+
       it 'returns correct next levels when rc* p', ->
         levels = [
           { practice: false, complete: true }

--- a/test/app/core/utils.spec.coco.coffee
+++ b/test/app/core/utils.spec.coco.coffee
@@ -430,7 +430,7 @@ describe 'Utility library', ->
 
     describe 'when no practice needed', ->
       needsPractice = false
-      it 'returns correct next levels when rc* p optional locked', ->
+      it 'returns correct next levels when required complete level followed by optional locked practice level', ->
         levels = [
           { practice: false, complete: true }
           { practice: true, complete: false, optional: true, locked: true }
@@ -438,7 +438,7 @@ describe 'Utility library', ->
         expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(2)
         expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
 
-      it 'returns correct next levels when pc* p r optional locked', ->
+      it 'returns correct next levels when completed practice level followed by optional locked practice level and incomplete level', ->
         levels = [
           { practice: true, complete: true }
           { practice: true, complete: false, optional: true, locked: true }
@@ -447,7 +447,7 @@ describe 'Utility library', ->
         expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(2)
         expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
 
-      it 'returns correct next levels when pc* p p optional not locked', ->
+      it  'returns correct next levels when completed practice level followed by optional unlocked practice level and incomplete practice level', ->
         levels = [
           { practice: true, complete: true }
           { practice: true, complete: false, optional: true, locked: false }
@@ -456,7 +456,7 @@ describe 'Utility library', ->
         expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(3)
         expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
 
-      it 'returns correct next levels when rc* p rc optional locked', ->
+      it 'returns correct next levels when required complete level followed by optional locked practice level and required complete level', ->
         levels = [
           { practice: false, complete: true }
           { practice: true, complete: false, optional: true, locked: true }
@@ -465,7 +465,7 @@ describe 'Utility library', ->
         expect(utils.findNextLevel(levels, 0, needsPractice)).toEqual(3)
         expect(utils.findNextAssessmentForLevel(levels, 0, needsPractice)).toEqual(-1)
 
-      it 'returns correct next levels when rc rc rc* a r optional not locked', ->
+      it 'returns correct next levels when sequence of required complete levels followed by optional unlocked level and assessment level', ->
         levels = [
           { practice: false, complete: true }
           { practice: false, complete: true }
@@ -475,7 +475,7 @@ describe 'Utility library', ->
         ]
         expect(utils.findNextLevel(levels, 2, needsPractice)).toEqual(4)
         expect(utils.findNextAssessmentForLevel(levels, 2, needsPractice)).toEqual(3)    
-      it 'returns correct next levels when not nl nl l nl nl nl', ->
+      it 'returns correct next levels when sequence of normal levels with a locked level in between', ->
         levels = [
           { practice: false, complete: true }
           { practice: false, complete: true }
@@ -486,7 +486,7 @@ describe 'Utility library', ->
         ]
         expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(-1)
         expect(utils.findNextAssessmentForLevel(levels, 2, needsPractice)).toEqual(-1)   
-      it 'returns correct next levels when not nl nl l/o nl nl nl', ->
+      it 'returns correct next levels when sequence of normal levels with an optional locked level in between', ->
         levels = [
           { practice: false, complete: true }
           { practice: false, complete: true }
@@ -497,7 +497,7 @@ describe 'Utility library', ->
         ]
         expect(utils.findNextLevel(levels, 3, needsPractice)).toEqual(4)
         expect(utils.findNextAssessmentForLevel(levels, 2, needsPractice)).toEqual(-1)
-      it 'returns correct next levels when not nl/c nl/c l/o nl/c nl/c nl/c', ->
+      it 'returns correct next levels when sequence of normal/complete levels with an optional unlocked level in between', ->
         levels = [
           { practice: false, complete: true }
           { practice: false, complete: true }


### PR DESCRIPTION
Pls check the [backend PR](https://github.com/codecombat/codecombat-server/pull/698) as well.

The new teacher dashboard can be accessed if you switch it on by running `localStorage.setItem('newDT', true);` in the console.

![teacher-dashboard-merge](https://github.com/codecombat/codecombat/assets/11805970/d91d2930-46ed-4c44-8881-4d0a3cf5ee69)

Level names are appearing Coco style (showing if practice, and level index as 1, 2, 3a, 3b etc...)
<img width="1242" alt="Ozaria_-_Teacher_Dashboard" src="https://github.com/codecombat/codecombat/assets/11805970/47ca8fd7-c93b-41c5-915b-ffb96dceecb9">

Level access settings are appearing for student as well:
![Play_CodeCombat_Levels_-_Learn_Python__JavaScript__and_HTML___CodeCombat](https://github.com/codecombat/codecombat/assets/11805970/fd5d944d-bce5-436e-9b47-a6a9005925dd)

