### PR TITLE
ENG-458 - Ozaria: course instances not created

### DIFF
--- a/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
@@ -183,7 +183,8 @@ export default Vue.extend({
     ...mapActions({
       updateClassroom: 'classrooms/updateClassroom',
       createClassroom: 'classrooms/createClassroom',
-      fetchClassroomSessions: 'levelSessions/fetchForClassroomMembers'
+      fetchClassroomSessions: 'levelSessions/fetchForClassroomMembers',
+      createFreeCourseInstances: 'courseInstances/createFreeCourseInstances'
     }),
     updateGrades (event) {
       const grade = event.target.name


### PR DESCRIPTION
Missing method added, because it is called here: 
 https://github.com/codecombat/codecombat/blob/master/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue#L296