### PR TITLE
change styling of classroom create modal so that create button comes …

### DIFF
--- a/ozaria/site/components/common/ModalDivider.vue
+++ b/ozaria/site/components/common/ModalDivider.vue
@@ -37,7 +37,7 @@ export default Vue.extend({
   flex-direction: row;
   align-items: center;
   margin-bottom: 10px;
-  margin-top: 21px;
+  margin-top: 10px;
   span {
     font-family: Work Sans;
     font-size: 28px;

--- a/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
@@ -846,7 +846,7 @@ export default Vue.extend({
           </a>
           <!--eslint-enable-->
         </div>
-        <div class="form-group row buttons">
+        <div class="form-group row">
           <div class="col-xs-12 buttons">
             <tertiary-button
               v-if="archived"
@@ -922,8 +922,8 @@ export default Vue.extend({
 }
 
 .buttons {
-  align-self: flex-end;
   display: flex;
+  justify-content: flex-end;
   margin-top: 15px;
 
   button {

--- a/ozaria/site/components/teacher-dashboard/modals/common/ButtonGoogleClassroom.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/common/ButtonGoogleClassroom.vue
@@ -29,6 +29,9 @@ export default Vue.extend({
 <template>
   <div class="google-classroom-button">
     <div
+      v-tooltip.bottom="{
+        content: inactive ? $t('teachers.google_classroom_disabled_text') : null
+      }"
       class="link-google-classroom"
       :class="{ disabled: inactive || inProgress }"
       @click="onClick"
@@ -43,10 +46,6 @@ export default Vue.extend({
       >
       <span class="google-classroom-text"> {{ text }} </span>
     </div>
-    <span
-      v-if="inactive"
-      class="inactive-text"
-    > {{ $t("teachers.google_classroom_disabled_text") }} </span>
   </div>
 </template>
 
@@ -71,6 +70,11 @@ export default Vue.extend({
     cursor: default;
     box-shadow: none;
     color: #757575;
+    padding: 5px;
+    .google-classroom-text {
+      font-size: 14px;
+      line-height: 16px;
+    }
   }
 }
 .google-classroom-text {

--- a/ozaria/site/components/teacher-dashboard/modals/common/ButtonGoogleClassroom.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/common/ButtonGoogleClassroom.vue
@@ -85,8 +85,4 @@ export default Vue.extend({
   line-height: 21px;
   margin-left: 10px;
 }
-.inactive-text {
-  @include font-p-4-paragraph-smallest-gray;
-  margin-top: 5px;
-}
 </style>


### PR DESCRIPTION
…in frame and align buttons to right

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Adjusted spacing in modal dividers for a more compact layout.
  - Improved button alignment in the class edit modal for better visual consistency.
  
- **New Features**
  - Added tooltips for inactive state on Google Classroom buttons for better user guidance.
  
- **Bug Fixes**
  - Updated styles for Google Classroom buttons to ensure consistent appearance and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->