### PR TITLE
add how to delete account info in privacy doc

### DIFF
--- a/app/templates/privacy.pug
+++ b/app/templates/privacy.pug
@@ -100,6 +100,13 @@ block content
 
     p If you disable cookies, it will turn off some of the features that make your site experience more efficient and some of our services will not function properly.
 
+    p
+      strong Delete Your Account
+
+    p
+      span To delete your account and all personal data relating to your account, go to
+      a(href="https://codecombat.com/account/settings" target="_blank")  https://codecombat.com/account/settings
+      span  and scroll down to the section Delete Your Account . Enter your email address and password, and click Delete this account permanently. All user data will then be deleted.
 
     p
       strong Third Party Disclosure


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a section with instructions on how to delete an account and associated personal data, including a direct link to the account settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->