### PR TITLE
Add option to let teachers turn on level chat for their students

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1642,6 +1642,12 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     classroom_items_description: "Whether students should earn gems and equip items during gameplay."
     classroom_live_completion: "Whether to enable coding autocomplete in this classroom. Disabled: turns autocomplete off for all levels. Enabled: allows students to choose. We recommend leaving this enabled."
     not_allow_to_solution: '# Licenses needed to view solutions'
+    classroom_level_chat: 'Level Chat with AI'
+    classroom_level_chat_blurb: 'Control whether students can interact with the AI in level chat.'
+    classroom_level_chat_option_free_form: 'Free form'
+    classroom_level_chat_option_fixed_prompt_only: 'Fixed prompt only'
+    classroom_level_chat_option_none: 'No chat'
+
 
   no_licenses_page:
     are_your_students_ready: "Are your students excited and ready to learn more?"

--- a/app/schemas/models/classroom.schema.coffee
+++ b/app/schemas/models/classroom.schema.coffee
@@ -21,7 +21,7 @@ _.extend ClassroomSchema.properties,
   aceConfig:
     language: {type: 'string', 'enum': ['python', 'javascript', 'cpp', 'java']}
     liveCompletion: {type: 'boolean', default: true}
-    levelChat: {type: 'string', enum: ['free_form', 'fixed_prompt_only', 'none']}
+    levelChat: {type: 'string', enum: ['fixed_prompt_only', 'none']}
   averageStudentExp: { type: 'string' }
   ageRangeMin: { type: 'string' }
   ageRangeMax: { type: 'string' }

--- a/app/schemas/models/classroom.schema.coffee
+++ b/app/schemas/models/classroom.schema.coffee
@@ -21,6 +21,7 @@ _.extend ClassroomSchema.properties,
   aceConfig:
     language: {type: 'string', 'enum': ['python', 'javascript', 'cpp', 'java']}
     liveCompletion: {type: 'boolean', default: true}
+    levelChat: {type: 'string', enum: ['free_form', 'fixed_prompt_only', 'none']}
   averageStudentExp: { type: 'string' }
   ageRangeMin: { type: 'string' }
   ageRangeMax: { type: 'string' }

--- a/app/styles/courses/classroom-settings-modal.sass
+++ b/app/styles/courses/classroom-settings-modal.sass
@@ -29,7 +29,7 @@
     display: inline-block
     vertical-align: bottom
 
-  #live-completion, #classroom-items
+  #live-completion, #classroom-items, #level-chat
     margin-left: 15px
     width: 18px
     height: 18px

--- a/app/templates/courses/classroom-settings-modal.pug
+++ b/app/templates/courses/classroom-settings-modal.pug
@@ -91,13 +91,10 @@ block modal-body-content
         .form-group
           label
             span(data-i18n="teachers.classroom_level_chat")
-          - var aceConfig = _.assign({levelChat: 'none'},  view.classroom.get('aceConfig'))
-          - var levelChat = aceConfig.levelChat
-          - var options = view.classroom.schema().properties.aceConfig.levelChat.enum
-          div
-            select.form-control#level-chat(name="levelChat", value=levelChat)
-              each option in options
-                option(value=option, data-i18n=`teachers.classroom_level_chat_option_${option}`)     
+            - var aceConfig = _.assign({levelChat: 'none'},  view.classroom.get('aceConfig'))
+            - var levelChat = aceConfig.levelChat
+            - var levelChatAllowed = levelChat === 'fixed_prompt_only'
+            input#level-chat(name="levelChat" checked=levelChatAllowed value='fixed_prompt_only' type='checkbox')
           .help-block.small.text-navy(data-i18n="teachers.classroom_level_chat_blurb")
 
       .col-lg-6.col-md-12

--- a/app/templates/courses/classroom-settings-modal.pug
+++ b/app/templates/courses/classroom-settings-modal.pug
@@ -87,6 +87,19 @@ block modal-body-content
             input#live-completion(name="liveCompletion" checked=liveCompletion type='checkbox')
           .help-block.small.text-navy(data-i18n="teachers.classroom_live_completion")
 
+
+        .form-group
+          label
+            span(data-i18n="teachers.classroom_level_chat")
+          - var aceConfig = _.assign({levelChat: 'none'},  view.classroom.get('aceConfig'))
+          - var levelChat = aceConfig.levelChat
+          - var options = view.classroom.schema().properties.aceConfig.levelChat.enum
+          div
+            select.form-control#level-chat(name="levelChat", value=levelChat)
+              each option in options
+                option(value=option, data-i18n=`teachers.classroom_level_chat_option_${option}`)     
+          .help-block.small.text-navy(data-i18n="teachers.classroom_level_chat_blurb")
+
       .col-lg-6.col-md-12
         .form-group
           label

--- a/app/views/courses/ClassroomSettingsModal.coffee
+++ b/app/views/courses/ClassroomSettingsModal.coffee
@@ -97,7 +97,6 @@ module.exports = class ClassroomSettingsModal extends ModalView
       return
 
     @classroom.set(attrs)
-    debugger
     schemaErrors = @classroom.getValidationErrors()
     if schemaErrors
       for error in schemaErrors

--- a/app/views/courses/ClassroomSettingsModal.coffee
+++ b/app/views/courses/ClassroomSettingsModal.coffee
@@ -78,6 +78,10 @@ module.exports = class ClassroomSettingsModal extends ModalView
       attrs.aceConfig.liveCompletion = attrs.liveCompletion[0] == 'on'
       delete attrs.liveCompletion
 
+    if attrs.levelChat
+      attrs.aceConfig.levelChat = attrs.levelChat
+      delete attrs.levelChat
+
     if !@isGoogleClassroom and !@showLMSDropDown
       delete attrs.googleClassroomId
       delete attrs.lmsClassroomId
@@ -93,6 +97,7 @@ module.exports = class ClassroomSettingsModal extends ModalView
       return
 
     @classroom.set(attrs)
+    debugger
     schemaErrors = @classroom.getValidationErrors()
     if schemaErrors
       for error in schemaErrors

--- a/app/views/play/level/LevelChatView.coffee
+++ b/app/views/play/level/LevelChatView.coffee
@@ -33,13 +33,14 @@ module.exports = class LevelChatView extends CocoView
     @session = options.session
     @sessionID = options.sessionID
     @bus = LevelBus.get(@levelID, @sessionID)
+    @aceConfig = options.aceConfig
     super options
     @onWindowResize = _.debounce @onWindowResize, 50
     $(window).on 'resize', @onWindowResize
 
     ## TODO: we took out session.multiplayer, so this will not fire. If we want to resurrect it, we'll of course need a new way of activating chat.
     #@listenTo(@session, 'change:multiplayer', @updateMultiplayerVisibility)
-    @visible = me.getLevelChatExperimentValue() is 'beta'  # not 'control'
+    @visible = @aceConfig.levelChat isnt 'none' or me.getLevelChatExperimentValue() is 'beta'  # not 'control'
 
     @regularlyClearOldMessages()
     @playNoise = _.debounce(@playNoise, 100)

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -201,6 +201,7 @@ module.exports = class PlayLevelView extends RootView
       @supermodel.trackRequest fetchAceConfig
       fetchAceConfig.then (classroom) =>
         @classroomAceConfig.liveCompletion = classroom.aceConfig?.liveCompletion ? true
+        @classroomAceConfig.levelChat = classroom.aceConfig?.levelChat ? 'none'
         @teacherID = classroom.ownerID
 
         if @teaching and (not @teacherID.equals(me.id))
@@ -455,7 +456,7 @@ module.exports = class PlayLevelView extends RootView
     @insertSubView new GameDevTrackView {} if @level.isType('game-dev')
     @insertSubView new HUDView {level: @level} unless @level.isType('web-dev')
     @insertSubView new LevelDialogueView {level: @level, sessionID: @session.id}
-    @insertSubView new ChatView levelID: @levelID, sessionID: @session.id, session: @session
+    @insertSubView new ChatView levelID: @levelID, sessionID: @session.id, session: @session, aceConfig: @classroomAceConfig
     @insertSubView new ProblemAlertView session: @session, level: @level, supermodel: @supermodel
     @insertSubView new SurfaceContextMenuView session: @session, level: @level
     @insertSubView new DuelStatsView level: @level, session: @session, otherSession: @otherSession, supermodel: @supermodel, thangs: @world.thangs, showsGold: goldInDuelStatsView if @level.isLadder()


### PR DESCRIPTION
We have 3 options:
- Free form
- Fixed prompt only
- None

Live Chat is shown for students for both **Free from** and **Fixed prompt only** options. 
<img width="1317" alt="My_Classes___CodeCombat" src="https://github.com/codecombat/codecombat/assets/11805970/f55e7eaf-7eb1-4dcf-95f7-f37abaf50abe">
