### PR TITLE
make ace scrollable again

### DIFF
--- a/ozaria/site/views/play/level/tome/SpellView.coffee
+++ b/ozaria/site/views/play/level/tome/SpellView.coffee
@@ -812,6 +812,11 @@ module.exports = class SpellView extends CocoView
       # Force the popup back
       @ace?.completer?.showPopup(@ace)
 
+    screenLineCount = @aceSession.getScreenLength() - 1
+    if screenLineCount isnt @lastScreenLineCount
+      @lastScreenLineCount = screenLineCount
+      @updateAceLines(screenLineCount)
+
     # Ensure current user code line visible and not truncated at bottom of editor
     if cursorPosition.row >= lineCount - 2
       @ace.scrollToLine lineCount, true, true


### PR DESCRIPTION
fix ENG-275
since ace-diff set options as `maxLines: infinity` (and update ace-diff maybe lead to coco issues)
so add updateAceLines into ozaria updateLines too (coco does that)

can scroll again
![image](https://github.com/codecombat/codecombat/assets/11417632/0df23ef6-5380-4777-9976-42d6015358b4)
