### PR TITLE
close backbone modal when route vue paths

### DIFF
--- a/app/core/Router.js
+++ b/app/core/Router.js
@@ -641,6 +641,9 @@ module.exports = (CocoRouter = (function () {
         if ((ViewClass === SingletonAppVueComponentView) && globalVar.currentView instanceof SingletonAppVueComponentView) {
           // The SingletonAppVueComponentView maintains its own Vue app with its own routing layer.  If it
           // is already routed we do not need to route again
+          // but let's remove backbone modal anyway
+          globalVar.currentView.modalClosed()
+          $('.modal-backdrop').remove()
           console.debug('Skipping route in Backbone - delegating to Vue app')
           return
         } else if (options.vueRoute) { // Routing to a vue component using VueComponentView


### PR DESCRIPTION
fix ENG-700

the bug comes from new home-beta page is a vue component and parent signup is also a vue component and click parent path trigger the `routeDirectly` in router which returns early for vue. and we have close modal logic in `this.openView` but won't trigger for vue routes. so add one