### PR TITLE
Fix whole course locking issue

### DIFF
--- a/app/models/ClassroomLib.js
+++ b/app/models/ClassroomLib.js
@@ -29,7 +29,6 @@ const ClassroomLib = {
 
     if (!classroom.studentLockMap[studentId]) {
       classroom.studentLockMap[studentId] = {
-        courseId,
         lockedLevels: {}
       }
     }


### PR DESCRIPTION
Without this fix, when locking levels for a student for the first time, the whole level will appear as locked.
By this fix, only the selected ones will be locked.