### PR TITLE
fb login fixes

### DIFF
--- a/app/core/social-handlers/FacebookHandler.js
+++ b/app/core/social-handlers/FacebookHandler.js
@@ -93,14 +93,15 @@ module.exports = (FacebookHandler = (FacebookHandler = (function () {
             xfbml: true, // parse XFBML
             version: 'v20.0'
           })
-          return FB.getLoginStatus(response => {
-            if (response.status === 'connected') {
-              this.connected = true
-              this.trigger('connect', { response })
-            }
-            this.apiLoaded = true
-            return this.trigger('load-api')
-          })
+          return this.trigger('load-api')
+          // return FB.getLoginStatus(response => {
+          //   if (response.status === 'connected') {
+          //     this.connected = true
+          //     this.trigger('connect', { response })
+          //   }
+          //   this.apiLoaded = true
+          //   return this.trigger('load-api')
+          // })
         }
         return window.fbAsyncInit
       }

--- a/app/core/social-handlers/FacebookHandler.js
+++ b/app/core/social-handlers/FacebookHandler.js
@@ -35,7 +35,7 @@ module.exports = (FacebookHandler = (FacebookHandler = (function () {
       super()
     }
 
-    token () { return (this.authResponse != null ? this.authResponse.accessToken : undefined) }
+    token () { return null }
 
     fakeAPI () {
       window.FB = {
@@ -96,7 +96,6 @@ module.exports = (FacebookHandler = (FacebookHandler = (function () {
           return FB.getLoginStatus(response => {
             if (response.status === 'connected') {
               this.connected = true
-              this.authResponse = response.authResponse
               this.trigger('connect', { response })
             }
             this.apiLoaded = true
@@ -114,9 +113,8 @@ module.exports = (FacebookHandler = (FacebookHandler = (function () {
       return FB.login(response => {
         if (response.status === 'connected') {
           this.connected = true
-          this.authResponse = response.authResponse
           this.trigger('connect', { response })
-          return options.success.bind(options.context)()
+          return options.success.bind(options.context)(response)
         }
       }
       , { scope: 'email' })

--- a/app/core/social-handlers/FacebookHandler.js
+++ b/app/core/social-handlers/FacebookHandler.js
@@ -94,14 +94,6 @@ module.exports = (FacebookHandler = (FacebookHandler = (function () {
             version: 'v20.0'
           })
           return this.trigger('load-api')
-          // return FB.getLoginStatus(response => {
-          //   if (response.status === 'connected') {
-          //     this.connected = true
-          //     this.trigger('connect', { response })
-          //   }
-          //   this.apiLoaded = true
-          //   return this.trigger('load-api')
-          // })
         }
         return window.fbAsyncInit
       }

--- a/app/core/social-handlers/FacebookHandler.js
+++ b/app/core/social-handlers/FacebookHandler.js
@@ -78,6 +78,8 @@ module.exports = (FacebookHandler = (FacebookHandler = (function () {
           js.id = id
           js.async = true
           js.src = '//connect.facebook.net/en_US/sdk.js'
+          js.defer = true
+          js.crossorigin = 'anonymous'
 
           // js.src = '//connect.facebook.net/en_US/all/debug.js'
           ref.parentNode.insertBefore(js, ref)
@@ -89,7 +91,7 @@ module.exports = (FacebookHandler = (FacebookHandler = (function () {
             channelUrl: document.location.origin + '/channel.html', // Channel File
             cookie: true, // enable cookies to allow the server to access the session
             xfbml: true, // parse XFBML
-            version: 'v3.2'
+            version: 'v20.0'
           })
           return FB.getLoginStatus(response => {
             if (response.status === 'connected') {

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -854,20 +854,20 @@ module.exports = (User = (function () {
       return this.fetch(options)
     }
 
-    fetchFacebookUser (facebookID, options = {}) {
+    fetchFacebookUser (facebookID, fbAccessToken, options = {}) {
       if (options.data == null) { options.data = {} }
       options.data.facebookID = facebookID
-      options.data.facebookAccessToken = application.facebookHandler.token()
+      options.data.facebookAccessToken = fbAccessToken
       return this.fetch(options)
     }
 
-    loginFacebookUser (facebookID, options = {}) {
+    loginFacebookUser (facebookID, fbAccessToken, options = {}) {
       options.url = '/auth/login-facebook'
       options.type = 'POST'
       options.xhrFields = { withCredentials: true }
       if (options.data == null) { options.data = {} }
       options.data.facebookID = facebookID
-      options.data.facebookAccessToken = application.facebookHandler.token()
+      options.data.facebookAccessToken = fbAccessToken
       return this.fetch(options)
     }
 

--- a/app/templates/teachers/create-teacher-account-view.pug
+++ b/app/templates/teachers/create-teacher-account-view.pug
@@ -11,10 +11,10 @@ block content
           a.login-link(data-i18n="login.log_in")
         if me.useSocialSignOn()
           #social-network-signups.m-y-2
-            button#facebook-signup-btn.btn.btn-facebook.btn-lg.m-x-1
-              span.spr(data-i18n="teachers_quote.connect_with")
-              | Facebook
-              img.m-l-1(src='/images/pages/community/logo_facebook.png')
+            //- button#facebook-signup-btn.btn.btn-facebook.btn-lg.m-x-1
+            //-   span.spr(data-i18n="teachers_quote.connect_with")
+            //-   | Facebook
+            //-   img.m-l-1(src='/images/pages/community/logo_facebook.png')
             div(id='google-login-button-ctav')
 
     #gplus-logged-in-row.row.text-center.hide

--- a/app/templates/teachers/request-quote-view.pug
+++ b/app/templates/teachers/request-quote-view.pug
@@ -155,7 +155,7 @@ block content
                 option 501-1000
                 option 1000+
               .help-block.small
-                em.text-info(data-i18n="teachers_quote.num_students_help", data-i18n-options=JSON.stringify({ product })) 
+                em.text-info(data-i18n="teachers_quote.num_students_help", data-i18n-options=JSON.stringify({ product }))
 
           .col-md-4.col-sm-6
             .form-group
@@ -211,10 +211,10 @@ block content
               //-   img.m-l-1(src='/images/pages/community/logo_facebook.png')
               a#google-login-button-ctav
             else
-              button#facebook-signup-btn.btn.btn-facebook.btn-lg.m-x-1
-                span.spr(data-i18n="teachers_quote.signup_with")
-                | Facebook
-                img.m-l-1(src='/images/pages/community/logo_facebook.png')
+              //- button#facebook-signup-btn.btn.btn-facebook.btn-lg.m-x-1
+              //-   span.spr(data-i18n="teachers_quote.signup_with")
+              //-   | Facebook
+              //-   img.m-l-1(src='/images/pages/community/logo_facebook.png')
               a#google-login-button-ctav
 
           .text-h1.text-uppercase(data-i18n="general.or")

--- a/app/views/core/AuthModal.js
+++ b/app/views/core/AuthModal.js
@@ -268,10 +268,12 @@ module.exports = (AuthModal = (function () {
     }
 
     onFacebookLoginError (res) {
-      this.$('#unknown-error-alert').addClass('hide')
+      this?.$('#unknown-error-alert').addClass('hide')
       if (res.errorID && (res.errorID === 'individuals-not-supported')) {
         forms.setErrorToProperty(this.$el, 'emailOrUsername', $.i18n.t('login.individual_users_not_supported'))
-        const showingError = true
+        this.$('#unknown-error-alert').removeClass('hide')
+      } else if (res.code === 404) {
+        forms.setErrorToProperty(this.$el, 'emailOrUsername', $.i18n.t('loading_error.user_not_found'))
         this.$('#unknown-error-alert').removeClass('hide')
       }
 

--- a/app/views/core/AuthModal.js
+++ b/app/views/core/AuthModal.js
@@ -240,16 +240,16 @@ module.exports = (AuthModal = (function () {
       const btn = this.$('#facebook-login-btn')
       return application.facebookHandler.connect({
         context: this,
-        success () {
+        success (response) {
           btn.find('.sign-in-blurb').text($.i18n.t('login.logging_in'))
           btn.attr('disabled', true)
           return application.facebookHandler.loadPerson({
             context: this,
             success (facebookAttrs) {
               const existingUser = new User()
-              return existingUser.fetchFacebookUser(facebookAttrs.facebookID, {
+              return existingUser.fetchFacebookUser(facebookAttrs.facebookID, response?.authResponse?.accessToken, {
                 success: () => {
-                  return me.loginFacebookUser(facebookAttrs.facebookID, {
+                  return me.loginFacebookUser(facebookAttrs.facebookID, response?.authResponse?.accessToken, {
                     success: () => {
                       application.tracker.identifyAfterNextPageLoad()
                       return application.tracker.identify().then(() => {

--- a/app/views/core/AuthModal.js
+++ b/app/views/core/AuthModal.js
@@ -73,7 +73,8 @@ module.exports = (AuthModal = (function () {
         }
       }
       this.subModalContinue = options.subModalContinue
-      return this.showLibraryModal = userUtils.shouldShowLibraryLoginModal()
+      this.showLibraryModal = userUtils.shouldShowLibraryLoginModal()
+      this.onFacebookLoginError = this.onFacebookLoginError.bind(this)
     }
 
     afterRender () {

--- a/test/app/views/teachers/CreateTeacherAccountView.spec.js
+++ b/test/app/views/teachers/CreateTeacherAccountView.spec.js
@@ -116,7 +116,7 @@ describe('CreateTeacherAccountView', function() {
         });
       });
 
-      return describe('when the user connects with Facebook and there isn\'t already an associated account', function() {
+      return xdescribe('when the user connects with Facebook and there isn\'t already an associated account', function() {
         beforeEach(function() {
           const request = jasmine.Ajax.requests.mostRecent();
           return request.respondWith({ status: 404, responseText: '{}' });

--- a/test/app/views/teachers/CreateTeacherAccountView.spec.js
+++ b/test/app/views/teachers/CreateTeacherAccountView.spec.js
@@ -91,7 +91,7 @@ describe('CreateTeacherAccountView', function() {
   }));
 
   if (!window.features.chinaUx) {
-    describe('clicking the Facebook button', function() {
+    xdescribe('clicking the Facebook button', function() {
 
       beforeEach(function() {
         application.facebookHandler.fakeAPI();

--- a/test/app/views/teachers/RequestQuoteView.spec.js
+++ b/test/app/views/teachers/RequestQuoteView.spec.js
@@ -122,7 +122,7 @@ describe('RequestQuoteView', function() {
 
           it('fills the username field with the given first and last names', () => expect(view.$('input[name="name"]').val()).toBe('A B'));
 
-          it('includes a facebook button which will sign them in immediately', function() {
+          xit('includes a facebook button which will sign them in immediately', function() {
             if (window.features.chinUx) { return pending(); }
             view.$('#facebook-signup-btn').click();
             const request = jasmine.Ajax.requests.mostRecent();


### PR DESCRIPTION
- You are overriding current access token, that means some other app is expecting different access token and you will probably break things. Please consider passing access_token directly to API parameters instead of overriding the global settings.
- update version to 20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the Facebook SDK to version 20.0 with improved loading attributes.
  - Simplified Facebook login status handling for a smoother user experience.

- **Bug Fixes**
  - Facebook token method now consistently returns null, ensuring better error handling.

- **Chores**
  - Commented out Facebook signup buttons and related content in various templates.
  - Skipped specific Facebook-related test cases to streamline test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->