### PR TITLE
run button space need to be always left

### DIFF
--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -867,14 +867,15 @@ module.exports = class SpellView extends CocoView
     windowHeight = $(window).innerHeight()
     topOffset = $(aceCls).offset()?.top or 0
     spellPaletteAllowedMinHeight = Math.min spellPaletteHeight, 0.4 * (windowHeight  - topOffset)
-    spellPaletteAllowedMinHeight = Math.max 150, spellPaletteAllowedMinHeight if spellPaletteHeight > 0  # At least room for four props
+    spellPaletteAllowedMinHeight = Math.max 75, spellPaletteAllowedMinHeight if spellPaletteHeight > 0  # At least room for four props
+    runButtonHeight = if aceCls == '.ace' then 75 else 0
     gameHeight = $('#game-area').innerHeight()
     heightScale = if aceCls == '.ace' then 1 else 0.5
 
     # If the spell palette is too tall, we'll need to shrink it.
     maxHeightOffset = 0
     minHeightOffset = if hasBlocks or isCinematic then 0 else 100
-    maxHeight = windowHeight - topOffset - spellPaletteAllowedMinHeight - maxHeightOffset
+    maxHeight = windowHeight - topOffset - spellPaletteAllowedMinHeight - maxHeightOffset - runButtonHeight
     minHeight = Math.min maxHeight * heightScale, Math.min(gameHeight, windowHeight) - spellPaletteHeight - minHeightOffset
     minHeight = maxHeight if hasBlocks or isCinematic
 
@@ -886,6 +887,7 @@ module.exports = class SpellView extends CocoView
     linesAtMaxHeight = Math.floor(maxHeight / lineHeight)
     lines = Math.max linesAtMinHeight, Math.min(screenLineCount + 2, linesAtMaxHeight), hardMinLines
     lines = 8 if _.isNaN lines
+    console.log "Setting Ace to #{lines} lines"
 
     ace.setOptions minLines: lines, maxLines: lines
 

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -887,7 +887,6 @@ module.exports = class SpellView extends CocoView
     linesAtMaxHeight = Math.floor(maxHeight / lineHeight)
     lines = Math.max linesAtMinHeight, Math.min(screenLineCount + 2, linesAtMaxHeight), hardMinLines
     lines = 8 if _.isNaN lines
-    console.log "Setting Ace to #{lines} lines"
 
     ace.setOptions minLines: lines, maxLines: lines
 


### PR DESCRIPTION
![image](https://github.com/codecombat/codecombat/assets/11417632/aa3e7c98-176f-4fc3-ac71-cfc31d001d12)

we left the run button space in `spellPaletteAllowedMinHeight` before, while actually spellPaletteHeight could be 0 but we still left the run button space, so split them out

fix ENG-845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved layout calculations to better adjust to different screen sizes.
  - Added logging to provide better insights during debugging.

- **Bug Fixes**
  - Fixed an issue where the run button height was not considered, leading to layout inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->