### PR TITLE
handle different types of data.description

### DIFF
--- a/app/views/editor/level/components/LevelComponentEditView.js
+++ b/app/views/editor/level/components/LevelComponentEditView.js
@@ -216,7 +216,10 @@ class PropertyDocumentationNode extends TreemaObjectNode {
     if (data.owner && data.owner !== 'this' && data.owner !== 'snippets') { s += `${data.owner}.` }
     s += data.name
     if (data.type) { s += `: ${data.type}` }
-    if (data.description) { s += ` - ${data.description.slice(0, 100)}${data.description.length > 100 ? '...' : ''}` }
+    if (data.description) {
+      const description = JSON.stringify(data.description)
+      s += ` - ${description.slice(0, 100)}${description.length > 100 ? '...' : ''}`
+    }
     const result = this.buildValueForDisplaySimply(valEl, s)
     // Doesn't work, would need a bit more effort to figure out how to enrich this with useful shorthands
     // if (data.i18n) {


### PR DESCRIPTION
fix ENG-295
![image](https://github.com/codecombat/codecombat/assets/11417632/cb60e289-09eb-4722-b587-40a91da0c325)
since data.description can be object. we need stringify it
![image](https://github.com/codecombat/codecombat/assets/11417632/f02ab981-0e5c-46e1-a1c8-1d696ecda03a)