### PR TITLE
ENG-281 - Adamk/fix hash modal new home

### DIFF
--- a/app/views/core/CreateAccountModal/CreateAccountModal.js
+++ b/app/views/core/CreateAccountModal/CreateAccountModal.js
@@ -332,9 +332,8 @@ module.exports = (CreateAccountModal = (function () {
 
     onClickDismiss () {
       if (window.location.hash) {
-        // Force back to root (in case url changed) or reload to avoid issues with sign up state and CTA's for signing up on the home page:
-        application.router.navigate('/', { trigger: true })
-        return window.location.reload()
+        // Avoid issues with sign up state and CTA's for signing up on the home page:
+        history.pushState('', document.title, window.location.pathname + window.location.search)
       }
     }
 

--- a/app/views/core/RootView.coffee
+++ b/app/views/core/RootView.coffee
@@ -109,7 +109,6 @@ module.exports = class RootView extends CocoView
       .catch((err) -> errors.showNotyNetworkError(err))
 
   onClickSignupButton: (e) ->
-    CreateAccountModal = require 'views/core/CreateAccountModal'
     switch @id
       when 'home-view'
         properties = {
@@ -130,19 +129,27 @@ module.exports = class RootView extends CocoView
 
     if userUtils.isInLibraryNetwork()
       options.startOnPath = 'individual'
+    
+    @openCreateAccountModal(options)
+
+  openCreateAccountModal: (options) ->
+    CreateAccountModal = require 'views/core/CreateAccountModal'
     @openModalView new CreateAccountModal(options)
 
   onClickLoginButton: (e) ->
     loginMessage = e.target.dataset.loginMessage
     nextUrl = e.target.dataset.nextUrl
-    AuthModal = require 'views/core/AuthModal'
     if @id is 'home-view'
       properties = { category: if utils.isCodeCombat then 'Homepage' else 'Home' }
       window.tracker?.trackEvent 'Login', properties
 
       eventAction = $(e.target)?.data('event-action')
       window.tracker?.trackEvent(eventAction, properties) if eventAction
-    @openModalView new AuthModal({loginMessage, nextUrl})
+    @openAuthModal({ loginMessage, nextUrl })
+
+  openAuthModal: (options) ->
+    AuthModal = require 'views/core/AuthModal'
+    @openModalView new AuthModal(options)  
 
   onTrackClickEvent: (e) ->
     eventAction = $(e.target)?.closest('a')?.data('event-action')

--- a/app/views/core/SingletonAppVueComponentView.js
+++ b/app/views/core/SingletonAppVueComponentView.js
@@ -5,6 +5,14 @@ import cocoVueRouter from 'app/core/vueRouter'
 
 import Root from '../../components/Root'
 
+const utils = require('core/utils')
+const CreateAccountModal = require('views/core/CreateAccountModal/CreateAccountModal')
+const MineModal = require('views/core/MineModal') // Roblox modal
+const storage = require('core/storage')
+
+
+
+
 export default class SingletonAppVueComponentView extends VueComponentView {
 
   constructor () {
@@ -14,6 +22,77 @@ export default class SingletonAppVueComponentView extends VueComponentView {
     // Head tag management will be performed inside of Vue app
     this.skipMetaBinding = true
   }
+
+
+  afterRender () {
+    if (me.isAnonymous()) {
+      if ((document.location.hash === '#create-account') || (utils.getQueryVariable('registering') === true)) {
+        _.defer(() => { if (!this.destroyed) { return this.openModalView(new CreateAccountModal()) } })
+      }
+      if (document.location.hash === '#create-account-individual') {
+        _.defer(() => { if (!this.destroyed) { return this.openModalView(new CreateAccountModal({ startOnPath: 'individual' })) } })
+      }
+      if (document.location.hash === '#create-account-home') {
+        _.defer(() => { if (!this.destroyed) { return this.openModalView(new CreateAccountModal({ startOnPath: 'individual-basic' })) } })
+      }
+      if (document.location.hash === '#create-account-student') {
+        _.defer(() => { if (!this.destroyed) { return this.openModalView(new CreateAccountModal({ startOnPath: 'student' })) } })
+      }
+      if (document.location.hash === '#create-account-teacher') {
+        _.defer(() => { if (!this.destroyed) { return this.openModalView(new CreateAccountModal({ startOnPath: 'teacher' })) } })
+      }
+      if (utils.getQueryVariable('create-account') === 'teacher') {
+        _.defer(() => { if (!this.destroyed) { return this.openModalView(new CreateAccountModal({ startOnPath: 'teacher' })) } })
+      }
+      if (document.location.hash === '#login') {
+        const AuthModal = require('app/views/core/AuthModal')
+        const url = new URLSearchParams(window.location.search)
+        _.defer(() => { if (!this.destroyed) { return this.openModalView(new AuthModal({ initialValues: { email: url.get('email') } })) } })
+      }
+    }
+
+    _.defer(() => { if (!storage.load('roblox-clicked') && !this.destroyed) { return this.openModalView(new MineModal()) } })
+
+    if (utils.isCodeCombat) {
+      let needle, needle1, paymentResult, title, type
+      if ((needle = utils.getQueryVariable('payment-studentLicenses'), ['success', 'failed'].includes(needle)) && !this.renderedPaymentNoty) {
+        paymentResult = utils.getQueryVariable('payment-studentLicenses')
+        if (paymentResult === 'success') {
+          title = $.i18n.t('payments.studentLicense_successful')
+          type = 'success'
+          if (utils.getQueryVariable('tecmilenio')) {
+            title = '¡Felicidades! El alumno recibirá más información de su profesor para acceder a la licencia de CodeCombat.'
+          }
+          this.trackPurchase(`Student license purchase ${type}`)
+        } else {
+          title = $.i18n.t('payments.failed')
+          type = 'error'
+        }
+        noty({ text: title, type, timeout: 10000, killer: true })
+        this.renderedPaymentNoty = true
+      } else if ((needle1 = utils.getQueryVariable('payment-homeSubscriptions'), ['success', 'failed'].includes(needle1)) && !this.renderedPaymentNoty) {
+        paymentResult = utils.getQueryVariable('payment-homeSubscriptions')
+        if (paymentResult === 'success') {
+          title = $.i18n.t('payments.homeSubscriptions_successful')
+          type = 'success'
+          this.trackPurchase(`Home subscription purchase ${type}`)
+        } else {
+          title = $.i18n.t('payments.failed')
+          type = 'error'
+        }
+        noty({ text: title, type, timeout: 10000, killer: true })
+        this.renderedPaymentNoty = true
+      }
+    } else {
+      window.addEventListener('load', () => __guard__($('#core-curriculum-carousel').data('bs.carousel'), x => x.$element.on('slid.bs.carousel', function (event) {
+        const nextActiveSlide = $(event.relatedTarget).index()
+        const $buttons = $('.control-buttons > button')
+        $buttons.removeClass('active')
+        return $('[data-slide-to=\'' + nextActiveSlide + '\']').addClass('active')
+      })))
+    }
+    return super.afterRender()
+  }  
 
   buildVueComponent () {
     this.router = cocoVueRouter()


### PR DESCRIPTION
`#create-account` hashes are now working in new home page. Also the Payment response handling (`?payment-studentLicenses=success`) is ported into new home.

- No reference to CreateAccountModal in SingletonAppVue
- Payment response handling is now in PageHome