### PR TITLE
fix ladderTabView by checking if session exists

### DIFF
--- a/app/views/ladder/LadderTabView.js
+++ b/app/views/ladder/LadderTabView.js
@@ -585,20 +585,22 @@ module.exports.LeaderboardData = (LeaderboardData = (LeaderboardData = class Lea
     }
     if (!score) { return [] }
     let l = []
-    const above = this.playersAbove.models
-    l = l.concat(above)
+    const above = this.playersAbove?.models
+    l = l.concat(above || [])
     l.reverse()
     if ((this.session != null ? this.session.get('creatorAge') : undefined) && !(this.session != null ? this.session.ageBracket : undefined)) {
       // add ageBracket for @session
       this.session.ageBracket = utils.ageToBracket(this.session.get('creatorAge'))
     }
-    l.push(this.session)
-    if (this.myWins) {
+    if (this.session) {
+      l.push(this.session)
+    }
+    if (this.myWins && this.session) {
       this.session.myWins = this.myWins
       this.session.myLosses = this.myLosses
       this.session.myTotalScore = this.myTotalScore
     }
-    l = l.concat(this.playersBelow.models)
+    l = l.concat(this.playersBelow?.models || [])
     if (this.myRank === 'unknown') {
       for (session of Array.from(l)) { if (session.rank == null) { session.rank = '' } }
     } else if (this.myRank) {


### PR DESCRIPTION
Error below occurred [here](https://codecombat.com/play/ladder/frozen-fortress?tournament=64260960f1c07d0018299145)
`4909-df9f8ce9c739f16b8377.bundle.js:1 Uncaught TypeError: Cannot read properties of undefined (reading 'models')
    at a.value (4909-df9f8ce9c739f16b8377.bundle.js:1:19674)`
    
## The cause
 - the http://localhost:3000/db/level/frozen-fortress/my_sessions?_=1702586407548 request returns `[]`
 - which is because there are no matching LevelSession records:
<img width="496" alt="Robo_3T_-_1_4" src="https://github.com/codecombat/codecombat/assets/11805970/91adf669-e515-4e45-af71-177e52aec5cf">

 - but the code tries to work with them 
 - which leads to error
 
## The fix: 
Check if `session` exists, to prevent error. 

## Before / After
<img width="1962" alt="Cursor_and_Frozen_Fortress___Multiplayer_Arenas___CodeCombat_and_Frozen_Fortress___Multiplayer_Arenas___CodeCombat" src="https://github.com/codecombat/codecombat/assets/11805970/7954ec48-664b-4f52-973f-4f0ee5d24e7e">

