### PR TITLE
add curriculum and access button for arena

### DIFF
--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -100,6 +100,12 @@ const CODE_FORMAT_IPAD = ['blocks-text', 'blocks-icons']
 const CODE_FORMAT_TEXT = ['text-code', 'blocks-and-code']
 const JUNIOR_LANGUAGES = ['python', 'javascript']
 
+const ARENA_CURRICULUM = {
+  equinox: 'https://drive.google.com/drive/folders/16lYF5Bt_WupEUv9rNfTN_byL8DSJK3iX?usp=drive_link',
+  'tundra-tower': 'https://drive.google.com/drive/folders/1xhl8oMNLU5gwuEChg1wCair2VKK-A3ln?usp=drive_link',
+  sandstorm: 'https://drive.google.com/drive/folders/1gXBG1tpuAhYkJKX5GvvHZHX48duPnZ7O?usp=drive_link'
+}
+
 module.exports = {
   STARTER_LICENSE_COURSE_IDS,
   FREE_COURSE_IDS,
@@ -118,5 +124,6 @@ module.exports = {
   CODE_FORMAT_BLOCKS,
   CODE_FORMAT_IPAD,
   CODE_FORMAT_TEXT,
-  JUNIOR_LANGUAGES
+  JUNIOR_LANGUAGES,
+  ARENA_CURRICULUM
 }

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -4987,7 +4987,7 @@ module.exports = {
       no_tournaments: 'There is no tournament now',
       edit_tournament: 'Edit Tournament',
       create_tournament: 'Create a Tournament',
-      access_tournament: 'Access',
+      view_tournament: 'View Tournament',
       upcoming: 'Upcoming',
       starting: 'Starting',
       ended: 'Ended',

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -4987,6 +4987,7 @@ module.exports = {
       no_tournaments: 'There is no tournament now',
       edit_tournament: 'Edit Tournament',
       create_tournament: 'Create a Tournament',
+      access_tournament: 'Access',
       upcoming: 'Upcoming',
       starting: 'Starting',
       ended: 'Ended',

--- a/app/views/ladder/components/LadderPanel.vue
+++ b/app/views/ladder/components/LadderPanel.vue
@@ -40,6 +40,14 @@
         <div class="arena__helpers__bottom__permission">
           <span class="arena__helpers-element">
             <button
+              v-if="arenaCurriculum"
+              class="btn btn-secondary dusk-btn"
+              :disabled="disabled"
+              @click="openCurriculum"
+            >
+              {{ $t('nav.curriculum') }}
+            </button>
+            <button
               v-if="!canEdit"
               class="btn btn-secondary btn-moon"
               :disabled="disabled"
@@ -47,16 +55,23 @@
             >
               {{ $t('tournament.create_tournament') }}
             </button>
-          </span>
-          <span class="arena__helpers-element">
-            <button
+            <template
               v-if="canEdit"
-              class="btn btn-secondary btn-moon"
-              :disabled="disabled"
-              @click="$emit('edit-tournament')"
             >
-              {{ $t('tournament.edit_tournament') }}
-            </button>
+              <button
+                class="btn btn-secondary btn-moon"
+                :disabled="disabled"
+                @click="$emit('edit-tournament')"
+              >
+                {{ $t('tournament.edit_tournament') }}
+              </button>
+              <button
+                class="btn btn-secondary btn-moon"
+                @click="goTournament"
+              >
+                {{ $t('tournament.access_tournament') }}
+              </button>
+            </template>
           </span>
         </div>
       </div>
@@ -67,6 +82,7 @@
 <script>
 import moment from 'moment'
 import { mapGetters } from 'vuex'
+import { ARENA_CURRICULUM } from 'app/core/constants'
 export default {
   name: 'LadderPanel',
   props: {
@@ -140,6 +156,9 @@ export default {
         return baseUrl + `/clan/${this.clanId}`
       }
       return baseUrl
+    },
+    arenaCurriculum () {
+      return ARENA_CURRICULUM?.[this.arena.slug]
     }
   },
   methods: {
@@ -153,6 +172,12 @@ export default {
       if (imgExtensionIndex === -1) return description
       const startPosition = imgExtensionIndex + imgExtension.length + 1
       return description.slice(startPosition) || null
+    },
+    goTournament () {
+      return application.router.navigate(this.url, { trigger: true })
+    },
+    openCurriculum () {
+      window.open(this.arenaCurriculum, '_blank')
     }
   }
 }
@@ -160,10 +185,18 @@ export default {
 
 <style scoped lang="scss">
 @import "app/styles/common/button";
+@import "ozaria/site/styles/common/variables.scss";
+@import "ozaria/site/components/teacher-dashboard/common/dusk-button";
 
-/* .btn-moon {
-   padding: 0.5rem 0 !important;
-   } */
+.btn-moon {
+  font-size: 14px;
+  padding: 0.5rem 1rem;
+  min-width: 120px;
+}
+
+.dusk-btn {
+  display: unset !important;
+}
 
 .arena {
   &__info {

--- a/app/views/ladder/components/LadderPanel.vue
+++ b/app/views/ladder/components/LadderPanel.vue
@@ -66,10 +66,10 @@
                 {{ $t('tournament.edit_tournament') }}
               </button>
               <button
-                class="btn btn-secondary btn-moon"
+                class="btn btn-secondary dusk-btn"
                 @click="goTournament"
               >
-                {{ $t('tournament.access_tournament') }}
+                {{ $t('tournament.view_tournament') }}
               </button>
             </template>
           </span>
@@ -188,7 +188,7 @@ export default {
 @import "ozaria/site/styles/common/variables.scss";
 @import "ozaria/site/components/teacher-dashboard/common/dusk-button";
 
-.btn-moon {
+.btn-moon, .dusk-btn {
   font-size: 14px;
   padding: 0.5rem 1rem;
   min-width: 120px;

--- a/ozaria/site/components/teacher-dashboard/common/_dusk-button.scss
+++ b/ozaria/site/components/teacher-dashboard/common/_dusk-button.scss
@@ -4,8 +4,8 @@
   border-radius: 4px;
   border-width: 0;
   text-shadow: unset;
-  font-weight: bold;
   @include font-p-3-small-button-text-black;
+  font-weight: bold;
   background-image: unset;
 
   &:hover {
@@ -18,4 +18,5 @@
   padding: 0 17px;
   justify-content: center;
   align-items: center;
+  text-transform: uppercase;
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dcfb45ae-7832-406d-b0b1-c990fc698195)
fixes ENG-1048, ENG-1090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced the `ARENA_CURRICULUM` constant for structured access to curriculum resources.
	- Added a new button in the Ladder Panel for accessing the curriculum and tournaments, enhancing user interaction.
	- Implemented new navigation methods for improved accessibility to curriculum and tournament links.
- **Localization**
	- Expanded localization support with the addition of the `access_tournament` and `view_tournament` labels in the English locale.
- **Style**
	- Enhanced button styling for better visibility and readability with updated CSS properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->