### PR TITLE
Make teacher toolkit accessible for non-teachers

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseResourceHub/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseResourceHub/index.vue
@@ -56,8 +56,11 @@ export default {
   async mounted () {
     this.setTeacherId(me.get('_id'))
     this.setPageTitle(PAGE_TITLES[this.$options.name])
-    await this.fetchTeacherPrepaids({ teacherId: me.get('_id') })
-    this.fetchData({ componentName: this.$options.name, options: { loadedEventName: 'Resource Hub: Loaded' } })
+
+    if (me.isTeacher()) {
+      await this.fetchTeacherPrepaids({ teacherId: me.get('_id') })
+      this.fetchData({ componentName: this.$options.name, options: { loadedEventName: 'Resource Hub: Loaded' } })
+    }
 
     getResourceHubResources().then(allResources => {
       if (!Array.isArray(allResources) || allResources.length === 0) {

--- a/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
@@ -95,6 +95,7 @@ export default {
     },
 
     showNonTeacherPreview () {
+      console.log('hi, testing')
       if (!me.isTeacher() && this.$route.path.startsWith(('/teachers/resources'))) {
         console.log('yes preview')
         return true
@@ -361,7 +362,7 @@ export default {
           <span class="right">&#x25B6;</span>
         </div>
       </div>
-      <div class="teacher-dashboard__body">
+      <div :class="['teacher-dashboard__body', { 'sidebar-hidden': showNonTeacherPreview }]">
         <title-bar
           :title="pageTitle"
           :show-class-info="showClassInfo"
@@ -762,6 +763,10 @@ export default {
       width: 250px;
       height: max-content;
     }
+  }
+
+  .sidebar-hidden {
+  width: calc(100% - 0px);
   }
 
   &__body {

--- a/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
@@ -54,6 +54,7 @@ export default {
       showRemoveStudentsModal: false,
       showOnboardingModal: false,
       showTeacherDetailsModal: false,
+      showPreviewMode: false,
       // // We may want to pull this out. For locality with dashboard this reduces abstraction.
       runningTour: null,
       createdFirstClass: false,
@@ -134,9 +135,11 @@ export default {
   },
   created () {
     if (!me.isTeacher()) { // TODO Restrict this from Router itself similar to how `RestrictedToTeachersView` works
+      this.showPreviewMode = true
       this.showRestrictedDiv = true
       this.showOnboardingModal = !me.get('seenNewDashboardModal')
     } else {
+      this.showPreviewMode = false
       this.showRestrictedDiv = false
       this.updateStoreOnNavigation()
       this.handleTrialRequest()
@@ -325,14 +328,7 @@ export default {
 </script>
 
 <template>
-  <div
-    v-if="showRestrictedDiv"
-    class="restricted-div"
-  >
-    <h5> {{ $t('teacher.access_restricted') }} </h5>
-    <p> {{ $t('teacher.teacher_account_required') }} </p>
-  </div>
-  <div v-else>
+  <div>
     <base-curriculum-guide :default-language="getLanguage" />
     <panel />
     <div class="teacher-dashboard">
@@ -356,6 +352,7 @@ export default {
           :courses="classroomCourses"
           :selected-course-id="selectedCourseId"
           :all-classes-page="isAllClassesPage"
+          :show-preview-mode="showPreviewMode"
           @change-course="onChangeCourse"
           @newClass="openNewClassModal"
           @addStudentsClicked="showAddStudentsModal = true"

--- a/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
@@ -386,7 +386,7 @@ export default {
       @close="closeOnboardingModal"
     />
     <modal-edit-class
-      v-if="showNewClassModal && !editCurrent"
+      v-if="showNewClassModal && !editCurrent && !showNonTeacherPreview"
       :classroom="newClassroom"
       @close="closeShowNewModal"
       @created="handleCreatedClass"

--- a/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
@@ -54,7 +54,6 @@ export default {
       showRemoveStudentsModal: false,
       showOnboardingModal: false,
       showTeacherDetailsModal: false,
-      showPreviewMode: false,
       // // We may want to pull this out. For locality with dashboard this reduces abstraction.
       runningTour: null,
       createdFirstClass: false,
@@ -92,6 +91,16 @@ export default {
         return this.classroom.name || ''
       } else {
         return this.getPageTitle
+      }
+    },
+
+    showNonTeacherPreview () {
+      if (!me.isTeacher() && this.$route.path.startsWith(('/teachers/resources'))) {
+        console.log('yes preview')
+        return true
+      } else {
+        console.log('no preview')
+        return false
       }
     },
 
@@ -135,11 +144,9 @@ export default {
   },
   created () {
     if (!me.isTeacher()) { // TODO Restrict this from Router itself similar to how `RestrictedToTeachersView` works
-      this.showPreviewMode = true
       this.showRestrictedDiv = true
       this.showOnboardingModal = !me.get('seenNewDashboardModal')
     } else {
-      this.showPreviewMode = false
       this.showRestrictedDiv = false
       this.updateStoreOnNavigation()
       this.handleTrialRequest()
@@ -328,11 +335,21 @@ export default {
 </script>
 
 <template>
-  <div>
+  <div
+    v-if="showRestrictedDiv && !showNonTeacherPreview"
+    class="restricted-div"
+  >
+    <h5> {{ $t('teacher.access_restricted') }} </h5>
+    <p> {{ $t('teacher.teacher_account_required') }} </p>
+  </div>
+  <div v-else>
     <base-curriculum-guide :default-language="getLanguage" />
     <panel />
     <div class="teacher-dashboard">
-      <div :class="['teacher-dashboard__sidebar', { 'collapsed': sidebarCollapsed }]">
+      <div
+        v-if="!showNonTeacherPreview"
+        :class="['teacher-dashboard__sidebar', { 'collapsed': sidebarCollapsed }]"
+      >
         <div class="content">
           <secondary-teacher-navigation :classrooms="allClassrooms" />
         </div>
@@ -352,7 +369,7 @@ export default {
           :courses="classroomCourses"
           :selected-course-id="selectedCourseId"
           :all-classes-page="isAllClassesPage"
-          :show-preview-mode="showPreviewMode"
+          :show-preview-mode="showNonTeacherPreview"
           @change-course="onChangeCourse"
           @newClass="openNewClassModal"
           @addStudentsClicked="showAddStudentsModal = true"

--- a/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
@@ -95,14 +95,7 @@ export default {
     },
 
     showNonTeacherPreview () {
-      console.log('hi, testing')
-      if (!me.isTeacher() && this.$route.path.startsWith(('/teachers/resources'))) {
-        console.log('yes preview')
-        return true
-      } else {
-        console.log('no preview')
-        return false
-      }
+      return !me.isTeacher() && this.$route.path.startsWith(('/teachers/resources'))
     },
 
     getLanguage () {

--- a/ozaria/site/components/teacher-dashboard/common/TitleBar.vue
+++ b/ozaria/site/components/teacher-dashboard/common/TitleBar.vue
@@ -29,6 +29,10 @@ export default {
       type: Boolean,
       default: false
     },
+    showPreviewMode: {
+      type: Boolean,
+      default: false
+    },
     classroom: {
       type: Object,
       default: () => {}
@@ -195,7 +199,10 @@ export default {
         </button>
       </div>
     </div>
-    <div class="sub-nav">
+    <div
+      v-if="!showPreviewMode"
+      class="sub-nav"
+    >
       <div
         v-if="sharePermission"
         class="small-text"


### PR DESCRIPTION
fixes ENG-598
The teacher toolkit is now previewable for non-teachers.
![image](https://github.com/codecombat/codecombat/assets/164280260/767bb1e5-c7e7-446f-99aa-e95705b03756)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a preview mode for non-teacher users in the teacher dashboard.
  - Introduced conditional rendering based on user roles to enhance user-specific views.

- **Improvements**
  - Enhanced sidebar visibility controls with new CSS classes for a better user experience.
  - Improved the TitleBar component with a new preview mode prop for more flexible display options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->