### PR TITLE
Hide wide editor option for ozaria

### DIFF
--- a/app/templates/play/menu/options-view.pug
+++ b/app/templates/play/menu/options-view.pug
@@ -40,7 +40,7 @@
       span(data-i18n="options.editor_config_behaviors_label") Enable Smart Behaviors
     span.help-block(data-i18n="options.editor_config_behaviors_description") Autocompletes brackets, braces, and quotes.
 
-  if !(features.china)
+  if !(features.china) && view.utils.isCodeCombat
     .form-group.checkbox
       label(for="option-wide-editor")
         input#option-wide-editor(name="wide-editor", type="checkbox", checked=aceConfig.preferWideEditor)
@@ -57,5 +57,5 @@
           .glyphicon.glyphicon-ok
         span(data-i18n="options.editor_config_screen_reader_mode_label") Enable Screen Reader Mode
       span.help-block(data-i18n="options.editor_config_screen_reader_mode_description") Display levels in text rather than visually.
-  
+
     button.ozaria-button.ozaria-primary-button.done-button(data-i18n="play_level.done") Done


### PR DESCRIPTION
fixes ENG-955
![image](https://github.com/user-attachments/assets/fb67c9eb-a8a1-4dca-8a4e-c3ae6ffb7e20)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved logic for rendering options based on user context, enhancing the display of the "wide editor" option.
  
- **Bug Fixes**
  - Refined conditions for displaying certain features, ensuring they are only shown when relevant to the user's context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->