### PR TITLE
Adjust how we show tournament tiles on student dashboard

### DIFF
--- a/app/templates/courses/tournament-tile-mixin.pug
+++ b/app/templates/courses/tournament-tile-mixin.pug
@@ -1,5 +1,5 @@
 mixin tournamentTileMixin(tournament)
-  - showLink = false
+  - var showLink = false
   // show link when tournament starting/ended or in 1 day to start
   if tournament.state == 'initializing'
     - now = new Date().getTime()
@@ -8,19 +8,22 @@ mixin tournamentTileMixin(tournament)
       - showLink = true
   else
     - showLink = true
+  - var showLadderImage = tournament.state != 'initializing' && view.ladderImageMap[tournament.levelOriginal]
 
   a.ai-league-btn.tile(href=showLink ? `/play/ladder/${tournament.slug}/clan/${tournament.clan}?tournament=${tournament._id}`: 'javascript: void(0)', title=tournament.description)
     // do not show preview image for initializing tournaments
-    if tournament.state != 'initializing' && view.ladderImageMap[tournament.levelOriginal]
+    if showLadderImage
       img.level-image(src=view.ladderImageMap[tournament.levelOriginal], alt=tournament.name).img-rounded
     else
       img.level-image(src="/images/pages/play/ladder/multiplayer_notext.jpg", alt=tournament.name).img-rounded
-    h3.dynamic-level-name.overlay-text= tournament.displayName
+      h3.dynamic-level-name.overlay-text= tournament.displayName
     .tile-text-backdrop
     .stats-text-container
       .overlay-text.stats-text
-        if tournament.state != 'initializing'
-          span= tournament.slug
+        if showLadderImage
+          span= tournament.displayName || tournament.name
+        else
+          span= tournament.name
     .play-text-container
       .overlay-text.play-text
         if tournament.state == 'initializing'
@@ -28,6 +31,6 @@ mixin tournamentTileMixin(tournament)
           - time = (new Date(tournament.startDate).getTime() - now)/(24*3600*1000)|0
           span(data-i18n="tournament.estimate_days", data-i18n-options={time})
         else if tournament.state == 'starting'
-          span(data-i18n="common.play")
+          span(data-i18n="courses.play_tournament")
         else if tournament.state == 'ended'
           span(data-i18n="tournament.view_results")


### PR DESCRIPTION
If we are showing the banner image, move the arena display name to the bottom left, falling back to tournament name (not slug).

Otherwise, keep it in the middle over the generic banner.

Don't overlap banner's level name with tournament name.

Show "Play Tournament" instead of "Play" as the CTA.

Old:

<img width="454" alt="Screenshot 2024-06-05 at 16 17 30" src="https://github.com/codecombat/codecombat/assets/99704/c0db0710-0d3c-4d33-aa8a-25067c610714">
<img width="458" alt="Screenshot 2024-06-05 at 16 20 50" src="https://github.com/codecombat/codecombat/assets/99704/34c49e89-16b2-413c-a6d4-6a5c923ae6b5">

New:

<img width="747" alt="Screenshot 2024-06-05 at 16 17 03" src="https://github.com/codecombat/codecombat/assets/99704/3feed245-eb42-48a4-95fb-397d55397b6f">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced tournament tile display to conditionally show links and images based on tournament states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->