### PR TITLE
ENG-157 - show error message if student tries to load a locked level

### DIFF
--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -3,6 +3,8 @@ LevelComponent = require 'models/LevelComponent'
 LevelSystem = require 'models/LevelSystem'
 Article = require 'models/Article'
 LevelSession = require 'models/LevelSession'
+CourseInstance = require 'models/CourseInstance'
+Classroom = require 'models/Classroom'
 {me} = require 'core/auth'
 ThangType = require 'models/ThangType'
 ThangNamesCollection = require 'collections/ThangNamesCollection'
@@ -84,6 +86,23 @@ module.exports = class LevelLoader extends CocoClass
       console.debug 'LevelLoader: loading level:', @level if LOG
       @level = @supermodel.loadModel(@level, 'level', { data: { cacheEdge: true } }).model
       @listenToOnce @level, 'sync', @onLevelLoaded
+    
+    if not @classroomId
+      @courseInstance = new CourseInstance({_id: @courseInstanceID})
+      @courseInstance.fetch().then () =>
+        @classroomId = @courseInstance.get('classroomID')
+        @classroomIdLoaded()
+    else 
+      @classroomIdLoaded()
+
+  classroomIdLoaded: ->
+    @classroom = new Classroom({_id: @classroomId})
+    @classroom.fetch().then () =>
+      @classroomLoaded()
+
+  classroomLoaded: ->
+    locked = @classroom.isStudentOnLockedLevel(me.get('_id'), @courseID, @level.get('original'))
+    Backbone.Mediator.publish 'level:locked', level: @level, session: @session
 
   reportLoadError: ->
     return if @destroyed

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -2241,6 +2241,7 @@ module.exports = {
       course_membership_required_to_play: "You'll need to join a course to play this level.",
       license_required_to_play_coco: 'Ask your teacher to assign a license to you so you can continue to play CodeCombat!',
       license_required_to_play_ozar: 'Ask your teacher to assign you a license so you can continue to play Ozaria!',
+      level_locked: 'This level is locked.',
       update_old_classroom: 'New school year, new levels!',
       update_old_classroom_detail: "To make sure you're getting the most up-to-date levels, make sure you create a new class for this semester by clicking Create a New Class on your",
       teacher_dashboard: 'teacher dashboard',

--- a/app/styles/play/level/level-loading-view.sass
+++ b/app/styles/play/level/level-loading-view.sass
@@ -290,7 +290,7 @@ $UNVEIL_TIME: 1.2s
           font-variant: small-caps
           text-transform: none
 
-    .subscription-required, .course-membership-required, .could-not-load, .license-required, .resource-not-found
+    .subscription-required, .course-membership-required, .could-not-load, .license-required, .level-locked, .resource-not-found
       display: none
       margin-top: 40px
       color: black

--- a/app/templates/play/level/level-loading-view.pug
+++ b/app/templates/play/level/level-loading-view.pug
@@ -55,6 +55,11 @@ if view.utils.isCodeCombat
     span(data-i18n=("courses.license_required_to_play_"+product))
     a.btn.btn-lg.btn-warning(data-i18n=("courses.back_courses_" + product), href="/students")
 
+  .level-locked
+    span(data-i18n=("courses.level_locked"))
+    a.btn.btn-lg.btn-warning(data-i18n=("courses.back_courses_" + product), href="/students")
+
+
   if view.utils.isCodeCombat
     #tip-wrapper.picoctf-hide
       strong.tip(data-i18n='play_level.tip_toggle_play') Toggle play/paused with Ctrl+P.

--- a/app/views/play/level/LevelLoadingView.coffee
+++ b/app/views/play/level/LevelLoadingView.coffee
@@ -24,6 +24,7 @@ module.exports = class LevelLoadingView extends CocoView
     'level:subscription-required': 'onSubscriptionRequired'  # If they'd need a subscription.
     'level:course-membership-required': 'onCourseMembershipRequired'  # If they need to be added to a course.
     'level:license-required': 'onLicenseRequired' # If they need a license.
+    'level:locked': 'onLevelLocked'
     'subscribe-modal:subscribed': 'onSubscribed'
 
   shortcuts:
@@ -302,6 +303,10 @@ module.exports = class LevelLoadingView extends CocoView
   onLicenseRequired: (e) ->
     @$el.find('.level-loading-goals, .tip, .progress-or-start-container').hide()
     @$el.find('.license-required').show()
+
+  onLevelLocked: (e) ->
+    @$el.find('.level-loading-goals, .tip, .progress-or-start-container').hide()
+    @$el.find('.level-locked').show()    
 
   onLoadError: (resource) ->
     startCase = (str) -> str.charAt(0).toUpperCase() + str.slice(1)


### PR DESCRIPTION
Previously if student inspected the level slug on the map, and replaced in the url, they could play any level regardless if it was locked or not. Now we show this message if student tries to open a locked level:

<img width="782" alt="CodeCombat___CodeCombat" src="https://github.com/codecombat/codecombat/assets/11805970/22edbfe7-ed48-444b-9e10-3c186c5a1da0">
