### PR TITLE
hide hints when open game-menu

### DIFF
--- a/app/schemas/subscriptions/tome.js
+++ b/app/schemas/subscriptions/tome.js
@@ -191,4 +191,6 @@ module.exports = {
   'tome:fix-code-preview-end': c.object({}),
 
   'blockly:clicked-block': c.object({ required: ['block', 'text'] }, { block: { type: 'object' }, text: { type: 'string' } }),
+
+  'tome:game-menu-opened': c.object({}),
 }

--- a/app/views/play/level/ControlBarView.coffee
+++ b/app/views/play/level/ControlBarView.coffee
@@ -154,6 +154,7 @@ module.exports = class ControlBarView extends CocoView
     c
 
   showGameMenuModal: (e, tab=null) ->
+    Backbone.Mediator.publish 'tome:game-menu-opened', {}
     gameMenuModal = new GameMenuModal {@level, @session, @supermodel, showTab: tab, classroomAceConfig: @options.classroomAceConfig, hintsState: @options.hintsState, teacherID: @options.teacherID, @team, @courseID, @courseInstanceID}
     @openModalView gameMenuModal
     @listenToOnce gameMenuModal, 'change-hero', ->

--- a/app/views/play/level/tome/SpellTopBarView.coffee
+++ b/app/views/play/level/tome/SpellTopBarView.coffee
@@ -20,6 +20,7 @@ module.exports = class SpellTopBarView extends CocoView
     'tome:spell-loaded': 'onSpellLoaded'
     'tome:spell-changed': 'onSpellChanged'
     'tome:spell-changed-language': 'onSpellChangedLanguage'
+    'tome:game-menu-opened': 'onGameMenuOpened'
     'websocket:user-online': 'onUserOnlineChanged'
 
   events:
@@ -79,6 +80,11 @@ module.exports = class SpellTopBarView extends CocoView
 
   onClickImageGalleryButton: (e) ->
     @openModalView new ImageGalleryModal()
+
+  onGameMenuOpened: ->
+    hintState = @hintsState.get('hidden')
+    if (!hintState)
+      @hintsState.set('hidden', not hintState)
 
   onClickHintsButton: ->
     return unless @hintsState?

--- a/app/views/play/level/tome/SpellTopBarView.coffee
+++ b/app/views/play/level/tome/SpellTopBarView.coffee
@@ -83,7 +83,7 @@ module.exports = class SpellTopBarView extends CocoView
 
   onGameMenuOpened: ->
     hintState = @hintsState.get('hidden')
-    if (!hintState)
+    unless hintState
       @hintsState.set('hidden', not hintState)
 
   onClickHintsButton: ->


### PR DESCRIPTION
fix ENG-707
![output](https://github.com/codecombat/codecombat/assets/11417632/d080aa5d-1695-4a89-82a6-efa3a0eedc01)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new event `'tome:game-menu-opened'` which triggers when the game menu is opened.
  - Added a new event handler to toggle hint visibility based on the game menu state.

- **Enhancements**
  - Improved the `SpellTopBarView` with additional event handling for hint visibility and new modal views for image gallery and AI help.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->