### PR TITLE
make sure classrooms can't be set to java/cpp blocks

### DIFF
--- a/app/templates/courses/classroom-settings-modal.pug
+++ b/app/templates/courses/classroom-settings-modal.pug
@@ -87,37 +87,37 @@ block modal-body-content
             input#live-completion(name="liveCompletion" checked=liveCompletion type='checkbox')
           .help-block.small.text-navy(data-i18n="teachers.classroom_live_completion")
 
-        if view.enableBlocks
-          // Icon blocks only ready for Junior, which isn't in classroom yet
-          // - var allCodeFormats = ['text-code', 'blocks-and-code', 'blocks-text', 'blocks-icons']
-          - var allCodeFormats = ['text-code', 'blocks-and-code', 'blocks-text']
-          label
-            span(data-i18n="teachers.code_formats")
-          .form-group
-            - var aceConfig = view.classroom.get('aceConfig') || {}
-            - var codeFormats = aceConfig.codeFormats
-            if codeFormats === undefined
-              - codeFormats = ['text-code']
-              // Later, we can turn everything on by default
-              // - codeFormats = isJunior ? allCodeFormats : _.omit(allCodeFormats, 'blocks-icons')
-            each format in allCodeFormats
-              - var i18nPrefix = 'choose_hero.' + format.replace(/-/g, '_')
-              label.checkbox-inline(data-i18n="[title]" + i18nPrefix + "_blurb")
-                input(name="codeFormats" value=format checked=codeFormats.includes(format) type='checkbox')
-                span(data-i18n="choose_hero." + format.replace(/-/g, '_'))
-            .help-block.small.text-navy(data-i18n="teachers.code_formats_description")
+        .code-formats-part
+          if view.enableBlocks
+            // TODO: check is junior course included
+            - var allCodeFormats = ['text-code', 'blocks-and-code', 'blocks-text', 'blocks-icons']
             label
-              span(data-i18n="teachers.default_code_format")
-            - var aceConfig = view.classroom.get('aceConfig') || {}
-            - var codeFormatDefault = aceConfig.codeFormatDefault
-            if codeFormatDefault === undefined
-              - codeFormatDefault = 'text-code'
-            select.form-control(name="codeFormatDefault" value=codeFormatDefault)
+              span(data-i18n="teachers.code_formats")
+            .form-group
+              - var aceConfig = view.classroom.get('aceConfig') || {}
+              - var codeFormats = aceConfig.codeFormats
+              if codeFormats === undefined
+                - codeFormats = ['text-code']
+                // Later, we can turn everything on by default
+                // - codeFormats = isJunior ? allCodeFormats : _.omit(allCodeFormats, 'blocks-icons')
               each format in allCodeFormats
                 - var i18nPrefix = 'choose_hero.' + format.replace(/-/g, '_')
-                option(value=format)= $.i18n.t(i18nPrefix) + ' - ' + $.i18n.t(i18nPrefix + '_blurb')
-            .help-block.small.text-navy(data-i18n="teachers.default_code_format_description")
-
+                label.checkbox-inline(data-i18n="[title]" + i18nPrefix + "_blurb")
+                  input.codeformats-checkbox(name="codeFormats" value=format checked=codeFormats.includes(format) type='checkbox')
+                  span(data-i18n="choose_hero." + format.replace(/-/g, '_'))
+              .help-block.small.text-navy(data-i18n="teachers.code_formats_description")
+              label
+                span(data-i18n="teachers.default_code_format")
+              - var aceConfig = view.classroom.get('aceConfig') || {}
+              - var codeFormatDefault = aceConfig.codeFormatDefault
+              if codeFormatDefault === undefined
+                - codeFormatDefault = 'text-code'
+              select.form-control#default-codeformat-select(name="codeFormatDefault" value=codeFormatDefault)
+                each format in view.enabledCodeFormats
+                  - var i18nPrefix = 'choose_hero.' + format.replace(/-/g, '_')
+                  option(value=format)= $.i18n.t(i18nPrefix) + ' - ' + $.i18n.t(i18nPrefix + '_blurb')
+              .help-block.small.text-navy(data-i18n="teachers.default_code_format_description")
+  
         .form-group
           label
             span(data-i18n="teachers.classroom_level_chat")

--- a/app/views/courses/ClassroomSettingsModal.js
+++ b/app/views/courses/ClassroomSettingsModal.js
@@ -42,7 +42,9 @@ module.exports = (ClassroomSettingsModal = (function () {
         'click .create-manually': 'onClickCreateManually',
         'click .pick-image-button': 'onPickImage',
         'click #link-lms-classroom-btn': 'onClickLinkLMSClassroom',
-        'change #classroom-items': 'onChangeClassroomItems'
+        'change #classroom-items': 'onChangeClassroomItems',
+        'change #programming-language-select': 'onChangeProgrammingLanguage',
+        'change .codeformats-checkbox': 'onChangeCodeFormats'
       }
     }
 
@@ -67,6 +69,7 @@ module.exports = (ClassroomSettingsModal = (function () {
         })
       }
       this.showLMSDropDown = false
+      this.enabledCodeFormats = this.classroom.get('aceConfig')?.codeFormats || ['text-code']
     }
 
     afterRender () {
@@ -77,6 +80,18 @@ module.exports = (ClassroomSettingsModal = (function () {
     onChangeClassroomItems (e) {
       // Unless we manually change this, we're not saving it, so that we can easily change the schema default later
       this.hasChangedClassroomItems = true
+    }
+
+    onChangeProgrammingLanguage (e) {
+      const language = $(e.target).val()
+      this.enableBlocks = ['python', 'javascript', 'lua'].includes(language)
+      this.renderSelectors('.code-formats-part')
+    }
+
+    onChangeCodeFormats (e) {
+      const codeFormats = this.$('.codeformats-checkbox:checked').map((i, el) => $(el).val()).get()
+      this.enabledCodeFormats = codeFormats
+      this.renderSelectors('#default-codeformat-select')
     }
 
     onSubmitForm (e) {
@@ -107,6 +122,11 @@ module.exports = (ClassroomSettingsModal = (function () {
       if (attrs.liveCompletion) {
         attrs.aceConfig.liveCompletion = attrs.liveCompletion[0] === 'on'
         delete attrs.liveCompletion
+      }
+
+      if (!this.enableBlocks) {
+        attrs.codeFormats = ['text-code']
+        attrs.codeFormatDefault = 'text-code'
       }
 
       if (attrs.codeFormats) {

--- a/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
@@ -126,11 +126,18 @@ export default Vue.extend({
       return (this.classroom || {}).classroomItems
     },
     enableBlocks () {
-      return ['python', 'javascript', 'lua'].includes(this.language || 'python')
+      return ['python', 'javascript', 'lua'].includes(this.newProgrammingLanguage || 'python')
     },
     allCodeFormats () {
       // TODO: only show blocks-icons if a Junior course is included
-      return ['text-code', 'blocks-and-code', 'blocks-text', 'blocks-icons']
+      if (this.enableBlocks) {
+        return ['text-code', 'blocks-and-code', 'blocks-text', 'blocks-icons']
+      } else {
+        return ['text-code']
+      }
+    },
+    enabledCodeFormats () {
+      return this.newCodeFormats
     },
     codeFormats () {
       // Later, we can turn everything on by default
@@ -262,6 +269,11 @@ export default Vue.extend({
 
       if (this.newClassroomItems !== this.classroomItems) {
         updates.classroomItems = this.newClassroomItems
+      }
+
+      if (!this.enableBlocks) {
+        this.newCodeFormats = ['text-code']
+        this.newCodeFormatDefault = 'text-code'
       }
 
       // Make sure that codeFormats includes codeFormatDefault, including when these aren't specified
@@ -526,7 +538,7 @@ export default Vue.extend({
               name="codeFormatDefault"
             >
               <option
-                v-for="codeFormat in allCodeFormats"
+                v-for="codeFormat in enabledCodeFormats"
                 :key="codeFormat"
                 :value="codeFormat"
               >


### PR DESCRIPTION
fix CCJ-111

now old dashboard:
![image](https://github.com/codecombat/codecombat/assets/11417632/69d2fb54-a18a-47ab-af43-bcf5120026a7)
![image](https://github.com/codecombat/codecombat/assets/11417632/14cbf0f4-cf09-40d2-b88b-e54a8f84e280)

new dashboard:
![image](https://github.com/codecombat/codecombat/assets/11417632/06577202-7c2c-468f-b320-d9dd1ba4b30a)
![image](https://github.com/codecombat/codecombat/assets/11417632/718df885-4fb8-4869-b5f4-be2524e382cc)

also update the defaultCodeFormats can only select from checked codeformats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dropdown for selecting default code formats in classroom settings.
  - Updated logic to dynamically show code formats based on programming language selection.

- **Bug Fixes**
  - Fixed issues with code format checkboxes not displaying correctly.

- **Enhancements**
  - Improved the user interface for code format selection in teacher dashboard modals.
  - Enhanced the handling of code formats based on the selected programming language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->