### PR TITLE
ENG-725 - ABTest variant: easy signup

### DIFF
--- a/app/core/Router.js
+++ b/app/core/Router.js
@@ -299,9 +299,7 @@ module.exports = (CocoRouter = (function () {
 
         standards: go('core/SingletonAppVueComponentView'),
 
-        'schools' () {
-          return this.routeDirectly('SchoolsView', [], { vueRoute: true, baseTemplate: 'base-flat-vue' })
-        },
+        schools: go('core/SingletonAppVueComponentView'),
 
         'league/academica': redirect('/league/autoclan-school-network-academica'), // Redirect for Academica.
         'league/kipp': redirect('/league/autoclan-school-network-kipp'), // Redirect for KIPP.

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -107,6 +107,10 @@ export default function getVueRouter () {
           component: () => import(/* webpackChunkName: "pd" */ 'app/views/funding/FundingView.vue')
         },
         {
+          path: '/schools',
+          component: () => import(/* webpackChunkName: "SchoolsView" */ 'app/views/schools/PageSchools.vue')
+        },
+        {
           path: '/school-administrator',
           component: () => {
             if (utils.isCodeCombat) {

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -5328,6 +5328,7 @@ module.exports = {
       stat_card_6_description: 'ESports Players',
       learn_to_code: 'Learn to **code** and use **AI**, all through the **power of play**.',
       innovative_play_experiences: 'We create innovative play experiences to make computer science engaging and accessible to all.',
+      sing_up_today: 'Sign-up today to play for free and explore our games and resources.',
       im_an_educator: 'I’m an Educator',
       im_a_parent: 'I’m a Parent',
       im_a_student: 'I’m a Student',

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -5328,7 +5328,7 @@ module.exports = {
       stat_card_6_description: 'ESports Players',
       learn_to_code: 'Learn to **code** and use **AI**, all through the **power of play**.',
       innovative_play_experiences: 'We create innovative play experiences to make computer science engaging and accessible to all.',
-      sing_up_today: 'Sign-up today to play for free and explore our games and resources.',
+      sign_up_today: 'Sign-up today to play for free and explore our games and resources.',
       im_an_educator: 'I’m an Educator',
       im_a_parent: 'I’m a Parent',
       im_a_student: 'I’m a Student',

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -1061,6 +1061,17 @@ module.exports = (User = (function () {
       const experimentName = 'educator-signup-modal'
       let value = me.getExperimentValue(experimentName, null)
 
+      if ((value == null) && !/^en/.test(me.get('preferredLanguage', true))) {
+        // Don't include non-English-speaking users
+        value = 'control'
+      }
+
+      const oneDayAgo = new Date(new Date() - 24 * 60 * 60 * 1000)
+      if ((value == null) && (new Date(me.get('dateCreated')) < oneDayAgo)) {
+        // Don't include users created more than a day ago; they've probably seen the old homepage before without having started the experiment somehow
+        value = 'control'
+      }
+
       if (value === null) {
         const probability = window.serverConfig?.experimentProbabilities?.[experimentName]?.beta || 0.5
         let valueProbability

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -1057,6 +1057,27 @@ module.exports = (User = (function () {
       return value
     }
 
+    getEducatorSignupExperimentValue () {
+      const experimentName = 'educator-signup-modal'
+      let value = me.getExperimentValue(experimentName, null)
+
+      if (value === null) {
+        const probability = window.serverConfig?.experimentProbabilities?.[experimentName]?.beta || 0.5
+        let valueProbability
+        const rand = Math.random()
+        if (rand < probability) {
+          value = 'beta'
+          valueProbability = probability
+        } else {
+          value = 'control'
+          valueProbability = 1 - probability
+        }
+        me.startExperiment(experimentName, value, valueProbability)
+      }
+
+      return value
+    }
+
     getM7ExperimentValue () {
       let left
       let value = { true: 'beta', false: 'control', control: 'control', beta: 'beta' }[utils.getQueryVariable('m7')]

--- a/app/views/home/ButtonSection.vue
+++ b/app/views/home/ButtonSection.vue
@@ -5,7 +5,7 @@
       class="button-section"
     >
       <CTAButton
-        href="/schools"
+        :href="`/schools${educatorSignupExperiment? '#create-account-teacher' : ''}`"
         @click="homePageEvent(isCodeCombat ? 'Homepage Click Teacher Button #1 CTA' : 'Started Signup')"
       >
         {{ $t('new_home.im_an_educator') }}
@@ -83,7 +83,11 @@ export default {
     },
     me () {
       return me
-    }
+    },
+    educatorSignupExperiment () {
+      const value = me.getEducatorSignupExperimentValue()
+      return value === 'beta'
+    },
   },
   beforeDestroy () {
     if (this.modal) {

--- a/app/views/home/ButtonSection.vue
+++ b/app/views/home/ButtonSection.vue
@@ -5,7 +5,7 @@
       class="button-section"
     >
       <CTAButton
-        :href="`/schools${educatorSignupExperiment? '#create-account-teacher' : ''}`"
+        :href="`/schools${ educatorSignupExperiment ? '#create-account-teacher' : '' }`"
         @click="homePageEvent(isCodeCombat ? 'Homepage Click Teacher Button #1 CTA' : 'Started Signup')"
       >
         {{ $t('new_home.im_an_educator') }}

--- a/app/views/home/PageHome.vue
+++ b/app/views/home/PageHome.vue
@@ -8,7 +8,7 @@
               <mixed-color-label :text="$t('home_v3.learn_to_code')" />
             </h1>
             <p class="text-24">
-              {{ $t(educatorSignupExperiment ? 'home_v3.sing_up_today' :'home_v3.innovative_play_experiences') }}
+              {{ $t(educatorSignupExperiment ? 'home_v3.sign_up_today' :'home_v3.innovative_play_experiences') }}
             </p>
             <div class="buttons">
               <ButtonSection />

--- a/app/views/home/PageHome.vue
+++ b/app/views/home/PageHome.vue
@@ -8,7 +8,7 @@
               <mixed-color-label :text="$t('home_v3.learn_to_code')" />
             </h1>
             <p class="text-24">
-              {{ $t('home_v3.innovative_play_experiences') }}
+              {{ $t(educatorSignupExperiment ? 'home_v3.sing_up_today' :'home_v3.innovative_play_experiences') }}
             </p>
             <div class="buttons">
               <ButtonSection />
@@ -447,7 +447,12 @@ export default Vue.extend({
   computed: {
     me () {
       return me
-    }
+    },
+
+    educatorSignupExperiment () {
+      const value = me.getEducatorSignupExperimentValue()
+      return value === 'beta'
+    },
   },
   mounted () {
     this.checkPaymentTracking()


### PR DESCRIPTION
 - New experiment added: `educator-signup-modal`
   - change subhead text
   - open signup modal automatically for _I'm an Educator_ button (& and navigate to /schools)
 
 - Modified `/schools` page to use vue router so modal open hash work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new route for `/schools` pointing to the `PageSchools.vue` component.
  - Introduced a new string key `sign_up_today` to encourage users to sign up for free access to games and resources.

- **Enhancements**
  - Updated `ButtonSection.vue` and `PageHome.vue` to conditionally modify content based on the new `educatorSignupExperiment` value.
  - Added `getEducatorSignupExperimentValue` method in the user model to support the new experiment-based feature.

- **Refactor**
  - Simplified the `schools` method in the router to use a more consistent approach with the `go` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->