### PR TITLE
Yuqiang/improve spectate

### DIFF
--- a/app/schemas/subscriptions/play.js
+++ b/app/schemas/subscriptions/play.js
@@ -268,4 +268,6 @@ module.exports = {
     session: { type: 'object' },
     level: { type: 'object' }
   }),
+
+  'ladder:refresh': c.object({})
 }

--- a/app/styles/play/ladder/ladder.sass
+++ b/app/styles/play/ladder/ladder.sass
@@ -232,6 +232,20 @@
         p
           margin-top: 12px
 
+  #spectate-row
+    margin-top: 20px
+    font-size: 24px
+    display: flex
+    align-items: center
+    justify-content: center
+
+    span
+      font-weight: bold
+
+    .spectate-players
+      margin-left: 15px
+      margin-right: 15px
+
 #tournament-status
   width: 100%
   display: flex

--- a/app/templates/play/ladder/ladder.pug
+++ b/app/templates/play/ladder/ladder.pug
@@ -183,7 +183,24 @@ block content
             a.btn.btn-illustrated.btn-block.btn-lg.btn-info.early-results-button(href='#results')
               span.glyphicon.glyphicon-star
               span.spl(data-i18n="tournament.view_results")
-
+    if view.level.isType('ladder')
+      div#spectate-row.row
+        span Spectate
+        div.spectate-players
+          input(type='search' id='spectate-player-1' list="spectate-players-1")
+          datalist(id='spectate-players-1')
+            each rk in view.leaderboardRankings
+              option(value=`${rk[2]}-${rk[3]}`)
+        span VS.
+        div.spectate-players
+          input(type='search' id='spectate-player-2' list="spectate-players-2")
+          datalist(id='spectate-players-2')
+            each rk in view.leaderboardRankings
+              option(value=`${rk[2]}-${rk[3]}`)
+        a.btn.btn-illustrated.btn-block.btn-lg.btn-info.spectate-button(href='/play/spectate/' + view.level.get('slug') + '?tournament=' + view.tournamentId + (view.league ? "&league=" + view.league.id : ""))
+          span.glyphicon.glyphicon-eye-open
+          span.spl(data-i18n="play.spectate")
+      
   if view.level.isType('ladder')
     if view.winners
       ul.nav.nav-pills

--- a/app/templates/play/ladder/ladder.pug
+++ b/app/templates/play/ladder/ladder.pug
@@ -135,11 +135,6 @@ block content
             div.column.column-4
               a.btn.btn-illustrated.btn-block.btn-lg.btn-success.play-button(data-team='humans')
                 span(data-i18n="common.play")
-            if view.ladderTab
-              div.column.column-2
-                a.btn.btn-illustrated.btn-block.btn-lg.btn-info.spectate-button(href='/play/spectate/' + view.level.get('slug') + (view.league ? "?league=" + view.league.id : ""))
-                  span.glyphicon.glyphicon-eye-open
-                  span.spl(data-i18n="play.spectate")
             if !window.features.chinaUx
               div.column.column-2
                 a.btn.btn-illustrated.btn-block.btn-lg.btn-info(data-team='humans' href="https://www.youtube.com/watch?v=niKXOofTckEor" target="_blank")
@@ -169,11 +164,6 @@ block content
           div.column.column-4
             a.btn.btn-illustrated.btn-block.btn-lg.btn-info.play-arena-button(href="/play/ladder/"+view.levelID)
               span(data-i18n="courses.play_arena")
-        if view.ladderTab
-          div.column.column-2
-            a.btn.btn-illustrated.btn-block.btn-lg.btn-info.spectate-button(href='/play/spectate/' + view.level.get('slug') + '?tournament=' + view.tournamentId + (view.league ? "&league=" + view.league.id : ""))
-              span.glyphicon.glyphicon-eye-open
-              span.spl(data-i18n="play.spectate")
         if view.tournamentState === 'waiting' && view.league && (me.get('_id') === view.league.get('ownerID') || me.isAdmin())
           div.column.column-2
             a.btn.btn-illustrated.btn-block.btn-lg.btn-success.publish-button
@@ -185,21 +175,22 @@ block content
               span.spl(data-i18n="tournament.view_results")
     if view.level.isType('ladder')
       div#spectate-row.row
-        span Spectate
+        span(data-i18n="play.spectate")
+        span :
         div.spectate-players
-          input(type='search' id='spectate-player-1' list="spectate-players-1")
+          input(type='search' id='spectate-player-1' list="spectate-players-1" autocomplete="off")
           datalist(id='spectate-players-1')
             each rk in view.leaderboardRankings
-              option(value=`${rk[2]}-${rk[3]}`)
+              option(value=`${rk[2]}: ${rk[3]}`)
         span VS.
         div.spectate-players
-          input(type='search' id='spectate-player-2' list="spectate-players-2")
+          input(type='search' id='spectate-player-2' list="spectate-players-2" autocomplete="off")
           datalist(id='spectate-players-2')
             each rk in view.leaderboardRankings
-              option(value=`${rk[2]}-${rk[3]}`)
-        a.btn.btn-illustrated.btn-block.btn-lg.btn-info.spectate-button(href='/play/spectate/' + view.level.get('slug') + '?tournament=' + view.tournamentId + (view.league ? "&league=" + view.league.id : ""))
+              option(value=`${rk[2]}: ${rk[3]}`)
+        a.btn.btn-illustrated.btn-info.new-spectate-button
           span.glyphicon.glyphicon-eye-open
-          span.spl(data-i18n="play.spectate")
+          span.spl(data-i18n="hackstack.view")
       
   if view.level.isType('ladder')
     if view.winners

--- a/app/views/ladder/LadderView.js
+++ b/app/views/ladder/LadderView.js
@@ -133,7 +133,7 @@ module.exports = (LadderView = (function () {
       this.prototype.subscriptions =
         {
           'application:idle-changed': 'onIdleChanged',
-          'ladder:refresh': 'updateSpectateList'
+          'ladder:refresh': 'updateSpectateList',
         }
 
       this.prototype.events = {
@@ -144,7 +144,7 @@ module.exports = (LadderView = (function () {
         'click .new-spectate-button': 'onClickNewSpectateButton',
         'click .simulate-all-button': 'onClickSimulateAllButton',
         'click .early-results-button': 'onClickEarlyResultsButton',
-        'click .join-clan-button': 'onClickJoinClanButton'
+        'click .join-clan-button': 'onClickJoinClanButton',
       }
 
       this.prototype.onCourseInstanceLoaded = co.wrap(function * (courseInstance) {
@@ -161,7 +161,7 @@ module.exports = (LadderView = (function () {
 
       this.prototype.teamOffers = [
         { slug: 'hyperx', clanId: '60a4378875b540004c78f121', name: 'Team HyperX', clanSlug: 'hyperx' },
-        { slug: 'derbezt', clanId: '601351bb4b79b4013e198fbe', name: 'Team DerBezt', clanSlug: 'team-derbezt' }
+        { slug: 'derbezt', clanId: '601351bb4b79b4013e198fbe', name: 'Team DerBezt', clanSlug: 'team-derbezt' },
       ]
     }
 
@@ -169,8 +169,8 @@ module.exports = (LadderView = (function () {
       return $.ajax({
         type: 'HEAD',
         success: (result, status, xhr) => {
-          return this.timeOffset = new Date(xhr.getResponseHeader('Date')).getTime() - Date.now()
-        }
+          return (this.timeOffset = new Date(xhr.getResponseHeader('Date')).getTime() - Date.now())
+        },
       })
     }
 

--- a/app/views/ladder/LadderView.js
+++ b/app/views/ladder/LadderView.js
@@ -71,6 +71,7 @@ module.exports = (LadderView = (function () {
       this.leagueType = leagueType
       this.leagueID = leagueID
       this.refreshViews = this.refreshViews.bind(this)
+      this.leaderboardRankings = []
 
       let tournamentEndDate, tournamentStartDate
       this.level = this.supermodel.loadModel(new Level({ _id: this.levelID })).model
@@ -130,7 +131,10 @@ module.exports = (LadderView = (function () {
       this.prototype.showBackground = false
 
       this.prototype.subscriptions =
-        { 'application:idle-changed': 'onIdleChanged' }
+        {
+          'application:idle-changed': 'onIdleChanged',
+          'ladder:refresh': 'updateSpectateList'
+        }
 
       this.prototype.events = {
         'click .play-button': 'onClickPlayButton',
@@ -308,7 +312,7 @@ module.exports = (LadderView = (function () {
         null
       } else { // starting, or unset
         if (this.level.isType('ladder')) {
-          this.insertSubView(this.ladderTab = new TournamentLeaderboard({ league: this.league, leagueType: this.leagueType, course: this.course, myTournamentSubmission: this.myTournamentSubmission }, this.level, this.sessions, this.anonymousPlayerName))
+          this.insertSubView(this.ladderTab = new TournamentLeaderboard({ league: this.league, leagueType: this.leagueType, course: this.course, myTournamentSubmission: this.myTournamentSubmission, updateSpectateList: this.updateSpectateList }, this.level, this.sessions, this.anonymousPlayerName))
         } else {
           this.insertSubView(this.ladderTab = new LadderTabView({ league: this.league, tournament: this.tournamentId }, this.level, this.sessions))
         }
@@ -476,6 +480,12 @@ module.exports = (LadderView = (function () {
     }
 
     isAILeagueArena () { return _.find(utils.arenas, { slug: this.levelID }) }
+
+    updateSpectateList () {
+      if (!this.level?.isType('ladder')) return
+      this.leaderboardRankings = this.ladderTab?.rankings || []
+      this.renderSelectors('.spectate-players')
+    }
 
     destroy () {
       clearInterval(this.refreshInterval)

--- a/app/views/ladder/LadderView.js
+++ b/app/views/ladder/LadderView.js
@@ -141,6 +141,7 @@ module.exports = (LadderView = (function () {
         'click a:not([data-toggle])': 'onClickedLink',
         'click .publish-button': 'onClickPublishButton',
         'click .spectate-button': 'onClickSpectateButton',
+        'click .new-spectate-button': 'onClickNewSpectateButton',
         'click .simulate-all-button': 'onClickSimulateAllButton',
         'click .early-results-button': 'onClickEarlyResultsButton',
         'click .join-clan-button': 'onClickJoinClanButton'
@@ -485,6 +486,21 @@ module.exports = (LadderView = (function () {
       if (!this.level?.isType('ladder')) return
       this.leaderboardRankings = this.ladderTab?.rankings || []
       this.renderSelectors('.spectate-players')
+    }
+
+    onClickNewSpectateButton () {
+      const player1Index = parseInt(this.$el.find('#spectate-player-1').val().split(':')[0]) - 1
+      const player2Index = parseInt(this.$el.find('#spectate-player-2').val().split(':')[0]) - 1
+      const player1 = this.leaderboardRankings[player1Index]
+      const player2 = this.leaderboardRankings[player2Index]
+      const humanSession = player1 != null ? player1[player1.length - 1] : undefined
+      const ogreSession = player2 != null ? player2[player2.length - 1] : undefined
+      let url = `/play/spectate/${this.level.get('slug')}?`
+      if (humanSession && ogreSession) { url += `session-one=${humanSession}&session-two=${ogreSession}` }
+      if (this.league) { url += '&league=' + this.league.id }
+      if (key.command) { url += '&autoplay=false' }
+      if (this.tournamentState === 'ended') { url += '&tournament=' + this.tournamentId }
+      return window.open(url, key.command ? '_blank' : 'spectate') // New tab for spectating specific matches
     }
 
     destroy () {

--- a/app/views/ladder/components/Leaderboard.js
+++ b/app/views/ladder/components/Leaderboard.js
@@ -139,6 +139,7 @@ module.exports = (LeaderboardView = (function () {
         })
       }
 
+      Backbone.Mediator.publish('ladder:refresh', {})
       return super.afterRender(...arguments)
     }
 
@@ -224,7 +225,8 @@ module.exports = (LeaderboardView = (function () {
       const teamSession = _.find(this.sessions.models, session => session.get('team') === 'humans')
       this.leaderboards = new LeaderboardData(this.level, 'humans', teamSession, this.ladderLimit, this.league, this.tournament, this.ageBracket, this.options.myTournamentSubmission)
       this.leaderboardRes = this.supermodel.addModelResource(this.leaderboards, 'leaderboard', { cache: false }, 3)
-      return this.leaderboardRes.load()
+      this.leaderboardRes.load()
+      Backbone.Mediator.publish('ladder:refresh', {})
     }
 
     onClickLoadMore () {

--- a/app/views/ladder/components/Leaderboard.js
+++ b/app/views/ladder/components/Leaderboard.js
@@ -52,7 +52,8 @@ module.exports = (LeaderboardView = (function () {
         { slug: 'win-rate', col: 1, title: $.i18n.t('ladder.win_rate') },
         { slug: 'clan', col: 2, title: $.i18n.t('league.team') },
         { slug: 'age', col: 1, title: $.i18n.t('ladder.age_bracket') },
-        { slug: 'country', col: 1, title: '🏴‍☠️' }
+        { slug: 'country', col: 1, title: '🏴‍☠️' },
+        { slug: 'hide', col: 0, title: '' },
       ]
       if (this.hidesTeams) {
         _.remove(this.tableTitles, { slug: 'clan' })
@@ -68,7 +69,7 @@ module.exports = (LeaderboardView = (function () {
           { slug: 'clan', col: 2, title: $.i18n.t('league.team') },
           { slug: 'age', col: 1, title: $.i18n.t('ladder.age') },
           { slug: 'when', col: 1, title: $.i18n.t('general.when') },
-          { slug: 'fight', col: 1, title: '' }
+          { slug: 'fight', col: 1, title: '' },
         ]
         if (this.hidesTeams) {
           _.remove(this.propsData.tableTitles, { slug: 'clan' })
@@ -191,7 +192,8 @@ module.exports = (LeaderboardView = (function () {
             (((wins || 0) / (((wins || 0) + (losses || 0)) || 1)) * 100).toFixed(2) + '%',
             this.hidesTeams ? '__hide' : this.getClanName(model),
             this.getAgeBracket(model),
-            model.get('creatorCountryCode')
+            model.get('creatorCountryCode'),
+            model.get('levelSession'),
           ].filter(x => x !== '__hide')
         } else {
           return [
@@ -203,7 +205,7 @@ module.exports = (LeaderboardView = (function () {
             this.hidesTeams ? '__hide' : this.getClanName(model),
             this.getAgeBracket(model),
             moment(model.get('submitDate')).fromNow().replace('a few ', ''),
-            model.get('_id')
+            model.get('_id'),
           ].filter(x => x !== '__hide')
         }
       })

--- a/app/views/ladder/components/Leaderboard.vue
+++ b/app/views/ladder/components/Leaderboard.vue
@@ -310,7 +310,7 @@ export default Vue.extend({
               span  players
 
         tr
-          th(v-for="t in tableTitles" v-if="t.slug !='creator'" :key="t.slug" :colspan="t.col" :class="computeClass(t.slug)")
+          th(v-for="t in tableTitles" v-if="!(['creator', 'hide'].includes(t.slug))" :key="t.slug" :colspan="t.col" :class="computeClass(t.slug)")
             | {{ t.title }}
             span &nbsp;
             span.age-filter(v-if="t.slug == 'age'")
@@ -319,26 +319,19 @@ export default Vue.extend({
                 .slug(v-for="bracket in ageBrackets" @click="filterAge(bracket.slug)")
                   span {{bracket.name}}
 
-          th.iconic-cell
-            .glyphicon.glyphicon-eye-open
-
       tbody
         tr(v-for="row, rank in rankings" :key="rank" :class="classForRow(row)")
           template(v-if="row.type==='BLANK_ROW'")
             td(colspan=3) ...
           template(v-else)
-            td(v-for="item, index in row" v-if="index > 0 && tableTitles[index].slug != 'fight'" :key="'' + rank + index" :colspan="tableTitles[index].col" :style="computeStyle(item, index)" :class="computeClass(tableTitles[index].slug, item)" :title="computeTitle(tableTitles[index].slug, item)" @click="onClickUserRow(rank, tableTitles[index].slug)") {{index != 1 ? computeBody(tableTitles[index].slug, item): '' }}
+            td(v-for="item, index in row" v-if="index > 0 && !(['fight', 'hide'].includes(tableTitles[index].slug))" :key="'' + rank + index" :colspan="tableTitles[index].col" :style="computeStyle(item, index)" :class="computeClass(tableTitles[index].slug, item)" :title="computeTitle(tableTitles[index].slug, item)" @click="onClickUserRow(rank, tableTitles[index].slug)") {{index != 1 ? computeBody(tableTitles[index].slug, item): '' }}
             td(colspan=1 v-if="tableTitles[row.length-1].slug == 'fight'" v-html="computeBody('fight', row[row.length-1])" @click="onClickUserRow(rank, 'fight')")
-            td.spectate-cell.iconic-cell(@click="onClickSpectateCell(rank + '-top')")
-              .glyphicon(:class="{'glyphicon-eye-open': selectedRow.indexOf(rank + '-top') != -1}")
 
         tr(v-for="row, rank in playerRankings" :key="'player-'+rank" :class="classForRow(row)")
           template(v-if="row.type==='BLANK_ROW'")
             td(colspan=3) ...
           template(v-else)
             td(v-for="item, index in row" v-if="index > 0" :key="'player-' + rank + index" :colspan="tableTitles[index].col" :style="computeStyle(item, index)" :class="computeClass(tableTitles[index].slug, item)" :title="computeTitle(tableTitles[index].slug, item)" v-html="index != 1 ? computeBody(tableTitles[index].slug, item): ''" @click="onClickUserRow(rank, tableTitles[index].slug, true)")
-            td.spectate-cell.iconic-cell(@click="onClickSpectateCell(rank + '-nearby')")
-              .glyphicon(:class="{'glyphicon-eye-open': selectedRow.indexOf(rank + '-nearby') != -1}")
 
     #load-more.btn.btn-sm(data-i18n='editor.more', @click="loadMore")
 </template>


### PR DESCRIPTION
fix ENG-1124
oh sad, gif do not include the input datalist 😂  see pic 2
![example](https://github.com/user-attachments/assets/c664da19-9686-45b5-a9eb-5f837ba30799)
![image](https://github.com/user-attachments/assets/470091ec-78a6-4d6e-9552-ca64f0a5e05a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new spectator interface for ladder-type levels, allowing users to select players to spectate.
  - Added functionality for refreshing the spectator list and handling ladder refresh events.

- **Style Improvements**
  - Enhanced the layout and appearance of the spectate row for better user experience.

- **Bug Fixes**
  - Streamlined leaderboard rendering logic and ensured consistent refresh mechanisms for updated data display.
  - Improved filtering logic for rendering table headers and data cells in the leaderboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->