### PR TITLE
sort clan by _id:-1

### DIFF
--- a/app/core/store/modules/clans.js
+++ b/app/core/store/modules/clans.js
@@ -20,7 +20,7 @@ export default {
     },
 
     myClans (state) {
-      return (me.get('clans') || []).map(id => state.clans[id])
+      return (me.get('clans') || []).map(id => state.clans[id]).sort((a, b) => b._id.localeCompare(a._id))
     },
 
     clanByIdOrSlug (state) {

--- a/app/core/store/modules/clans.js
+++ b/app/core/store/modules/clans.js
@@ -2,6 +2,15 @@ import { getPublicClans, getMyClans, getClan, getChildClanDetails, getTournament
 import { getTournamentsByMember } from '../../api/tournaments'
 const _ = require('lodash')
 
+const sortClan = (clans) => {
+  const firstClassClan = _.findIndex(clans, (clan) => clan.slug.startsWith('autoclan-classroom'))
+  const classClans = clans.filter((clan) => clan.slug.startsWith('autoclan-classroom'))
+  const otherClans = clans.filter((clan) => !clan.slug.startsWith('autoclan-classroom'))
+  classClans.sort((a, b) => b._id.localeCompare(a._id))
+  otherClans.splice(firstClassClan, 0, ...classClans)
+  return otherClans
+}
+
 export default {
   namespaced: true,
   state: {
@@ -20,7 +29,7 @@ export default {
     },
 
     myClans (state) {
-      return (me.get('clans') || []).map(id => state.clans[id]).sort((a, b) => b._id.localeCompare(a._id))
+      return sortClan((me.get('clans') || []).map(id => state.clans[id]))
     },
 
     clanByIdOrSlug (state) {


### PR DESCRIPTION
fix ENG-1156

i think for all clans usage, we can show most recent one at first. that make sense to me. so order in top level

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a sorting function that organizes user-associated clans into two categories, enhancing the display order for better user experience.
	- Clans starting with `autoclan-classroom` are now sorted in descending order, while other clans retain their original order.

- **Bug Fixes**
	- Improved the presentation of clan information for a more structured user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->