### PR TITLE
Make the done button visible in setting options for ozaria

### DIFF
--- a/app/styles/play/menu/game-menu-modal.sass
+++ b/app/styles/play/menu/game-menu-modal.sass
@@ -112,7 +112,7 @@
       background: #ffffff
       border-radius: 8px
       width: 478px
-      height: 570px
+      max-height: 630px
       margin-top: 15px
       padding: 35px
       overflow-y: scroll

--- a/app/styles/play/menu/game-menu-modal.sass
+++ b/app/styles/play/menu/game-menu-modal.sass
@@ -108,11 +108,11 @@
     .game-menu-tab-content
       position: absolute
       left: 85px
-      top: 190px
+      top: 100px
       background: #ffffff
       border-radius: 8px
       width: 478px
-      height: 500px
+      height: 570px
       margin-top: 15px
       padding: 35px
       overflow-y: scroll


### PR DESCRIPTION
fixes ENG-929
I've checked to see if this breaks anything else and I don't believe it does. But please let me know if it causes any issues.
![image](https://github.com/user-attachments/assets/fe2056fd-e31e-43ae-b6f9-09b0f6b59b0e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved layout of the game menu tab, including adjusting the top position and increasing the height for better content fit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->