### PR TITLE
ENG-807 - Show level number on intro contents (e.g. cinematic)

### DIFF
--- a/app/core/store/modules/gameContent.js
+++ b/app/core/store/modules/gameContent.js
@@ -121,7 +121,7 @@ export default {
         .finally(() => commit('toggleLoadingForClassroom', classroomId))
     },
 
-    fetchGameContentForCampaign: ({ commit, state }, { campaignId, options = {} }) => {
+    fetchGameContentForCampaign: ({ commit, state }, { campaignId, language, options = {} }) => {
       if (state.gameContent.byCampaign[campaignId]) {
         return Promise.resolve()
       }
@@ -131,10 +131,10 @@ export default {
         cinematics: (options.project || {}).cinematics || defaultProjections.cinematics,
         interactives: (options.project || {}).interactives || defaultProjections.interactives,
         cutscenes: (options.project || {}).cutscenes || defaultProjections.cutscenes,
-        levels: (options.project || {}).levels || defaultProjections.levels
+        levels: (options.project || {}).levels || defaultProjections.levels,
       }
 
-      return campaignsApi.fetchGameContent(campaignId, { data: { project: projectData, cacheEdge: true }, callOz: options.callOz })
+      return campaignsApi.fetchGameContent(campaignId, { data: { project: projectData, cacheEdge: true, language: language || 'python' }, callOz: options.callOz })
         .then(res => {
           if (res) {
             commit('addContentForCampaign', {
@@ -149,12 +149,13 @@ export default {
         .finally(() => commit('toggleLoadingForCampaign', campaignId))
     },
 
-    async generateLevelNumberMap ({ commit, state, dispatch, getters }, { campaignId }) {
+    async generateLevelNumberMap ({ commit, state, dispatch, getters }, { campaignId, language }) {
       let gameContent = state.gameContent.byCampaign[campaignId]
 
       if (!gameContent) {
         await dispatch('fetchGameContentForCampaign', {
           campaignId,
+          language
         })
       }
       gameContent = getters.getContentForCampaign(campaignId)

--- a/ozaria/site/components/cinematic/PageCinematic/index.vue
+++ b/ozaria/site/components/cinematic/PageCinematic/index.vue
@@ -30,21 +30,31 @@ module.exports = Vue.extend({
     cinematicData: null
   }),
 
-  async created () {
-    await this.getCinematicData()
-    this.handleSoundMuted()
-  },
-
   computed: {
     ...mapGetters({
-      soundOn: 'layoutChrome/soundOn'
+      soundOn: 'layoutChrome/soundOn',
+      getLevelNumber: 'gameContent/getLevelNumber'
     }),
     title () {
       if (this.cinematicData === null) {
         return ''
       }
-      return utils.i18n(this.cinematicData, 'displayName') || utils.i18n(this.cinematicData, 'name')
+      const id = this.cinematicData._id
+      const levelNumber = this.getLevelNumber(id)
+      const levelName = utils.i18n(this.cinematicData, 'displayName') || utils.i18n(this.cinematicData, 'name')
+      return `${levelNumber ? `${levelNumber}.` : ''} ${levelName}`
     }
+  },
+
+  watch: {
+    soundOn () {
+      this.handleSoundMuted()
+    }
+  },
+
+  async created () {
+    await this.getCinematicData()
+    this.handleSoundMuted()
   },
 
   methods: {
@@ -71,12 +81,6 @@ module.exports = Vue.extend({
       } else {
         Howler.mute(true)
       }
-    }
-  },
-
-  watch: {
-    soundOn () {
-      this.handleSoundMuted()
     }
   }
 })

--- a/ozaria/site/components/interactive/PageInteractive/common/BaseInteractiveLayout.vue
+++ b/ozaria/site/components/interactive/PageInteractive/common/BaseInteractiveLayout.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapGetters } from 'vuex'
 import InteractiveTitle from './InteractiveTitle'
 import LayoutAspectRatioContainer from '../../../common/LayoutAspectRatioContainer'
 import LayoutChrome from '../../../common/LayoutChrome'
@@ -23,8 +24,18 @@ export default {
     }
   },
   computed: {
+    ...mapGetters({
+      soundOn: 'layoutChrome/soundOn',
+      getLevelNumber: 'gameContent/getLevelNumber'
+    }),
     title () {
-      return utils.i18n(this.interactive, 'displayName') || utils.i18n(this.interactive, 'name')
+      if (!this.interactive) {
+        return ''
+      }
+      const id = this.interactive._id
+      const levelNumber = this.getLevelNumber(id) || this.getLevelNumber(this.interactive.original)
+      const levelName = utils.i18n(this.interactive, 'displayName') || utils.i18n(this.interactive, 'name')
+      return `${levelNumber ? `${levelNumber}.` : ''} ${levelName}`
     }
   }
 }

--- a/ozaria/site/components/play/PageIntroLevel/index.vue
+++ b/ozaria/site/components/play/PageIntroLevel/index.vue
@@ -149,7 +149,8 @@ export default Vue.extend({
     },
     fetchLevelNumber () {
       this.generateLevelNumberMap({
-        campaignId: this.campaignId
+        campaignId: this.campaignId,
+        language: this.language
       }).then(() => {
         this.levelNumber = this.getLevelNumber(this.introLevelData.original)
       })

--- a/ozaria/site/components/play/PagePlayLevel/index.vue
+++ b/ozaria/site/components/play/PagePlayLevel/index.vue
@@ -98,7 +98,8 @@ module.exports = Vue.extend({
     },
     fetchLevelNumber () {
       this.generateLevelNumberMap({
-        campaignId: store.state.game.level.campaign
+        campaignId: store.state.game.level.campaign,
+        language: utils.getQueryVariable('codeLanguage') || 'python'
       }).then(() => {
         this.levelNumber = this.getLevelNumber(store.state.game.level.original)
       })

--- a/ozaria/site/components/play/PageUnitMap/common/UnitMapBackground.vue
+++ b/ozaria/site/components/play/PageUnitMap/common/UnitMapBackground.vue
@@ -92,7 +92,7 @@ export default Vue.extend({
     // TODO move heroName to Vuex store `me` and use its getter as computed property.
     this.heroName = (me.get('ozariaUserOptions') || {}).playerHeroName
 
-    this.generateLevelNumberMap({ campaignId: this.campaignData._id })
+    this.generateLevelNumberMap({ campaignId: this.campaignData._id, language: this.codeLanguage })
   },
   methods: {
     ...mapActions({

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/curriculum-guide-helper.js
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/curriculum-guide-helper.js
@@ -82,11 +82,19 @@ export function generateLevelNumberMap (contentTypes) {
 
   const levelNumberMap = utils.createLevelNumberMap(levels)
 
-  return contentTypes.reduce((acc, level, index) => {
+  const map = contentTypes.reduce((acc, level, index) => {
     const original = level.original || level.fromIntroLevelOriginal
     acc[original] = levelNumberMap[level.original] || index + 1
     return acc
   }, {})
+
+  // add index for ids that are missing from levelNumberMap
+  contentTypes.forEach(({ original, _id }, index) => {
+    map[original] = map[original] || index + 1
+    map[_id] = map[_id] || index + 1
+  })
+
+  return map
 }
 
 function getContentDescription (content) {


### PR DESCRIPTION
 - level numbering added to cinematics / interactives
 - code language added to game-content request, because interactive ids can be different for the js, python etc...
 
 
<img width="1813" alt="Ozaria_-_Computer_science_that_captivates_and_Ozaria_-_Computer_science_that_captivates_and_Ozaria_-_Computer_science_that_captivates_and_Ozaria_-_Computer_science_that_captivates" src="https://github.com/codecombat/codecombat/assets/11805970/dc4752a1-094a-4412-a17b-1cfa53a1f9b4">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added language support to various components and functions for fetching and displaying game content.
- **Enhancements**
	- Updated title computations to include level numbers for better context.
	- Improved `generateLevelNumberMap` to handle missing IDs in level mappings.
- **Refactor**
	- Rearranged computed properties and lifecycle hooks for improved code organization and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->