### PR TITLE
get ride of ladder matches/scorehistory... so on

### DIFF
--- a/app/collections/LevelSessions.js
+++ b/app/collections/LevelSessions.js
@@ -58,6 +58,7 @@ module.exports = (LevelSessionCollection = (function () {
       let skip = 0
       const size = _.size(classroom.get('members'))
       if (options.data == null) { options.data = {} }
+      options.data.project = options.data.project || 'state.complete,state.introContentSessionComplete,state.goalStates,level,creator,changed,created,dateFirstCompleted,submitted,codeConcepts,code,codeLanguage,introContentSessionComplete,playtime'
       options.data.memberLimit = limit
       options.remove = false
       const jqxhrs = []


### PR DESCRIPTION
coco fetch all level session by now which lead to load ladder's long long session which is not necessary in classrooms. so let's project it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured the `project` property is always initialized with a default value in session data, improving data consistency and preventing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->