### PR TITLE
make change-language-tab options correct

### DIFF
--- a/app/lib/LevelSetupManager.coffee
+++ b/app/lib/LevelSetupManager.coffee
@@ -118,7 +118,7 @@ module.exports = class LevelSetupManager extends CocoClass
      @inventoryModal.setHero(e.hero) if window.currentModal is @inventoryModal
 
   onHeroesModalConfirmClicked: (e) ->
-    if @level.get('product', true) is 'codecombat-junior' or (@options.courseID and !@options.classroomItems?)
+    if @level.get('product', true) is 'codecombat-junior' or (@options.courseID and !@options.classroomItems)
       # Skip inventory screen
       return @onInventoryModalPlayClicked()
     @options.parent.openModalView(@inventoryModal)

--- a/app/lib/LevelSetupManager.coffee
+++ b/app/lib/LevelSetupManager.coffee
@@ -118,7 +118,12 @@ module.exports = class LevelSetupManager extends CocoClass
      @inventoryModal.setHero(e.hero) if window.currentModal is @inventoryModal
 
   onHeroesModalConfirmClicked: (e) ->
-    if @level.get('product', true) is 'codecombat-junior' or (@options.courseID and !@options.classroomItems)
+    skipInventroyModal = false
+    if @level.get('product', true) is 'codecombat-junior'
+      skipInventroyModal = true
+    else if @options.classroom and @options.classroom.get('classroomItems')? and not @options.classroom.get('classroomItems', true)
+      skipInventroyModal = true
+    if skipInventroyModal
       # Skip inventory screen
       return @onInventoryModalPlayClicked()
     @options.parent.openModalView(@inventoryModal)

--- a/app/lib/LevelSetupManager.coffee
+++ b/app/lib/LevelSetupManager.coffee
@@ -118,7 +118,7 @@ module.exports = class LevelSetupManager extends CocoClass
      @inventoryModal.setHero(e.hero) if window.currentModal is @inventoryModal
 
   onHeroesModalConfirmClicked: (e) ->
-    if @level.get('product', true) is 'codecombat-junior'
+    if @level.get('product', true) is 'codecombat-junior' or (@options.courseID and !@options.classroomItems?)
       # Skip inventory screen
       return @onInventoryModalPlayClicked()
     @options.parent.openModalView(@inventoryModal)

--- a/app/templates/play/common/change-language-tab.pug
+++ b/app/templates/play/common/change-language-tab.pug
@@ -1,13 +1,13 @@
+mixin language-select(options, selected)
+  select&attributes(attributes)
+    for option in options
+      option(value=option.id, selected=selected === option.id, disabled=option.disabled)= option.name
+  
 .form
-  if view.showChangeLanguage()
-    .form-group.select-group.half-width.code-language-form
-      span.help-block(data-i18n="choose_hero.programming_language")
-      select#option-code-language(name="code-language")
-        for option in codeLanguages
-          option(value=option.id, selected=codeLanguage === option.id)= option.name
-  .form-group.select-group.code-format-form(class=!view.showChangeLanguage() ? '' : 'half-width')
+  .form-group.select-group.code-format-form.half-width
     span.help-block(data-i18n="choose_hero.code_format")
-    select#option-code-format(name="code-format")
-      for option in codeFormats
-        if !me.isStudent() || ((view.classroomAceConfig ? view.classroomAceConfig.codeFormats : null) || ['text-code']).includes(option.id)
-          option(value=option.id, selected=codeFormat === option.id)= option.name
+    +language-select(codeFormats, codeFormat)#option-code-format(name="code-format")
+        //- if !me.isStudent() || ((view.classroomAceConfig ? view.classroomAceConfig.codeFormats : null) || ['text-code']).includes(option.id)
+  .form-group.select-group.half-width.code-language-form
+    span.help-block(data-i18n="choose_hero.programming_language")
+    +language-select(codeLanguages, codeLanguage)#option-code-language(name="code-language")

--- a/app/templates/play/modal/play-heroes-modal.pug
+++ b/app/templates/play/modal/play-heroes-modal.pug
@@ -104,9 +104,8 @@
             span.spr(data-i18n="subscribe.subscribe_title") Subscribe
 
         else if visibleHero.loaded
-          if !me.isStudent() || (view.classroomAceConfig && (view.classroomAceConfig.codeFormats || ['text-code']).length > 1)
-            #hero-footer-text-background
-              .image-block
-                img(src= "/images/pages/play/modal/language-selector-background.png")
-            #change-language-tab-view
+          #hero-footer-text-background
+            .image-block
+              img(src= "/images/pages/play/modal/language-selector-background.png")
+          #change-language-tab-view
           a#confirm-button(data-i18n=confirmButtonI18N)

--- a/app/views/play/common/ChangeLanguageTab.js
+++ b/app/views/play/common/ChangeLanguageTab.js
@@ -31,16 +31,57 @@ module.exports = (ChangeLanguageTab = (function () {
       super(options)
       this.session = options.session
       this.isJunior = this.options.level?.get('product') === 'codecombat-junior' || this.options.campaign?.get('slug') === 'junior'
-      this.utils = utils
-      this.initCodeLanguageList()
       this.classroomAceConfig = options.classroomAceConfig
-      this.codeFormatList = [
-        { id: 'text-code', name: `${$.i18n.t('choose_hero.text_code')} (${$.i18n.t('choose_hero.default')})` },
-        { id: 'blocks-and-code', name: `${$.i18n.t('choose_hero.blocks_and_code')}` },
-        { id: 'blocks-text', name: `${$.i18n.t('choose_hero.blocks_text')}` },
-        { id: 'blocks-icons', name: `${$.i18n.t('choose_hero.blocks_icons')}` },
-      ]
-      this.propCodeFormat = this.options.codeFormat
+      this.utils = utils
+      this.codeLanguageObject = {
+        python: {
+          id: 'python',
+          name: `Python (${$.i18n.t('choose_hero.default')})`
+        },
+        javascript: {
+          id: 'javascript',
+          name: 'JavaScript'
+        },
+        coffeescript: {
+          id: 'coffeescript',
+          name: 'CoffeeScript'
+        },
+        lua: {
+          id: 'lua',
+          name: 'Lua'
+        },
+        cpp: {
+          id: 'cpp',
+          name: 'C++'
+        },
+        java: {
+          id: 'java',
+          name: `Java (${$.i18n.t('choose_hero.experimental')})`
+        }
+      }
+      this.codeFormatObject = {
+        'text-code': {
+          id: 'text-code',
+          name: `${$.i18n.t('choose_hero.text_code')} (${$.i18n.t('choose_hero.default')})`
+        },
+        'blocks-and-code': {
+          id: 'blocks-and-code',
+          name: `${$.i18n.t('choose_hero.blocks_and_code')}`
+        },
+        'blocks-text': {
+          id: 'blocks-text',
+          name: `${$.i18n.t('choose_hero.blocks_text')}`
+        },
+        'blocks-icons': {
+          id: 'blocks-icons',
+          name: `${$.i18n.t('choose_hero.blocks_icons')}`
+        }
+      }
+      this.codeFormat = this.options.codeFormat || me.get('aceConfig')?.codeFormat || 'text-code'
+      this.codeLanguage = this.options?.session?.get('codeLanguage') || me.get('aceConfig')?.language || 'python'
+
+      this.updateCodeFormatList()
+      this.updateCodeLanguageList()
     }
 
     afterRender () {
@@ -53,37 +94,118 @@ module.exports = (ChangeLanguageTab = (function () {
     getRenderData (context) {
       if (context == null) { context = {} }
       context = super.getRenderData(context)
-      context.codeLanguages = this.codeLanguageList
-      context.codeLanguage = this.codeLanguage = this.options?.session?.get('codeLanguage') || me.get('aceConfig')?.language || 'python'
-      context.codeFormats = this.codeFormatList.filter(({ id }) => (this.classroomAceConfig?.codeFormats || ['text-code', 'blocks-and-code', 'blocks-text', 'blocks-icons']).includes(id))
-      const defaultCodeFormat = this.isJunior ? 'blocks-icons' : 'text-code'
-      context.codeFormat = this.codeFormat = this.propCodeFormat || me.get('aceConfig')?.codeFormat || defaultCodeFormat
+      context.codeLanguages = Object.values(this.codeLanguageObject)
+      context.codeLanguage = this.codeLanguage
+      context.codeFormats = Object.values(this.codeFormatObject)
+      context.codeFormat = this.codeFormat
       return context
     }
 
-    initCodeLanguageList () {
-      if (application.isIPadApp) {
-        this.codeLanguageList = [
-          { id: 'python', name: `Python (${$.i18n.t('choose_hero.default')})` },
-          { id: 'javascript', name: 'JavaScript' }
-        ]
-      } else {
-        this.subscriberCodeLanguageList = [
-          { id: 'cpp', name: 'C++' },
-          { id: 'java', name: `Java (${$.i18n.t('choose_hero.experimental')})` }
-        ]
-        this.codeLanguageList = [
-          { id: 'python', name: `Python (${$.i18n.t('choose_hero.default')})` },
-          { id: 'javascript', name: 'JavaScript' },
-          { id: 'coffeescript', name: 'CoffeeScript' },
-          { id: 'lua', name: 'Lua' },
-          ...this.subscriberCodeLanguageList
-        ]
-        if (this.options?.session?.get('codeLanguage') || me.get('aceConfig')?.language !== 'coffeescript') {
-          // Not really useful to show this any more. Let's get rid of it unless they're currently using it.
-          this.codeLanguageList = _.filter(this.codeLanguageList, language => language.id !== 'coffeescript')
+    updateCodeFormatList () {
+      for (const format in this.codeFormatObject) {
+        this.codeFormatObject[format].disabled = false
+      }
+      let onlyText = true
+      const classroomFormats = this.options?.classroomAceConfig?.codeFormats
+      // non-junior should only have text-code
+      if (this.isJunior) {
+        if (['python', 'javascript'].includes(this.codeLanguage)) {
+          if (me.isStudent()) {
+            if (classroomFormats?.length) {
+              if (classroomFormats.length > 1 || classroomFormats[0] !== 'text-code') {
+                onlyText = false
+              }
+            } else {
+              onlyText = false
+            }
+          } else {
+            onlyText = false
+          }
         }
       }
+
+      if (onlyText) {
+        ['blocks-and-code', 'blocks-text', 'blocks-icons'].forEach(format => {
+          this.codeFormatObject[format].disabled = true
+          this.codeFormatObject[format].reason = 'not supported'
+        })
+      } else {
+        if (me.isStudent() && classroomFormats.length) {
+          ['text-code', 'blocks-and-code', 'blocks-text', 'blocks-icons'].forEach(format => {
+            if (!classroomFormats.includes(format)) {
+              this.codeFormatObject[format].disabled = true
+              this.codeFormatObject[format].reason = 'disabled by teacher'
+            }
+          })
+        }
+      }
+
+      // todo: better check mobile
+      if (application.isIPadApp) {
+        Array.from(['text-code', 'blocks-and-code']).forEach(format => {
+          this.codeFormatObject[format].disabled = true
+        })
+        Array.from(['blocks-text', 'blocks-icons']).forEach(format => {
+          this.codeFormatObject[format].disabled = false
+        })
+      }
+
+      if (this.codeFormatObject[this.codeFormat].disabled) {
+        this.codeFormat = _.find(this.codeFormatObject, { disabled: false })?.id
+      }
+      this.renderSelectors('.code-format-form')
+      this.buildCodeFormats()
+    }
+
+    updateCodeLanguageList () {
+      for (const lang in this.codeLanguageObject) {
+        this.codeLanguageObject[lang].disabled = false
+      }
+      if ((this.options?.session?.get('codeLanguage') || me.get('aceConfig')?.language) !== 'coffeescript') {
+        // Not really useful to show this any more. Let's get rid of it unless they're currently using it.
+        delete this.codeLanguageObject.coffeescript
+      }
+
+      let canChangeLanguage = true
+      if (me.isStudent() && this.options?.level?.get('type') !== 'ladder') {
+        canChangeLanguage = false
+      }
+
+      if (canChangeLanguage) {
+        let premium = false
+        if (me.isHomeUser() && me.isPremium()) {
+          premium = true
+        } else if (me.isStudent() && me.isEnrolled()) {
+          premium = true
+        } else if (me.isTeacher()) {
+          // allow teacher to test cpp/java
+          premium = true
+        }
+        if (!premium) {
+          Array.from(['cpp', 'java']).forEach(language => {
+            this.codeLanguageObject[language].disabled = true
+            this.codeLanguageObject[language].reason = 'Subscriber Only'
+          })
+        }
+        if (this.codeFormat !== 'text-code') {
+          Array.from(['lua', 'cpp', 'java']).forEach(language => {
+            this.codeLanguageObject[language].disabled = true
+            this.codeLanguageObject[language].reason = 'Not supported with blocks'
+          })
+        }
+      } else {
+        for (const language in this.codeLanguageObject) {
+          if (language !== this.codeLanguage) {
+            this.codeLanguageObject[language].disabled = true
+          }
+        }
+      }
+
+      if (this.codeLanguageObject[this.codeLanguage].disabled) {
+        this.codeLanguage = _.find(this.codeLanguageObject, { disabled: false }).id
+      }
+      this.renderSelectors('.code-language-form')
+      this.buildCodeLanguages()
     }
 
     buildCodeFormats () {
@@ -99,6 +221,11 @@ module.exports = (ChangeLanguageTab = (function () {
           return $(this).text(`${formatName} - ${blurb}`)
         }
       })
+      if ($select.parent().find('.options li').length === 1) {
+        $select.trigger('disable.fs')
+      } else {
+        $select.trigger('enable.fs')
+      }
     }
 
     buildCodeLanguages () {
@@ -114,11 +241,17 @@ module.exports = (ChangeLanguageTab = (function () {
           return $(this).text(`${languageName} - ${blurb}`)
         }
       })
+      if ($select.parent().find('.options li').length === 1) {
+        $select.trigger('disable.fs')
+      } else {
+        $select.trigger('enable.fs')
+      }
     }
 
     onCodeLanguageChanged (e) {
       this.codeLanguage = this.$el.find('#option-code-language').val()
       this.codeLanguageChanged = true
+      this.updateCodeFormatList()
       window.tracker?.trackEvent('Campaign changed code language', { category: 'Campaign Hero Select', codeLanguage: this.codeLanguage, levelSlug: this.options.level?.get('slug') })
       if (this.codeFormat === 'blocks-and-code' && ['python', 'javascript'].indexOf(this.codeLanguage) === -1) {
         // Blockly can't support languages like C++/Java. (Some day we'll have Lua.)
@@ -130,21 +263,12 @@ module.exports = (ChangeLanguageTab = (function () {
     onCodeFormatChanged (e) {
       this.codeFormat = this.$el.find('#option-code-format').val()
       this.codeFormatChanged = true
+      this.updateCodeLanguageList()
       window.tracker?.trackEvent('Campaign changed code format', { category: 'Campaign Hero Select', codeFormat: this.codeFormat, levelSlug: this.options.level?.get('slug') })
       if (this.codeFormat === 'blocks-and-code' && ['python', 'javascript'].indexOf(this.codeLanguage) === -1) {
         // Blockly can't support languages like C++/Java. (Some day we'll have Lua.)
         noty({ text: `Can't show blocks and code with ${this.codeLanguage}`, layout: 'bottomCenter', type: 'error', killer: false, timeout: 3000 })
         this.$el.find('#option-code-language').val('javascript').change()
-      }
-    }
-
-    showChangeLanguage () {
-      // web-dev change language do nothing
-      // student cannot change language unless they're playing ai-leauge ladder
-      if (this.options.level) {
-        return !this.options.level.isType('web-dev') && !(me.isStudent() && !this.options.level.isType('ladder'))
-      } else {
-        return !me.isStudent()
       }
     }
   }

--- a/app/views/play/level/ControlBarView.coffee
+++ b/app/views/play/level/ControlBarView.coffee
@@ -159,7 +159,7 @@ module.exports = class ControlBarView extends CocoView
     @openModalView gameMenuModal
     @listenToOnce gameMenuModal, 'change-hero', ->
       @setupManager?.destroy()
-      @setupManager = new LevelSetupManager({@supermodel, @level, @levelID, parent: @, @session, @courseID, @courseInstanceID, classroomItems: @classroom.get('classroomItems', true)})
+      @setupManager = new LevelSetupManager({@supermodel, @level, @levelID, parent: @, @session, @courseID, @courseInstanceID, classroom: @classroom})
       @setupManager.open()
 
   onClickHome: (e) ->

--- a/app/views/play/level/ControlBarView.coffee
+++ b/app/views/play/level/ControlBarView.coffee
@@ -159,7 +159,7 @@ module.exports = class ControlBarView extends CocoView
     @openModalView gameMenuModal
     @listenToOnce gameMenuModal, 'change-hero', ->
       @setupManager?.destroy()
-      @setupManager = new LevelSetupManager({@supermodel, @level, @levelID, parent: @, @session, @courseID, @courseInstanceID})
+      @setupManager = new LevelSetupManager({@supermodel, @level, @levelID, parent: @, @session, @courseID, @courseInstanceID, classroomItems: @classroom.get('classroomItems', true)})
       @setupManager.open()
 
   onClickHome: (e) ->

--- a/app/views/play/level/tome/TomeView.coffee
+++ b/app/views/play/level/tome/TomeView.coffee
@@ -112,7 +112,7 @@ module.exports = class TomeView extends CocoView
 
   determineCodeFormat: ->
     language = @options.session.get('codeLanguage') ? me.get('aceConfig')?.language ? 'python'
-    if @options.level.isType('web-dev') or (language not in ['python', 'javascript', 'lua'])
+    if @options.level.isType('web-dev') or (language not in ['python', 'javascript', 'lua']) or @options.level.get('product') != 'codecombat-junior'
       # TODO: eventually we could get game-dev working, if we figure out how to list spawnables
       newCodeFormat = 'text-code'
     else

--- a/app/views/play/menu/GameMenuModal.js
+++ b/app/views/play/menu/GameMenuModal.js
@@ -84,9 +84,9 @@ module.exports = (GameMenuModal = (function () {
 
     showsChooseHero () {
       const useHero = this.level.usesSessionHeroThangType()
-      if (this.classroomAceConfig) {
-        return this.classroomAceConfig.classroomItems && useHero
-      }
+      // if (this.classroomAceConfig) {
+      //   return this.classroomAceConfig.classroomItems && useHero
+      // }
       return useHero
     }
 

--- a/app/views/play/modal/PlayHeroesModal.js
+++ b/app/views/play/modal/PlayHeroesModal.js
@@ -356,7 +356,7 @@ module.exports = (PlayHeroesModal = (function () {
     saveAndHide () {
       this.codeLanguage = this.changeLanguageView.codeLanguage
       this.codeFormat = this.changeLanguageView.codeFormat
-      this.subscriberCodeLanguageList = this.changeLanguageView.subscriberCodeLanguageList
+      this.subscriberCodeLanguageList = [{ id: 'cpp' }, { id: 'java' }]
       let changed
       if (!me.hasSubscription() && this.subscriberCodeLanguageList.find(l => l.id === this.codeLanguage) && !me.isStudent()) {
         this.openModalView(new SubscribeModal())


### PR DESCRIPTION
fix ENG-881
the play-hero-modal now has the change-language-options shows correct. and only shows available options, 
- [ ] don't have time to make single option select shows like fancy-select, can do later.
- [ ] also cannot make fancy-select shows `disabled` options .  maybe we can use raw CSS to style the select instead of fancy-select (which is an outdated [package](https://github.com/paulstraw/FancySelect)) ?
![image](https://github.com/codecombat/codecombat/assets/11417632/d2b2110f-f5bf-44bc-93e0-ea30afa4944d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved language selection in the settings with dynamic options generation.
  - Enhanced hero selection logic to provide more consistent and relevant choices.
  
- **Bug Fixes**
  - Fixed issues with language and format updates not reflecting changes dynamically.
  - Resolved inconsistencies in the display logic for certain user types and configurations.

- **Refactor**
  - Streamlined the code handling language and format options.
  - Simplified hero selection logic to improve maintainability.

- **Chores**
  - Updated methods and conditions to support new configurations and product types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->