### PR TITLE
dont't show level number in ozaria curriculum guide if no classroom selected

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleContent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleContent.vue
@@ -96,8 +96,12 @@ export default {
         const levelNumber = this.classroomInstance.getLevelNumber(original, index)
         return levelNumber
       } else {
-        const map = this.levelNumberMap
-        return map[original] || index
+        if (utils.isOzaria) {
+          return ''
+        } else {
+          const map = this.levelNumberMap
+          return map[original] || index
+        }
       }
     },
     trackEvent (eventName) {

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleRow.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleRow.vue
@@ -120,7 +120,7 @@ export default {
         :icon="iconType"
       />
       <p class="content-heading">
-        <b>{{ `${levelNumber }${nameType ? '.' : ':'} ${getContentTypeHeader} ${ displayName.replace('Course: ', '')}` }}</b>
+        <b>{{ `${levelNumber }${levelNumber ? (nameType ? '.' : ':') : ''} ${getContentTypeHeader} ${ displayName.replace('Course: ', '')}` }}</b>
       </p>
       <p class="content-desc">
         {{ clearDescription }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved display logic for level numbers and names in the teacher dashboard to ensure correct formatting and visibility.
  - Adjusted content heading in module rows to handle different conditions for level numbers and name types more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->