### PR TITLE
support run batch

### DIFF
--- a/app/templates/editor/verifier/verifier-view.pug
+++ b/app/templates/editor/verifier/verifier-view.pug
@@ -41,6 +41,17 @@ block content
               label(for=codeLanguageID)= codeLanguage.id
           .pull-right
             button.btn.btn-primary#go-button(disabled=!!view.testsByLevelAndLanguage) Start Tests
+        .row
+          .form-group
+            input(id='enable-fuzzy-verifier' type='checkbox')
+            label(for='enable-fuzzy-verifier') Enable Fuzzy Verifier
+          .form-group
+            label(for='fuzzy-batch-skip') Skip
+            input(id='fuzzy-batch-skip' type='number' step="1")
+          .form-group
+            label(for='fuzzy-batch-limit') Limit
+            input(id='fuzzy-batch-limit' type='number' step="1")
+
 
     if view.levelsToLoad && !view.testsByLevelAndLanguage
       .progress

--- a/app/views/editor/verifier/VerifierView.js
+++ b/app/views/editor/verifier/VerifierView.js
@@ -145,6 +145,13 @@ module.exports = (VerifierView = (function () {
           codeLanguage.checked = false
         }
       }
+
+      this.enableFuzzy = this.$('#enable-fuzzy-verifier').is(':checked')
+      if (this.enableFuzzy) {
+        this.skip = this.$('#fuzzy-batch-skip').val() || 0
+        this.limit = this.$('#fuzzy-batch-limit').val() || 1
+        this.levelIDs = this.levelIDs.splice(this.skip, this.limit)
+      }
       return this.startTestingLevels()
     }
 
@@ -238,7 +245,7 @@ module.exports = (VerifierView = (function () {
                 return next()
               }
             }
-            , chunkSupermodel, task.language, { solution: task.solution })
+            , chunkSupermodel, task.language, { solution: task.solution, enableFuzzyVerifier: this.enableFuzzy })
             this.tests.push(test)
             if (this.testsByLevelAndLanguage[task.level] == null) { this.testsByLevelAndLanguage[task.level] = {} }
             if (this.testsByLevelAndLanguage[task.level][task.language] == null) { this.testsByLevelAndLanguage[task.level][task.language] = [] }


### PR DESCRIPTION
fix ENG-492
![1720688211340](https://github.com/codecombat/codecombat/assets/11417632/cb77274e-abf4-41b6-81b3-e180623ce2b6)

now in `/editor/verifier` page we can use skip and limit to run fuzzy-verifier. 

NOTE: fuzzy-verifier now is just print the suggest results but never update the level. we can determine if want the fuzzy-verifier to update level or let game-dev to update level manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Fuzzy Verifier section with settings and checkboxes in the verifier view.
  - Enabled fuzzy verification in test scenarios with new input fields for batch skip and limit values. 

- **Enhancements**
  - Improved logging of property values and suggestions during verification.
  - Enhanced calculation and condition checks for property values in testing.
  - Introduced new parameters and properties to support the fuzzy verifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->