### PR TITLE
new esper version to fix junior bug

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "nanoscroller": "~0.8.0",
     "treema": "https://github.com/codecombat/treema.git#master",
     "validated-backbone-mediator": "~0.1.3",
-    "esper.js": "https://files.codecombat.com/esper-2024-01-11.tar.gz",
+    "esper.js": "https://files.codecombat.com/esper-2024-06-15-1.tar.gz",
     "algolia-autocomplete.js": "^0.17.0",
     "algolia-autocomplete-no-conflict": "1.0.0",
     "font-awesome": "fontawesome#^4.7.0",


### PR DESCRIPTION
woooooow
![image](https://github.com/codecombat/codecombat/assets/11417632/3bdf2a8d-7700-4270-be7d-7c9115ac177d)

btw today's first esper package has directory format issue so use `-1` name to avoid cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `esper.js` dependency to the latest version for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->