### PR TITLE
Let teachers change hero/language for CCJ from curriculum guide

### DIFF
--- a/app/lib/LevelSetupManager.coffee
+++ b/app/lib/LevelSetupManager.coffee
@@ -144,6 +144,8 @@ module.exports = class LevelSetupManager extends CocoClass
     route += "&codeLanguage=" + @level.get('primerLanguage') if @level.get('primerLanguage')
     if @options.courseID? and @options.courseInstanceID?
       route += "&course=#{@options.courseID}&course-instance=#{@options.courseInstanceID}"
+    else if @options.courseID?
+      route += "&course=#{@options.courseID}"
     @supermodel.registerModel(@session)
     Backbone.Mediator.publish 'router:navigate', {
       route, viewClass

--- a/app/views/play/modal/PlayHeroesModal.js
+++ b/app/views/play/modal/PlayHeroesModal.js
@@ -109,7 +109,8 @@ module.exports = (PlayHeroesModal = (function () {
       hero.unlockBySubscribing = ['samurai', 'ninja', 'librarian'].includes(hero.attributes.slug)
       hero.premium = !hero.free && !hero.unlockBySubscribing
       hero.locked = !me.ownsHero(original) && !(hero.unlockBySubscribing && me.isPremium())
-      if (me.isStudent() && me.showHeroAndInventoryModalsToStudents() && (hero.get('heroClass') === 'Warrior')) { hero.locked = false }
+      if ((me.isStudent() || me.isTeacher()) && me.showHeroAndInventoryModalsToStudents() && (hero.get('heroClass') === 'Warrior')) { hero.locked = false }
+      if ((me.isStudent() || me.isTeacher()) && this.options.level?.get('product') === 'codecombat-junior') { hero.locked = false }
       hero.purchasable = hero.locked && me.isPremium()
       if (this.options.level && (allowedHeroes = this.options.level.get('allowedHeroes'))) {
         let needle


### PR DESCRIPTION
Previously, they would be prompted to subscribe if it were a premium hero, and selecting anything would go back to teacher dashboard instead of reloading the level with new hero, code format, or code language.

This was one of the bugs:
![Screenshot by Dropbox Capture](https://github.com/codecombat/codecombat/assets/99704/53373e54-6b98-45d9-84b8-f61a5a8f7e7b)

(and if you did pick anything, it didn't include ?course= so redirected to teacher dashboard)

Now that works, and you can pick premium heroes in teacher or student mode in CCJ.

<img width="909" alt="Screenshot 2024-05-08 at 17 07 35" src="https://github.com/codecombat/codecombat/assets/99704/8bccfe2f-de56-4b8a-bb8d-f36b01eece19">
