### PR TITLE
bundle the babylon plugin into esper.js to make java works better

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "nanoscroller": "~0.8.0",
     "treema": "https://github.com/codecombat/treema.git#master",
     "validated-backbone-mediator": "~0.1.3",
-    "esper.js": "https://files.codecombat.com/esper-2022-08-26.tar.gz",
+    "esper.js": "https://files.codecombat.com/esper-2023-09-25.tar.gz",
     "algolia-autocomplete.js": "^0.17.0",
     "algolia-autocomplete-no-conflict": "1.0.0",
     "font-awesome": "fontawesome#^4.7.0",


### PR DESCRIPTION
to test it. clone the pr and run bower install or npm install to get latest esper.js. then see if the bug https://codecombat-core.slack.com/archives/C49HU8WLA/p1694833855629179 still exists.