### PR TITLE
Set classname order in sidebar the same as main class view

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseMyClasses/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseMyClasses/index.vue
@@ -4,11 +4,11 @@ import { COMPONENT_NAMES, PAGE_TITLES } from '../common/constants.js'
 import ClassStatCalculator from './components/ClassStatCalculator'
 import ModalEditClass from '../modals/ModalEditClass'
 import ModalAddStudents from '../modals/ModalAddStudents'
-import moment from 'moment'
 import ModalShareWithTeachers from '../modals/ModalShareWithTeachers'
 import BannerHoC from 'app/views/courses/BannerHoC'
 import ButtonsSchoolAdmin from './ButtonsSchoolAdmin'
 import PodcastItemContainer from 'app/views/courses/PodcastItemContainer'
+import sortClassroomMixin from '../mixins/sortClassroomMixin.js'
 
 export default {
   name: COMPONENT_NAMES.MY_CLASSES_ALL,
@@ -21,6 +21,10 @@ export default {
     ModalShareWithTeachers,
     PodcastItemContainer
   },
+
+  mixins: [
+    sortClassroomMixin
+  ],
 
   props: {
     teacherId: { // sent from DSA
@@ -124,9 +128,6 @@ export default {
       this.showShareClassWithTeacherModal = true
       this.editClassroomObject = classroom
     },
-    classroomSortById (a, b) {
-      return moment(parseInt(b._id.substring(0, 8), 16) * 1000).diff(moment(parseInt(a._id.substring(0, 8), 16) * 1000))
-    }
   }
 }
 </script>

--- a/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
+++ b/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
@@ -72,6 +72,12 @@ export default {
       // TODO: do show the assessments if it is CodeNinjas, but not in a camp context
       return utils.isCodeCombat && !me.isCodeNinja()
     },
+
+    sortedClasses () {
+      const classrooms = [...this.classrooms]
+      classrooms.sort(this.classroomSortById)
+      return classrooms
+    },
   },
 
   methods: {
@@ -82,6 +88,10 @@ export default {
     setHackStackClassroom (classroomId) {
       this.$store.commit('teacherDashboard/setClassroomId', classroomId)
       this.$store.commit('teacherDashboard/setSelectedCourseIdCurrentClassroom', { courseId: utils.courseIDs.HACKSTACK })
+    },
+
+    classroomSortById (a, b) {
+      return moment(parseInt(b._id.substring(0, 8), 16) * 1000).diff(moment(parseInt(a._id.substring(0, 8), 16) * 1000))
     },
 
     trackEvent (e) {
@@ -144,7 +154,7 @@ export default {
           </router-link>
         </li>
         <li
-          v-for="classroom in classrooms"
+          v-for="classroom in sortedClasses"
           :key="classroom._id"
           :class="classesTabSelected && classroomSelected === classroom._id ? 'selected' : null"
         >

--- a/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
+++ b/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
@@ -2,11 +2,16 @@
 import { mapState } from 'vuex'
 import utils from 'core/utils'
 import DashboardToggle from 'ozaria/site/components/teacher-dashboard/common/DashboardToggle'
+import sortClassroomMixin from '../mixins/sortClassroomMixin.js'
 
 export default {
   components: {
     DashboardToggle
   },
+
+  mixins: [
+    sortClassroomMixin
+  ],
 
   props: {
     classrooms: {

--- a/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
+++ b/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
@@ -95,10 +95,6 @@ export default {
       this.$store.commit('teacherDashboard/setSelectedCourseIdCurrentClassroom', { courseId: utils.courseIDs.HACKSTACK })
     },
 
-    classroomSortById (a, b) {
-      return moment(parseInt(b._id.substring(0, 8), 16) * 1000).diff(moment(parseInt(a._id.substring(0, 8), 16) * 1000))
-    },
-
     trackEvent (e) {
       const eventName = e.target.dataset.action
       const eventLabel = e.target.dataset.label

--- a/ozaria/site/components/teacher-dashboard/mixins/sortClassroomMixin.js
+++ b/ozaria/site/components/teacher-dashboard/mixins/sortClassroomMixin.js
@@ -1,0 +1,9 @@
+import moment from 'moment'
+
+export default {
+  methods: {
+    classroomSortById (a, b) {
+      return moment(parseInt(b._id.substring(0, 8), 16) * 1000).diff(moment(parseInt(a._id.substring(0, 8), 16) * 1000))
+    },
+  },
+}


### PR DESCRIPTION
fixes ENG-713
This uses the same sorting logic as in the main class view.
![Screenshot from 2024-05-23 22-02-47](https://github.com/codecombat/codecombat/assets/164280260/2017aa95-8f12-4f97-9f38-60d483fc1228)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new mixin to sort classrooms by ID in the Teacher Dashboard.
  - Updated classroom sorting in the Teacher Dashboard for better organization.

- **Improvements**
  - Enhanced the Teacher Dashboard navigation to display sorted classrooms for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->