### PR TITLE
Use a new set of pet heroes in CodeCombat Junior

### DIFF
--- a/app/core/api/thang-types.js
+++ b/app/core/api/thang-types.js
@@ -45,7 +45,7 @@ export const getThangTypeOriginal = original => {
 
 export const getHeroes = (options) => {
   const data = {
-    view: 'heroes'
+    view: options.product === 'codecombat-junior' ? 'heroes-junior' : 'heroes'
   }
   if (options && options.project) {
     _.assign(data, {

--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -7,6 +7,7 @@ CourseInstance = require 'models/CourseInstance'
 Classroom = require 'models/Classroom'
 {me} = require 'core/auth'
 ThangType = require 'models/ThangType'
+ThangTypeConstants = require 'lib/ThangTypeConstants'
 ThangNamesCollection = require 'collections/ThangNamesCollection'
 LZString = require 'lz-string'
 
@@ -344,6 +345,14 @@ module.exports = class LevelLoader extends CocoClass
       else
         # Default to Tharin in home mode
         ThangType.heroes.knight
+    if @level.get('product', true) is 'codecombat-junior'
+      # If we got into a codecombat-junior level with a codecombat hero, pick an equivalent codecombat-junior hero to use instead
+      juniorHeroReplacement = ThangTypeConstants.juniorHeroReplacements[_.invert(ThangTypeConstants.heroes)[heroThangType]]
+    else
+      # If we got into a codecombat level with a codecombat-junior hero, pick an equivalent codecombat hero to use instead
+      juniorHeroReplacement = _.invert(ThangTypeConstants.juniorHeroReplacements)[_.invert(ThangTypeConstants.heroes)[heroThangType]]
+    heroThangType = ThangTypeConstants.heroes[juniorHeroReplacement] if juniorHeroReplacement
+
     url = "/db/thang.type/#{heroThangType}/version"
     if heroResource = @maybeLoadURL(url, ThangType, 'thang')
       console.debug "Pushing hero ThangType resource: ", heroResource if LOG

--- a/app/lib/LevelSetupManager.coffee
+++ b/app/lib/LevelSetupManager.coffee
@@ -75,7 +75,7 @@ module.exports = class LevelSetupManager extends CocoClass
       return
 
     # Build modals and prevent them from disappearing.
-    @heroesModal = new PlayHeroesModal({supermodel: @supermodel, session: @session, confirmButtonI18N: 'play.next', level: @level, hadEverChosenHero: @options.hadEverChosenHero, courseInstanceID: @options.courseInstanceID })
+    @heroesModal = new PlayHeroesModal({supermodel: @supermodel, session: @session, confirmButtonI18N: 'play.next', level: @level, campaign: @options.campaign, hadEverChosenHero: @options.hadEverChosenHero, courseInstanceID: @options.courseInstanceID })
     @inventoryModal = new InventoryModal({supermodel: @supermodel, session: @session, level: @level})
     @heroesModalDestroy = @heroesModal.destroy
     @inventoryModalDestroy = @inventoryModal.destroy

--- a/app/lib/ThangTypeConstants.coffee
+++ b/app/lib/ThangTypeConstants.coffee
@@ -22,6 +22,24 @@ ThangTypeConstants =
     stalwart: '5a576ec52db68a00269b7a08'
     'armando-hoyos': '6037ed81ad0ac000f5e9f0b5'
     'ned-fulmer': '6136fe7e9f1147002c1316b4'
+    'wolf-pup-hero': '663cedaa5a5f9b8a296f9383'
+    'cougar-hero': '663ced3e5a5f9b8a296f92c8'
+    'polar-bear-cub-hero': '663ced2d5a5f9b8a296f92b9'
+    'frog-hero': '663ced675a5f9b8a296f92ff'
+    'turtle-hero': '663cedc65a5f9b8a296f93a5'
+    'blue-fox-hero': '663ced805a5f9b8a296f931d'
+    'panther-cub-hero': '663ced735a5f9b8a296f930e'
+    'brown-rat-hero': '663ced225a5f9b8a296f92aa'
+    'duck-hero': '663ced9f5a5f9b8a296f9374'
+    'tiger-cub-hero': '663ced955a5f9b8a296f9365'
+    'pugicorn-hero': '663ced085a5f9b8a296f928b'
+    'raven-hero': '663ced8a5a5f9b8a296f932c'
+    'baby-griffin-hero': '663ced185a5f9b8a296f929b'
+    'yetibab-hero': '663ced485a5f9b8a296f92d4'
+    'mimic-hero': '663cedcf5a5f9b8a296f93b2'
+    'phoenix-hero': '663ced555a5f9b8a296f92e4'
+    'dragonling-hero': '663ced5e5a5f9b8a296f92f3'
+    'kindling-elemental-hero': '663cedbb5a5f9b8a296f9396'
   ozariaHeroes:
     'hero-a': '5d1630bf14281c002af1ee51'  # Male, thin
     'hero-b': '5d164dfedf16b90034a2ce89'  # Female, thin
@@ -37,10 +55,22 @@ ThangTypeConstants =
     'hero-e': '60ff9bc75b55bb002971ba41'  # Female, androgynous
     'hero-f': '60ff9bd728067a00236eaa57'  # Male, wheelchair
   heroClasses:
-    Warrior: ['champion', 'duelist', 'captain', 'knight', 'samurai', 'raider', 'goliath', 'guardian', 'code-ninja', 'stalwart', 'armando-hoyos', 'ned-fulmer']
+    Warrior: ['champion', 'duelist', 'captain', 'knight', 'samurai', 'raider', 'goliath', 'guardian', 'code-ninja', 'stalwart', 'armando-hoyos', 'ned-fulmer', 'wolf-pup-hero', 'cougar-hero', 'polar-bear-cub-hero', 'frog-hero', 'turtle-hero', 'blue-fox-hero', 'panther-cub-hero', 'brown-rat-hero', 'duck-hero', 'tiger-cub-hero', 'pugicorn-hero', 'raven-hero', 'baby-griffin-hero', 'yetibab-hero', 'mimic-hero', 'phoenix-hero', 'dragonling-hero', 'kindling-elemental-hero']
     Ranger: ['ninja', 'forest-archer', 'trapper', 'pixie', 'assassin']
     Wizard: ['librarian', 'potion-master', 'sorcerer', 'necromancer', 'master-wizard']
   items:
     'simple-boots': '53e237bf53457600003e3f05'
+  juniorHeroReplacements:
+    captain: 'wolf-pup-hero'
+    knight: 'cougar-hero'
+    samurai: 'polar-bear-cub-hero'
+    raider: 'frog-hero'
+    goliath: 'turtle-hero'
+    guardian: 'blue-fox-hero'
+    duelist: 'panther-cub-hero'
+    champion: 'tiger-cub-hero'
+    stalwart: 'duck-hero'
+    'armando-hoyos': 'brown-rat-hero'
+    'ned-fulmer': 'brown-rat-hero'
 
 module.exports = ThangTypeConstants

--- a/app/models/Level.js
+++ b/app/models/Level.js
@@ -68,8 +68,8 @@ module.exports = (Level = (function () {
       o.thangTypes = []
       for (const tt of Array.from(supermodel.getModels('ThangType'))) {
         if (tmap[tt.get('original')] ||
-          ((tt.get('kind') !== 'Hero') && (tt.get('kind') != null) && tt.get('components') && !tt.notInLevel) ||
-          ((tt.get('kind') === 'Hero') && (this.isType('course', 'course-ladder', 'game-dev') || Array.from(sessionHeroes).includes(tt.get('original'))))) {
+          ((tt.get('kind') !== 'Hero' && tt.get('kind') !== 'Junior Hero') && (tt.get('kind') != null) && tt.get('components') && !tt.notInLevel) ||
+          ((tt.get('kind') === 'Hero' || tt.get('kind') === 'Junior Hero') && (this.isType('course', 'course-ladder', 'game-dev') || Array.from(sessionHeroes).includes(tt.get('original'))))) {
           o.thangTypes.push(({ original: tt.get('original'), name: tt.get('name'), components: $.extend(true, [], tt.get('components')), kind: tt.get('kind') }))
         }
       }
@@ -252,6 +252,17 @@ module.exports = (Level = (function () {
             heroThangType = ThangTypeConstants.heroes.captain
           }
           if (heroThangType) {
+            let juniorHeroReplacement
+            if (this.get('product', true) === 'codecombat-junior') {
+              // If we got into a codecombat-junior level with a codecombat hero, pick an equivalent codecombat-junior hero to use instead
+              juniorHeroReplacement = ThangTypeConstants.juniorHeroReplacements[_.invert(ThangTypeConstants.heroes)[heroThangType]]
+            } else {
+              // If we got into a codecombat level with a codecombat-junior hero, pick an equivalent codecombat hero to use instead
+              juniorHeroReplacement = _.invert(ThangTypeConstants.juniorHeroReplacements)[_.invert(ThangTypeConstants.heroes)[heroThangType]]
+            }
+            if (juniorHeroReplacement) {
+              heroThangType = ThangTypeConstants.heroes[juniorHeroReplacement]
+            }
             levelThang.thangType = heroThangType
           }
         }
@@ -520,7 +531,7 @@ module.exports = (Level = (function () {
       return true
     }
 
-    isAssessment () { return (this.get('assessment') != null) }
+    isAssessment () { return Boolean(this.get('assessment')) }
 
     isCapstone () { return this.get('ozariaType') === 'capstone' }
 

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -388,8 +388,24 @@ module.exports = (User = (function () {
     }
 
     heroes () {
-      let left
-      const heroes = ((left = this.get('purchased')?.heroes) != null ? left : []).concat([ThangTypeConstants.heroes.captain, ThangTypeConstants.heroes.knight, ThangTypeConstants.heroes.champion, ThangTypeConstants.heroes.duelist])
+      const heroes = (this.get('purchased')?.heroes || []).concat([
+        // Free CodeCombat heroes
+        ThangTypeConstants.heroes.captain,
+        ThangTypeConstants.heroes.knight,
+        ThangTypeConstants.heroes.champion,
+        ThangTypeConstants.heroes.duelist,
+        // Free CodeCombat Junior heroes
+        ThangTypeConstants.heroes['wolf-pup-hero'],
+        ThangTypeConstants.heroes['cougar-hero'],
+        ThangTypeConstants.heroes['polar-bear-cub-hero'],
+        ThangTypeConstants.heroes['frog-hero'],
+        ThangTypeConstants.heroes['turtle-hero'],
+        ThangTypeConstants.heroes['blue-fox-hero'],
+        ThangTypeConstants.heroes['panther-cub-hero'],
+        ThangTypeConstants.heroes['brown-rat-hero'],
+        ThangTypeConstants.heroes['duck-hero'],
+        ThangTypeConstants.heroes['tiger-cub-hero'],
+      ])
       if (window.serverConfig.codeNinjas) { heroes.push(ThangTypeConstants.heroes['code-ninja']) }
       for (const clanHero of utils.clanHeroes) {
         if ((this.get('clans') || []).includes(clanHero.clanId)) {

--- a/app/schemas/models/thang_type.js
+++ b/app/schemas/models/thang_type.js
@@ -179,7 +179,7 @@ _.extend(ThangTypeSchema.properties, {
     containers: c.object({ title: 'Containers', additionalProperties: ContainerObjectSchema }),
     animations: c.object({ title: 'Animations', additionalProperties: RawAnimationObjectSchema })
   }),
-  kind: c.shortString({ enum: ['Unit', 'Floor', 'Wall', 'Doodad', 'Misc', 'Mark', 'Item', 'Hero', 'Missile', 'Junior'], default: 'Misc', title: 'Kind' }),
+  kind: c.shortString({ enum: ['Unit', 'Floor', 'Wall', 'Doodad', 'Misc', 'Mark', 'Item', 'Hero', 'Missile', 'Junior', 'Junior Hero'], default: 'Misc', title: 'Kind' }),
   terrains: c.array({ title: 'Terrains', description: 'If specified, limits this ThangType to levels with matching terrains.', uniqueItems: true }, c.terrainString),
   gems: { type: 'integer', minimum: 0, title: 'Gem Cost', description: 'How many gems this item or hero costs.' },
   subscriber: { type: 'boolean', title: 'Subscriber (items only)', description: 'This item is for subscribers only.' },

--- a/app/templates/play/modal/play-heroes-modal.pug
+++ b/app/templates/play/modal/play-heroes-modal.pug
@@ -1,4 +1,4 @@
-.modal-dialog(class=level ? level.get('product', true) : '')
+.modal-dialog(class=isJunior ? 'codecombat-junior' : '')
   .modal-content
 
     img(src="/images/pages/play/modal/choosehero-background.png", draggable="false")#play-heroes-background
@@ -28,10 +28,10 @@
               img(draggable="false")
             .hero-stats.rtl-allowed(dir="auto")
               h2= hero.name
-              if (!level || level.get('product', true) != 'codecombat-junior')
+              if (!isJunior)
                 .hero-description= hero.description
 
-              if !me.isStudent() && (!level || level.get('product', true) != 'codecombat-junior')
+              if !me.isStudent() && !isJunior
                 .hero-stat-row
                   .stat-label(data-i18n='leaderboard.difficulty')
                   .stat-value.hero-status-value(data-i18n=hero.class == 'ranger' ? 'general.medium' : (hero.class == 'wizard' ? 'general.hard' : 'general.easy'))
@@ -44,7 +44,7 @@
                   .stat-label(data-i18n='choose_hero.weapons')
                   .stat-value(data-i18n='choose_hero.weapons_'+hero.class)
 
-              if hero.stats && (!level || level.get('product', true) != 'codecombat-junior')
+              if hero.stats && !isJunior
                 if hero.stats.skills.length && !me.isStudent()
                   .hero-stat-row
                     .stat-label(data-i18n='choose_hero.skills')

--- a/app/views/courses/CoursesView.js
+++ b/app/views/courses/CoursesView.js
@@ -524,7 +524,14 @@ module.exports = (CoursesView = (function () {
       if (window.tracker != null) {
         window.tracker.trackEvent('Students Change Hero Started', { category: 'Students' })
       }
-      const modal = new HeroSelectModal({ currentHeroID: this.hero.id })
+      let hasOnlyJuniorCourses = true
+      for (const courseInstance of this.courseInstances.models) {
+        if (courseInstance.get('courseID') !== utils.courseIDs.JUNIOR) {
+          hasOnlyJuniorCourses = false
+          break
+        }
+      }
+      const modal = new HeroSelectModal({ currentHeroID: this.hero.id, product: hasOnlyJuniorCourses ? 'codecombat-junior' : null })
       this.openModalView(modal)
       this.listenTo(modal, 'hero-select:success', newHero => {
         // @hero.url = "/db/thang.type/#{me.get('heroConfig').thangType}/version"

--- a/app/views/courses/HeroSelectModal.js
+++ b/app/views/courses/HeroSelectModal.js
@@ -11,11 +11,6 @@ require('app/styles/courses/hero-select-modal.sass')
 const ModalView = require('views/core/ModalView')
 const HeroSelectView = require('views/core/HeroSelectView')
 const template = require('app/templates/courses/hero-select-modal')
-const Classroom = require('models/Classroom')
-const ThangTypes = require('collections/ThangTypes')
-const State = require('models/State')
-const ThangType = require('models/ThangType')
-const User = require('models/User')
 
 module.exports = (HeroSelectModal = (function () {
   HeroSelectModal = class HeroSelectModal extends ModalView {
@@ -28,9 +23,9 @@ module.exports = (HeroSelectModal = (function () {
         { 'click .select-hero-btn': 'onClickSelectHeroButton' }
     }
 
-    constructor () {
-      super()
-      this.listenTo(this.insertSubView(new HeroSelectView({ showCurrentHero: true })),
+    constructor (options) {
+      super(options)
+      this.listenTo(this.insertSubView(new HeroSelectView({ showCurrentHero: true, product: (options || {}).product })),
         'hero-select:success', function (hero) {
           if (!this.destroyed) { return this.trigger('hero-select:success', hero) }
         })

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -463,7 +463,7 @@ module.exports = (CampaignView = (function () {
 
     openPlayHeroesModal (e) {
       e.stopPropagation()
-      return this.openModalView(new PlayHeroesModal())
+      return this.openModalView(new PlayHeroesModal({ campaign: this.campaign }))
     }
 
     openPlayAchievementsModal (e) {
@@ -1459,7 +1459,7 @@ ${problem.category} - ${problem.score} points\
       const classroomLevel = this.classroomLevelMap ? this.classroomLevelMap[levelOriginal] : undefined
       const session = this.preloadedSession?.loaded && this.preloadedSession.levelSlug === levelSlug ? this.preloadedSession : null
       const codeLanguage = classroomLevel?.get('primerLanguage') || this.classroom?.get('aceConfig')?.language || session?.get('codeLanguage')
-      const options = { supermodel: this.supermodel, levelID: levelSlug, levelPath: levelElement.data('level-path'), levelName: levelElement.data('level-name'), hadEverChosenHero: this.hadEverChosenHero, parent: this, session, courseID, courseInstanceID, codeLanguage }
+      const options = { supermodel: this.supermodel, levelID: levelSlug, levelPath: levelElement.data('level-path'), levelName: levelElement.data('level-name'), campaign: this.campaign, hadEverChosenHero: this.hadEverChosenHero, parent: this, session, courseID, courseInstanceID, codeLanguage }
       this.setupManager = new LevelSetupManager(options)
       if (!(this.setupManager != null ? this.setupManager.navigatingToPlay : undefined)) {
         if (this.$levelInfo != null) {

--- a/app/views/play/level/tome/SpellPaletteView.coffee
+++ b/app/views/play/level/tome/SpellPaletteView.coffee
@@ -5,7 +5,6 @@ filters = require 'lib/image_filter'
 SpellPaletteEntryView = require './SpellPaletteEntryView'
 LevelComponent = require 'models/LevelComponent'
 ThangType = require 'models/ThangType'
-LevelSetupManager = require 'lib/LevelSetupManager'
 ace = require('lib/aceContainer')
 aceUtils = require 'core/aceUtils'
 

--- a/app/views/play/modal/PlayHeroesModal.js
+++ b/app/views/play/modal/PlayHeroesModal.js
@@ -63,7 +63,8 @@ module.exports = (PlayHeroesModal = (function () {
       this.animateHeroes = this.animateHeroes.bind(this)
       this.confirmButtonI18N = options.confirmButtonI18N != null ? options.confirmButtonI18N : 'common.save'
       this.heroes = new CocoCollection([], { model: ThangType })
-      this.heroes.url = '/db/thang.type?view=heroes'
+      this.isJunior = this.options.level?.get('product') === 'codecombat-junior' || this.options.campaign?.get('slug') === 'junior'
+      this.heroes.url = '/db/thang.type?view=' + (this.isJunior ? 'heroes-junior' : 'heroes')
       this.heroes.setProjection(['original', 'name', 'slug', 'soundTriggers', 'featureImages', 'gems', 'heroClass', 'description', 'components', 'extendedName', 'shortName', 'unlockLevelName', 'i18n', 'poseImage', 'tier', 'releasePhase', 'ozaria'])
       this.heroes.comparator = 'gems'
       this.listenToOnce(this.heroes, 'sync', this.onHeroesLoaded)
@@ -93,7 +94,7 @@ module.exports = (PlayHeroesModal = (function () {
         this.heroes.reset(this.heroes.filter(hero => !hero.locked))
       }
       if (!me.isAdmin()) {
-        return this.heroes.reset(this.heroes.filter(hero => hero.get('releasePhase') !== 'beta'))
+        this.heroes.reset(this.heroes.filter(hero => hero.get('releasePhase') !== 'beta'))
       }
     }
 
@@ -105,12 +106,12 @@ module.exports = (PlayHeroesModal = (function () {
       hero.description = utils.i18n(hero.attributes, 'description')
       hero.unlockLevelName = utils.i18n(hero.attributes, 'unlockLevelName')
       const original = hero.get('original')
-      hero.free = ['captain', 'knight', 'champion', 'duelist'].includes(hero.attributes.slug)
-      hero.unlockBySubscribing = ['samurai', 'ninja', 'librarian'].includes(hero.attributes.slug)
+      hero.free = ['captain', 'knight', 'champion', 'duelist', 'wolf-pup-hero', 'cougar-hero', 'polar-bear-cub-hero', 'frog-hero', 'turtle-hero', 'blue-fox-hero', 'panther-cub-hero', 'brown-rat-hero', 'duck-hero', 'tiger-cub-hero'].includes(hero.attributes.slug)
+      hero.unlockBySubscribing = ['samurai', 'ninja', 'librarian', 'pugicorn-hero', 'raven-hero', 'baby-griffin-hero'].includes(hero.attributes.slug)
       hero.premium = !hero.free && !hero.unlockBySubscribing
       hero.locked = !me.ownsHero(original) && !(hero.unlockBySubscribing && me.isPremium())
       if ((me.isStudent() || me.isTeacher()) && me.showHeroAndInventoryModalsToStudents() && (hero.get('heroClass') === 'Warrior')) { hero.locked = false }
-      if ((me.isStudent() || me.isTeacher()) && this.options.level?.get('product') === 'codecombat-junior') { hero.locked = false }
+      if ((me.isStudent() || me.isTeacher()) && this.isJunior) { hero.locked = false }
       hero.purchasable = hero.locked && me.isPremium()
       if (this.options.level && (allowedHeroes = this.options.level.get('allowedHeroes'))) {
         let needle
@@ -151,6 +152,7 @@ module.exports = (PlayHeroesModal = (function () {
       context.level = this.options.level
       context.confirmButtonI18N = this.confirmButtonI18N
       context.visibleHero = this.visibleHero
+      context.isJunior = this.isJunior
       context.gems = me.gems()
       return context
     }


### PR DESCRIPTION
This hooks up ThangType constants for the new pet heroes, makes the logic for when to display pet-style hero selection also encompass whether the campaign is Junior (not just the level), and tries to swap back to pet heroes when a player would get into a CodeCombat Junior level with a normal warrior hero.

There's also a start of handling student hero choice between heroes in the student dashboard, but that'll need more work once we really know whether a student is just going to be doing CCJ or also other courses in advance, on account creation.

<img width="1163" alt="Screenshot 2024-05-09 at 14 35 27" src="https://github.com/codecombat/codecombat/assets/99704/ae68bfd0-3e9e-4aca-a820-4d27f6283ab6">