### PR TITLE
Google Classroom: create free courses for CoCo as well

### DIFF
--- a/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
@@ -293,9 +293,7 @@ export default Vue.extend({
         let savedClassroom
         if (this.classroomInstance.isNew()) {
           savedClassroom = await this.createClassroom({ ...this.classroom.attributes, ...updates })
-          if (this.isOzaria) {
-            await this.createFreeCourseInstances({ classroom: savedClassroom, courses: this.courses })
-          }
+          await this.createFreeCourseInstances({ classroom: savedClassroom, courses: this.courses })
 
           this.$emit('created')
         } else {


### PR DESCRIPTION
For some unknown reason, `createFreeCourseInstances` was only called in Ozaria.
By this fix course instances will be created for all free courses at classroom creation.