### PR TITLE
level chat fixes

### DIFF
--- a/app/templates/play/menu/my-code-view.pug
+++ b/app/templates/play/menu/my-code-view.pug
@@ -23,14 +23,15 @@
       .col.col.xs-8
         span.action-help Clean up and reformat current code
 
-  .row.action-row
-    .col.col-xs-4
-      .btn.btn-block.btn-illustrated.btn-primary.ai-hint(data-i18n="[title]play_level.problem_alert_ask_the_ai")
-        .glyphicon.glyphicon-question-sign
-        span= ' '
-        span(data-i18n="play_level.problem_alert_ask_the_ai")
-    .col.col.xs-8
-      span.action-help(data-i18n="play_level.problem_alert_need_hint")
+  if view.askAiBot
+    .row.action-row
+      .col.col-xs-4
+        .btn.btn-block.btn-illustrated.btn-primary.ai-hint(data-i18n="[title]play_level.problem_alert_ask_the_ai")
+          .glyphicon.glyphicon-question-sign
+          span= ' '
+          span(data-i18n="play_level.problem_alert_ask_the_ai")
+      .col.col.xs-8
+        span.action-help(data-i18n="play_level.problem_alert_need_hint")
 
   if view.options.courseID && me.isStudent() && view.teacherOnline()
     .row.action-row

--- a/app/views/play/menu/MyCodeView.js
+++ b/app/views/play/menu/MyCodeView.js
@@ -40,6 +40,7 @@ module.exports = (MyCodeView = (function () {
       super(options)
       this.wsBus = globalVar.application.wsBus
       this.teaching = utils.getQueryVariable('teaching')
+      this.askAiBot = options.classroomAceConfig?.levelChat !== 'none'
     }
 
     getRenderData (c) {

--- a/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
@@ -257,9 +257,13 @@ export default Vue.extend({
         updates.aceConfig = aceConfig
       }
 
-      if (this.newLevelChat !== (this.levelChat === 'fixed_prompt_only')) {
-        aceConfig.levelChat = this.newLevelChat ? 'fixed_prompt_only' : 'none'
+      if (this.newLevelChat) {
+        aceConfig.levelChat = 'fixed_prompt_only'
+      } else {
+        aceConfig.levelChat = 'none'
       }
+      updates.aceConfig = aceConfig
+
       if (this.newClassroomDescription !== this.classroomDescription) {
         updates.description = this.newClassroomDescription
       }
@@ -543,7 +547,6 @@ export default Vue.extend({
           </div>
         </div>
         <div
-          v-if="isCodeCombat"
           class="form-group row"
         >
           <div class="col-xs-12">
@@ -555,7 +558,6 @@ export default Vue.extend({
               v-model="newLevelChat"
               type="checkbox"
               name="levelChat"
-              value="fixed_prompt_only"
             >
             <span class="help-block small text-navy">{{ $t("teachers.classroom_level_chat_blurb") }}</span>
           </div>
@@ -825,7 +827,6 @@ export default Vue.extend({
             </tertiary-button>
             <secondary-button
               :disabled="saving"
-              :inactive="!isFormValid"
               @click="saveClass"
             >
               {{ classroomInstance.isNew() ? $t("courses.create_class") : $t("common.save_changes") }}

--- a/ozaria/site/views/play/level/tome/ProblemAlertView.coffee
+++ b/ozaria/site/views/play/level/tome/ProblemAlertView.coffee
@@ -47,8 +47,10 @@ module.exports = class ProblemAlertView extends CocoView
     if @aceConfig.levelChat != 'none'
       if me.isHomeUser() && me.getLevelChatExperimentValue() == 'beta'
         @showAiBotHelp = true
-      else if not me.isHomeUser()
+      else if me.isTeacher()
         @showAiBotHelp = true
+      else if me.isStudent()
+        @showAiBotHelp = @aceConfig.levelChat and @aceConfig.levelChat != 'none' and typeof @aceConfig.levelChat == 'string'
 
   destroy: ->
     $(window).off 'resize', @onWindowResize


### PR DESCRIPTION
fixes ENG-616

Ozaria didn't handle level-chat toggle correctly on edit class modal and student side
'Ask the AI' button in Game menu on Coco wasn't toggled based on class settings

We stored true/false in ozaria classroom levelChat config. It will be fixed via script for old entries