### PR TITLE
Don't allow undefined keys on CocoModels

### DIFF
--- a/app/models/CocoModel.coffee
+++ b/app/models/CocoModel.coffee
@@ -12,7 +12,7 @@ class CocoModel extends Backbone.Model
   @schema: null
 
   constructor: (attributes, options)  ->
-    if 'undefined' of (attributes or {})
+    if _.isObject(attributes) and ('undefined' of attributes)
       console.error "Unsetting `undefined` property key during construction of #{@constructor.className} model with value #{attributes['undefined']}"
       delete attributes['undefined']
     super(arguments...)

--- a/app/models/CocoModel.coffee
+++ b/app/models/CocoModel.coffee
@@ -11,6 +11,12 @@ class CocoModel extends Backbone.Model
   notyErrors: true
   @schema: null
 
+  constructor: (attributes, options)  ->
+    if 'undefined' of (attributes or {})
+      console.error "Unsetting `undefined` property key during construction of #{@constructor.className} model with value #{attributes['undefined']}"
+      delete attributes['undefined']
+    super(arguments...)
+
   initialize: (attributes, options) ->
     super(arguments...)
     options ?= {}
@@ -94,6 +100,12 @@ class CocoModel extends Backbone.Model
     delete @attributesWithDefaults unless attributes is 'thangs'  # unless attributes is 'thangs': performance optimization for Levels keeping their cache.
     inFlux = @loading or not @loaded
     @markToRevert() unless inFlux or @_revertAttributes or @project or options?.fromMerge
+    if _.isString(attributes) and (attributes is 'undefined' or attributes is undefined)
+      console.error "Blocking setting of #{attributes} property to #{@constructor.className} model with value #{options}"
+      return
+    else if _.isObject(attributes) and ('undefined' of attributes)
+      console.error "Blocking setting of `undefined` property key to #{@constructor.className} model with value #{attributes['undefined']}"
+      delete attributes['undefined']
     res = super attributes, options
     @saveBackup() if @saveBackups and (not inFlux)
     res

--- a/test/app/views/teachers/ConvertToTeacherAccountView.spec.coffee
+++ b/test/app/views/teachers/ConvertToTeacherAccountView.spec.coffee
@@ -97,6 +97,7 @@ describe 'ConvertToTeacherAccountView (/teachers/update-account)', ->
   describe 'when the user has role "student"', ->
     beforeEach ->
       me.set('role', 'student')
+      # TODO: is this next line right? Seems to try to construct a TrialRequest with `[]` as its attributes (and below as well)
       _.last(view.trialRequests.fakeRequests).respondWith({ status: 200, responseText: JSON.stringify('[]') })
       view.render()
 


### PR DESCRIPTION
I noticed my user object keeps getting `undefined: 2` or similar values set to it. Not sure where, but when it happens, validation starts failing and the object can't save.

This makes it generally log and ignore `"undefined"` as a property key in CocoModel initialization and `set` calls.