### PR TITLE
fix choose hero and codeFomat

### DIFF
--- a/app/views/play/common/ChangeLanguageTab.js
+++ b/app/views/play/common/ChangeLanguageTab.js
@@ -56,7 +56,6 @@ module.exports = (ChangeLanguageTab = (function () {
       context.codeLanguages = this.codeLanguageList
       context.codeLanguage = this.codeLanguage = this.options?.session?.get('codeLanguage') || me.get('aceConfig')?.language || 'python'
       context.codeFormats = this.codeFormatList.filter(({ id }) => (this.classroomAceConfig?.codeFormats || ['text-code', 'blocks-and-code', 'blocks-text', 'blocks-icons']).includes(id))
-      console.log('codeFormatList', context.codeFormats)
       const defaultCodeFormat = this.isJunior ? 'blocks-icons' : 'text-code'
       context.codeFormat = this.codeFormat = this.propCodeFormat || me.get('aceConfig')?.codeFormat || defaultCodeFormat
       return context

--- a/app/views/play/common/ChangeLanguageTab.js
+++ b/app/views/play/common/ChangeLanguageTab.js
@@ -40,6 +40,7 @@ module.exports = (ChangeLanguageTab = (function () {
         { id: 'blocks-text', name: `${$.i18n.t('choose_hero.blocks_text')}` },
         { id: 'blocks-icons', name: `${$.i18n.t('choose_hero.blocks_icons')}` },
       ]
+      this.propCodeFormat = this.options.codeFormat
     }
 
     afterRender () {
@@ -54,9 +55,10 @@ module.exports = (ChangeLanguageTab = (function () {
       context = super.getRenderData(context)
       context.codeLanguages = this.codeLanguageList
       context.codeLanguage = this.codeLanguage = this.options?.session?.get('codeLanguage') || me.get('aceConfig')?.language || 'python'
-      context.codeFormats = this.codeFormatList
+      context.codeFormats = this.codeFormatList.filter(({ id }) => (this.classroomAceConfig?.codeFormats || ['text-code', 'blocks-and-code', 'blocks-text', 'blocks-icons']).includes(id))
+      console.log('codeFormatList', context.codeFormats)
       const defaultCodeFormat = this.isJunior ? 'blocks-icons' : 'text-code'
-      context.codeFormat = this.codeFormat = me.get('aceConfig')?.codeFormat || defaultCodeFormat
+      context.codeFormat = this.codeFormat = this.propCodeFormat || me.get('aceConfig')?.codeFormat || defaultCodeFormat
       return context
     }
 

--- a/app/views/play/modal/PlayHeroesModal.js
+++ b/app/views/play/modal/PlayHeroesModal.js
@@ -190,6 +190,7 @@ module.exports = (PlayHeroesModal = (function () {
       this.renderSelectors('#hero-footer')
       const changeLanguageOptions = _.clone(this.options)
       changeLanguageOptions.classroomAceConfig = this.classroomAceConfig
+      changeLanguageOptions.codeFormat = this.changeLanguageView?.codeFormat
       this.insertSubView(this.changeLanguageView = new ChangeLanguageTab(changeLanguageOptions))
       return this.$el.find('#gems-count-container').toggle(Boolean(this.visibleHero?.purchasable))
     }


### PR DESCRIPTION
fix CCJ-217 and fix ENG-772

in the gif, you can see that change hero now keep the selected code format.
and also only 2 options in select (classroom limited)
![output](https://github.com/codecombat/codecombat/assets/11417632/01fef330-c0f8-4036-ac2d-eea79f6f2cce)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced language tab to better handle code formats based on classroom configurations.
  - Improved user experience by setting the code format using available options.

- **Bug Fixes**
  - Ensured the correct code formats are displayed in the language tab based on configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->