### PR TITLE
Add AI leauge to ozaria using modal popup

### DIFF
--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -4686,8 +4686,8 @@ module.exports = {
       ready_to_review: 'Ready to Review',
       ozaria_hs_modal_title: 'Access AI Hackstack Exclusively on CodeCombat',
       ozaria_hs_modal_blurb: 'Educators can now access AI Hackstack directly on **[https://codecombat.com/teachers/ai-league]CodeCombat** using the same credentials as Ozaria. For added convenience, you can easily import your classes from Ozaria into CodeCombat.',
-      ozaria_ai_leauge_modal_title: 'Access AI Leauge Exclusively on CodeCombat',
-      ozaria_ai_leauge_modal_blurb: 'Educators can now access AI Leauge directly on **[https://codecombat.com/teachers/ai-league]CodeCombat** using the same credentials as Ozaria. For added convenience, you can easily import your classes from Ozaria into CodeCombat.'
+      ozaria_ai_league_modal_title: 'Access AI League Exclusively on CodeCombat',
+      ozaria_ai_league_modal_blurb: 'Educators can now access AI League directly on **[https://codecombat.com/teachers/ai-league]CodeCombat** using the same credentials as Ozaria. For added convenience, you can easily import your classes from Ozaria into CodeCombat.'
     },
 
     outcomes: {

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -4685,7 +4685,9 @@ module.exports = {
       test_student_only: '(Test Student Only)',
       ready_to_review: 'Ready to Review',
       ozaria_hs_modal_title: 'Access AI Hackstack Exclusively on CodeCombat',
-      ozaria_hs_modal_blurb: 'Educators can now access AI Hackstack directly on **[https://codecombat.com/teachers/classes]CodeCombat** using the same credentials as Ozaria. For added convenience, you can easily import your classes from Ozaria into CodeCombat.'
+      ozaria_hs_modal_blurb: 'Educators can now access AI Hackstack directly on **[https://codecombat.com/teachers/ai-league]CodeCombat** using the same credentials as Ozaria. For added convenience, you can easily import your classes from Ozaria into CodeCombat.',
+      ozaria_ai_leauge_modal_title: 'Access AI Leauge Exclusively on CodeCombat',
+      ozaria_ai_leauge_modal_blurb: 'Educators can now access AI Leauge directly on **[https://codecombat.com/teachers/ai-league]CodeCombat** using the same credentials as Ozaria. For added convenience, you can easily import your classes from Ozaria into CodeCombat.'
     },
 
     outcomes: {

--- a/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
+++ b/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
@@ -387,13 +387,14 @@ export default {
         </li>
       </ul>
     </li>
-    <li v-if="isCodeCombat">
-      <router-link
+    <li>
+      <component
+        :is="isCodeCombat ? 'router-link' : 'a'"
         id="AILeague"
         to="/teachers/ai-league"
         :class="{ 'current-route': isCurrentRoute('/teachers/ai-league') }"
         data-action="AI League: Nav Clicked"
-        @click.native="trackEvent"
+        @click="AILeagueClicked"
       >
         <div id="IconKeepPlaying" />
         <img
@@ -408,32 +409,7 @@ export default {
           class="league-name league-name__blue"
           src="/images/pages/league/ai-league-name_blue.svg"
         >
-      </router-link>
-    </li>
-    <li
-      v-else
-      @click="AILeagueClicked"
-    >
-      <a
-        id="AILeague"
-        :class="{ 'current-route': isCurrentRoute('/teachers/ai-league') }"
-        data-action="AI League: Nav Clicked"
-        @click.native="trackEvent"
-      >
-        <div id="IconKeepPlaying" />
-        <img
-          class="league-name league-name__gray"
-          src="/images/pages/league/ai-league-name.svg"
-        >
-        <img
-          class="league-name league-name__moon"
-          src="/images/pages/league/ai-league-name_moon.svg"
-        >
-        <img
-          class="league-name league-name__blue"
-          src="/images/pages/league/ai-league-name_blue.svg"
-        >
-      </a>
+      </component>
     </li>
     <li
       role="presentation"

--- a/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
+++ b/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
@@ -161,7 +161,7 @@ export default {
         noty({ text: $.i18n.t('teacher_dashboard.create_class_hackstack'), type: 'warning', layout: 'center', timeout: 5000 })
       }
     },
-    AILeaugeClicked () {
+    AILeagueClicked () {
       if (utils.isOzaria) {
         this.$refs.ModalOzariaAILeague.openModal()
       }
@@ -412,7 +412,7 @@ export default {
     </li>
     <li
       v-else
-      @click="AILeaugeClicked"
+      @click="AILeagueClicked"
     >
       <a
         id="AILeague"

--- a/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
+++ b/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
@@ -7,6 +7,7 @@ import ModalHackStackBeta from 'ozaria/site/components/teacher-dashboard/modals/
 import ModalTestStudentPromotion from 'ozaria/site/components/teacher-dashboard/modals/ModalTestStudentPromotion.vue'
 import ModalCurriculumPromotion from 'ozaria/site/components/teacher-dashboard/modals/ModalCurriculumPromotion.vue'
 import ModalOzariaHackStack from 'ozaria/site/components/teacher-dashboard/modals/ModalOzariaHackStack'
+import ModalOzariaAILeague from 'ozaria/site/components/teacher-dashboard/modals/ModalOzariaAILeague'
 import IconAI from 'ozaria/site/components/teacher-dashboard/common/NavIconAI'
 import IconAPCSP from 'ozaria/site/components/teacher-dashboard/common/NavIconAPCSP'
 import IconAssessments from 'ozaria/site/components/teacher-dashboard/common/NavIconAssessments'
@@ -18,6 +19,7 @@ export default {
     ModalTestStudentPromotion,
     ModalCurriculumPromotion,
     ModalOzariaHackStack,
+    ModalOzariaAILeague,
     IconAI,
     IconAPCSP,
     IconAssessments
@@ -157,6 +159,11 @@ export default {
       }
       if (this.hackStackClassrooms.length === 0) {
         noty({ text: $.i18n.t('teacher_dashboard.create_class_hackstack'), type: 'warning', layout: 'center', timeout: 5000 })
+      }
+    },
+    AILeaugeClicked () {
+      if (utils.isOzaria) {
+        this.$refs.ModalOzariaAILeague.openModal()
       }
     },
   }
@@ -404,6 +411,31 @@ export default {
       </router-link>
     </li>
     <li
+      v-else
+      @click="AILeaugeClicked"
+    >
+      <a
+        id="AILeague"
+        :class="{ 'current-route': isCurrentRoute('/teachers/ai-league') }"
+        data-action="AI League: Nav Clicked"
+        @click.native="trackEvent"
+      >
+        <div id="IconKeepPlaying" />
+        <img
+          class="league-name league-name__gray"
+          src="/images/pages/league/ai-league-name.svg"
+        >
+        <img
+          class="league-name league-name__moon"
+          src="/images/pages/league/ai-league-name_moon.svg"
+        >
+        <img
+          class="league-name league-name__blue"
+          src="/images/pages/league/ai-league-name_blue.svg"
+        >
+      </a>
+    </li>
+    <li
       role="presentation"
       class="dropdown"
       @click="hackstackClicked"
@@ -543,6 +575,10 @@ export default {
     <ModalOzariaHackStack
       v-if="isOzaria"
       ref="modalOzariaHackStack"
+    />
+    <ModalOzariaAILeague
+      v-if="isOzaria"
+      ref="ModalOzariaAILeague"
     />
     <ModalTestStudentPromotion />
   </ul>

--- a/ozaria/site/components/teacher-dashboard/modals/ModalOzariaAILeague.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalOzariaAILeague.vue
@@ -1,0 +1,73 @@
+<template>
+  <ModalDynamicContent
+    ref="modal"
+    :auto-show="false"
+  >
+    <template #content>
+      <div class="ozar-hs-modal-content">
+        <h3 class="text-h3">
+          {{ $t('teacher_dashboard.ozaria_ai_leauge_modal_title') }}
+        </h3>
+        <p>
+          <mixed-color-label
+            :text="$t('teacher_dashboard.ozaria_ai_leauge_modal_blurb')"
+          />
+        </p>
+        <a
+          href="https://codecombat.com/teachers/ai-league"
+          target="_blank"
+        >
+          <img src="/images/ozaria/teachers/dashboard/png_img/import-classroom.webp">
+        </a>
+        <div class="continue">
+          <a
+            class="btn btn-primary btn-lg dusk-btn"
+            href="https://codecombat.com/teachers/ai-league"
+            target="_blank"
+          >
+            {{ $t('home_v3.try_it_now') }}
+          </a>
+        </div>
+      </div>
+    </template>
+  </ModalDynamicContent>
+</template>
+
+<script>
+import ModalDynamicContent from 'ozaria/site/components/teacher-dashboard/modals/ModalDynamicContent.vue'
+import MixedColorLabel from 'app/components/common/labels/MixedColorLabel.vue'
+
+export default {
+  name: 'OzariaHackStackModal',
+  components: {
+    ModalDynamicContent,
+    MixedColorLabel
+  },
+  methods: {
+    openModal () {
+      this.$refs.modal.openModal()
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+@import "ozaria/site/styles/common/variables.scss";
+@import "ozaria/site/components/teacher-dashboard/common/_dusk-button";
+.ozar-hs-modal-content {
+  max-width: min(600px, 90vw);
+  .text-h3 {
+    font-size: 24px;
+    margin: 10px auto 10px;
+  }
+  img {
+    max-width: 100%;
+  }
+
+  .continue {
+    display: flex;
+    justify-content: center;
+    margin-top: 20px;
+  }
+}
+</style>

--- a/ozaria/site/components/teacher-dashboard/modals/ModalOzariaAILeague.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalOzariaAILeague.vue
@@ -38,7 +38,7 @@ import ModalDynamicContent from 'ozaria/site/components/teacher-dashboard/modals
 import MixedColorLabel from 'app/components/common/labels/MixedColorLabel.vue'
 
 export default {
-  name: 'OzariaHackStackModal',
+  name: 'OzariaAILeagueModal',
   components: {
     ModalDynamicContent,
     MixedColorLabel

--- a/ozaria/site/components/teacher-dashboard/modals/ModalOzariaAILeague.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalOzariaAILeague.vue
@@ -6,11 +6,11 @@
     <template #content>
       <div class="ozar-hs-modal-content">
         <h3 class="text-h3">
-          {{ $t('teacher_dashboard.ozaria_ai_leauge_modal_title') }}
+          {{ $t('teacher_dashboard.ozaria_ai_league_modal_title') }}
         </h3>
         <p>
           <mixed-color-label
-            :text="$t('teacher_dashboard.ozaria_ai_leauge_modal_blurb')"
+            :text="$t('teacher_dashboard.ozaria_ai_league_modal_blurb')"
           />
         </p>
         <a


### PR DESCRIPTION
fixes ENG-993
A modal will open when AI leauge is clicked in ozaria, which links the user to https://codecombat.com/teachers/ai-league
![Screenshot from 2024-09-15 16-22-36](https://github.com/user-attachments/assets/8a261d1c-7636-4b41-83d9-ebadb86c06ba)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new modal for the AI League, enhancing access to resources for educators.
	- Updated navigation to include an AI League option in the teacher dashboard.
	- Added localized text for the AI League modal, including title and description.

- **Bug Fixes**
	- Corrected the URL for accessing AI Hackstack resources.

- **Documentation**
	- Enhanced user guidance with updated text strings related to the AI League.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->