### PR TITLE
remove roblox ab test and use new one

### DIFF
--- a/app/core/Router.js
+++ b/app/core/Router.js
@@ -435,7 +435,6 @@ module.exports = (CocoRouter = (function () {
         'social-and-emotional-learning': go('core/SingletonAppVueComponentView'),
 
         roblox: go('core/SingletonAppVueComponentView'),
-        'roblox-beta': go('core/SingletonAppVueComponentView'),
         grants: go('core/SingletonAppVueComponentView'),
 
         seen: me.useChinaHomeView() ? go('HomeCNView') : go('HomeView'),

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -304,14 +304,9 @@ export default function getVueRouter () {
 
         },
         {
-          path: '/roblox-beta',
-          component: () => import(/* webpackChunkName: "RobloxView" */ 'app/views/landing-pages/roblox/NewPageRoblox'),
-          meta: { theme: 'teal' }
-        },
-        {
           path: '/roblox',
-          component: () => import(/* webpackChunkName: "RobloxView" */ `app/views/landing-pages/roblox/${me.getRobloxPageExperimentValue() === 'beta' ? 'New' : ''}PageRoblox`),
-          meta: { theme: 'teal' }
+          component: () => import(/* webpackChunkName: "RobloxView" */ 'app/views/landing-pages/roblox/NewPageRoblox'),
+          meta: { theme: 'teal' },
         },
         {
           path: '/grants',

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -1109,10 +1109,6 @@ module.exports = (User = (function () {
       return value
     }
 
-    getRobloxPageExperimentValue () {
-      return this.getFilteredExperimentValue({ experimentName: 'roblox-page-filtered' })
-    }
-
     getHomePageExperimentValue () {
       return this.getFilteredExperimentValue({ experimentName: 'home-page-filtered-v2' })
     }


### PR DESCRIPTION
fix ENG-1217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The routing for `/roblox` has been simplified to consistently load the `NewPageRoblox` component.

- **Bug Fixes**
	- Removed the now-defunct route mapping for `/roblox-beta`, ensuring the application no longer attempts to redirect to this route.

- **Chores**
	- Removed the method `getRobloxPageExperimentValue`, streamlining the user model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->