### PR TITLE
fix access token not passed in fb signup

### DIFF
--- a/app/models/User.js
+++ b/app/models/User.js
@@ -797,7 +797,7 @@ module.exports = (User = (function () {
       options.url = _.result(this, 'url') + '/signup-with-facebook'
       options.type = 'POST'
       if (options.data == null) { options.data = {} }
-      _.extend(options.data, { name, email, facebookID, facebookAccessToken: application.facebookHandler.token() })
+      _.extend(options.data, { name, email, facebookID, facebookAccessToken: options.facebookAccessToken })
       options.contentType = 'application/json'
       options.xhrFields = { withCredentials: true }
       options.data = JSON.stringify(options.data)

--- a/app/views/core/CreateAccountModal/BasicInfoView.js
+++ b/app/views/core/CreateAccountModal/BasicInfoView.js
@@ -440,19 +440,23 @@ module.exports = (BasicInfoView = (function () {
           }
 
           switch (this.signupState.get('ssoUsed')) {
-            case 'gplus':
+            case 'gplus': {
               var { email, gplusID } = this.signupState.get('ssoAttrs')
               var { name } = forms.formToObject(this.$el)
               jqxhr = me.signupWithGPlus(name, email, gplusID)
               break
-            case 'facebook':
+            }
+            case 'facebook': {
               ({ email, facebookID } = this.signupState.get('ssoAttrs'));
               ({ name } = forms.formToObject(this.$el))
-              jqxhr = me.signupWithFacebook(name, email, facebookID)
+              const facebookAccessToken = this.signupState.get('ssoResp')?.authResponse?.accessToken
+              jqxhr = me.signupWithFacebook(name, email, facebookID, { facebookAccessToken })
               break
-            default:
+            }
+            default: {
               ({ name, email, password } = forms.formToObject(this.$el))
               jqxhr = me.signupWithPassword(name, email, password)
+            }
           }
 
           return new Promise(jqxhr.then)
@@ -576,7 +580,7 @@ module.exports = (BasicInfoView = (function () {
             resp,
             context: this,
             success (ssoAttrs) {
-              this.signupState.set({ ssoAttrs })
+              this.signupState.set({ ssoAttrs, ssoResp: resp })
               const { email } = ssoAttrs
               return User.checkEmailExists(email).then(({ exists }) => {
                 this.signupState.set({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added handling for Facebook authentication during account creation. Users can now sign up using their Facebook account seamlessly. 

- **Bug Fixes**
  - Improved the accuracy of Facebook access token assignment during the signup process to enhance reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->