### PR TITLE
Switch to specific campaigns based on then url

### DIFF
--- a/app/core/Router.js
+++ b/app/core/Router.js
@@ -496,6 +496,7 @@ module.exports = (CocoRouter = (function () {
         'teachers/resources': utils.isCodeCombat && me.useChinaHomeView() ? go('teachers/ResourceHubView', { redirectStudents: true }) : go('core/SingletonAppVueComponentView', { redirectStudents: true }),
         'teachers/resources_new': go('core/SingletonAppVueComponentView'),
         'teachers/curriculum': teacherProxyRoute(go('teachers/curriculum', { redirectStudents: true })),
+        'teachers/curriculum/:campaign': teacherProxyRoute(go('teachers/curriculum', { redirectStudents: true })),
         'teachers/resources/ap-cs-principles': go('teachers/ApCsPrinciplesView', { redirectStudents: true }),
         'teachers/resources/:name': go('teachers/MarkdownResourceView', { redirectStudents: true }),
         'teachers/professional-development': teacherProxyRoute(go('pd/PDView', { redirectStudents: true })),

--- a/app/core/store/modules/teacherDashboard.js
+++ b/app/core/store/modules/teacherDashboard.js
@@ -363,7 +363,7 @@ export default {
     async fetchDataCurriculumGuideAsync ({ state, dispatch, rootGetters }, options = {}) {
       const fetchPromises = []
       fetchPromises.push(dispatch('prepaids/fetchPrepaidsForTeacher', { teacherId: state.teacherId }, { root: true }))
-      fetchPromises.push(dispatch('teacherDashboard/fetchDataCurriculumGuide', undefined, { root: true }))
+      fetchPromises.push(dispatch('teacherDashboard/fetchDataCurriculumGuide', options, { root: true }))
       await Promise.all(fetchPromises)
     },
 
@@ -384,7 +384,7 @@ export default {
     },
 
     // Curriculum guides panel
-    async fetchDataCurriculumGuide ({ dispatch, rootGetters, getters }) {
+    async fetchDataCurriculumGuide ({ dispatch, rootGetters, getters }, options = {}) {
       let sortedCourses = rootGetters['courses/sorted'] || []
       if (sortedCourses.length === 0) {
         await dispatch('courses/fetchReleased', undefined, { root: true })
@@ -397,6 +397,12 @@ export default {
         let selectedCourse
         if (classroomCourseIds.length) {
           selectedCourse = sortedCourses.find((c) => classroomCourseIds.includes(c._id))
+        }
+        if (options.campaignUrl) {
+          const course = sortedCourses.find(c => c.slug === options.campaignUrl)
+          if (course) {
+            selectedCourse = course
+          }
         }
         selectedCourse = selectedCourse || sortedCourses[0]
         dispatch('baseCurriculumGuide/setSelectedCampaign', selectedCourse.campaignID, { root: true })

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -298,6 +298,7 @@ export default function getVueRouter () {
             },
             { path: 'professional-development', component: () => import(/* webpackChunkName: "pd" */ '../views/pd/PDViewV2.vue') },
             { path: 'curriculum', component: () => import(/* webpackChunkName: "curriculum" */ '../../ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue') },
+            { path: 'curriculum/:campaign', component: () => import(/* webpackChunkName: "curriculum" */ '../../ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue'), props: true },
             {
               path: 'ai-league',
               component: () => import(/* webpackChunkName: "ai-league" */ '../views/ai-league/AILeagueView.vue'),

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterNav.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterNav.vue
@@ -2,6 +2,20 @@
 import { mapGetters, mapActions } from 'vuex'
 import utils from 'core/utils'
 export default {
+  props: {
+    campaignUrl: {
+      type: String,
+      default: '',
+      required: false
+    }
+  },
+
+  data () {
+    return {
+      loadPageToUrl: false,
+    }
+  },
+
   computed: {
     ...mapGetters({
       chapterNavBar: 'baseCurriculumGuide/chapterNavBar',
@@ -29,6 +43,21 @@ export default {
 
     courseName () {
       return this.getCurrentCourse?.name || ''
+    }
+  },
+
+  watch: {
+    getCurrentCourse () {
+      if (!this.loadPageToUrl) {
+        if (this.getCurrentCourse && this.courses) {
+          const courses = this.courses
+          const course = courses.find(course => course.slug === this.campaignUrl)
+          if (course) {
+            this.setSelectedCampaign(course.campaignID)
+          }
+          this.loadPageToUrl = true
+        }
+      }
     }
   },
 

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterNav.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterNav.vue
@@ -2,14 +2,6 @@
 import { mapGetters, mapActions } from 'vuex'
 import utils from 'core/utils'
 export default {
-  props: {
-    campaignUrl: {
-      type: String,
-      default: '',
-      required: false
-    }
-  },
-
   data () {
     return {
       loadPageToUrl: false,
@@ -43,21 +35,6 @@ export default {
 
     courseName () {
       return this.getCurrentCourse?.name || ''
-    }
-  },
-
-  watch: {
-    getCurrentCourse () {
-      if (!this.loadPageToUrl) {
-        if (this.getCurrentCourse && this.courses) {
-          const courses = this.courses
-          const course = courses.find(course => course.slug === this.campaignUrl)
-          if (course) {
-            this.setSelectedCampaign(course.campaignID)
-          }
-          this.loadPageToUrl = true
-        }
-      }
     }
   },
 

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterNav.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterNav.vue
@@ -2,12 +2,6 @@
 import { mapGetters, mapActions } from 'vuex'
 import utils from 'core/utils'
 export default {
-  data () {
-    return {
-      loadPageToUrl: false,
-    }
-  },
-
   computed: {
     ...mapGetters({
       chapterNavBar: 'baseCurriculumGuide/chapterNavBar',

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue
@@ -26,6 +26,11 @@ export default {
     defaultLanguage: {
       type: String,
       default: 'python'
+    },
+    campaign: {
+      type: String,
+      default: '',
+      required: false
     }
   },
 
@@ -127,7 +132,7 @@ export default {
         </div>
       </div>
 
-      <chapter-nav />
+      <chapter-nav :campaign-url="campaign" />
       <chapter-info />
 
       <div class="fluid-container">

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue
@@ -66,7 +66,7 @@ export default {
   mounted () {
     this.setTeacherId(me.get('_id'))
     this.setPageTitle(PAGE_TITLES[this.$options.name])
-    this.fetchData({ componentName: this.$options.name, options: { loadedEventName: 'Curriculum Guide: Loaded' } })
+    this.fetchData({ componentName: this.$options.name, options: { campaignUrl: this.campaign, loadedEventName: 'Curriculum Guide: Loaded' } })
   },
 
   methods: {
@@ -132,7 +132,7 @@ export default {
         </div>
       </div>
 
-      <chapter-nav :campaign-url="campaign" />
+      <chapter-nav />
       <chapter-info />
 
       <div class="fluid-container">


### PR DESCRIPTION
fixes ENG-1068
The url for the campaign tabs is `teachers/curriculum/{campaign-slug}`
![image](https://github.com/user-attachments/assets/db5edcfb-2d5a-4de8-8dbf-a302fa6a41f7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic routing for teachers to access campaign-specific curriculum.
	- Enhanced curriculum guide component to accept and utilize a campaign URL for improved navigation and context-aware rendering.
	- Added options for flexible data fetching in the teacher dashboard, allowing for context-sensitive behavior based on campaign URLs.

- **Bug Fixes**
	- Improved logic to prevent unnecessary executions when selecting campaigns based on the current course context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->