### PR TITLE
hide language and format for clubs which do not need them

### DIFF
--- a/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
@@ -285,7 +285,10 @@ export default Vue.extend({
         !this.classroom.otherProductId &&
         !this.isGoogleClassroomForm &&
         !this.isOtherProductForm
-    }
+    },
+    hideCodeLanguageAndFormat () {
+      return this.asClub && ['club-roblox', 'club-hackstack'].includes(this.newClubType)
+    },
   },
 
   watch: {
@@ -429,6 +432,7 @@ export default Vue.extend({
           this.saving = false
           return
         }
+
         if (this.newClubType) {
           updates.type = this.newClubType
         }
@@ -739,7 +743,7 @@ export default Vue.extend({
             class="col-xs-12"
             :class="{ 'has-error': $v.newClubType.$error }"
           >
-            <label for="default-code-format-select">
+            <label for="club-type-select">
               <span class="control-label"> {{ $t("teachers.club_type") }} </span>
             </label>
             <select
@@ -827,6 +831,7 @@ export default Vue.extend({
           </div>
         </div>
         <div
+          v-if="!hideCodeLanguageAndFormat"
           class="form-group row language"
           :class="{ 'has-error': $v.newProgrammingLanguage.$error }"
         >
@@ -861,7 +866,7 @@ export default Vue.extend({
         </div>
 
         <div
-          v-if="isCodeCombat"
+          v-if="isCodeCombat && !hideCodeLanguageAndFormat"
           class="form-group row code-format"
         >
           <div class="col-xs-12">

--- a/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
@@ -287,7 +287,7 @@ export default Vue.extend({
         !this.isOtherProductForm
     },
     hideCodeLanguageAndFormat () {
-      return this.asClub && ['club-roblox', 'club-hackstack'].includes(this.newClubType)
+      return this.asClub && ['club-esports', 'club-roblox', 'club-hackstack'].includes(this.newClubType)
     },
   },
 


### PR DESCRIPTION
fix ENG-1183
![image](https://github.com/user-attachments/assets/bc328768-b4a9-42eb-be35-0e6aea387f7c)
![image](https://github.com/user-attachments/assets/2003464d-c83c-48ef-987d-03db22b52c19)
![image](https://github.com/user-attachments/assets/324573c2-0b63-4466-83cc-50ada5eeab79)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced UI for club creation with context-sensitive visibility for code language and format sections.
	- Updated dropdown label for club type selection to improve clarity.

- **Bug Fixes**
	- Adjusted conditional rendering to ensure proper display of code format section based on club type and state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->