### PR TITLE
ozaria play level view has different layout with coco, so should not …

### DIFF
--- a/ozaria/site/styles/play/play-level-view.sass
+++ b/ozaria/site/styles/play/play-level-view.sass
@@ -188,8 +188,6 @@ $level-resize-transition-time: 0.5s
     transform: translate(0, -110%)
     transition: transform 1s
     z-index: 1024
-    min-height: 800px
-    max-height: 100vh
     box-shadow: none
     background: transparent
     opacity: 0
@@ -208,7 +206,7 @@ $level-resize-transition-time: 0.5s
     #solution-view
       position: absolute
       width: 100%
-      top: 21.3%
+      top: $goals-vega-height
       height: 78.7%
       display: flex
       z-index: 5

--- a/ozaria/site/views/play/level/tome/SpellView.coffee
+++ b/ozaria/site/views/play/level/tome/SpellView.coffee
@@ -762,44 +762,18 @@ module.exports = class SpellView extends CocoView
     @updateAceLines(screenLineCount, ace, aceCls, areaId)
 
   updateAceLines: (screenLineCount, ace=@ace, aceCls='.ace', areaId='#code-area') =>
-    lineHeight = ace.renderer.lineHeight or 20
+    lineHeight = ace.renderer.lineHeight or 21
     if @courseID && @courseID == utils.courseIDs.CHAPTER_ONE
       lineHeight = 29
-    spellPaletteView = $('#tome-view #spell-palette-view-bot')
-    spellTopBarHeight = $('#spell-top-bar-view').outerHeight()
-    if aceCls == '.ace'
-      spellPaletteHeight = spellPaletteView.outerHeight()
-    else
-      spellPaletteHeight = 0
-    windowHeight = $(window).innerHeight()
-    spellPaletteAllowedHeight = Math.min spellPaletteHeight, windowHeight / 2
-    topOffset = $(aceCls).offset().top
+    goalsViewHeight = $('#goals-view').outerHeight()
     gameHeight = $('#game-area').innerHeight()
-    heightScale = if aceCls == '.ace' then 1 else 0.5
+    buttonsHeight = $('.spell-toolbar-view').outerHeight()
 
-    # If the spell palette is too tall, we'll need to shrink it.
-    maxHeightOffset = 75
-    minHeightOffset = 175
-    maxHeight = Math.min(windowHeight, Math.max(windowHeight, 600)) - topOffset - spellPaletteAllowedHeight - maxHeightOffset
-    minHeight = Math.min maxHeight * heightScale, Math.min(gameHeight, Math.max(windowHeight, 600)) - spellPaletteHeight - minHeightOffset
-
-    spellPalettePosition = if spellPaletteHeight > 0 then 'bot' else 'mid'
-    minLinesBuffer = if spellPalettePosition is 'bot' then 0 else 2
-    linesAtMinHeight = Math.max(8, Math.floor(minHeight / lineHeight - minLinesBuffer))
-    linesAtMaxHeight = Math.floor(maxHeight / lineHeight)
-    lines = Math.max linesAtMinHeight, Math.min(screenLineCount + 2, linesAtMaxHeight), 8
+    codeHeight = gameHeight - goalsViewHeight - buttonsHeight
+    lines = Math.floor(codeHeight / lineHeight)
     lines = 8 if _.isNaN lines
 
     ace.setOptions minLines: lines, maxLines: lines
-
-    # If bot: move spell palette up, slightly overlapping us.
-    newTop = 185 + lineHeight * lines
-    if aceCls == '.ace'
-      spellPaletteView.css('top', newTop)
-
-      codeAreaBottom = if spellPaletteHeight then windowHeight - (newTop + spellPaletteHeight + 20) else 0
-      $(areaId).css('bottom', codeAreaBottom)
-    #console.log { lineHeight, spellTopBarHeight, spellPaletteHeight, spellPaletteAllowedHeight, windowHeight, topOffset, gameHeight, minHeight, maxHeight, linesAtMinHeight, linesAtMaxHeight, lines, newTop, screenLineCount }
 
   updateLines: =>
     # Make sure there are always blank lines for the player to type on, and that the editor resizes to the height of the lines.
@@ -815,7 +789,7 @@ module.exports = class SpellView extends CocoView
       # Force the popup back
       @ace?.completer?.showPopup(@ace)
 
-    screenLineCount = @aceSession.getScreenLength() - 1
+    screenLineCount = @aceSession.getScreenLength()
     if screenLineCount isnt @lastScreenLineCount
       @lastScreenLineCount = screenLineCount
       @updateAceLines(screenLineCount)


### PR DESCRIPTION
…use coco calculation

bug comes from [here](https://github.com/codecombat/codecombat/pull/7231)
fix ENG-1200
![image](https://github.com/user-attachments/assets/de518f3e-009c-4a40-91f2-884225379793)

ozaria play-level-view code area height is much easier than coco (since it's stable) so the height calculation is easy too

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Dynamic positioning adjustments for the solution view based on variable heights.
	- Enhanced spell view with updated line height settings for improved readability.

- **Bug Fixes**
	- Resolved issues with line calculations in the spell editor, ensuring a minimum of 8 lines is displayed.

- **Style**
	- Removed fixed height constraints for a more flexible layout in the play level view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->