### PR TITLE
Remove duplicate curriculum button

### DIFF
--- a/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
+++ b/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
@@ -272,18 +272,6 @@ export default {
     </li>
     <li>
       <router-link
-        id="CurriculumAnchor"
-        to="/teachers/curriculum"
-        :class="{ 'current-route': isCurrentRoute('/teachers/curriculum') }"
-        data-action="Curriculum Guide: Nav Clicked"
-        @click.native="trackEvent"
-      >
-        <div id="IconCurriculum" />
-        {{ $t('teacher_dashboard.curriculum') }}
-      </router-link>
-    </li>
-    <li>
-      <router-link
         id="ResourceAnchor"
         to="/teachers/resources"
         :class="{ 'current-route': isCurrentRoute('/teachers/resources') }"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified navigation in the teacher dashboard by removing the curriculum link from the Secondary Teacher Navigation.
	
- **Impact**
	- Changes the user experience by eliminating direct access to the curriculum guide, potentially affecting teachers' ability to navigate easily to curriculum resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->