### PR TITLE
fix unlock button

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/LockOrSkip.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/LockOrSkip.vue
@@ -178,7 +178,7 @@ export default {
       <LevelAccessStatusButton
         :active="isActionActive(isHackStack ? UNLOCK_SCENARIO : UNLOCK)"
         :text="$t('teacher_dashboard.unlock')"
-        @click="action=isHackStack ? UNLOCK_SCENARIO : LOCK"
+        @click="action=isHackStack ? UNLOCK_SCENARIO : UNLOCK"
       />
 
       <div


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected button click event to properly unlock scenarios when `isHackStack` is false in the teacher dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->