### PR TITLE
project only hero placeholder thang for levels fetch in campaign/clas…

### DIFF
--- a/app/core/store/modules/campaigns.js
+++ b/app/core/store/modules/campaigns.js
@@ -156,7 +156,7 @@ export default {
     },
     fetchCampaignLevels: async ({ commit, state }, { campaignHandle, callOz }) => {
       if (state.campaignLevelsFetched[campaignHandle]) return
-      const levels = await campaignsApi.fetchLevels(campaignHandle, { data: { project: 'thangs,name,slug,campaign,tasks,original,kind,practice' }, callOz })
+      const levels = await campaignsApi.fetchLevels(campaignHandle, { data: { project: 'heroThang,name,slug,campaign,tasks,original,kind,practice' }, callOz })
       commit('setCampaignLevels', { campaignId: campaignHandle, levels })
       commit('setCampaignLevelsFetched', { campaignHandle, flag: true })
     }

--- a/app/core/store/modules/gameContent.js
+++ b/app/core/store/modules/gameContent.js
@@ -11,7 +11,7 @@ const defaultProjections = {
   cinematics: '_id,i18n,name,slug,displayName,description',
   interactives: '_id,i18n,name,slug,displayName,interactiveType,unitCodeLanguage,documentation,draggableOrderingData,insertCodeData,draggableStatementCompletionData,defaultArtAsset,promptText',
   cutscenes: '_id,i18n,name,slug,displayName,description',
-  levels: 'original,name,description,slug,concepts,displayName,type,ozariaType,practice,shareable,i18n,assessment,goals,additionalGoals,documentation,thangs,screenshot,exemplarProjectUrl,exemplarCodeUrl,projectRubricUrl,totalStages'
+  levels: 'original,name,description,slug,concepts,displayName,type,ozariaType,practice,shareable,i18n,assessment,goals,additionalGoals,documentation,heroThang,screenshot,exemplarProjectUrl,exemplarCodeUrl,projectRubricUrl,totalStages'
 }
 
 export default {

--- a/ozaria/site/store/TeacherDashboardPanel.js
+++ b/ozaria/site/store/TeacherDashboardPanel.js
@@ -361,7 +361,7 @@ export default {
           sessionContentObject: practiceLevelData({
             starterCode: level.getSampleCode()?.[language] || '',
             studentCode: studentSessions[normalizedOriginal]?.code?.['hero-placeholder']?.plan || '',
-            solutionCode: solutionCode.source || '',
+            solutionCode: solutionCode?.source || '',
             language
           })
         })


### PR DESCRIPTION
…sroom

fix ENG-779

when fetch campaign and game-content let's do not fetch all level.thangs. 
reduce many request size. 
one example : 
before: 
![image](https://github.com/codecombat/codecombat/assets/11417632/4d25470d-6947-4215-96d4-925ab2df52f3)
after:
![image](https://github.com/codecombat/codecombat/assets/11417632/b92a3a91-da31-4881-9d2e-c12202ffe70a)

new dashboard still works fine after this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data consistency by updating field names from 'thangs' to 'heroThang' in campaign level fetch operations.

- **Enhancements**
  - Enhanced data retrieval projections for game levels to include 'heroThang' instead of 'thangs.'

- **Code Quality**
  - Improved robustness in Teacher Dashboard to handle potential null values using optional chaining for `solutionCode` properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->