### PR TITLE
Allow all teachers to set classroom code formats to blocks, blocks-and-code, blocks-icons

### DIFF
--- a/app/views/courses/ClassroomSettingsModal.js
+++ b/app/views/courses/ClassroomSettingsModal.js
@@ -54,7 +54,7 @@ module.exports = (ClassroomSettingsModal = (function () {
       this.isGoogleClassroom = false
       this.enableCpp = me.enableCpp()
       this.enableJava = me.enableJava()
-      this.enableBlocks = ['python', 'javascript', 'lua'].includes(this.classroom.get('aceConfig')?.language || 'python') && (me.isBetaTester() || me.isAdmin())
+      this.enableBlocks = ['python', 'javascript', 'lua'].includes(this.classroom.get('aceConfig')?.language || 'python')
       this.uploadFilePath = `db/classroom/${this.classroom.id}`
       initializeFilePicker()
       if (this.shouldShowLMSButton()) {

--- a/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
@@ -118,7 +118,7 @@ export default Vue.extend({
       return (this.classroom || {}).classroomItems
     },
     enableBlocks () {
-      return ['python', 'javascript', 'lua'].includes(this.language || 'python') && (this.me.isBetaTester() || this.me.isAdmin())
+      return ['python', 'javascript', 'lua'].includes(this.language || 'python')
     },
     allCodeFormats () {
       // TODO: only show blocks-icons if a Junior course is included


### PR DESCRIPTION
It still has a (beta) label on it, but it's no longer restricted to the teachers explicitly marked as beta testers.
<img width="743" alt="Screenshot 2024-05-09 at 15 52 48" src="https://github.com/codecombat/codecombat/assets/99704/8b48adc4-e8aa-484a-b67d-2ebb5b90bd36">
