### PR TITLE
Show practice instead of undefined in parent dashboard

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleRow.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleRow.vue
@@ -88,8 +88,9 @@ export default {
     },
 
     getContentTypeHeader () {
-      if (this.nameType) {
-        const name = getGameContentDisplayType(this.nameType, true, true)
+      if (this.nameType || this.iconType) {
+        const type = this.nameType ? this.nameType : this.iconType
+        const name = getGameContentDisplayType(type, true, true)
         return `${name}:`
       } else {
         return ''
@@ -120,7 +121,7 @@ export default {
         :icon="iconType"
       />
       <p class="content-heading">
-        <b>{{ `${levelNumber ? levelNumber : 'Practice' }${levelNumber ? (nameType ? '.' : ':') : ''} ${getContentTypeHeader} ${ displayName.replace('Course: ', '')}` }}</b>
+        <b>{{ `${levelNumber ? levelNumber : '' }${levelNumber ? (nameType ? '.' : ':') : ''} ${getContentTypeHeader} ${ displayName.replace('Course: ', '')}` }}</b>
       </p>
       <p class="content-desc">
         {{ clearDescription }}

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleRow.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleRow.vue
@@ -120,7 +120,7 @@ export default {
         :icon="iconType"
       />
       <p class="content-heading">
-        <b>{{ `${levelNumber }${levelNumber ? (nameType ? '.' : ':') : ''} ${getContentTypeHeader} ${ displayName.replace('Course: ', '')}` }}</b>
+        <b>{{ `${levelNumber ? levelNumber : 'Practice' }${levelNumber ? (nameType ? '.' : ':') : ''} ${getContentTypeHeader} ${ displayName.replace('Course: ', '')}` }}</b>
       </p>
       <p class="content-desc">
         {{ clearDescription }}


### PR DESCRIPTION
fixes ENG-873
![image](https://github.com/codecombat/codecombat/assets/164280260/b0950127-62db-4817-90f3-95dbf2b1329e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the display logic for content headings in the teacher dashboard to ensure 'Practice' is shown when the level number is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->