### PR TITLE
fix undefined bug in trasnlate-utils

### DIFF
--- a/app/lib/translate-utils.coffee
+++ b/app/lib/translate-utils.coffee
@@ -62,6 +62,7 @@ translateJSBrackets = (jsCode, language='cpp', fullCode=true) ->
         cc -= 1
         return i+2 unless cc
   splitFunctions = (str) ->
+    return [] unless str
     creg = /\n?[ \t]*[^\/]/
     startCommentReg = /^\n?(\/\/.*?\n)*\n/
     comments = startCommentReg.exec(str)


### PR DESCRIPTION
not sure why but one student met bug when `str` is undefined. so add an check