### PR TITLE
ENG-1114 - Fix _Identify_ Events

### DIFF
--- a/app/core/Tracker2/InternalTracker.js
+++ b/app/core/Tracker2/InternalTracker.js
@@ -21,8 +21,8 @@ export default class InternalTracker extends BaseTracker {
 
   async identify (traits = {}) {
     await this.initializationComplete
-    const { me } = this.store.state
-    traits = _.merge(extractDefaultUserTraits(me), traits)
+    const { me: user } = this.store.state
+    traits = _.merge(extractDefaultUserTraits(user), traits)
     traits.host = document.location.host
     if (me.isTeacher(true)) {
       traits.teacher = true
@@ -45,7 +45,9 @@ export default class InternalTracker extends BaseTracker {
   }
 
   trackEventInternal (event, properties) {
-    if (this.disableAllTracking) return this.log('not tracking', event, 'because of disableAllTtracking')
+    if (this.disableAllTracking) {
+      return this.log('not tracking', event, 'because of disableAllTtracking')
+    }
     if (this.store.state.me.isAdmin) return this.log('not tracking', event, 'because of admin')
     // Skipping heavily logged actions we don't use internally
     if (['Simulator Result', 'Started Level Load', 'Finished Level Load', 'View Load'].indexOf(event) !== -1) return this.log('not tracking common event', event)


### PR DESCRIPTION
Error was thrown because [`me.isTeacher`](https://github.com/codecombat/codecombat/compare/adamk/identify-events-missing-in-analytics?expand=1#diff-34ca13206c09ece2c1dd2ef2dbfe8e518f1952ef0e635b2fbaf3f83853d442bbR27) was `undefined`. 

Caused by `me` was not the real `me` object, but some [other data](https://github.com/codecombat/codecombat/compare/adamk/identify-events-missing-in-analytics?expand=1#diff-34ca13206c09ece2c1dd2ef2dbfe8e518f1952ef0e635b2fbaf3f83853d442bbL24) from the store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved variable naming in the `identify` method for better clarity.
	- Enhanced readability of control flow in the `trackEventInternal` method without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->