### PR TITLE
use normal lazyload of iframe instead of custom to avoid downloading …

### DIFF
--- a/app/components/common/BaseCloudflareVideo.vue
+++ b/app/components/common/BaseCloudflareVideo.vue
@@ -47,107 +47,28 @@ export default {
       required: false
     }
   },
-
-  watch: {
-    soundOn () {
-      const video = this.$refs.cloudflareVideo
-      if (!video) {
-        return
+  computed: {
+    videoUrl () {
+      const baseUrl = `https://customer-burj9xtby325x4f1.cloudflarestream.com/${this.videoCloudflareId}/iframe`
+      const params = {}
+      if (this.thumbnailUrl) {
+        params.poster = encodeURIComponent(this.thumbnailUrl)
       }
-      video.muted = !this.soundOn
-    }
-  },
-
-  mounted () {
-    /**
-     * Create and attach the script that streams the video.
-     */
-    const cloudflareScript = document.createElement('script')
-    cloudflareScript.setAttribute('src', `https://embed.videodelivery.net/embed/r4xu.fla9.latest.js?video=${this.cloudflareID}`)
-    cloudflareScript.defer = true
-    cloudflareScript.setAttribute('type', 'text/javascript')
-    cloudflareScript.setAttribute('data-cfasync', 'false')
-    cloudflareScript.onload = this.onVideoLoaded
-
-    document.body.appendChild(cloudflareScript)
-  },
-
-  methods: {
-    onVideoLoaded () {
-      const video = this.$refs.cloudflareVideo
-
-      if (video) {
-        if (this.playWhenVisible) {
-          const observer = new IntersectionObserver((entries, opts) => {
-            entries.forEach(entry => {
-              if (entry.isIntersecting) {
-                this.playVideo()
-              } else {
-                this.pauseVideo()
-              }
-            })
-          }, {
-            root: null, // default is the viewport
-            threshold: 0.5 // percentage of target's visible area. 0.5 means when 50% of the target is visible
-          })
-
-          // Use the observer to observe an element
-          observer.observe(video)
-        }
-
-        video.muted = !this.soundOn
-        video.addEventListener('ended', () => this.onCompleted())
-
-        // Check if the video is in the viewport on page load
-        if (this.playWhenVisible && this.isInViewport(video)) {
-          this.playVideo()
-        }
-
-        this.setTitleForIframe(video)
+      if (this.autoplay) {
+        params.autoplay = true
       }
-      this.$emit('loaded')
-    },
-
-    isInViewport (element) {
-      const rect = element.getBoundingClientRect()
-      return (
-        rect.top >= 0 &&
-        rect.left >= 0 &&
-        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-        rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-      )
-    },
-
-    setTitleForIframe (video) {
-      // Find the iframe inside the <stream> element
-      const iframe = video.querySelector('iframe')
-
-      // Set the title attribute of the iframe
-      if (iframe) {
-        iframe.setAttribute('title', this.title)
+      if (this.loop) {
+        params.loop = true
       }
-    },
-
-    onCompleted () {
-      this.$emit('completed')
-    },
-
-    playVideo () {
-      const video = this.$refs.cloudflareVideo
-      if (video && typeof video.pause === 'function') {
-        video.play()
+      if (!this.soundOn) {
+        params.muted = true
       }
-    },
-
-    pauseVideo () {
-      const video = this.$refs.cloudflareVideo
-      if (video && typeof video.pause === 'function') {
-        video.pause()
+      params.preload = this.preload
+      const arr = []
+      for (const [key, val] of Object.entries(params)) {
+        arr.push(`${key}=${val}`)
       }
-    },
-
-    getVideo () {
-      return this.$refs.cloudflareVideo
+      return `${baseUrl}?${arr.join('&')}`
     }
   }
 }
@@ -155,22 +76,12 @@ export default {
 
 <template>
   <div class="cloudflare-video-div">
-    <stream
-      ref="cloudflareVideo"
-      :preload="preload"
-      :poster="thumbnailUrl"
-      :src="videoCloudflareId"
-      letterbox-color="transparent"
-      :loop="loop"
-      :autoplay="autoplay"
-      :controls="controls"
-    >
-      <track
-        v-if="cloudflareCaptionUrl"
-        kind="captions"
-        :src="cloudflareCaptionUrl"
-        default
-      >
-    </stream>
+    <iframe
+      :src="videoUrl"
+      loading="lazy"
+      style="border: none; position: absolute; top: 0; left: 0; height: 100%; width: 100%;"
+      allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;"
+      allowfullscreen="true"
+    />
   </div>
 </template>

--- a/app/components/common/BaseCloudflareVideo.vue
+++ b/app/components/common/BaseCloudflareVideo.vue
@@ -1,4 +1,5 @@
 <script>
+const BASE_CLOUDFLARE_STREAM = 'https://customer-burj9xtby325x4f1.cloudflarestream.com'
 export default {
   props: {
     videoCloudflareId: {
@@ -45,14 +46,21 @@ export default {
       type: String,
       default: 'Your descriptive text here',
       required: false
+    },
+    thumbnailUrlTime: {
+      type: Number,
+      default: null,
+      description: 'Time from which the thumbnail should be taken for the video in seconds'
     }
   },
   computed: {
     videoUrl () {
-      const baseUrl = `https://customer-burj9xtby325x4f1.cloudflarestream.com/${this.videoCloudflareId}/iframe`
+      const baseUrl = `${BASE_CLOUDFLARE_STREAM}/${this.videoCloudflareId}/iframe`
       const params = {}
       if (this.thumbnailUrl) {
         params.poster = encodeURIComponent(this.thumbnailUrl)
+      } else if (this.thumbnailUrlTime) {
+        params.poster = `${BASE_CLOUDFLARE_STREAM}/${this.videoCloudflareId}/thumbnails/thumbnail.jpg?time=${this.thumbnailUrlTime}s`
       }
       if (this.autoplay) {
         params.autoplay = true

--- a/app/components/common/image-containers/VideoBox.vue
+++ b/app/components/common/image-containers/VideoBox.vue
@@ -9,6 +9,7 @@
     :controls="false"
     :play-when-visible="true"
     :title="title"
+    :thumbnail-url-time="thumbnailUrlTime"
     @loaded="onVideoLoaded"
   />
 </template>
@@ -30,6 +31,10 @@ export default {
       type: String,
       default: 'Your descriptive text here',
       required: false
+    },
+    thumbnailUrlTime: {
+      type: Number,
+      default: null
     }
   },
   methods: {

--- a/app/views/home/PageHome.vue
+++ b/app/views/home/PageHome.vue
@@ -15,6 +15,7 @@
                 class="header__video"
                 video-id="da0d63c489741f4bd20448af1846292a"
                 title="Video to illustrate the header"
+                :thumbnail-url-time="2"
               />
             </template>
           </content-box>


### PR DESCRIPTION
…non-viewable videos especially on home-page

fixes ENG-740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable `thumbnailUrlTime` property to the `VideoBox` component for customizing thumbnail display time.

- **Refactor**
  - Updated the `BaseCloudflareVideo` component to use a computed property for constructing video URLs and replaced the `<stream>` element with an `<iframe>` for video embedding.

- **Enhancements**
  - Modified the `PageHome` view to set the video thumbnail display time to 2 seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->