### PR TITLE
fix no-classroom announcement for coco

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -2204,6 +2204,7 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     classroom_live_completion: "Classroom Code Autocomplete: "
     learn_without_classroom_title: "You can still learn and play without a classroom"
     learn_without_classroom_blurb: "Start by playing the free Sky Mountain chapter by <a href='/play/chapter-1-sky-mountain'>clicking here</a>."
+    learn_without_classroom_blurb_coco: "Start by playing the free Hour of Code campaign by <a href='/play/intro'>clicking here</a>."
     all_courses_completed: "All Courses Completed!"
     all_units_completed: "All Units Completed!"
 

--- a/app/templates/courses/courses-view.pug
+++ b/app/templates/courses/courses-view.pug
@@ -225,7 +225,10 @@ mixin classrooms_content()
      h5(data-i18n="learn_without_classroom_title")
      ul
        li
-         b(data-i18n="[html]courses.learn_without_classroom_blurb")
+         if view.utils.isCodeCombat
+          b(data-i18n="[html]courses.learn_without_classroom_blurb_coco")
+         else
+          b(data-i18n="[html]courses.learn_without_classroom_blurb")
 
  hr.class-break
  h3(data-i18n="courses.join_class")


### PR DESCRIPTION
By mistake we were showing the Ozar level for Coco students.

| BEFORE | AFTER |
| --- | --- |
| ![Screenshot 2023-10-17 at 5 27 27 PM](https://github.com/codecombat/codecombat/assets/11805970/63c6974a-4964-4f82-9ef4-df6370876e31) | <img width="619" alt="CodeCombat_-_Coding_games_to_learn_Python_and_JavaScript___CodeCombat" src="https://github.com/codecombat/codecombat/assets/11805970/dd16bf7b-1ca7-4eda-a921-589fdd761209"> | 
