### PR TITLE
ENG-1161 - don't redirect from ai-league after creating class

### DIFF
--- a/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
@@ -572,7 +572,10 @@ export default Vue.extend({
         // redirect to classes if user was not on classes page when creating a new class
         if (this.classroomInstance.isNew()) {
           const path = window.location.pathname
-          if (path !== '/teachers' && !path.match('/teachers/classes')) {
+          if (path !== '/teachers' &&
+            !path.match('/teachers/classes') &&
+            !path.match('/teachers/ai-league')
+          ) {
             window.location.href = '/teachers/classes'
           }
         }


### PR DESCRIPTION
After this fix when you click the **Add new class** button on ai-league page, you won't be redirected to all classrooms page, but you'll remain on ai-league.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved user experience by refining redirection logic after creating a new class, preventing unnecessary redirection for users on the AI League page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->