### PR TITLE
ENG-1075 - Start ABTest from inside new and old home page

### DIFF
--- a/app/models/User.js
+++ b/app/models/User.js
@@ -1075,7 +1075,7 @@ module.exports = (User = (function () {
 
         if (forcedValue) {
           value = forcedValue
-          valueProbability = 1
+          valueProbability = value === 'beta' ? probability : 1 - probability
         } else {
           const rand = Math.random()
           if (rand < probability) {

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -1045,6 +1045,7 @@ module.exports = (User = (function () {
 
     getFilteredExperimentValue ({
       experimentName,
+      forcedValue
     }) {
       let value = me.getExperimentValue(experimentName, null)
 
@@ -1071,13 +1072,19 @@ module.exports = (User = (function () {
       if (value === null) {
         const probability = window.serverConfig?.experimentProbabilities?.[experimentName]?.beta || 0.5
         let valueProbability
-        const rand = Math.random()
-        if (rand < probability) {
-          value = 'beta'
-          valueProbability = probability
+
+        if (forcedValue) {
+          value = forcedValue
+          valueProbability = 1
         } else {
-          value = 'control'
-          valueProbability = 1 - probability
+          const rand = Math.random()
+          if (rand < probability) {
+            value = 'beta'
+            valueProbability = probability
+          } else {
+            value = 'control'
+            valueProbability = 1 - probability
+          }
         }
         me.startExperiment(experimentName, value, valueProbability)
       }
@@ -1090,7 +1097,14 @@ module.exports = (User = (function () {
     }
 
     getHomePageExperimentValue () {
-      return this.getFilteredExperimentValue({ experimentName: 'home-page-filtered' })
+      return this.getFilteredExperimentValue({ experimentName: 'home-page-filtered-v2' })
+    }
+
+    startHomeControlExperiment (forcedValue) {
+      return this.getFilteredExperimentValue({
+        experimentName: 'home-page-filtered-control-experiment',
+        forcedValue
+      })
     }
 
     getParentsPageExperimentValue () {

--- a/app/views/HomeView.js
+++ b/app/views/HomeView.js
@@ -346,6 +346,8 @@ module.exports = (HomeView = (function () {
           return $('[data-slide-to=\'' + nextActiveSlide + '\']').addClass('active')
         })))
       }
+
+      me.startHomeControlExperiment('control')
       return super.afterRender()
     }
 

--- a/app/views/home/PageHome.vue
+++ b/app/views/home/PageHome.vue
@@ -454,6 +454,7 @@ export default Vue.extend({
       this.engagingBoxes[1].signupModalPath = null
       this.engagingBoxes[1].link = '/teachers/classes'
     }
+    me.startHomeControlExperiment('beta')
   },
   methods: {
     checkPaymentTracking () {


### PR DESCRIPTION
- new experiment for homepage: `home-page-filtered-v2`
- new experiment from inside the pages with forced `beta`(new) and `control`(old) values: `'home-page-filtered-control-experiment'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new parameter for more flexible handling of experiment values, allowing explicit control over experiment assignments.
	- Added functionality to initiate control experiments for the home view, enhancing user interaction and data handling.
	- Expanded the `PageHome` component to initiate a home control experiment, improving user engagement tracking.

- **Bug Fixes**
	- Updated experiment names to ensure consistency and clarity in experiment tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->