### PR TITLE
coco curriculum guide shouldn't have play-course

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterInfo.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterInfo.vue
@@ -306,6 +306,7 @@ export default {
               rel="noreferrer"
             >
               <button-play-chapter
+                v-if="isOzaria"
                 v-tooltip.top="{
                   content: $t(isOzaria ? 'teacher_dashboard.want_to_save_tooltip': 'teacher_dashboard.want_to_save_tooltip_coco'),
                   classes: 'teacher-dashboard-tooltip lighter-p'


### PR DESCRIPTION
fix CCJ-224

codecombat doesn't allow teacher to open campaign view to play, so the button `play course` is not make sense to show in coco. let's hide it.
![image](https://github.com/codecombat/codecombat/assets/11417632/ee336203-939e-41e4-a113-25112a977547)
