### PR TITLE
enable AI HS for beta users

### DIFF
--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -462,7 +462,8 @@ module.exports = {
       ai_hackstack_description: 'The first generative AI companion tool specifically crafted for those new to AI with a focus on student privacy and safety.',
       ai_junior_description: 'Introduces multimodal generative AI in a simple and intuitive platform designed specifically for K-5 students.',
       learning_options: 'Learning Options',
-      ai_hackstack: 'AI HackStack'
+      ai_hackstack: 'AI HackStack',
+      beta: 'Beta'
     },
 
     modal: {
@@ -4594,7 +4595,8 @@ module.exports = {
       failed_attempts: 'Failed Attempts',
       no_failed_attempts: 'No Failed Attempts',
       failed_attempts_subtext: 'Number of times incorrect option was selected',
-      open_project: 'Open Project'
+      open_project: 'Open Project',
+      create_class_hackstack: 'Please create a New Class to access AI HackStack'
     },
 
     outcomes: {

--- a/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
+++ b/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
@@ -57,7 +57,7 @@ export default {
     },
 
     showHackStack () {
-      return utils.isCodeCombat && this.hackStackClassrooms.length > 0 && me.isInternal()
+      return utils.isCodeCombat && (me.isInternal() || me.isBetaTester())
     },
 
     showPD () {
@@ -93,6 +93,11 @@ export default {
         } else {
           window.tracker?.trackEvent(eventName, { category: 'Teachers' })
         }
+      }
+    },
+    hackstackClicked () {
+      if (this.hackStackClassrooms.length === 0) {
+        noty({ text: $.i18n.t('teacher_dashboard.create_class_hackstack'), type: 'warning', layout: 'center', timeout: 5000 })
       }
     }
   }
@@ -319,6 +324,7 @@ export default {
       v-if="showHackStack"
       role="presentation"
       class="dropdown"
+      @click="hackstackClicked"
     >
       <a
         id="HackstackClassesDropdown"
@@ -330,7 +336,7 @@ export default {
         aria-expanded="false"
       >
         <div id="IconMyClasses" />
-        <span>{{ $t('nav.ai_hackstack') }}</span>
+        <span>{{ $t('nav.ai_hackstack') }}</span><span class="beta">({{ $t('nav.beta') }})</span>
         <span class="caret" />
       </a>
       <ul
@@ -671,5 +677,12 @@ li.open > #AILeague,
 
 .dashboard-toggle {
   margin: 5px 0 10px;
+}
+
+.beta {
+  font-size: 12px;
+  line-height: 15px;
+  position: relative;
+  bottom: 5px;
 }
 </style>


### PR DESCRIPTION
fixes ENG-768

Backend: https://github.com/codecombat/codecombat-server/pull/953

<img width="261" alt="Screenshot 2024-06-06 at 4 34 11 PM" src="https://github.com/codecombat/codecombat/assets/6376157/f7a23b7d-3303-4d63-b550-fbf99f66cbf5">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a beta tag next to the AI Hackstack navigation item for beta testers.
  - Introduced a notification for users to create a new class when accessing AI HackStack with no existing classrooms.

- **Improvements**
  - Updated logic to show AI Hackstack based on user roles, including beta testers.

- **Style**
  - Enhanced visual styling for the beta tag in the navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->