### PR TITLE
support test-student only license

### DIFF
--- a/app/core/api/prepaids.js
+++ b/app/core/api/prepaids.js
@@ -71,6 +71,17 @@ module.exports = {
 
   joinByCodes (options) {
     if (options == null) { options = {} }
-    return fetchJson('/db/prepaids/-/join-by-codes', options)
-  }
+    return fetchJson('/db/prepaids/-/join-by-codes', _.assign({}, {
+      method: 'POST',
+      json: options
+    }))
+  },
+
+  getOrCreateTestLicense (options) {
+    if (options == null) { options = {} }
+    return fetchJson('/db/prepaids/-/test-student-license', _.assign({}, {
+      method: 'POST',
+      json: options
+    }))
+  },
 }

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -2373,6 +2373,7 @@ module.exports = {
       all_units_completed: 'All Units Completed!',
       hide_options: 'Hide Options',
       more_options: 'More Options',
+      get_test_license: 'Get Test Student License'
     },
 
     project_gallery: {
@@ -4620,7 +4621,8 @@ module.exports = {
       no_failed_attempts: 'No Failed Attempts',
       failed_attempts_subtext: 'Number of times incorrect option was selected',
       open_project: 'Open Project',
-      create_class_hackstack: 'Please create a New Class to access AI HackStack'
+      create_class_hackstack: 'Please create a New Class to access AI HackStack',
+      test_student_only: 'Test Student Only',
     },
 
     outcomes: {

--- a/app/schemas/models/prepaid.schema.js
+++ b/app/schemas/models/prepaid.schema.js
@@ -28,7 +28,10 @@ const PrepaidSchema = c.object({ title: 'Prepaid', required: ['type'] }, {
   code: c.shortString({ title: 'Unique code to redeem' }),
   type: { type: 'string' },
   properties: c.object({ additionalProperties: true },
-    { activatedByTeacher: { type: 'boolean', description: 'if this Prepaid used for teacher-activation code.' } }),
+    {
+      activatedByTeacher: { type: 'boolean', description: 'if this Prepaid used for teacher-activation code.' },
+      testStudentOnly: { type: 'boolean', description: 'if this Prepaid is for test-student only' }
+    }),
   exhausted: { type: 'boolean' },
   startDate: c.stringDate(),
   vendorPurchased: c.object({}, {

--- a/ozaria/site/components/teacher-dashboard/BaseTeacherLicenses/PageLicenses.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseTeacherLicenses/PageLicenses.vue
@@ -42,6 +42,18 @@ export default {
         label: 'How To: Manage Licenses',
         link: 'https://docs.google.com/presentation/d/1SfM5ZMjae8wm8HESHoXXO0wBnKJmJD53BgtG9XwVW9k/edit?usp=sharing'
       }
+    },
+    showGetTestLicense () {
+      const testStudentRelation = (me.get('related') || []).filter(related => related.relation === 'TestStudent')[0]
+      if (!testStudentRelation) {
+        return false
+      }
+      const testLicense = _.find(this.activeLicenses, (prepaid) => prepaid.properties.testStudentOnly)
+      if (testLicense) {
+        return false
+      } else {
+        return true
+      }
     }
   },
   methods: {
@@ -80,6 +92,14 @@ export default {
       >
         {{ $t("courses.get_enrollments") }}
       </primary-button>
+      <primary-button
+        v-if="showGetTestLicense"
+        class="get-test-license"
+        @click="$emit('getTestLicense', { teacherId } )"
+        @click.native="trackEvent('My Licenses: Get Test Student Licenses Clicked')"
+      >
+        {{ $t('courses.get_test_license') }}
+      </primary-button>
       <div class="side-bar-text">
         {{ $t('teacher_dashboard.see_also_our') }} <a href="/funding">{{ $t('nav.funding_resources_guide') }}</a> {{ $t('teacher_dashboard.for_more_funding_resources') }}
       </div>
@@ -101,6 +121,7 @@ export default {
           :end-date="license.endDate"
           :owner="getUserById(license.creator)"
           :teacher-id="teacherId"
+          :properties="license.properties"
           @apply="$emit('apply')"
           @share="$emit('share', license)"
           @stats="$emit('stats', license)"
@@ -122,6 +143,7 @@ export default {
           :end-date="license.endDate"
           :owner="getUserById(license.creator)"
           :teacher-id="teacherId"
+          :properties="license.properties"
           :expired="true"
           @stats="$emit('stats', license)"
         />
@@ -166,7 +188,7 @@ export default {
   margin: 10px 0px;
 }
 
-.get-licenses-btn {
+.get-licenses-btn, .get-test-license {
   width: 100%;
   max-width: 220px;
   height: 50px;

--- a/ozaria/site/components/teacher-dashboard/BaseTeacherLicenses/PageLicenses.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseTeacherLicenses/PageLicenses.vue
@@ -49,11 +49,7 @@ export default {
         return false
       }
       const testLicense = _.find(this.activeLicenses, (prepaid) => prepaid.properties.testStudentOnly)
-      if (testLicense) {
-        return false
-      } else {
-        return true
-      }
+      return !testLicense
     }
   },
   methods: {

--- a/ozaria/site/components/teacher-dashboard/BaseTeacherLicenses/common/LicenseCard.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseTeacherLicenses/common/LicenseCard.vue
@@ -39,6 +39,10 @@ export default {
       type: Boolean,
       default: false
     },
+    properties: {
+      type: Object,
+      default: () => {}
+    },
     disableApplyLicenses: {
       type: Boolean,
       default: false
@@ -82,6 +86,9 @@ export default {
     },
     licenseStatsIcon () {
       return 'IconLicense_Blue'
+    },
+    testStudentOnly () {
+      return this.properties.testStudentOnly
     }
   }
 }
@@ -112,6 +119,11 @@ export default {
       <div class="dates">
         <div>{{ $t('teacher_dashboard.start_date', { date: startDateFormat }) }}</div>
         <div>{{ $t('teacher_dashboard.end_date', { date: endDateFormat }) }}</div>
+      </div>
+      <div class="special">
+        <div v-if="testStudentOnly">
+          {{ $t('teacher_dashboard.test_student_only') }}
+        </div>
       </div>
     </div>
     <div
@@ -188,6 +200,13 @@ export default {
   text-align: center;
   margin: 10px 0px 20px 0px;
   font-weight: 600;
+}
+
+.special {
+    font-size: 12px;
+    color: white;
+    text-align: center;
+    height: 0;
 }
 
 .dates {

--- a/ozaria/site/components/teacher-dashboard/BaseTeacherLicenses/common/LicenseCard.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseTeacherLicenses/common/LicenseCard.vue
@@ -203,10 +203,10 @@ export default {
 }
 
 .special {
-    font-size: 12px;
-    color: white;
-    text-align: center;
-    height: 0;
+  font-size: 12px;
+  color: white;
+  text-align: center;
+  height: 0;
 }
 
 .dates {

--- a/ozaria/site/components/teacher-dashboard/BaseTeacherLicenses/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseTeacherLicenses/index.vue
@@ -65,7 +65,8 @@ export default {
 
   methods: {
     ...mapActions({
-      fetchData: 'teacherDashboard/fetchData'
+      fetchData: 'teacherDashboard/fetchData',
+      getTestLicense: 'prepaids/getTestLicense'
     }),
     ...mapMutations({
       resetLoadingState: 'teacherDashboard/resetLoadingState',
@@ -102,6 +103,7 @@ export default {
       :teacher-id="getTeacherId"
       :display-only="displayOnly"
       @getLicenses="getLicenses"
+      @getTestLicense="getTestLicense"
       @apply="applyLicenses"
       @share="shareLicenses"
       @stats="seeLicenseStats"


### PR DESCRIPTION
fix ENG-926
adding test-student-only license.

when a teacher create test-student and he has the licenses, auto create a test-only license and apply to the test-student.
when a teacher has test-student and then he has the licenses/ when old test-only licenses expires and the teacher still has active licenses (new) , we show a button in license page which helps teacher to get the free test-only license and auto apply to the test-student.

![image](https://github.com/user-attachments/assets/3446b7fa-e007-4037-b811-ca863bd881b2)
![image](https://github.com/user-attachments/assets/d1a5d0fe-80df-490f-8e6f-38091d190aac)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a method for obtaining test student licenses in the teacher dashboard.
	- Added functionality to categorize and manage test licenses for teachers.
	- Enhanced the user interface with additional localization strings for improved guidance.

- **Bug Fixes**
	- Improved handling of various license states (expired, pending, available) in the prepaid management system.

- **Documentation**
	- Updated localization messages to enhance user understanding of test licenses.

- **Style**
	- Minor CSS adjustments to accommodate new button styling in the teacher dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->