### PR TITLE
ENG-1057 - Improve modal experience

### DIFF
--- a/app/core/store/modules/modals.js
+++ b/app/core/store/modules/modals.js
@@ -8,11 +8,7 @@ export default {
       const index = state.modals.findIndex(m => m.name === modal.name)
       if (index === -1) {
         state.modals.push(modal)
-      } else {
-        // Remove the modal from its current position
-        const [existingModal] = state.modals.splice(index, 1)
-        // Push the existing modal to the end of the array
-        state.modals.push(existingModal)
+        state.modals.sort((a, b) => b.priority - a.priority)
       }
     },
     removeModal (state, modalName) {
@@ -24,7 +20,25 @@ export default {
   },
   getters: {
     getTopModal: (state) => {
-      return state.modals[state.modals.length - 1]
+      const topModal = state.modals[0]
+
+      // If there's no top modal, return null
+      if (!topModal) {
+        return null
+      }
+
+      // If the top modal isn't restricted  by a seenPromotionsProperty, show it
+      if (!topModal.seenPromotionsProperty) {
+        return topModal
+      }
+
+      // If the user should see the promotion, return the top modal
+      if (me.shouldSeePromotion(topModal.seenPromotionsProperty)) {
+        return topModal
+      }
+
+      // If none of the above conditions are met, return null
+      return null
     },
   },
 }

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -680,9 +680,26 @@ module.exports = (User = (function () {
       return seenPromotions[key]
     }
 
+    shouldSeePromotion (key) {
+      if (!key) {
+        return true
+      }
+
+      const seenPromotion = this.getSeenPromotion(key)
+      if (seenPromotion) {
+        return false
+      }
+      const latestDate = Object.values(this.get('seenPromotions') || {})
+        .reduce((a, b) => new Date(a) > new Date(b) ? new Date(a) : new Date(b), new Date(0))
+
+      const aWeekAgo = new Date()
+      aWeekAgo.setDate(aWeekAgo.getDate() - 7)
+      return latestDate < aWeekAgo
+    }
+
     setSeenPromotion (key) {
       const seenPromotions = this.get('seenPromotions') || {}
-      Object.assign(seenPromotions, { [key]: true })
+      Object.assign(seenPromotions, { [key]: new Date() })
       this.set('seenPromotions', seenPromotions)
     }
 

--- a/app/schemas/models/user.js
+++ b/app/schemas/models/user.js
@@ -406,9 +406,9 @@ _.extend(UserSchema.properties, {
   seenPromotions: {
     type: 'object',
     properties: {
-      'hackstack-beta-release-modal': { type: 'boolean' },
-      'curriculum-sidebar-promotion-modal': { type: 'boolean' },
-      'hp-junior-modal': { type: 'boolean' }
+      'hackstack-beta-release-modal': c.date(),
+      'curriculum-sidebar-promotion-modal': c.date(),
+      'hp-junior-modal': c.date()
     }
   },
 

--- a/app/schemas/models/user.js
+++ b/app/schemas/models/user.js
@@ -406,9 +406,9 @@ _.extend(UserSchema.properties, {
   seenPromotions: {
     type: 'object',
     properties: {
-      'hackstack-beta-release-modal': c.date(),
-      'curriculum-sidebar-promotion-modal': c.date(),
-      'hp-junior-modal': c.date()
+      'hackstack-beta-release-modal': [c.date(), { type: 'boolean' }],
+      'curriculum-sidebar-promotion-modal': [c.date(), { type: 'boolean' }],
+      'hp-junior-modal': [c.date(), { type: 'boolean' }],
     }
   },
 

--- a/ozaria/site/components/teacher-dashboard/modals/ModalDynamicContent.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalDynamicContent.vue
@@ -45,6 +45,10 @@ export default Vue.extend({
     ozarOnly: {
       type: Boolean,
       default: false
+    },
+    priority: {
+      type: Number,
+      default: 5
     }
   },
 
@@ -74,7 +78,7 @@ export default Vue.extend({
       this.autoShow &&
       (
         !this.seenPromotionsProperty ||
-        !me.getSeenPromotion(this.seenPromotionsProperty)
+        me.shouldSeePromotion(this.seenPromotionsProperty)
       )
     ) {
       this.openModal()
@@ -87,7 +91,13 @@ export default Vue.extend({
       removeModal: 'modals/removeModal'
     }),
     addModalToStore () {
-      this.addModal({ name: this.name })
+      if (!this.seenPromotionsProperty || me.shouldSeePromotion(this.seenPromotionsProperty)) {
+        this.addModal({
+          name: this.name,
+          seenPromotionsProperty: this.seenPromotionsProperty,
+          priority: this.priority
+        })
+      }
     },
     removeModalFromStore () {
       this.removeModal(this.name)

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,6 @@
+{
+    "env": {
+      "jest": true,
+      "mocha": true
+    }
+  }

--- a/test/app/core/store/modules/modals.spec.js
+++ b/test/app/core/store/modules/modals.spec.js
@@ -1,0 +1,57 @@
+import { createLocalVue } from '@vue/test-utils'
+import Vuex from 'vuex'
+import modalsModule from 'app/core/store/modules/modals'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+describe('Vuex Modals Module', () => {
+  let store
+
+  beforeEach(() => {
+    store = new Vuex.Store({
+      modules: {
+        modals: modalsModule
+      }
+    })
+  })
+
+  afterEach(() => {
+    store.state.modals.modals = []
+  })
+
+  describe('mutations', () => {
+    it('adds a modal to the state', () => {
+      const modal = { name: 'testModal', priority: 1 }
+      store.commit('modals/addModal', modal)
+      const addedModal = store.state.modals.modals.find(m => m.name === modal.name)
+      expect(addedModal.name).toEqual(modal.name)
+      expect(addedModal.priority).toEqual(modal.priority)
+    })
+
+    it('removes a modal from the state', () => {
+      const modal = { name: 'testModal', priority: 1 }
+      store.commit('modals/addModal', modal)
+      store.commit('modals/removeModal', 'testModal')
+      const removedModal = store.state.modals.modals.find(m => m.name === modal.name)
+      expect(removedModal).toBeUndefined()
+    })
+  })
+
+  describe('getters', () => {
+    it('returns the top modal', () => {
+      const testModalLowerPrio = { name: 'testModalLowerPrio', priority: 0 }
+      const testModalHigh = { name: 'testModalHigh', priority: 9 }
+      const testModalLowPrio = { name: 'testModalLowPrio', priority: 3 }
+      store.commit('modals/addModal', testModalLowerPrio)
+      store.commit('modals/addModal', testModalHigh)
+      store.commit('modals/addModal', testModalLowPrio)
+      const topModal = store.getters['modals/getTopModal']
+      expect(topModal.name).toEqual(testModalHigh.name)
+    })
+
+    it('returns null if there is no top modal', () => {
+      expect(store.getters['modals/getTopModal']).toBeNull()
+    })
+  })
+})

--- a/test/app/models/User.spec.js
+++ b/test/app/models/User.spec.js
@@ -4,86 +4,124 @@
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/main/docs/suggestions.md
  */
-const User = require('models/User');
+const User = require('models/User')
 
-describe('UserModel', function() {
-  it('experience functions are correct', function() {
-    expect(User.expForLevel(User.levelFromExp(0))).toBe(0);
-    expect(User.levelFromExp(User.expForLevel(1))).toBe(1);
-    expect(User.levelFromExp(User.expForLevel(10))).toBe(10);
-    expect(User.expForLevel(1)).toBe(0);
-    return expect(User.expForLevel(2)).toBeGreaterThan(User.expForLevel(1));
-  });
+describe('UserModel', function () {
+  it('experience functions are correct', function () {
+    expect(User.expForLevel(User.levelFromExp(0))).toBe(0)
+    expect(User.levelFromExp(User.expForLevel(1))).toBe(1)
+    expect(User.levelFromExp(User.expForLevel(10))).toBe(10)
+    expect(User.expForLevel(1)).toBe(0)
+    return expect(User.expForLevel(2)).toBeGreaterThan(User.expForLevel(1))
+  })
 
-  it('level is calculated correctly', function() {
-    me.clear();
-    me.set('points', 0);
-    expect(me.level()).toBe(1);
+  it('level is calculated correctly', function () {
+    me.clear()
+    me.set('points', 0)
+    expect(me.level()).toBe(1)
 
-    me.set('points', 50);
-    return expect(me.level()).toBe(User.levelFromExp(50));
-  });
+    me.set('points', 50)
+    return expect(me.level()).toBe(User.levelFromExp(50))
+  })
 
-  describe('user emails', function() {
-    it('has anyNotes, generalNews and recruitNotes enabled by default', function() {
-      const u = new User();
-      expect(u.get('emails')).toBeUndefined();
-      const defaultEmails = u.get('emails', true);
-      expect(defaultEmails.anyNotes.enabled).toBe(true);
-      expect(defaultEmails.generalNews.enabled).toBe(true);
-      return expect(defaultEmails.recruitNotes.enabled).toBe(true);
-    });
+  describe('user emails', function () {
+    it('has anyNotes, generalNews and recruitNotes enabled by default', function () {
+      const u = new User()
+      expect(u.get('emails')).toBeUndefined()
+      const defaultEmails = u.get('emails', true)
+      expect(defaultEmails.anyNotes.enabled).toBe(true)
+      expect(defaultEmails.generalNews.enabled).toBe(true)
+      return expect(defaultEmails.recruitNotes.enabled).toBe(true)
+    })
 
-    it('maintains defaults of other emails when one is explicitly set', function() {
-      const u = new User();
-      u.setEmailSubscription('recruitNotes', false);
-      const defaultEmails = u.get('emails', true);
-      expect(defaultEmails.anyNotes != null ? defaultEmails.anyNotes.enabled : undefined).toBe(true);
-      expect(defaultEmails.generalNews != null ? defaultEmails.generalNews.enabled : undefined).toBe(true);
-      return expect(defaultEmails.recruitNotes.enabled).toBe(false);
-    });
+    it('maintains defaults of other emails when one is explicitly set', function () {
+      const u = new User()
+      u.setEmailSubscription('recruitNotes', false)
+      const defaultEmails = u.get('emails', true)
+      expect(defaultEmails.anyNotes != null ? defaultEmails.anyNotes.enabled : undefined).toBe(true)
+      expect(defaultEmails.generalNews != null ? defaultEmails.generalNews.enabled : undefined).toBe(true)
+      return expect(defaultEmails.recruitNotes.enabled).toBe(false)
+    })
 
-    return it('does not populate raw data for other emails when one is explicitly set', function() {
-      const u = new User();
-      u.setEmailSubscription('recruitNotes', false);
-      u.buildAttributesWithDefaults();
-      const emails = u.get('emails');
-      expect(emails.anyNotes).toBeUndefined();
-      return expect(emails.generalNews).toBeUndefined();
-    });
-  });
+    return it('does not populate raw data for other emails when one is explicitly set', function () {
+      const u = new User()
+      u.setEmailSubscription('recruitNotes', false)
+      u.buildAttributesWithDefaults()
+      const emails = u.get('emails')
+      expect(emails.anyNotes).toBeUndefined()
+      return expect(emails.generalNews).toBeUndefined()
+    })
+  })
 
-  describe('validate', function() {
-    it('returns undefined if the user is valid', () => expect(new User().validate()).toBeUndefined());
+  describe('validate', function () {
+    it('returns undefined if the user is valid', () => expect(new User().validate()).toBeUndefined())
 
-    it('returns an array of errors if the user is invalid', function() {
-      const res = new User({invalidProp:'...'}).validate();
-      return expect(_.isArray(res)).toBe(true);
-    });
+    it('returns an array of errors if the user is invalid', function () {
+      const res = new User({ invalidProp: '...' }).validate()
+      return expect(_.isArray(res)).toBe(true)
+    })
 
-    return it('returns undefined if the user is invalid but has no new validation errors since when last marked to revert', function() {
-      const user = new User({invalidProp:'...'});
-      user.markToRevert();
-      user.set('name', 'this is fine');
-      expect(user.validate()).toBeUndefined();
-      user.set('newInvalidProp', '...');
-      return expect(_.isArray(user.validate())).toBe(true);
-    });
-  });
+    return it('returns undefined if the user is invalid but has no new validation errors since when last marked to revert', function () {
+      const user = new User({ invalidProp: '...' })
+      user.markToRevert()
+      user.set('name', 'this is fine')
+      expect(user.validate()).toBeUndefined()
+      user.set('newInvalidProp', '...')
+      return expect(_.isArray(user.validate())).toBe(true)
+    })
+  })
 
-  return describe('inEU', function() {
-    it('true if in EU country', function() {
-      const u = new User({country: 'germany'});
-      return expect(u.inEU()).toEqual(true);
-    });
-    it('false if not in EU country', function() {
-      const u = new User({country: 'mexico'});
-      return expect(u.inEU()).toEqual(false);
-    });
-    return it('true if not defined', function() {
-      const u = new User();
-      expect(u.get('country')).toBeUndefined();
-      return expect(u.inEU()).toEqual(true);
-    });
-  });
-});
+  describe('inEU', function () {
+    it('true if in EU country', function () {
+      const u = new User({ country: 'germany' })
+      return expect(u.inEU()).toEqual(true)
+    })
+    it('false if not in EU country', function () {
+      const u = new User({ country: 'mexico' })
+      return expect(u.inEU()).toEqual(false)
+    })
+    return it('true if not defined', function () {
+      const u = new User()
+      expect(u.get('country')).toBeUndefined()
+      return expect(u.inEU()).toEqual(true)
+    })
+  })
+
+  describe('shouldSeePromotion', function () {
+    let user
+
+    beforeEach(function () {
+      user = new User()
+    })
+
+    it('returns true if no key is provided', function () {
+      expect(user.shouldSeePromotion()).toBe(true)
+    })
+
+    it('returns false if promotion has been seen', function () {
+      user.set('seenPromotions', { promoKey: new Date().toISOString() })
+      expect(user.shouldSeePromotion('promoKey')).toBe(false)
+    })
+
+    it('returns true if latest promotion was seen more than a week ago', function () {
+      const eightDaysAgo = new Date()
+      eightDaysAgo.setDate(eightDaysAgo.getDate() - 8)
+
+      user.set('seenPromotions', { otherPromoKey: eightDaysAgo.toISOString() })
+      expect(user.shouldSeePromotion('promoKey')).toBe(true)
+    })
+
+    it('returns false if latest promotion was seen less than a week ago', function () {
+      const sixDaysAgo = new Date()
+      sixDaysAgo.setDate(sixDaysAgo.getDate() - 6)
+      const eightDaysAgo = new Date()
+      eightDaysAgo.setDate(eightDaysAgo.getDate() - 8)
+
+      user.set('seenPromotions', {
+        otherPromoKey: sixDaysAgo.toISOString(),
+        otherPromoKey2: eightDaysAgo.toISOString()
+      })
+      expect(user.shouldSeePromotion('promoKey')).toBe(false)
+    })
+  })
+})

--- a/test/app/models/User.spec.js
+++ b/test/app/models/User.spec.js
@@ -87,7 +87,7 @@ describe('UserModel', function () {
     })
   })
 
-  describe('shouldSeePromotion', function () {
+  fdescribe('shouldSeePromotion', function () {
     let user
 
     beforeEach(function () {
@@ -101,6 +101,16 @@ describe('UserModel', function () {
     it('returns false if promotion has been seen', function () {
       user.set('seenPromotions', { promoKey: new Date().toISOString() })
       expect(user.shouldSeePromotion('promoKey')).toBe(false)
+    })
+
+    it('returns false if promotion has the legacy true value', function () {
+      user.set('seenPromotions', { promoKey: true })
+      expect(user.shouldSeePromotion('promoKey')).toBe(false)
+    })
+
+    it('returns true if promotion has the legacy false value', function () {
+      user.set('seenPromotions', { promoKey: false })
+      expect(user.shouldSeePromotion('promoKey')).toBe(true)
     })
 
     it('returns true if latest promotion was seen more than a week ago', function () {

--- a/test/app/models/User.spec.js
+++ b/test/app/models/User.spec.js
@@ -87,7 +87,7 @@ describe('UserModel', function () {
     })
   })
 
-  fdescribe('shouldSeePromotion', function () {
+  describe('shouldSeePromotion', function () {
     let user
 
     beforeEach(function () {


### PR DESCRIPTION
- Only show one modal automatically.
- When the modal was closed, save the date, and next modal should be shown only one week later.
- `<ModalDyanmicContent` has a new prop: `priority<number>`. The modal with **higher** prio will be shown first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced modal management with prioritized display based on user-specific promotion visibility.
  - Introduced a method to determine user eligibility for promotions, improving user engagement tracking.
  - Added a new property for modal prioritization in the UI.

- **Bug Fixes**
  - Improved logic for retrieving the top modal, ensuring accurate display based on user interactions.

- **Tests**
  - Added comprehensive unit tests for modal functionality and user promotion visibility, ensuring robust performance.
  - Enhanced test coverage for modal management and user promotion logic.

- **Documentation**
  - Updated ESLint configuration to support Jest and Mocha, enhancing code quality during development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->