### PR TITLE
Yuqiang/oz level number also buggy

### DIFF
--- a/app/models/User.js
+++ b/app/models/User.js
@@ -421,8 +421,9 @@ module.exports = (User = (function () {
     }
 
     levels () {
-      let left, left1
-      return ((left = this.get('earned')?.levels) != null ? left : []).concat((left1 = this.get('purchased')?.levels) != null ? left1 : []).concat(LevelConstants.levels['dungeons-of-kithgard']).concat(LevelConstants.levels['the-gem'])
+      const earned = this.get('earned')?.levels || []
+      const purchased = this.get('purchased')?.levels || []
+      return earned.concat(purchased).concat(LevelConstants.levels['dungeons-of-kithgard']).concat(LevelConstants.levels['the-gem'])
     }
 
     ownsHero (heroOriginal) {

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -747,12 +747,11 @@ module.exports = (CampaignView = (function () {
       if (this.campaigns) {
         let campaign, levels
         context.campaigns = {}
-        for (campaign of Array.from(this.campaigns.models)) {
+        for (campaign of this.campaigns.models) {
           if (campaign.get('slug') !== 'auditions') {
             context.campaigns[campaign.get('slug')] = campaign
-            if (this.sessions != null ? this.sessions.loaded : undefined) {
-              var left1
-              levels = _.values($.extend(true, {}, (left1 = campaign.get('levels')) != null ? left1 : {}))
+            if (this.sessions?.loaded) {
+              levels = _.values($.extend(true, {}, campaign.get('levels') || {}))
               if ((me.level() < 12) && (campaign.get('slug') === 'dungeon') && !this.editorMode) {
                 levels = _.reject(levels, { slug: 'signs-and-portents' })
               }
@@ -772,16 +771,22 @@ module.exports = (CampaignView = (function () {
             }
           }
         }
-        for (campaign of Array.from(this.campaigns.models)) {
-          var left2
-          const object = (left2 = campaign.get('adjacentCampaigns')) != null ? left2 : {}
-          for (const acID in object) {
-            const ac = object[acID]
+        for (campaign of this.campaigns.models) {
+          for (const [acID, ac] of Object.entries(campaign.get('adjacentCampaigns') || {})) {
             if (_.isString(ac.showIfUnlocked)) {
-              var needle
-              if ((needle = ac.showIfUnlocked, Array.from(me.levels()).includes(needle))) { __guard__(_.find(this.campaigns.models, { id: acID }), x => x.locked = false) }
+              if (me.levels().includes(ac.showIfUnlocked)) {
+                const campaign = _.find(this.campaigns.models, { id: acID })
+                if (campaign) {
+                  campaign.locked = false
+                }
+              }
             } else if (_.isArray(ac.showIfUnlocked)) {
-              if (_.intersection(ac.showIfUnlocked, me.levels()).length > 0) { __guard__(_.find(this.campaigns.models, { id: acID }), x1 => x1.locked = false) }
+              if (_.intersection(ac.showIfUnlocked, me.levels()).length > 0) {
+                const campaign = _.find(this.campaigns.models, { id: acID })
+                if (campaign) {
+                  campaign.locked = false
+                }
+              }
             }
           }
         }

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleContent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleContent.vue
@@ -92,7 +92,7 @@ export default {
 
   methods: {
     getLevelNumber (original, index) {
-      if (this.classroomId) {
+      if (utils.isCodeCombat && this.classroomId) {
         const levelNumber = this.classroomInstance.getLevelNumber(original, index, this.getCurrentCourse?._id)
         return levelNumber
       } else {


### PR DESCRIPTION
![image](https://github.com/codecombat/codecombat/assets/11417632/386e5685-c5b7-45d7-88df-9fa1ba942c19)

Ozaria classroom.course.levels has a strange order compare to game-content. so let's use game-content for ozaria level number directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved variable naming and logic in user level handling for better clarity and maintainability.
  - Simplified array iteration and object property access in campaign view.
  - Refined conditional checks for unlocking campaigns based on player levels.

- **New Features**
  - Added a condition to check for `utils.isCodeCombat` before executing certain code in the teacher dashboard module content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->