### PR TITLE
lazy load images on new home page

### DIFF
--- a/app/components/common/elements/BoxPanel.vue
+++ b/app/components/common/elements/BoxPanel.vue
@@ -45,6 +45,7 @@
               v-else
               :src="item.image"
               :alt="`Image to illustrate ${item.title}`"
+              :loading="lazyLoad ? 'lazy' : ''"
             >
           </template>
           <template #title>
@@ -105,6 +106,10 @@ export default {
       validator: function (value) {
         return ARRANGEMENT_OPTIONS.includes(value)
       }
+    },
+    lazyLoad: {
+      type: Boolean,
+      default: false
     }
   },
   methods: {

--- a/app/components/common/elements/CarouselComponent.vue
+++ b/app/components/common/elements/CarouselComponent.vue
@@ -62,6 +62,7 @@
                 class="content-icon"
                 :src="item.image"
                 :alt="item.alt || item.title"
+                :loading="lazyLoad ? 'lazy': ''"
               >
             </div>
             <div class="content-text">
@@ -114,6 +115,10 @@ export default {
     hasBackground: {
       type: Boolean,
       default: true
+    },
+    lazyLoad: {
+      type: Boolean,
+      default: false
     }
   },
   data () {

--- a/app/views/home/PageHome.vue
+++ b/app/views/home/PageHome.vue
@@ -39,6 +39,7 @@
           :show-tabs="false"
           :show-dots="true"
           :has-background="false"
+          :lazy-load="true"
         >
           <template
             v-for="(item, index) in testimonals"
@@ -59,7 +60,10 @@
     </background-container>
 
     <div class="container main-carousel">
-      <carousel-component :show-tabs="true">
+      <carousel-component
+        :show-tabs="true"
+        :lazy-load="true"
+      >
         <template
           v-for="(item, index) in carouselItems"
           #[`${index}`]
@@ -102,10 +106,12 @@
     <box-panel
       :title="$t('home_v3.engaging_play_experiences')"
       :items="engagingBoxes"
+      :lazy-load="true"
     />
     <box-panel
       :title="$t('home_v3.for_younger_learners')"
       :items="youngLearners"
+      :lazy-load="true"
     />
 
     <background-container type="sides">
@@ -140,6 +146,7 @@
     <box-panel
       :title="$t('home_v3.your_turnkey_solutions')"
       :items="solutions"
+      :lazy-load="true"
     />
 
     <div


### PR DESCRIPTION
fixes ENG-739

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced lazy loading for images in the `BoxPanel`, `CarouselComponent`, and various components on the home page to improve performance and loading times.
- **Enhancements**
  - Added a `lazyLoad` property to `BoxPanel` and `CarouselComponent` with a default value of `false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->