### PR TITLE
intro-video shouldn't full screen

### DIFF
--- a/app/views/special_event/HoC2018Component.vue
+++ b/app/views/special_event/HoC2018Component.vue
@@ -187,7 +187,7 @@
           .modal-body
             button.close(type='button' data-dismiss='modal' aria-label='Close')
               span(aria-hidden='true') &times;
-            base-cloudflare-video(:video-cloudflare-id="videoId" ref="video" width="100%" aspect-ratio="16 / 9")
+            base-cloudflare-video.video(:video-cloudflare-id="videoId" ref="video" width="100%" aspect-ratio="16 / 9")
 
 </template>
 
@@ -203,10 +203,18 @@ module.exports = Vue.extend({
 
   mounted: function () {
     $(this.$refs.modal).on('shown.bs.modal',() => {
-      this.player.playVideo();
+      try {
+        this.player.playVideo();
+      } catch (e) {
+        console.error(e);
+      }
     })
     $(this.$refs.modal).on('hide.bs.modal',() => {
-      this.player.pauseVideo();
+      try {
+        this.player.pauseVideo();
+      } catch (e) {
+        console.error(e);
+      }
     })
   },
 
@@ -398,7 +406,12 @@ module.exports = Vue.extend({
       position: absolute
       right: 4px
 
+    .video
+      position: relative
+
     iframe
+      position: relative !important
+      min-height: 400px
       height: auto
       aspect-ratio: 16 / 9
 

--- a/ozaria/site/components/teacher-dashboard/modals/ModalOnboardingVideo.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalOnboardingVideo.vue
@@ -84,6 +84,12 @@ export default Vue.extend({
 .video {
   width: 100%;
   padding: 20px 0px;
+
+  ::v-deep iframe {
+    position: relative !important;
+    width: 100%;
+    min-height: 300px;
+  }
 }
 
 .buttons {


### PR DESCRIPTION
fix ENG-901
we shouldn't use full screen styles for intro video
now in big screen:
![image](https://github.com/codecombat/codecombat/assets/11417632/261867b9-8d5a-4fd0-8c10-db107ba3d98e)
in small screen:
![image](https://github.com/codecombat/codecombat/assets/11417632/99a1cf21-8070-4e06-a5f4-d2e5bf693382)
both looks fine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the styling of onboarding video in the teacher dashboard for better alignment and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->