### PR TITLE
ENG-153 - fix Lock / Unlock Issues

### DIFF
--- a/ozaria/site/common/ozariaUtils.js
+++ b/ozaria/site/common/ozariaUtils.js
@@ -33,6 +33,10 @@ export const findNextLevelsBySession = (sessions, levels, levelStatusMap, classr
     levelDataMap = levels || {}
   }
   for (const [levelOriginal, level] of Object.entries(levelDataMap)) {
+    if (classroom && classroom.isStudentOnSkippedLevel(me.get('_id'), courseId, levelOriginal)) {
+      continue
+    }
+
     const levelStatus = levelStatusMap[levelOriginal]
     const isLevelStarted = typeof levelStatus === 'string' && levelStatus === 'started'
     const isLevelCompleted = typeof levelStatus === 'string' && levelStatus === 'complete'


### PR DESCRIPTION
It seems the `findNextLevelsBySession` logic ignored if level was skipped or not, and returned a `skipped` one as `next`.

![Students_and_Ozaria_-_Computer_science_that_captivates_and_ENG-153_Lock_unlock_issues](https://github.com/codecombat/codecombat/assets/11805970/5ba94661-ed3e-4262-b978-3b8b644072e6)
