### PR TITLE
Convert levelChat value to String from Boolean in Classroom Modal

### DIFF
--- a/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
@@ -134,7 +134,7 @@ export default Vue.extend({
       return ((this.classroom || {}).aceConfig || {}).codeFormatDefault || 'text-code'
     },
     levelChat () {
-      return _.assign({ levelChat: false }, (this.classroom || {}).aceConfig).levelChat
+      return _.assign({ levelChat: 'none' }, (this.classroom || {}).aceConfig).levelChat
     },
     classroomDescription () {
       return (this.classroom || {}).description
@@ -169,7 +169,7 @@ export default Vue.extend({
     this.newClassroomItems = this.classroomItems
     this.newCodeFormats = this.codeFormats
     this.newCodeFormatDefault = this.codeFormatDefault
-    this.newLevelChat = this.levelChat
+    this.newLevelChat = this.levelChat === 'fixed_prompt_only'
     this.newClassroomDescription = this.classroomDescription
     this.newAverageStudentExp = this.averageStudentExp
     this.newClassroomType = this.classroomType
@@ -257,8 +257,8 @@ export default Vue.extend({
         updates.aceConfig = aceConfig
       }
 
-      if (this.newLevelChat !== this.levelChat) {
-        aceConfig.levelChat = this.newLevelChat
+      if (this.newLevelChat !== (this.levelChat === 'fixed_prompt_only')) {
+        aceConfig.levelChat = this.newLevelChat ? 'fixed_prompt_only' : 'none'
       }
       if (this.newClassroomDescription !== this.classroomDescription) {
         updates.description = this.newClassroomDescription


### PR DESCRIPTION
The `levelChat` value in ModalEditClass was a Boolean, but was a [String in the schema](https://github.com/codecombat/codecombat/blob/17fb38f49ed3bc28c545f2cd547bdf2408151704/app/schemas/models/classroom.schema.js#L30), which lead to Validation Error when saving the class. 

By this fix, the levelChat value is saved as a String.