### PR TITLE
ENG-422 - handle /home and / routes by vueRouter only new homepage is on

### DIFF
--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -322,16 +322,20 @@ export default function getVueRouter () {
           name: 'StandardsPage',
           component: () => import(/* webpackChunkName: "standardsPage" */'app/views/standards/PageStandards')
         },
-        {
-          path: '/home',
-          name: 'HomeBeta1',
-          component: () => import(/* webpackChunkName: "homeBeta" */'app/views/home/PageHome')
-        },
-        {
-          path: '/',
-          name: 'HomeBeta2',
-          component: () => import(/* webpackChunkName: "homeBeta" */'app/views/home/PageHome')
-        },
+        ...(
+          me.getHomePageExperimentValue() === 'beta'
+            ? [{
+                path: '/home',
+                name: 'HomeBeta1',
+                component: () => import(/* webpackChunkName: "homeBeta" */'app/views/home/PageHome')
+              },
+              {
+                path: '/',
+                name: 'HomeBeta2',
+                component: () => import(/* webpackChunkName: "homeBeta" */'app/views/home/PageHome')
+              }]
+            : []
+        ),
         {
           path: '/admin/low-usage-users',
           name: 'LowUsageUsersAdmin',


### PR DESCRIPTION
When navigating from `/home` or from `/` using the vue router, it loaded first the page we were navigating from, ignoring the fact that those routes were already handled by the backbone router, and would normally not be handled by the vue router.

Condition added to vue router to only know about these routes when home page experiment is on.