### PR TITLE
Move curriculum button in teacher dashboard into a tab

### DIFF
--- a/app/core/Router.js
+++ b/app/core/Router.js
@@ -484,6 +484,7 @@ module.exports = (CocoRouter = (function () {
         'teachers/resources_old': go('teachers/ResourceHubView', { redirectStudents: true }),
         'teachers/resources': utils.isCodeCombat && me.useChinaHomeView() ? go('teachers/ResourceHubView', { redirectStudents: true }) : go('core/SingletonAppVueComponentView', { redirectStudents: true }),
         'teachers/resources_new': go('core/SingletonAppVueComponentView'),
+        'teachers/curriculum': teacherProxyRoute(go('teachers/curriculum', { redirectStudents: true })),
         'teachers/resources/ap-cs-principles': go('teachers/ApCsPrinciplesView', { redirectStudents: true }),
         'teachers/resources/:name': go('teachers/MarkdownResourceView', { redirectStudents: true }),
         'teachers/professional-development': teacherProxyRoute(go('pd/PDView', { redirectStudents: true })),

--- a/app/core/store/modules/teacherDashboard.js
+++ b/app/core/store/modules/teacherDashboard.js
@@ -213,6 +213,9 @@ export default {
         } else if (componentName === COMPONENT_NAMES.PD) {
           // PD page
           await dispatch('fetchDataPDAsync', options)
+        } else if (componentName === COMPONENT_NAMES.CURRICULUM_GUIDE) {
+          // Curriculum page
+          await dispatch('fetchDataCurriculumGuideAsync', options) // does not block loading indicator
         } else if (componentName === COMPONENT_NAMES.STUDENT_ASSESSMENTS) {
           // Assessments page
           await dispatch('fetchDataStudentAssessments', options)
@@ -358,6 +361,13 @@ export default {
         fetchPromises.push(dispatch('users/fetchCreatorOfPrepaid', id, { root: true }))
         fetchPromises.push(dispatch('prepaids/fetchJoinersForPrepaid', id, { root: true }))
       })
+      await Promise.all(fetchPromises)
+    },
+
+    async fetchDataCurriculumGuideAsync ({ state, dispatch, rootGetters }, options = {}) {
+      const fetchPromises = []
+      fetchPromises.push(dispatch('prepaids/fetchPrepaidsForTeacher', { teacherId: state.teacherId }, { root: true }))
+      fetchPromises.push(dispatch('teacherDashboard/fetchDataCurriculumGuide', undefined, { root: true }))
       await Promise.all(fetchPromises)
     },
 

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -271,6 +271,7 @@ export default function getVueRouter () {
               }
             },
             { path: 'professional-development', component: () => import(/* webpackChunkName: "pd" */ '../views/pd/PDView.vue') },
+            { path: 'curriculum', component: () => import(/* webpackChunkName: "curriculum" */ '../../ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue') },
             {
               path: 'ai-league',
               component: () => import(/* webpackChunkName: "ai-league" */ '../views/ai-league/AILeagueView.vue'),

--- a/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
@@ -6,8 +6,6 @@ import ModalRemoveStudents from '../modals/ModalRemoveStudents'
 import ModalOnboardingVideo from '../modals/ModalOnboardingVideo'
 import ModalEditClass from '../modals/ModalEditClass'
 
-import BaseCurriculumGuide from '../BaseCurriculumGuide'
-
 import SecondaryTeacherNavigation from '../common/SecondaryTeacherNavigation'
 import TitleBar from '../common/TitleBar'
 import LoadingBar from 'ozaria/site/components/common/LoadingBar'
@@ -37,7 +35,6 @@ export default {
     ModalAssignContent,
     ModalAddStudents,
     ModalRemoveStudents,
-    BaseCurriculumGuide,
     ModalOnboardingVideo,
     SecondaryTeacherNavigation,
     TitleBar,
@@ -159,9 +156,6 @@ export default {
   },
 
   beforeRouteUpdate (to, from, next) {
-    // Ensures we close curriculum guide when navigating between pages in the
-    // teacher dashboard.
-    this.closeCurriculumGuide()
     next()
   },
 
@@ -169,7 +163,6 @@ export default {
     ...mapMutations({
       setClassroomId: 'teacherDashboard/setClassroomId',
       setTeacherId: 'teacherDashboard/setTeacherId',
-      closeCurriculumGuide: 'baseCurriculumGuide/closeCurriculumGuide',
       setSelectedCourseId: 'teacherDashboard/setSelectedCourseIdCurrentClassroom',
       setTeacherPagesTrackCategory: 'teacherDashboard/setTrackCategory'
     }),
@@ -358,7 +351,6 @@ export default {
     <p> {{ $t('teacher.teacher_account_required') }} </p>
   </div>
   <div v-else>
-    <base-curriculum-guide :default-language="getLanguage" />
     <panel />
     <div class="teacher-dashboard">
       <div

--- a/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
+++ b/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
@@ -228,6 +228,18 @@ export default {
     </li>
     <li>
       <router-link
+        id="CurriculumAnchor"
+        to="/teachers/curriculum"
+        :class="{ 'current-route': isCurrentRoute('/teachers/curriculum') }"
+        data-action="Curriculum Guide: Nav Clicked"
+        @click.native="trackEvent"
+      >
+        <div id="IconCurriculum" />
+        {{ $t('teacher_dashboard.curriculum') }}
+      </router-link>
+    </li>
+    <li>
+      <router-link
         id="ResourceAnchor"
         to="/teachers/resources"
         :class="{ 'current-route': isCurrentRoute('/teachers/resources') }"
@@ -461,6 +473,19 @@ li.open > #LicensesAnchor,
   }
 }
 
+#CurriculumAnchor:hover{
+  #IconCurriculum {
+    background-image: url(/images/ozaria/teachers/dashboard/svg_icons/Icon_Assessments_Moon.svg);
+  }
+}
+
+li.open > #CurriculumAnchor,
+#CurriculumAnchor.current-route {
+  #IconCurriculum {
+    background-image: url(/images/ozaria/teachers/dashboard/svg_icons/Icon_Assessments_Blue.svg);
+  }
+}
+
 #ResourceAnchor:hover{
   #IconResourceHub {
     background-image: url(/images/ozaria/teachers/dashboard/svg_icons/IconResourceHub_Moon.svg);
@@ -540,6 +565,11 @@ li.open > #AILeague,
   margin-top: -2px;
 }
 
+#IconCurriculum {
+  background-image: url(/images/ozaria/teachers/dashboard/svg_icons/Icon_Assessments_Gray.svg);
+  margin-top: -3px;
+}
+
 #IconLicense {
   background-image: url(/images/ozaria/teachers/dashboard/svg_icons/IconLicense_Gray.svg);
   margin-top: -3px;
@@ -576,6 +606,7 @@ li.open > #AILeague,
 
 #IconCapstone,
 #IconMyClasses,
+#IconCurriculum,
 #IconLicense,
 #IconResourceHub,
 #IconPD,

--- a/ozaria/site/components/teacher-dashboard/common/TitleBar.vue
+++ b/ozaria/site/components/teacher-dashboard/common/TitleBar.vue
@@ -1,14 +1,13 @@
 <script>
 import { coursesWithProjects, isOzaria, isCodeCombat } from 'core/utils'
 import PrimaryButton from '../common/buttons/PrimaryButton'
-import ButtonCurriculumGuide from '../common/ButtonCurriculumGuide'
 import LicensesComponent from '../common/LicensesComponent'
 import NavSelectUnit from '../common/NavSelectUnit'
 import ClassInfoRow from './ClassInfoRow'
 import moment from 'moment'
 import zendeskResourceMixin from 'ozaria/site/components/teacher-dashboard/BaseResourceHub/index.vue'
 
-import { mapActions, mapGetters } from 'vuex'
+import { mapGetters } from 'vuex'
 
 const Classroom = require('models/Classroom')
 
@@ -23,7 +22,6 @@ const resourceHubSections = [
 export default {
   components: {
     'primary-button': PrimaryButton,
-    'button-curriculum-guide': ButtonCurriculumGuide,
     'licenses-component': LicensesComponent,
     'nav-select-unit': NavSelectUnit,
     'class-info-row': ClassInfoRow,
@@ -109,6 +107,10 @@ export default {
       }
     },
 
+    inCurriculum () {
+      return this.$route.path.startsWith('/teachers/curriculum')
+    },
+
     classroomCreationDate () {
       if ((this.classroom || {})._id) {
         return moment(parseInt(this.classroom._id.substring(0, 8), 16) * 1000).format('ll')
@@ -155,11 +157,6 @@ export default {
   },
 
   methods: {
-    ...mapActions({
-      toggleCurriculumGuide: 'baseCurriculumGuide/toggleCurriculumGuide',
-      setCurriculumAccessViaSharedClass: 'baseCurriculumGuide/setAccessViaSharedClass'
-    }),
-
     clickOutcomesReport () {
       window.tracker?.trackEvent('Outcomes Report Clicked', { category: 'Teachers', label: this.$route.path })
       this.$emit('outcomesReport')
@@ -173,22 +170,15 @@ export default {
       window.tracker?.trackEvent('Add New Class Clicked', { category: 'Teachers', label: this.$route.path })
       this.$emit('newClass')
     },
-
-    clickCurriculumGuide () {
-      let hasAccess = false
-      if (this.sharePermission) {
-        hasAccess = true
-      }
-      this.setCurriculumAccessViaSharedClass(hasAccess)
-      window.tracker?.trackEvent('Curriculum Guide Clicked', { category: 'Teachers', label: this.$route.path })
-      this.toggleCurriculumGuide()
-    }
   }
 }
 </script>
 
 <template>
-  <div class="teacher-title-bar">
+  <div
+    v-if="!inCurriculum"
+    class="teacher-title-bar"
+  >
     <div class="sub-nav">
       <h1 :class="showClassInfo ? 'short' : 'long'">
         {{ title }}
@@ -279,12 +269,6 @@ export default {
         >
           {{ $t('teacher_dashboard.add_class') }}
         </primary-button>
-
-        <button-curriculum-guide
-          id="curriculum-guide-btn-shepherd"
-          class="btn-margins-height"
-          @click="clickCurriculumGuide"
-        />
         <div
           v-if="showClassInfo"
           class="add-students"

--- a/ozaria/site/components/teacher-dashboard/common/constants.js
+++ b/ozaria/site/components/teacher-dashboard/common/constants.js
@@ -1,5 +1,5 @@
 
-// name of the vue component of each teacher dashboard page - used for fetching relevant data in teacherDahsboard vuex store
+// name of the vue component of each teacher dashboard page - used for fetching relevant data in teacherDashboard vuex store
 export const COMPONENT_NAMES = {
   MY_CLASSES_ALL: 'BaseMyClasses',
   MY_CLASSES_SINGLE: 'BaseSingleClass',
@@ -8,8 +8,8 @@ export const COMPONENT_NAMES = {
   RESOURCE_HUB: 'BaseResourceHub',
   PD: 'PD',
   STUDENT_ASSESSMENTS: 'BaseStudentAssessments',
-  AI_LEAGUE: 'AILeague'
-  // CURRICULUM_GUIDE: 'BaseCurriculumGuide'
+  AI_LEAGUE: 'AILeague',
+  CURRICULUM_GUIDE: 'BaseCurriculumGuide'
 }
 
 export const PAGE_TITLES = {
@@ -18,5 +18,6 @@ export const PAGE_TITLES = {
   [COMPONENT_NAMES.RESOURCE_HUB]: 'resource_hub',
   [COMPONENT_NAMES.PD]: 'pd',
   [COMPONENT_NAMES.AI_LEAGUE]: 'ai_league',
-  [COMPONENT_NAMES.APCSP]: 'apcsp'
+  [COMPONENT_NAMES.APCSP]: 'apcsp',
+  [COMPONENT_NAMES.CURRICULUM_GUIDE]: 'curriculum_guide'
 }


### PR DESCRIPTION
fixes ENG-781
![Screenshot from 2024-07-09 20-54-37](https://github.com/codecombat/codecombat/assets/164280260/b65c3110-8be2-4b88-af07-19b8a26da570)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new Curriculum Guide section for teachers, accessible via the dashboard.
  - Introduced a new route `/teachers/curriculum` for easy navigation.
  
- **Enhancements**
  - Updated the Teacher Dashboard to include new actions for handling Curriculum Guide data.
  - Enhanced the navigation with a new link to the Curriculum Guide, including visual updates for better user experience.

- **UI Improvements**
  - Improved the layout and styling of the Curriculum Guide and associated components for a more streamlined look.
  - Updated the TitleBar component for conditional rendering based on the current route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->