### PR TITLE
disable focustrap and allow modal close

### DIFF
--- a/app/components/common/ModalGetLicenses.vue
+++ b/app/components/common/ModalGetLicenses.vue
@@ -37,6 +37,10 @@ export default Vue.extend({
     modalTitle: {
       type: String,
       default: 'Contact Our Classroom Team'
+    },
+    backboneDismissModal: {
+      type: Boolean,
+      default: true
     }
   },
   mixins: [validationMixin],
@@ -136,7 +140,7 @@ export default Vue.extend({
 <template>
   <modal
     :title="modalTitle"
-    :backbone-dismiss-modal="true"
+    :backbone-dismiss-modal="backboneDismissModal"
     @close="closeModal"
   >
     <div class="style-ozaria teacher-form">

--- a/app/views/dei/DEIView.vue
+++ b/app/views/dei/DEIView.vue
@@ -97,7 +97,7 @@ export default {
             a.contact-modal {{ $t("general.contact_us") }}
             | .
 
-    modal-get-licenses(v-if="showModalGetLicenses" @close="showModalGetLicenses = false" subtitle="To learn more about Ozaria and DEI, send us a message and our classroom success team will be in touch!" email-message="Hi Ozaria! I'm interested in promoting DEI through my computer science program.")
+    modal-get-licenses(v-if="showModalGetLicenses" @close="showModalGetLicenses = false" :backboneDismissModal="false" subtitle="To learn more about Ozaria and DEI, send us a message and our classroom success team will be in touch!" email-message="Hi Ozaria! I'm interested in promoting DEI through my computer science program.")
 </template>
 
 <style lang="scss" scoped>

--- a/ozaria/site/components/char-customization/ModalCharCustomization/index.vue
+++ b/ozaria/site/components/char-customization/ModalCharCustomization/index.vue
@@ -82,6 +82,7 @@ const ozariaHeroes = {
 }
 
 module.exports = Vue.extend({
+  name: 'CharacterCustomization',
   components: {
     surface: Surface,
     BaseModalContainer
@@ -141,6 +142,9 @@ module.exports = Vue.extend({
   },
 
   mounted () {
+    if (!this.isInModal) {
+      return
+    }
     // TODO: do this generally for all modals
     this.focusTrap = focusTrap.createFocusTrap(this.$el, {
       initialFocus: 'input',


### PR DESCRIPTION
fix ENG-824

the focus-trap stops ouside click events in page. seems like we only want the focus-trap works in modal, so skip it in /dei

also the getLicensemodal stops close event for backbone , while /dei is a vue page. so pass in a option.

![image](https://github.com/codecombat/codecombat/assets/11417632/fdfe7e3f-7c11-46a6-a34c-8fe1b255a0af)
