### PR TITLE
skip age poll for library users

### DIFF
--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -1745,6 +1745,9 @@ ${problem.category} - ${problem.score} points\
 
     showPoll () {
       if (!this.shouldShow('poll')) { return false }
+      if (this.poll.get('slug') === 'how-old-are-you' && userUtils.isCreatedViaLibrary()) {
+        return false // since the answers of how-old-are-you poll do no have nextPoll, so just return is fine
+      }
       const pollModal = new PollModal({ supermodel: this.supermodel, poll: this.poll, userPollsRecord: this.userPollsRecord })
       this.openModalView(pollModal)
       const $pollButton = this.$el.find('button.poll')


### PR DESCRIPTION
fix ENG-201

the how-old-are-you poll do not have nextPoll. so just not show current modal is good to go
![image](https://github.com/codecombat/codecombat/assets/11417632/701ad868-bb6b-413e-9675-35cc5b005959)
