### PR TITLE
student should be able to change codeformat in level

### DIFF
--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -1269,7 +1269,7 @@ module.exports = {
       inventory_caption: 'Equip your hero',
       choose_hero_caption: 'Choose hero, language',
       change_langugae_caption: 'Choose language',
-      change_language_tab: 'Language',
+      change_language_tab: 'Code Format',
       options_caption: 'Configure settings',
       my_code_caption: 'Quick Code Actions',
       guide_caption: 'Docs and tips',

--- a/app/templates/play/common/change-language-tab.pug
+++ b/app/templates/play/common/change-language-tab.pug
@@ -1,11 +1,11 @@
 .form
-  if !me.isStudent()
+  if view.showChangeLanguage()
     .form-group.select-group.half-width.code-language-form
       span.help-block(data-i18n="choose_hero.programming_language")
       select#option-code-language(name="code-language")
         for option in codeLanguages
           option(value=option.id, selected=codeLanguage === option.id)= option.name
-  .form-group.select-group.code-format-form(class=me.isStudent() ? '' : 'half-width')
+  .form-group.select-group.code-format-form(class=!view.showChangeLanguage() ? '' : 'half-width')
     span.help-block(data-i18n="choose_hero.code_format")
     select#option-code-format(name="code-format")
       for option in codeFormats

--- a/app/views/play/common/ChangeLanguageTab.js
+++ b/app/views/play/common/ChangeLanguageTab.js
@@ -137,6 +137,16 @@ module.exports = (ChangeLanguageTab = (function () {
         this.$el.find('#option-code-language').val('javascript').change()
       }
     }
+
+    showChangeLanguage () {
+      // web-dev change language do nothing
+      // student cannot change language unless they're playing ai-leauge ladder
+      if (this.options.level) {
+        return !this.options.level.isType('web-dev') && !(me.isStudent() && !this.options.level.isType('ladder'))
+      } else {
+        return !me.isStudent()
+      }
+    }
   }
   ChangeLanguageTab.initClass()
   return ChangeLanguageTab

--- a/app/views/play/menu/GameMenuModal.js
+++ b/app/views/play/menu/GameMenuModal.js
@@ -69,7 +69,7 @@ module.exports = (GameMenuModal = (function () {
         options: 'cog',
         'save-load': 'floppy-disk',
       }
-      if (!this.showsChooseHero() && this.showsChangeLanguage()) {
+      if (!this.showsChooseHero()) {
         submenus.push('change-language')
         context.iconMap['change-language'] = 'globe'
       }
@@ -88,12 +88,6 @@ module.exports = (GameMenuModal = (function () {
         return this.classroomAceConfig.classroomItems && useHero
       }
       return useHero
-    }
-
-    showsChangeLanguage () {
-      // web-dev change language do nothing
-      // student cannot change language unless they're playing ai-leauge ladder
-      return !this.level.isType('web-dev') && !(me.isStudent() && !this.level.isType('ladder'))
     }
 
     afterRender () {


### PR DESCRIPTION
for now if a student plays junior then his code-format is setting to `blocks`, then when he goes into other course the code format can't be changed.  fix this edge bug case
![image](https://github.com/codecombat/codecombat/assets/11417632/2d6c7b36-c9ea-4b44-b4b5-15a780ad0a6a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Language change logic now adapts based on user level and type, with restrictions for students except in AI-league ladder.

- **Improvements**
  - Updated text from 'Language' to 'Code Format' for better clarity in the language change tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->