### PR TITLE
ENG-699 - don't load game-content if not needed

### DIFF
--- a/app/core/store/modules/teacherDashboard.js
+++ b/app/core/store/modules/teacherDashboard.js
@@ -260,7 +260,6 @@ export default {
       }
 
       fetchPromises.push(dispatch('prepaids/fetchPrepaidsForTeacher', { teacherId: state.teacherId }, { root: true }))
-      fetchPromises.push(dispatch('teacherDashboard/fetchDataCurriculumGuide', undefined, { root: true }))
 
       await Promise.all(fetchPromises)
     },
@@ -293,7 +292,6 @@ export default {
         }
       }
       fetchPromises.push(dispatch('prepaids/fetchPrepaidsForTeacher', { teacherId, sharedClassroomId: (isSharedClass ? state.classroomId : null) }, { root: true }))
-      fetchPromises.push(dispatch('teacherDashboard/fetchDataCurriculumGuide', undefined, { root: true }))
 
       await Promise.all(fetchPromises)
     },
@@ -313,7 +311,6 @@ export default {
     async fetchDataStudentProjectsAsync ({ state, dispatch }, options = {}) {
       const fetchPromises = []
       fetchPromises.push(dispatch('prepaids/fetchPrepaidsForTeacher', { teacherId: state.teacherId }, { root: true }))
-      fetchPromises.push(dispatch('teacherDashboard/fetchDataCurriculumGuide', undefined, { root: true }))
       await Promise.all(fetchPromises)
     },
 
@@ -351,7 +348,6 @@ export default {
     async fetchDataMyLicensesAsync ({ state, dispatch, getters }, options = {}) {
       const fetchPromises = []
 
-      fetchPromises.push(dispatch('teacherDashboard/fetchDataCurriculumGuide', undefined, { root: true }))
       fetchPromises.push(dispatch('classrooms/fetchClassroomsForTeacher', { teacherId: state.teacherId }, { root: true }))
 
       const licenses = getters.getActiveLicenses.concat(getters.getExpiredLicenses)
@@ -375,7 +371,6 @@ export default {
     async fetchDataResourceHubAsync ({ state, dispatch }, options = {}) {
       const fetchPromises = []
       fetchPromises.push(dispatch('prepaids/fetchPrepaidsForTeacher', { teacherId: state.teacherId }, { root: true }))
-      fetchPromises.push(dispatch('teacherDashboard/fetchDataCurriculumGuide', undefined, { root: true }))
       // Note: Why do we need all the classes on the resource page?
       fetchPromises.push(dispatch('classrooms/fetchClassroomsForTeacher', { teacherId: state.teacherId }, { root: true }))
       await Promise.all(fetchPromises)

--- a/app/core/store/modules/teacherDashboard.js
+++ b/app/core/store/modules/teacherDashboard.js
@@ -401,9 +401,6 @@ export default {
         selectedCourse = selectedCourse || sortedCourses[0]
         dispatch('baseCurriculumGuide/setSelectedCampaign', selectedCourse.campaignID, { root: true })
       }
-      sortedCourses.forEach(({ campaignID }) => {
-        dispatch('gameContent/fetchGameContentForCampaign', { campaignId: campaignID }, { root: true })
-      })
     },
 
     // Fetches classroom data for current state.classroomId

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue
@@ -9,6 +9,7 @@ import ChapterInfo from './components/ChapterInfo'
 import ConceptsCovered from './components/ConceptsCovered'
 import CstaStandards from './components/CstaStandards'
 import ModuleContent from './components/ModuleContent'
+import LoadingSpinner from 'app/components/common/elements/LoadingSpinner'
 
 export default {
   name: COMPONENT_NAMES.CURRICULUM_GUIDE,
@@ -17,7 +18,8 @@ export default {
     ChapterInfo,
     ConceptsCovered,
     CstaStandards,
-    ModuleContent
+    ModuleContent,
+    LoadingSpinner
   },
 
   props: {
@@ -137,6 +139,12 @@ export default {
               :module-num="num"
               :is-capstone="isCapstoneModule(num)"
             />
+            <div
+              v-if="moduleNumbers.length==0"
+              class="spinner-container"
+            >
+              <LoadingSpinner />
+            </div>
           </div>
           <div class="col-md-3">
             <concepts-covered :concept-list="conceptsCovered" />
@@ -242,5 +250,10 @@ export default {
 
     /* Sets this under the curriculum guide and over everything else */
     z-index: 1100;
+  }
+  .spinner-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 </style>

--- a/ozaria/site/components/teacher-dashboard/common/TitleBar.vue
+++ b/ozaria/site/components/teacher-dashboard/common/TitleBar.vue
@@ -5,7 +5,7 @@ import LicensesComponent from '../common/LicensesComponent'
 import NavSelectUnit from '../common/NavSelectUnit'
 import ClassInfoRow from './ClassInfoRow'
 import moment from 'moment'
-import zendeskResourceMixin from 'ozaria/site/components/teacher-dashboard/BaseResourceHub/index.vue'
+import zendeskResourceMixin from 'ozaria/site/components/teacher-dashboard/BaseResourceHub/mixins/zendeskResourceMixin'
 
 import { mapGetters } from 'vuex'
 

--- a/ozaria/site/store/BaseCurriculumGuide.js
+++ b/ozaria/site/store/BaseCurriculumGuide.js
@@ -142,8 +142,9 @@ export default {
       }
     },
 
-    setSelectedCampaign ({ state, commit }, campaignID) {
+    setSelectedCampaign ({ state, commit, dispatch }, campaignID) {
       commit('setSelectedCampaignId', campaignID)
+      dispatch('gameContent/fetchGameContentForCampaign', { campaignId: campaignID }, { root: true })
     },
     setAccessViaSharedClass ({ commit }, access) {
       commit('setAccessViaSharedClass', access)


### PR DESCRIPTION
| before | after |
| --- | --- |
| ![CodeCombat_Teacher_Dashboard](https://github.com/user-attachments/assets/1d11e87a-6682-4bd7-bb8e-faa1bc67dfaa) | <img width="469" alt="CodeCombat_Teacher_Dashboard" src="https://github.com/user-attachments/assets/6dfe590d-5e82-4bac-9bdb-bf2cafadf905"> | 

![spinner](https://github.com/user-attachments/assets/c9265fab-20da-47d2-b8f0-caf972bb9ec8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Removed unnecessary data-fetching calls in the teacher dashboard, streamlining data management.

- **New Features**
	- Updated the `TitleBar` component to use a mixin for improved modularity and maintainability.
	- Enhanced the campaign selection functionality to fetch related game content when a campaign is set.
	- Added a loading spinner to the `BaseCurriculumGuide` component for better user feedback during loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->