### PR TITLE
update results in UI and fix the memory leak

### DIFF
--- a/app/templates/editor/verifier/verifier-view.pug
+++ b/app/templates/editor/verifier/verifier-view.pug
@@ -136,3 +136,7 @@ block content
                         div.test-running ~ #{test.simulationFrameRate.toFixed(1)} FPS
                       else
                         div.test-failed ✘ #{test.simulationFrameRate.toFixed(1)} FPS
+                if test.fuzzyResults
+                  div.row.fuzzy-results
+                    span Suggest new ClampedProperties: 
+                    span= JSON.stringify(test.fuzzyResults)

--- a/app/views/editor/verifier/VerifierTest.js
+++ b/app/views/editor/verifier/VerifierTest.js
@@ -50,6 +50,14 @@ module.exports = class VerifierTest extends CocoClass {
   load () {
     this.supermodel.resetProgress()
     this.loadStartTime = new Date()
+    if (this.levelLoader) {
+      this.stopListening(this.levelLoader)
+      this.levelLoader.destroy()
+    }
+    if (this.god) {
+      this.stopListening(this.god)
+      this.god.destroy()
+    }
     this.god = new God({ maxAngels: 1, headless: true })
     this.levelLoader = new LevelLoader({ supermodel: this.supermodel, levelID: this.levelID, headless: true, fakeSessionConfig: { codeLanguage: this.language, callback: this.configureSession } })
     this.listenToOnce(this.levelLoader, 'world-necessities-loaded', function () { return _.defer(this.onWorldNecessitiesLoaded) })
@@ -342,6 +350,8 @@ module.exports = class VerifierTest extends CocoClass {
       console.log('find a solution within the clamped properties  for level: ', this.level.get('slug'))
       console.log('current clamped properties:', this.level.get('clampedProperties'))
       console.log('suggested adding properties as:', clampedProperties)
+      this.fuzzyResults = clampedProperties
+      this.reportResults()
       console.log('==============================================')
     }
   }

--- a/app/views/editor/verifier/VerifierView.js
+++ b/app/views/editor/verifier/VerifierView.js
@@ -252,7 +252,7 @@ module.exports = (VerifierView = (function () {
             this.testsByLevelAndLanguage[task.level][task.language].push(test)
             this.renderSelectors(`.tasks-group[data-task-slug='${task.level}'][data-task-language='${task.language}']`)
             this.renderSelectors('.verifier-row')
-            return this.renderSelectors('.progress')
+            this.renderSelectors('.progress')
           }
           , () => {
             if (!this.testsRemaining()) {


### PR DESCRIPTION
fix ENG-940

![image](https://github.com/user-attachments/assets/07efdb62-280d-4f1e-89b0-5ce991d34d43)

now the UI shows the results and at least it can run cs1(37 levels) at the same time without memory crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced fuzzy results display in the verifier UI, suggesting new properties based on test results.

- **Bug Fixes**
  - Improved resource management in `VerifierTest` by ensuring proper cleanup of instances.

- **Performance**
  - Optimized the verifier results reporting process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->