### PR TITLE
ENG-988 - Add Lesson Slides URLs to Junior Curriculum

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -248,6 +248,72 @@ if (isCodeCombat) {
   }
 
   courseModuleInfo = {
+    [courseIDs.JUNIOR]: {
+      1: {
+        python: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/1Y5_Eu5uVPrHpnqcoSuGfFR8qeAYkTIyE'
+        },
+        javascript: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/1Y5_Eu5uVPrHpnqcoSuGfFR8qeAYkTIyE'
+        }
+      },
+      2: {
+        python: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/18cse7g50mdcEwLiTovHR_edPhYd77UDM'
+        },
+        javascript: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/18cse7g50mdcEwLiTovHR_edPhYd77UDM'
+        }
+      },
+      3: {
+        python: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/1iQJEvgaQ0z3AMw64fTOwcZOYKu0zOqOr'
+        },  
+        javascript: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/1iQJEvgaQ0z3AMw64fTOwcZOYKu0zOqOr'
+        }
+      },
+      4: {
+        python: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/1v6DZfzb3zp_lmjM00vZvjTSRoUpBSqq8'
+        },
+        javascript: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/1v6DZfzb3zp_lmjM00vZvjTSRoUpBSqq8'
+        }
+      },
+      5: {
+        python: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/1-kKodhaMC1oL1OVnolQ5V9OVM0VEI7kF'
+        },
+        javascript: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/1-kKodhaMC1oL1OVnolQ5V9OVM0VEI7kF'
+        }
+      },
+      6: {
+        python: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/11SIA1sYVRdq69u0o0w0ihAF65MjoIq2W'
+        },
+        javascript: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/11SIA1sYVRdq69u0o0w0ihAF65MjoIq2W'
+        }
+      },
+      7: {
+        python: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/1-U3aJggcZibizu8fZPdT8veKOqby9uBj'
+        },
+        javascript: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/1-U3aJggcZibizu8fZPdT8veKOqby9uBj'
+        }
+      },
+      8: {
+        python: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/1hnLLCpxF4HeAhO3WVAaB9tYmoYQ9aKx1'
+        },
+        javascript: {
+          lessonSlidesUrl: 'https://drive.google.com/drive/folders/1hnLLCpxF4HeAhO3WVAaB9tYmoYQ9aKx1'
+        }
+      }
+    },
     [courseIDs.INTRODUCTION_TO_COMPUTER_SCIENCE]: {
       1: {
         python: {
@@ -437,14 +503,14 @@ if (isCodeCombat) {
   courseModuleLevels = {}
 
   courseModules[courseIDs.JUNIOR] = {
-    1: 'The `go()` Function',
-    2: 'Arguments',
-    3: 'The `hit()` Function',
-    4: 'The `spin()` Function',
-    5: 'The `zap()` Function',
-    6: 'For Loops',
-    7: 'Loop Combinations',
-    8: 'If Statements'
+    1: 'A1: Sequences',
+    2: 'A2: Arguments',
+    3: 'B1: Complex Arguments (Hit)',
+    4: 'B2: Complex Arguments (Spin)',
+    5: 'C1: Complex Arguments (Zap)',
+    6: 'C2: Intro to Loops',
+    7: 'D1: Complex Loops',
+    8: 'D2: Intro to Conditionals',
     // 9: 'Variables'
   }
 

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterInfo.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterInfo.vue
@@ -27,6 +27,7 @@ export default {
     return {
       levelsNameMap: {},
       courseLinks: {
+        junior: 'https://drive.google.com/drive/folders/1R2iON3JW2kWZpy8HUACl7Dw7BdVROwaq?usp=drive_link',
         'introduction-to-computer-science': 'https://drive.google.com/drive/folders/1-ww3rLkxj1cZwSvBm6_ThXqsEjwnu6Wn?usp=sharing',
         'game-development-1': 'https://drive.google.com/drive/folders/1YSJ9wcfHRJ2854F-vUdSWqoLBuSJye7V?usp=sharing',
         'computer-science-2': 'https://drive.google.com/drive/folders/1J3ywGVgDKtRBDaK_cK106Jn-l9GaKd3n?usp=sharing',

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleHeader.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleHeader.vue
@@ -37,6 +37,7 @@ export default {
   },
   computed: {
     ...mapGetters({
+      getCurrentCourse: 'baseCurriculumGuide/getCurrentCourse',
       getCurrentModuleNames: 'baseCurriculumGuide/getCurrentModuleNames',
       getCurrentModuleHeadingInfo: 'baseCurriculumGuide/getCurrentModuleHeadingInfo',
       getCapstoneInfo: 'baseCurriculumGuide/getCapstoneInfo',
@@ -99,7 +100,12 @@ export default {
   <div class="header">
     <div class="module-header">
       <h3>
-        <span>{{ $t('teacher_dashboard.module') }} {{ moduleNum }}: </span>
+        <span>{{ $t('teacher_dashboard.module') }} </span>
+        <span
+          v-if="getCurrentCourse.slug !== 'junior'"
+        >
+          {{ moduleNum }}:
+        </span>
         <!-- eslint-disable vue/no-v-html -->
         <span v-html="renderModuleName(moduleName || getCurrentModuleNames(moduleNum))" />
         <!-- eslint-enable vue/no-v-html -->


### PR DESCRIPTION
<img width="854" alt="CodeCombat_Teacher_Dashboard" src="https://github.com/user-attachments/assets/2cbf61f7-2234-45a9-800f-5aa657987893">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced lesson resources for the "JUNIOR" course, including detailed slide URLs.
	- Added a new course link for "junior" to the ChapterInfo component for easier resource access.
	- Improved display logic in the ModuleHeader component to better reflect the current course context. 

- **Bug Fixes**
	- Refined module number display based on the current course to enhance clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->