### PR TITLE
ENG-676 - make student level progress dot include more information like in old

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
@@ -183,7 +183,7 @@ export default {
               isPractice,
               playTime: playTimeMap[normalizedOriginal],
               completionDate: completionDateMap[normalizedOriginal],
-              tooltipName: levelNameMap[content._id].tooltipName
+              tooltipName: levelNameMap[content._id].levelName
             }
 
             if (content.type === 'game-dev') {
@@ -479,20 +479,24 @@ export default {
         let description = getLearningGoalsDocumentation(content)
 
         let tooltipName
+        let levelName
         if (utils.isCodeCombat) {
           const classroom = new Classroom(this.classroom)
           const levelNumber = classroom.getLevelNumber(original, index + 1)
           tooltipName = `${levelNumber}: ${utils.i18n(content, 'displayName') || utils.i18n(content, 'name')}`
+          levelName = tooltipName
         } else {
           tooltipName = getGameContentDisplayNameWithType(content)
+          levelName = tooltipName
         }
         if (fromIntroLevelOriginal) {
           const introLevel = intros[fromIntroLevelOriginal] || {}
+          levelName = tooltipName
           description = `<h3>${tooltipName}</h3><p>${utils.i18n(content, 'description') || getLearningGoalsDocumentation(content) || ''}</p>`
           tooltipName = `${Vue.t('teacher_dashboard.intro')}: ${utils.i18n(introLevel, 'displayName') || utils.i18n(introLevel, 'name')}`
         }
 
-        acc[_id] = { tooltipName, description }
+        acc[_id] = { tooltipName, description, levelName }
 
         return acc
       }, {})

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
@@ -183,7 +183,7 @@ export default {
               isPractice,
               playTime: playTimeMap[normalizedOriginal],
               completionDate: completionDateMap[normalizedOriginal],
-              tooltipName: levelNameMap[normalizedOriginal].tooltipName
+              tooltipName: levelNameMap[content._id].tooltipName
             }
 
             if (content.type === 'game-dev') {
@@ -474,8 +474,7 @@ export default {
 
     getLevelNameMap (moduleContent, intros) {
       return moduleContent.reduce((acc, content, index) => {
-        const { fromIntroLevelOriginal, original } = content
-        const normalizedOriginal = original || fromIntroLevelOriginal
+        const { _id, fromIntroLevelOriginal, original } = content
 
         let description = getLearningGoalsDocumentation(content)
 
@@ -493,7 +492,7 @@ export default {
           tooltipName = `${Vue.t('teacher_dashboard.intro')}: ${utils.i18n(introLevel, 'displayName') || utils.i18n(introLevel, 'name')}`
         }
 
-        acc[normalizedOriginal] = { tooltipName, description }
+        acc[_id] = { tooltipName, description }
 
         return acc
       }, {})
@@ -502,7 +501,7 @@ export default {
     // Creates summary stats table for the content. These are the icons along
     // the top of the track progress table.
     createModuleStatsTable (moduleDisplayName, moduleContent, intros, moduleNum) {
-      const levelMap = this.getLevelNameMap(moduleContent, intros)
+      const levelNameMap = this.getLevelNameMap(moduleContent, intros)
       return {
         moduleNum,
         displayName: moduleDisplayName,
@@ -556,7 +555,7 @@ export default {
             normalizedType,
             contentLevelSlug,
             isPractice,
-            ...levelMap[normalizedOriginal]
+            ...levelNameMap[_id]
           })
         }),
         studentSessions: {},

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/TableModuleGrid.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/TableModuleGrid.vue
@@ -80,7 +80,7 @@ export default {
   >
     <!-- FLAT REPRESENTATION OF ALL SESSIONS -->
     <div
-      v-for="({_id, status, flag, clickHandler, selectedKey, normalizedType, isLocked, isSkipped, lockDate, lastLockDate, original, normalizedOriginal,fromIntroLevelOriginal, isPlayable, isOptional }, index) of allStudentSessionsLinear"
+      v-for="({_id, status, playTime, tooltipName, completionDate, flag, clickHandler, selectedKey, normalizedType, isLocked, isSkipped, lockDate, lastLockDate, original, normalizedOriginal,fromIntroLevelOriginal, isPlayable, isOptional }, index) of allStudentSessionsLinear"
       :key="selectedKey"
       :class="cellClass(index)"
     >
@@ -99,6 +99,9 @@ export default {
         :track-category="getTrackCategory"
         :selected="selectedOriginals.includes(normalizedOriginal) && selectedStudentIds.includes(_id)"
         :hovered="hoveredLevels.includes(normalizedOriginal) && selectedStudentIds.includes(_id)"
+        :play-time="playTime"
+        :completion-date="completionDate"
+        :tooltip-name="tooltipName"
       />
     </div>
   </div>

--- a/ozaria/site/components/teacher-dashboard/common/progress/progressDot.vue
+++ b/ozaria/site/components/teacher-dashboard/common/progress/progressDot.vue
@@ -78,6 +78,18 @@ export default {
     isOptional: {
       type: Boolean,
       default: false
+    },
+    playTime: {
+      type: Number,
+      default: 0
+    },
+    completionDate: {
+      type: [Boolean, String],
+      default: null
+    },
+    tooltipName: {
+      type: String,
+      default: null
     }
   },
 
@@ -122,7 +134,14 @@ export default {
         'locked-with-timeframe': 'locked_with_timeframe'
       }[this.levelAccessStatus] || this.levelAccessStatus
 
-      return $.i18n.t(`teacher_dashboard.${label}`) + (!this.isSkipped && date ? ' ' + $.i18n.t('teacher_dashboard.until_date', { date: dateString }) : '')
+      const status = $.i18n.t(`teacher_dashboard.${label}`) + (!this.isSkipped && date ? ' ' + $.i18n.t('teacher_dashboard.until_date', { date: dateString }) : '')
+
+      return `
+        ${status}
+        ${this.tooltipName ? `<br><strong>${this.tooltipName}</strong>` : ''}
+        ${this.status === 'complete' && this.completionDate ? `<br>${$.i18n.t('teacher.completed')}: ${moment(this.completionDate).format('lll')}` : ''}
+        ${this.playTime ? `<br>${$.i18n.t('teacher.time_played_label')} ${moment.duration({ seconds: this.playTime }).humanize()}` : ''}
+      `
     },
 
     levelAccessStatus () {
@@ -180,7 +199,7 @@ export default {
     v-tooltip="tooltipContent && {
       content: tooltipContent,
       placement: 'right',
-      classes: 'layoutChromeTooltip',
+      classes: 'layoutChromeTooltip progress-dot-tooltip',
     }"
     :class="isClickedClasses"
     @click="clickHandler"
@@ -202,6 +221,15 @@ export default {
     </div>
   </div>
 </template>
+
+<style lang="scss">
+.progress-dot-tooltip {
+  max-width: max-content;
+  .tooltip-inner {
+    max-width: max-content;
+  }
+}
+</style>
 
 <style lang="scss" scoped>
 


### PR DESCRIPTION
![progressdot](https://github.com/codecombat/codecombat/assets/11805970/b0d39be8-c659-42f1-9a3c-569f980509f6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced teacher dashboard with additional session details:
    - Added tooltips with level names and descriptions.
    - Included playtime and completion dates for each session.
- **Improvements**
  - Improved data visualization in the teacher dashboard for better tracking of student progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->