### PR TITLE
Fix TeacherCourseSolutionView for Junior levels

### DIFF
--- a/app/collections/Levels.js
+++ b/app/collections/Levels.js
@@ -43,7 +43,10 @@ module.exports = (LevelCollection = (function () {
       return this.models.reduce((map, level) => {
         const targetLangs = level.get('primerLanguage') ? [level.get('primerLanguage')] : languages
         const allSolutions = _.filter(level.getSolutions(), s => !s.testOnly)
-        const solutions = this.constructor.getSolutionsHelper({ targetLangs, allSolutions })
+        let solutions = this.constructor.getSolutionsHelper({ targetLangs, allSolutions })
+        if (level.get('product') === 'codecombat-junior') {
+          solutions = _.filter(solutions, (s) => s.succeeds) // Don't show unsuccessful test case solutions
+        }
         map[level.get('original')] = solutions != null ? solutions.map(s => ({ source: this.fingerprint(s.source, s.language), description: s.description })) : undefined
         return map
       }

--- a/app/views/teachers/TeacherCourseSolutionView.js
+++ b/app/views/teachers/TeacherCourseSolutionView.js
@@ -170,11 +170,14 @@ ${translateUtils.translateJS(a.slice(13, +(a.length - 4) + 1 || undefined), this
           }
           try {
             if (utils.isCodeCombat) {
-              defaultCode = programmableMethod.languages[solutionLanguage] || ((this.language === 'cpp') && translateUtils.translateJS(programmableMethod.source, 'cpp')) || programmableMethod.source
+              defaultCode = programmableMethod.languages?.[solutionLanguage] || ((this.language === 'cpp') && translateUtils.translateJS(programmableMethod.source, 'cpp')) || programmableMethod.source
             } else {
-              defaultCode = programmableMethod.languages[level.get('primerLanguage') || this.language] || ((this.language === 'cpp') && translateUtils.translateJS(programmableMethod.source, 'cpp')) || programmableMethod.source
+              defaultCode = programmableMethod.languages?.[level.get('primerLanguage') || this.language] || ((this.language === 'cpp') && translateUtils.translateJS(programmableMethod.source, 'cpp')) || programmableMethod.source
             }
             translatedDefaultCode = _.template(defaultCode)(utils.i18n(programmableMethod, 'context'))
+            if (!translatedDefaultCode) {
+              translatedDefaultCode = '\n' // Distinguish empty starter code from nothing so it's not falsy
+            }
           } catch (e) {
             console.error('Broken solution for level:', level.get('name'))
             console.log(e)


### PR DESCRIPTION
Junior levels include succeeds: false test solutions we shouldn't show.

Junior levels sometimes have no sample code, which was not handled (it would say sample code is missing and coming soon).

Junior levels always translate their Python and other languages from JS, which wasn't handled and was having an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced solution filtering based on product type, ensuring only successful solutions are displayed for 'codecombat-junior'.
	- Improved handling of default code and translations in the teacher's course solution view.

- **Bug Fixes**
	- Added optional chaining to prevent runtime errors when accessing language properties, enhancing code stability.
	- Ensured consistent formatting of translated default code, addressing potential rendering issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->