### PR TITLE
ENG-564 - Curriculum guide doesn't escape level descriptions properly

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleRow.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleRow.vue
@@ -63,7 +63,9 @@ export default {
     }),
 
     clearDescription () {
-      return marked(this.description).replace(/<[^>]*>/g, '')
+      const description = marked(this.description).replace(/<[^>]*>/g, '')
+      const doc = new DOMParser().parseFromString(description, 'text/html')
+      return doc.documentElement.textContent
     },
 
     moduleRowClass () {


### PR DESCRIPTION
![CodeCombat_Teacher_Dashboard_🔊_and_CodeCombat_Teacher_Dashboard_and_PD_TOC_2024_04_pdf](https://github.com/codecombat/codecombat/assets/11805970/730d1617-d3ff-430e-bfc0-029963bc63d7)
