### PR TITLE
Automatically equip required items when in a level without them

### DIFF
--- a/app/models/Level.js
+++ b/app/models/Level.js
@@ -232,7 +232,7 @@ module.exports = (Level = (function () {
           if (equips.config == null) { equips.config = {} }
           // If we somehow don't have all our required properties, then grant the rest of them.
           if (!this.headless && !this.isEditorPreview) {
-            for (const [slot, defaultItemOriginal] of Object.entries(defaultEquipsConfig?.inventory)) {
+            for (const [slot, defaultItemOriginal] of Object.entries(defaultEquipsConfig?.inventory || {})) {
               // Look through this ThangType's components for one with config.programmableProperties, see if there's intersection between those and this.get('requiredProperties') and there is NOT such intersection for whatever item we would otherwise have in this slot, and if so, put that item in this slot.
               if (!defaultItemOriginal) { continue }
               const defaultItemThangType = thangTypesByOriginal[defaultItemOriginal]

--- a/app/models/Level.js
+++ b/app/models/Level.js
@@ -153,7 +153,20 @@ module.exports = (Level = (function () {
             }
             levelThang.components = [] // We have stored the placeholder values, so we can inherit everything else.
             heroThangType = __guard__(session != null ? session.get('heroConfig') : undefined, x => x.thangType)
-            if (heroThangType) { levelThang.thangType = heroThangType }
+            if (heroThangType) {
+              let juniorHeroReplacement
+              if (this.get('product', true) === 'codecombat-junior') {
+                // If we got into a codecombat-junior level with a codecombat hero, pick an equivalent codecombat-junior hero to use instead
+                juniorHeroReplacement = ThangTypeConstants.juniorHeroReplacements[_.invert(ThangTypeConstants.heroes)[heroThangType]]
+              } else {
+                // If we got into a codecombat level with a codecombat-junior hero, pick an equivalent codecombat hero to use instead
+                juniorHeroReplacement = _.invert(ThangTypeConstants.juniorHeroReplacements)[_.invert(ThangTypeConstants.heroes)[heroThangType]]
+              }
+              if (juniorHeroReplacement) {
+                heroThangType = ThangTypeConstants.heroes[juniorHeroReplacement]
+              }
+              levelThang.thangType = heroThangType
+            }
           }
         }
       }

--- a/app/models/Level.js
+++ b/app/models/Level.js
@@ -165,6 +165,7 @@ module.exports = (Level = (function () {
         configs[thangComponent.original] = thangComponent
       }
 
+      let defaultEquipsConfig
       for (const defaultThangComponent of Array.from((thangType != null ? thangType.get('components') : undefined) || [])) {
         let copy
         let levelThangComponent = configs[defaultThangComponent.original]
@@ -181,11 +182,9 @@ module.exports = (Level = (function () {
         if (utils.isCodeCombat) {
           if (isHero && (placeholderComponent = placeholders[defaultThangComponent.original])) {
             placeholdersUsed[placeholderComponent.original] = true
-            const placeholderConfig = placeholderComponent.config != null ? placeholderComponent.config : {}
+            const placeholderConfig = placeholderComponent.config || {}
             if (levelThangComponent.config == null) { levelThangComponent.config = {} }
-            ({
-              config
-            } = levelThangComponent)
+            config = levelThangComponent.config
             if (placeholderConfig.pos) { // Pull in Physical pos x and y
               if (config.pos == null) { config.pos = {} }
               config.pos.x = placeholderConfig.pos.x
@@ -198,14 +197,16 @@ module.exports = (Level = (function () {
             } else if (placeholderConfig.programmableMethods) {
               // Take the ThangType default Programmable and merge level-specific Component config into it
               copy = $.extend(true, {}, placeholderConfig)
-              const programmableProperties = (config != null ? config.programmableProperties : undefined) != null ? (config != null ? config.programmableProperties : undefined) : []
-              copy.programmableProperties = _.union(programmableProperties, copy.programmableProperties != null ? copy.programmableProperties : [])
+              const programmableProperties = config?.programmableProperties || []
+              copy.programmableProperties = _.union(programmableProperties, copy.programmableProperties || [])
               levelThangComponent.config = (config = _.merge(copy, config))
             } else if (placeholderConfig.extraHUDProperties) {
               config.extraHUDProperties = _.union(config.extraHUDProperties != null ? config.extraHUDProperties : [], placeholderConfig.extraHUDProperties)
             } else if (placeholderConfig.voiceRange) { // Pull in voiceRange
               config.voiceRange = placeholderConfig.voiceRange
               config.cooldown = placeholderConfig.cooldown
+            } else if (placeholderConfig.inventory) {
+              defaultEquipsConfig = placeholderConfig
             }
           }
         }
@@ -214,8 +215,59 @@ module.exports = (Level = (function () {
       if (utils.isCodeCombat && isHero) {
         const equips = _.find(levelThang.components, { original: LevelComponent.EquipsID })
         if (equips) {
-          const inventory = __guard__(session != null ? session.get('heroConfig') : undefined, x1 => x1.inventory)
+          const inventory = session?.get('heroConfig')?.inventory || {}
           if (equips.config == null) { equips.config = {} }
+          // If we somehow don't have all our required properties, then grant the rest of them.
+          if (!this.headless && !this.isEditorPreview) {
+            for (const [slot, defaultItemOriginal] of Object.entries(defaultEquipsConfig?.inventory)) {
+              // Look through this ThangType's components for one with config.programmableProperties, see if there's intersection between those and this.get('requiredProperties') and there is NOT such intersection for whatever item we would otherwise have in this slot, and if so, put that item in this slot.
+              if (!defaultItemOriginal) { continue }
+              const defaultItemThangType = thangTypesByOriginal[defaultItemOriginal]
+              if (!defaultItemThangType) { continue }
+
+              // Initialize the default item properties
+              let defaultItemProperties = []
+              for (const component of defaultItemThangType.get('components') || []) {
+                defaultItemProperties = defaultItemProperties.concat(component.config?.programmableProperties || [])
+              }
+
+              // Get the player's item in this slot
+              const playerItemOriginal = inventory[slot]
+
+              // Initialize player's item properties
+              let playerItemProperties = []
+              let playerItemThangType
+              if (playerItemOriginal) {
+                playerItemThangType = thangTypesByOriginal[playerItemOriginal]
+                if (playerItemThangType) {
+                  for (const component of playerItemThangType.get('components') || []) {
+                    playerItemProperties = playerItemProperties.concat(component.config?.programmableProperties || [])
+                  }
+                }
+              }
+
+              // Get required properties from the level
+              const requiredProperties = this.get('requiredProperties') || []
+              const requiredPropertiesForSlot = _.intersection(requiredProperties, defaultItemProperties)
+              const requiredGear = this.get('requiredGear')?.[slot]
+              const restrictedGear = this.get('restrictedGear')?.[slot]
+
+              // Check if the player's item covers all the required properties for this slot
+              const playerItemRequiredPropertiesForSlot = _.intersection(playerItemProperties, requiredPropertiesForSlot)
+              if (playerItemRequiredPropertiesForSlot.length === 0 && playerItemRequiredPropertiesForSlot.length < requiredPropertiesForSlot.length) {
+                // Player's item does not cover required properties, so equip the default item
+                console.log(`Auto-equipping default item ${defaultItemOriginal} ${defaultItemThangType.get('name')} in slot ${slot} to get required properties ${requiredPropertiesForSlot} out of requiredProperties ${requiredProperties}, because player item ${playerItemOriginal} ${playerItemThangType?.get('name')} only has properties ${playerItemProperties}`)
+                inventory[slot] = defaultItemOriginal
+              } else if (requiredGear?.length && !playerItemOriginal) {
+                // Player's item does not exist, so equip the default item. (Note that we do let them play with different items equipped in the slot.)
+                console.log(`Auto-equipping default item ${defaultItemOriginal} in slot ${slot} because player has no item equipped there and a required item is there`)
+                inventory[slot] = defaultItemOriginal
+              } else if (restrictedGear?.length && restrictedGear.includes(playerItemOriginal)) {
+                console.log(`Auto-equipping default item ${defaultItemOriginal} ${defaultItemThangType.get('name')} in slot ${slot} because player item ${playerItemOriginal} ${playerItemThangType?.get('name')} is in restricted list`)
+                inventory[slot] = defaultItemOriginal
+              }
+            }
+          }
           if (inventory) { equips.config.inventory = $.extend(true, {}, inventory) }
         }
         for (const original in placeholders) {


### PR DESCRIPTION
### Automatically equip required items when in a level without them
If https://github.com/codecombat/codecombat/pull/7696 helps solve an issue where we don't own the proper items when going into a level in the InventoryModal, this solves similar issues if we somehow find ourselves in a level without the proper items (like navigating there by direct level link, or some other buggy flow).

This checks for requiredProperties, requiredGear, and restrictedGear, and does some just-in-time adjustments to what we have equipped in our session's heroConfig.inventory to meet the requirements.

There are probably some edge cases that aren't handled perfectly, like unequipping stuff in restricted slots that the default level config doesn't equip anything for, or dealing with rings, but this should do a good-enough job at the common cases for a fallback defense system. More edge cases are handled in the InventoryModal logic, but that's overkill complexity for here.

Fixes ENG-538.

To test, should just play a few complex level and inventory setups, for home and students-in-classroom-with-items-enabled accounts, and make sure this logic doesn't unequip some valid equipment choice. (It will log any changes it makes in the console.)

<img width="1439" alt="Screenshot 2024-09-15 at 13 42 56" src="https://github.com/user-attachments/assets/291aaf28-01b5-45b3-8a38-555642d67199">

### Handle another edge case with junior -> codecombat hero replacement
If we start to try to play CodeCombat with a CodeCombat Junior hero, it's possible to stay using the Junior hero. This adds a replacement to use a corresponding CodeCombat hero to another place that needs it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced hero selection logic based on game mode, ensuring players have appropriate heroes for each level.
	- Implemented automatic equipment of default items to meet level requirements, improving player readiness.

- **Bug Fixes**
	- Resolved issues with hero type mismatches and inventory requirements, leading to a smoother gameplay experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->