### PR TITLE
hide oz classroom auto clans

### DIFF
--- a/app/views/ai-league/ClanSelectorTeachers.vue
+++ b/app/views/ai-league/ClanSelectorTeachers.vue
@@ -1,6 +1,6 @@
 <script>
 import QuestionmarkView from 'app/views/ai-league/QuestionmarkView.vue'
-import ClassroomsApi from 'app/core/api/classrooms.js'
+import { mapGetters } from 'vuex'
 
 export default {
   components: {
@@ -34,24 +34,17 @@ export default {
       default: () => false
     }
   },
-  data () {
-    return {
-      ozClassrooms: []
-    }
-  },
   computed: {
+    ...mapGetters({
+      activeCls: 'teacherDashboard/getActiveClassrooms',
+      archivedCls: 'teacherDashboard/getArchivedClassrooms',
+      sharedCls: 'teacherDashboard/getSharedClassrooms'
+    }),
     clansSanitized () {
-      return this.clans.filter(v => v !== undefined).filter(v => !this.ozClassroomsSlugs.includes(v.slug))
+      return this.clans.filter(v => v !== undefined).filter(v => !v.slug.startsWith('autoclan-classroom-') || this.cocoClassroomsSlugs.includes(v.slug))
     },
-    ozClassroomsSlugs () {
-      return this.ozClassrooms.map(c => `autoclan-classroom-${c._id}`)
-    }
-  },
-  async created () {
-    try {
-      this.ozClassrooms = (await ClassroomsApi.fetchByOwner(me.get('_id'), { callOz: true, project: '_id' }))
-    } catch (e) {
-      console.error('Error fetching oz classrooms', e)
+    cocoClassroomsSlugs () {
+      return [...this.activeCls, ...this.archivedCls, ...this.sharedCls].map(c => `autoclan-classroom-${c._id}`)
     }
   }
 }

--- a/app/views/ai-league/ClanSelectorTeachers.vue
+++ b/app/views/ai-league/ClanSelectorTeachers.vue
@@ -1,5 +1,6 @@
 <script>
 import QuestionmarkView from 'app/views/ai-league/QuestionmarkView.vue'
+import ClassroomsApi from 'app/core/api/classrooms.js'
 
 export default {
   components: {
@@ -33,10 +34,24 @@ export default {
       default: () => false
     }
   },
-
+  data () {
+    return {
+      ozClassrooms: []
+    }
+  },
   computed: {
     clansSanitized () {
-      return this.clans.filter(v => v !== undefined)
+      return this.clans.filter(v => v !== undefined).filter(v => !this.ozClassroomsSlugs.includes(v.slug))
+    },
+    ozClassroomsSlugs () {
+      return this.ozClassrooms.map(c => `autoclan-classroom-${c._id}`)
+    }
+  },
+  async created () {
+    try {
+      this.ozClassrooms = (await ClassroomsApi.fetchByOwner(me.get('_id'), { callOz: true, project: '_id' }))
+    } catch (e) {
+      console.error('Error fetching oz classrooms', e)
     }
   }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1b437c2b-538d-4e12-863a-a285612ebbbc)
fix ENG-1120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced classroom data management functionality in the Clan Selector component by integrating Vuex for state management.
	- Added the ability to fetch and display classroom information associated with the current user.
	- Implemented refined filtering of clans based on classroom slugs.

- **Bug Fixes**
	- Improved error handling during the fetching of classroom data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->