### PR TITLE
ENG-753 - add helptext on failed attempts

### DIFF
--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -4592,7 +4592,9 @@ module.exports = {
       refresh_progress: 'Refresh Progress',
       assign_content_first: 'Please ensure that content is assigned to students before adjusting access levels',
       failed_attempts: 'Failed Attempts',
-      no_failed_attempts: 'No Failed Attempts'
+      no_failed_attempts: 'No Failed Attempts',
+      failed_attempts_subtext: 'Number of times incorrect option was selected',
+      open_project: 'Open Project'
     },
 
     outcomes: {

--- a/ozaria/site/components/teacher-dashboard/Panel/components/AiProject.vue
+++ b/ozaria/site/components/teacher-dashboard/Panel/components/AiProject.vue
@@ -4,6 +4,7 @@
     <p>Progress: {{ progress }}%</p>
     <p v-if="failedAttempts">
       {{ $t('teacher_dashboard.failed_attempts') }}: {{ failedAttempts }}
+      <br><span class="subtext">Number of times incorrect option was selected'</span>
     </p>
     <p v-else>
       {{ $t('teacher_dashboard.no_failed_attempts') }}
@@ -11,7 +12,7 @@
     <a
       :href="`/ai/project/${aiProject._id}`"
       target="_blank"
-    >Open Project</a>
+    >{{ $t('teacher_dashboard.open_project') }}</a>
   </div>
 </template>
 
@@ -43,25 +44,31 @@ export default {
 
 <style scoped lang="scss">
 .ai-project {
-    width: 300px;
-    padding: 20px;
-    border-radius: 5px;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
-    background-color: #ffffff;
-    margin-bottom: 20px;
+  width: 300px;
+  padding: 20px;
+  border-radius: 5px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+  background-color: #ffffff;
+  margin-bottom: 20px;
 
-    h4 {
-        color: #333333;
-        margin-bottom: 10px;
+  h4 {
+    color: #333333;
+    margin-bottom: 10px;
+  }
+
+  p {
+    color: #666666;
+    margin-bottom: 15px;
+    line-height: 1.2em;
+
+    &:last-child {
+      margin-bottom: 0;
     }
 
-    p {
-        color: #666666;
-        margin-bottom: 5px;
-
-        &:last-child {
-            margin-bottom: 0;
-        }
+    .subtext {
+      font-size: 0.8em;
+      color: #999999;
     }
+  }
 }
 </style>

--- a/ozaria/site/components/teacher-dashboard/Panel/components/AiProject.vue
+++ b/ozaria/site/components/teacher-dashboard/Panel/components/AiProject.vue
@@ -4,7 +4,7 @@
     <p>Progress: {{ progress }}%</p>
     <p v-if="failedAttempts">
       {{ $t('teacher_dashboard.failed_attempts') }}: {{ failedAttempts }}
-      <br><span class="subtext">Number of times incorrect option was selected'</span>
+      <br><span class="subtext">{{ $t('teacher_dashboard.failed_attempts_subtext') }}</span>
     </p>
     <p v-else>
       {{ $t('teacher_dashboard.no_failed_attempts') }}


### PR DESCRIPTION
<img width="480" alt="CodeCombat_Teacher_Dashboard" src="https://github.com/codecombat/codecombat/assets/11805970/453953a5-955c-4fb1-bc4e-07bd72ab340a">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added subtext for failed attempts in the teacher dashboard.
  - Updated "Open Project" link to use a translation key.

- **Style**
  - Adjusted styling for paragraph elements and added a new style for subtext.

- **Localization**
  - Added new text entries for failed attempts and project opening in the English localization file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->