### PR TITLE
enable slider drag in mobile too

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -2441,6 +2441,14 @@ const shouldShowAiBotHelp = function (aceConfig) {
   return false
 }
 
+const isMobile = () => {
+  const mobileRELong = /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|iPhone|iPad|iPod|Android|webos/i
+
+  const mobileREShort = /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i
+  const ua = navigator.userAgent || navigator.vendor || window.opera
+  return mobileRELong.test(ua) || mobileREShort.test(ua.substr(0, 4))
+}
+
 module.exports = {
   ...module.exports,
   activeAndPastArenas,
@@ -2552,6 +2560,7 @@ module.exports = {
   isChinaOldBrowser,
   isCodeCombat,
   isOzaria,
+  isMobile,
   supportEmail,
   tournamentSortFn,
   cocoBaseURL,

--- a/app/views/core/CocoView.coffee
+++ b/app/views/core/CocoView.coffee
@@ -571,8 +571,7 @@ module.exports = class CocoView extends Backbone.View
     view
 
   isMobile: ->
-    ua = navigator.userAgent or navigator.vendor or window.opera
-    return mobileRELong.test(ua) or mobileREShort.test(ua.substr(0, 4))
+    utils.isMobile()
 
   isMac: ->
     navigator.platform.toUpperCase().indexOf('MAC') isnt -1
@@ -663,9 +662,5 @@ module.exports = class CocoView extends Backbone.View
     targetLanguage = 'en' if targetLanguage.split('-')[0] is 'en'
     githubUrl = "https://github.com/codecombat/codecombat/blob/master/app/locale/#{targetLanguage}.coffee#L#{lineNumber}"
     window.open githubUrl, target: '_blank'
-
-mobileRELong = /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i
-
-mobileREShort = /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i
 
 module.exports = CocoView

--- a/app/views/play/level/LevelPlaybackView.coffee
+++ b/app/views/play/level/LevelPlaybackView.coffee
@@ -224,10 +224,12 @@ module.exports = class LevelPlaybackView extends CocoView
   onProgressTapStart: (e, touchData) ->
     return unless application.isIPadApp or utils.isMobile()
     @onProgressEnter e
-    if e.handleObj.type == 'tapstart'
+    if e.handleObj?.type == 'tapstart'
       screenOffsetX = e.clientX ? touchData?.position.x ? 0
-    else
-      screenOffsetX = e.originalEvent.touches[0].clientX
+    else if e.handleObj?.type == 'touchstart'
+      screenOffsetX = e.originalEvent?.touches?[0]?.clientX ? 0
+    else  # unknown event type
+      return
     offsetX = screenOffsetX - $(e.target).closest('#timeProgress').offset().left
     offsetX = Math.max offsetX, 0
     @scrubTo offsetX / @$progressScrubber.width()
@@ -239,10 +241,12 @@ module.exports = class LevelPlaybackView extends CocoView
 
   onProgressTapMove: (e, touchData) ->
     return unless application.isIPadApp or utils.isMobile() # Not sure why the tap events would fire when it's not one.
-    if e.handleObj.type == 'tapmove'
+    if e.handleObj?.type == 'tapmove'
       screenOffsetX = e.clientX ? touchData?.position.x ? 0
-    else
-      screenOffsetX = e.originalEvent.touches[0].clientX
+    else if e.handleObj?.type == 'touchmove'
+      screenOffsetX = e.originalEvent?.touches?[0]?.clientX ? 0
+    else # unknown event type
+      return
     offsetX = screenOffsetX - $(e.target).closest('#timeProgress').offset().left
     offsetX = Math.max offsetX, 0
     @onProgressHover e, offsetX

--- a/app/views/play/level/LevelPlaybackView.coffee
+++ b/app/views/play/level/LevelPlaybackView.coffee
@@ -38,6 +38,9 @@ module.exports = class LevelPlaybackView extends CocoView
     'tapstart #timeProgress': 'onProgressTapStart'
     'tapend #timeProgress': 'onProgressTapEnd'
     'tapmove #timeProgress': 'onProgressTapMove'
+    'touchstart #timeProgress': 'onProgressTapStart'
+    'touchend #timeProgress': 'onProgressTapEnd'
+    'touchmove #timeProgress': 'onProgressTapMove'
 
   shortcuts:
     '⌘+p, p, ctrl+p': 'onTogglePlay'
@@ -219,21 +222,27 @@ module.exports = class LevelPlaybackView extends CocoView
       @timePopup.show()
 
   onProgressTapStart: (e, touchData) ->
-    return unless application.isIPadApp
+    return unless application.isIPadApp or utils.isMobile()
     @onProgressEnter e
-    screenOffsetX = e.clientX ? touchData?.position.x ? 0
+    if e.handleObj.type == 'tapstart'
+      screenOffsetX = e.clientX ? touchData?.position.x ? 0
+    else
+      screenOffsetX = e.originalEvent.touches[0].clientX
     offsetX = screenOffsetX - $(e.target).closest('#timeProgress').offset().left
     offsetX = Math.max offsetX, 0
     @scrubTo offsetX / @$progressScrubber.width()
     @onTogglePlay() if @$el.find('#play-button').hasClass 'playing'
 
   onProgressTapEnd: (e, touchData) ->
-    return unless application.isIPadApp
+    return unless application.isIPadApp or utils.isMobile()
     @onProgressLeave e
 
   onProgressTapMove: (e, touchData) ->
-    return unless application.isIPadApp  # Not sure why the tap events would fire when it's not one.
-    screenOffsetX = e.clientX ? touchData?.position.x ? 0
+    return unless application.isIPadApp or utils.isMobile() # Not sure why the tap events would fire when it's not one.
+    if e.handleObj.type == 'tapmove'
+      screenOffsetX = e.clientX ? touchData?.position.x ? 0
+    else
+      screenOffsetX = e.originalEvent.touches[0].clientX
     offsetX = screenOffsetX - $(e.target).closest('#timeProgress').offset().left
     offsetX = Math.max offsetX, 0
     @onProgressHover e, offsetX


### PR DESCRIPTION
not sure but in chrome devtool fake ipad Air/ipad Pro/windows surface seems not work. others works fine.

fix CCJ-139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced mobile device detection for improved handling of mobile-specific functionality.
  - Added touch event handlers for mobile devices to enhance user interaction in the playback view.

- **Improvements**
  - Refactored mobile detection logic to a utility function for cleaner and more maintainable code.
  - Updated existing event handlers to support both touch and mouse events for a seamless mobile experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->