### PR TITLE
Release level chat for errors generally for home users

### DIFF
--- a/app/locale/en.coffee
+++ b/app/locale/en.coffee
@@ -1648,8 +1648,8 @@ module.exports = nativeDescription: "English", englishDescription: "English", tr
     classroom_blocks_opt_in: "Off by default"
     classroom_blocks_opt_out: "On by default"
     not_allow_to_solution: '# Licenses needed to view solutions'
-    classroom_level_chat: 'Level Chat with AI'
-    classroom_level_chat_blurb: 'Control whether students can interact with the AI in level chat.'
+    classroom_level_chat: 'AI Hints'
+    classroom_level_chat_blurb: 'Whether students can request AI hints during levels.'
     classroom_level_chat_option_free_form: 'Free form'
     classroom_level_chat_option_fixed_prompt_only: 'Fixed prompt only'
     classroom_level_chat_option_none: 'No chat'

--- a/app/models/User.coffee
+++ b/app/models/User.coffee
@@ -792,36 +792,18 @@ module.exports = class User extends CocoModel
 
   getLevelChatExperimentValue: ->
     value = {true: 'beta', false: 'control', control: 'control', beta: 'beta'}[utils.getQueryVariable 'ai']
-    value ?= me.getExperimentValue('level-chat', null, 'beta')
     if not value? and utils.isOzaria
       # Don't include Ozaria for now
       value = 'control'
     if not value? and features?.china
       # Don't include China players for now
       value = 'control'
-    if userUtils.isInLibraryNetwork()
-      value = 'control'
-    if not value? and new Date(me.get('dateCreated')) < new Date('2023-07-20')
-      # Don't include users created before experiment start date
-      value = 'control'
-    if not value? and not /^en/.test me.get('preferredLanguage', true)
-      # Don't include non-English-speaking users before we fine-tune for other languages
-      value = 'control'
-    if not value? and me.get('hourOfCode')
-      # Don't include users coming in through Hour of Code
-      value = 'control'
     if not value? and me.get('role') is 'student'
       # Don't include student users (do include teachers, parents, home users, and anonymous)
       value = 'control'
     if not value?
-      probability = window.serverConfig?.experimentProbabilities?['level-chat']?.beta ? 0.02
-      if Math.random() < probability
-        value = 'beta'
-        valueProbability = probability
-      else
-        value = 'control'
-        valueProbability = 1 - probability
-      me.startExperiment('level-chat', value, valueProbability)
+      # No experiment any more, just on for everyone else
+      value = 'beta'
     value
 
   getHackStackExperimentValue: ->

--- a/app/styles/play/level/chat.sass
+++ b/app/styles/play/level/chat.sass
@@ -14,7 +14,7 @@
 
   position: absolute
   left: 30px
-  bottom: 30px
+  bottom: 5px
   height: 0
   font-size: 16px
   color: white

--- a/app/templates/play/level/chat.pug
+++ b/app/templates/play/level/chat.pug
@@ -5,6 +5,6 @@
 .open-chat-area.chat-area.secret
   .table
 
-textarea(data-i18n="[placeholder]play_level.chat_placeholder")
-i.icon-comment.icon-white
+//textarea(data-i18n="[placeholder]play_level.chat_placeholder")
+//i.icon-comment.icon-white
 

--- a/app/templates/play/level/tome/problem_alert.pug
+++ b/app/templates/play/level/tome/problem_alert.pug
@@ -12,7 +12,7 @@ table
         span.problem-subtitle!= view.message
       else
         span.problem-title!= view.message
-if me.getLevelChatExperimentValue() == 'beta'
+if me.getLevelChatExperimentValue() == 'beta' && view.aceConfig.levelChat != 'none'
   .chatbot-help
     img.avatar(src='/images/level/baby-griffin.png' alt='AI')
     span.spr(data-i18n="play_level.problem_alert_need_help")

--- a/app/views/play/level/LevelChatView.coffee
+++ b/app/views/play/level/LevelChatView.coffee
@@ -41,7 +41,8 @@ module.exports = class LevelChatView extends CocoView
 
     ## TODO: we took out session.multiplayer, so this will not fire. If we want to resurrect it, we'll of course need a new way of activating chat.
     #@listenTo(@session, 'change:multiplayer', @updateMultiplayerVisibility)
-    @visible = @aceConfig.levelChat isnt 'none' or me.getLevelChatExperimentValue() is 'beta'  # not 'control'
+    #@visible = @aceConfig.levelChat isnt 'none'
+    @visible = false  # Only show once AI starts chatting; don't let players do free-form chat
 
     @regularlyClearOldMessages()
     @playNoise = _.debounce(@playNoise, 100)
@@ -306,7 +307,7 @@ module.exports = class LevelChatView extends CocoView
     @fetchChatMessageStream chatMessage.id
 
   fetchChatMessageStream: (chatMessageId) ->
-    model = utils.getQueryVariable('model') or 'gpt-4' # or 'gpt-4'
+    model = utils.getQueryVariable('model') or 'gpt-4-1106-preview' # or 'gpt-4'
     fetch("/db/chat_message/#{chatMessageId}/ai-response?model=#{model}").then co.wrap (response) =>
       reader = response.body.getReader()
       decoder = new TextDecoder('utf-8')

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -463,7 +463,7 @@ module.exports = class PlayLevelView extends RootView
     @insertSubView new HUDView {level: @level} unless @level.isType('web-dev')
     @insertSubView new LevelDialogueView {level: @level, sessionID: @session.id}
     @insertSubView new ChatView levelID: @levelID, sessionID: @session.id, session: @session, aceConfig: @classroomAceConfig
-    @insertSubView new ProblemAlertView session: @session, level: @level, supermodel: @supermodel
+    @insertSubView new ProblemAlertView session: @session, level: @level, supermodel: @supermodel, aceConfig: @classroomAceConfig
     @insertSubView new SurfaceContextMenuView session: @session, level: @level
     @insertSubView new DuelStatsView level: @level, session: @session, otherSession: @otherSession, supermodel: @supermodel, thangs: @world.thangs, showsGold: goldInDuelStatsView if @level.isLadder()
     @insertSubView @controlBar = new ControlBarView {worldName: utils.i18n(@level.attributes, 'name'), session: @session, level: @level, supermodel: @supermodel, courseID: @courseID, courseInstanceID: @courseInstanceID, @classroomAceConfig}

--- a/app/views/play/level/tome/ProblemAlertView.coffee
+++ b/app/views/play/level/tome/ProblemAlertView.coffee
@@ -51,6 +51,7 @@ module.exports = class ProblemAlertView extends CocoView
       @onWindowResize()
     else
       @$el.hide()
+    @aceConfig = options.aceConfig
     @duckImg = _.sample(@duckImages)
     $(window).on 'resize', @onWindowResize
 


### PR DESCRIPTION
Quick and dirty hack to not allow free-form chat (should really clean up the unneeded code)

Tweaked classroom settings language to be about hints rather than chat.

Using gpt-4-1106-preview by default now.

Still needing to be done on this:
- Show appropriate messages when quota is up (not subscription modal for non-home-users)
- Show remaining credits in UI
- Translate error questions into user's locale
- Add a free-form hint button that's not connected to errors
- Don't include previous message conversation history any more now that it's not a conversation

When we have that stuff, we can just turn it on for student users, too (since teachers already have the setting in class settings, and it defaults to 'off').

Closes AI-165 when it's done