### PR TITLE
update fuzzy verifier to work good

### DIFF
--- a/app/lib/world/world.coffee
+++ b/app/lib/world/world.coffee
@@ -732,7 +732,8 @@ module.exports = class World
     return unless level.constrainHeroHealth
     hero = _.find @thangs, id: 'Hero Placeholder'
     if hero?
-      for prop, {min, max} of level.clampedProperties ? {}
+      for prop, {min, max, test} of level.clampedProperties ? {}
+        hero[prop] = test if test?
         hero[prop] = Math.min(hero[prop], max) if max?
         hero[prop] = Math.max(hero[prop], min) if min?
         hero.keepTrackedProperty prop

--- a/app/templates/editor/verifier/verifier-view.pug
+++ b/app/templates/editor/verifier/verifier-view.pug
@@ -34,7 +34,7 @@ block content
               input(id=campaignID, type="checkbox", checked=campaignInfo.checked, disabled=!!view.testsByLevelAndLanguage)
               label(for=campaignID)= campaign + ': ' + campaignInfo.levels.length
         .row
-          each codeLanguage in view.codeLanguages
+          each codeLanguage in view.codeLanguages || []
             .form-group.code-language-mix
               - var codeLanguageID = "code-language-" + codeLanguage.id + "-checkbox";
               input(id=codeLanguageID, type="checkbox", checked=codeLanguage.checked, disabled=!!view.testsByLevelAndLanguage)

--- a/app/views/editor/verifier/VerifierView.js
+++ b/app/views/editor/verifier/VerifierView.js
@@ -62,10 +62,11 @@ module.exports = (VerifierView = (function () {
       this.cores = window.navigator.hardwareConcurrency || 4
       this.careAboutFrames = utils.getQueryVariable('frames', true)
 
+      this.testLanguages = (utils.getQueryVariable('languages') || 'python,javascript,java,cpp,lua,coffeescript').split(',')
+      this.codeLanguages = this.testLanguages.map((c) => ({ id: c, checked: true }))
+
       if (this.levelID) {
         this.levelIDs = [this.levelID]
-        this.testLanguages = (utils.getQueryVariable('languages') || 'python,javascript,java,cpp,lua,coffeescript').split(',')
-        this.codeLanguages = this.testLanguages.map((c) => ({ id: c, checked: true }))
         this.cores = 1
         this.startTestingLevels()
       } else {


### PR DESCRIPTION
fix ENG-491
![image](https://github.com/codecombat/codecombat/assets/11417632/b7aaf8c4-f02f-4e5b-b218-3fff3abd5730)

----------------------------
before this pr:
1.  the verifier cannot open (not sure which changes cause it. but can be [fixed ](https://github.com/codecombat/codecombat/pull/7576/files#diff-02def52f377024387d3cdc24e151a2f88b76c2d4f0aed73aba646835643bc45bR65-R67)by setting `codeLanguages` globally.
2. when running fuzzy verifier, the binary search failed and fallback to increment search. [fixed  here](https://github.com/codecombat/codecombat/pull/7576/files#diff-effacf4eb439c142dc0fba97f421b2b40d4b06edd82d79e7ececeddd437cb892R156)
3. when running for all props, it finished when maxHealth is ready. [fixed here](https://github.com/codecombat/codecombat/pull/7576/files#diff-effacf4eb439c142dc0fba97f421b2b40d4b06edd82d79e7ececeddd437cb892R274-R323)
4. when running for maxSpeed, the prev `maxHealth` updates set in to levels so make things mess up. [fixed here](https://github.com/codecombat/codecombat/pull/7576/files#diff-effacf4eb439c142dc0fba97f421b2b40d4b06edd82d79e7ececeddd437cb892R144-R163) 
5. the maxHealth checking works good before ,but others do not since clampedProperties limit the `max, min` value but never change the `hero` properties, so when testing, the `max, min` doesn't help at all. [fixed here](https://github.com/codecombat/codecombat/pull/7576/files#diff-f19f0c28bdf7d25115da9b4f36d1294b668a2405712200bac261b42fd6f09993R736)

the overall fuzzy verifier thing:
background: after we enable the `items` for the classroom. now all players can play level with items. the different items and heroes has different stats  so some players play a level with really good health/attackDamage/speed, but others play with really low/high stats. it would lead to for example a enemy hit the player, player die. level fails. or a fast hero runs quickly so pick the coin fast but slower hero runs slow and cannot pick enough coin so level fails ... etc.  So that we build the fuzzy verifier to help a level knows a good stats range for health, attackDamage, speed that can anyway success in the level.
so the fuzy verifier did:
1. create a big range  of possible health/damage/speed in codecombat.
2. using binary search to find a good value for them.
3. for a single level, it find for health first, then min speed, min attackDamage, max speed, max attackDamage. we don't find max health since higher health won't lead into level fails, but higher speed/damage could. (while the `maxHealth`, `maxSpeed` is the key name in our system, or we can call it totalHealth or originalHealth, we need to find max `maxSpeed` and min `maxSpeed`. a little confusion here)

the known issue after this pr:
1. the code integrate into VerifierTest too deep, not a good practice, should use something like `PropertyBinarySearch` class to handle all fuzzy verifier logic and then use single command in verifierTest class to run.
2. the fuzzy verifier can run for single level good now. but if run for more levels at the same time, browser cannot provide enough memory to do that. maybe our `world` system do have some memory leak, or Verifier do.  consider that a single level need to run about 10-20 times to find out final results, run for a campaign -- which has about 50 - 150 levels at the same time also takes too long. also, buggy levels are few, so i don't think it worth supporting run for all. let's run for single level first.
----------------------------



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced fallback for `codeLanguages` in verifier view to use an empty array if not provided.
  - Added default language initialization for `testLanguages` and `codeLanguages` in verifier view.

- **Improvements**
  - Enhanced `World` class to handle optional `test` property in level configuration.
  - Enhanced verifier tests with original level and hero data tracking, and iterative property checks.

- **Bug Fixes**
  - Ensured that `testLanguages` and `codeLanguages` are always set in verifier view when `levelID` is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->