### PR TITLE
redirect to schools or parents based on role on visiting homepage /

### DIFF
--- a/app/core/Router.js
+++ b/app/core/Router.js
@@ -66,6 +66,11 @@ module.exports = (CocoRouter = (function () {
               return this.routeDirectly('HomeCNView', [])
             }
           }
+          if (me.isTeacher()) {
+            return this.navigate('/schools', { trigger: true, replace: true })
+          } else if (me.isParentHome()) {
+            return this.navigate('/parents', { trigger: true, replace: true })
+          }
           if (me.getHomePageExperimentValue() === 'beta') {
             return this.routeDirectly('HomeBeta', [], { vueRoute: true, baseTemplate: 'base-flat-vue' })
           } else {


### PR DESCRIPTION
fixes ENG-726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added role-based navigation: Teachers are now directed to '/schools' and parents to '/parents' upon login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->