### PR TITLE
Increase minimum number of API columns in various screen layouts

### DIFF
--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -756,6 +756,7 @@ module.exports = class PlayLevelView extends RootView
     minTomeHeight = switch
       when cinematic then Math.max(windowHeight * 0.15, 150)
       else Math.max(windowHeight * 0.25, 250)
+    hasManyAPIs = @tome?.spellPaletteView?.entries?.length > 16
     # Used to think min/max/desired code/workspace/toolbox width would be handled here, but actually currently SpellView is figuring that out and changing block zoom levels as needed.
     # Future work could be to also change font size and to move the relevant logic just to one place.
     minCodeChars = @tome?.spellView?.codeChars?.desired  # Also have min available. TODO: be smart here about min vs. desired based on how much space we have
@@ -774,6 +775,15 @@ module.exports = class PlayLevelView extends RootView
     acePaddingGutterAndMargin = 30 + 41 + 30  # 30px left and right padding, 41px gutter with 10-99 lines of code
     minCodeWidth = if codeLocation is 'none' then 0 else minCodeChars * minCodeCharWidth + acePaddingGutterAndMargin
     maxCodeWidth = if codeLocation is 'none' then 0 else maxCodeChars * maxCodeCharWidth + acePaddingGutterAndMargin
+    if minCodeWidth and hasManyAPIs and @codeFormat is 'text-code' and not @level?.isType('web-dev')
+      spellPaletteColumnWidth = 137
+      spellPaletteMargin = 54
+      minimumSpellPaletteColumns = 3
+      if @tome?.spellPaletteView?.entries?.length > 32 and windowWidth >= 1480 and windowAspectRatio >= 1.8
+        # We have a _lot_ of APIs and the window is very wide, so make sure to have even more spell palette columns
+        minimumSpellPaletteColumns = 4
+      minCodeWidth = Math.max minCodeWidth, spellPaletteColumnWidth * minimumSpellPaletteColumns + spellPaletteMargin
+      maxCodeWidth = Math.max maxCodeWidth, minCodeWidth
     minBlockChars = switch
       when @codeFormat is 'blocks-icons' and product is 'codecombat-junior' then 4
       when @codeFormat is 'blocks-icons' and cinematic then 6
@@ -817,6 +827,7 @@ module.exports = class PlayLevelView extends RootView
       when @level?.isType('web-dev') then 'left'
       when cinematic then 'none'
       when tomeLocation is 'bottom' then 'top'
+      when hasManyAPIs then 'left'  # Make more space for APIs
       when tomeWidthWhenControlBarRight > 160 and emptyHeightBelowCanvasWhenControlBarRight <= 0 then 'right'
       else 'left'
     controlBarHeight = if cinematic then 0 else 50

--- a/app/views/play/level/tome/SpellPaletteView.coffee
+++ b/app/views/play/level/tome/SpellPaletteView.coffee
@@ -94,7 +94,7 @@ module.exports = class SpellPaletteView extends CocoView
       when @shortenize then 175
       else 212
     nColumns = Math.floor availableWidth / columnWidth   # Aim to always have at least 2 columns
-    @hideImages = nColumns < 2 or @options.level.isType('game-dev', 'ladder')  # Don't show 38px images if really short on space or we don't need images
+    @hideImages = nColumns < 2 or @options.level.isType('game-dev', 'ladder') or @entries.length > 32  # Don't show 38px images if really short on space or we don't need images
     if @hideImages
       columnWidth -= 38
       nColumns = Math.floor availableWidth / columnWidth


### PR DESCRIPTION
- If we have many APIs, never stack the control bar above the editor
- If we have many APIs, always have at least 3 columns of APIs
- If we have a ton of APIs and a large screen, at least 4 columns
- If we have a ton of APIs, hide granting item images

Fix CCJ-192, ENG-540

Large screen at corner case of aspect ratios and code widths and API amounts that previously had 2 columns and stacked control bar now has more space for APIs:

https://github.com/codecombat/codecombat/assets/99704/0150623e-bf5b-4adf-aed8-8b7027810f9e

Medium-large screen that previously had 2 columns now has 4:

https://github.com/codecombat/codecombat/assets/99704/5b2ddb02-5ec0-4eca-9bb3-a6d978233550