### PR TITLE
Yuqiang/parents page dynamic corrily price

### DIFF
--- a/app/core/Router.js
+++ b/app/core/Router.js
@@ -339,7 +339,6 @@ module.exports = (CocoRouter = (function () {
         },
 
         parents: go('core/SingletonAppVueComponentView'),
-        'parents-v2': go('core/SingletonAppVueComponentView'),
         'parents/*path': go('core/SingletonAppVueComponentView'),
         'live-classes': go('core/SingletonAppVueComponentView'),
         live: go('core/SingletonAppVueComponentView'),

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -49,9 +49,8 @@ export default function getVueRouter () {
         {
           path: '/parents',
           props: (route) => ({ showPremium: true, type: route.query.type }),
-          component: () => import(/* webpackChunkName: "ParentsView" */ `app/views/landing-pages/parents${me.getParentsPageExperimentValue() === 'control' ? '' : '-v2'}/PageParents`),
-          meta: { theme: 'teal' }
-
+          component: () => import(/* webpackChunkName: "ParentsView" */ 'app/views/landing-pages/parents-v2/PageParents'),
+          meta: { theme: 'teal' },
         },
         {
           path: '/codequest',

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -6037,6 +6037,8 @@ module.exports = {
       grid_99_annual: '$99 Annual',
       grid_219_monthly: '$219 Monthly',
       grid_399_monthly: '$399 Monthly',
+      grid_self_paced_year_price: '$__price__ Annual',
+      grid_self_paced_year_price_without_currency: '__price__ Annual',
       grid_personalized_instruction: '1:1 Personalized Instruction',
       grid_premium_access: 'Premium Access',
       grid_codecombat: 'CodeCombat',

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -1116,12 +1116,8 @@ module.exports = (User = (function () {
     startHomeControlExperiment (forcedValue) {
       return this.getFilteredExperimentValue({
         experimentName: 'home-page-filtered-control-experiment',
-        forcedValue
+        forcedValue,
       })
-    }
-
-    getParentsPageExperimentValue () {
-      return this.getFilteredExperimentValue({ experimentName: 'parents-page-filtered' })
     }
 
     getEducatorSignupExperimentValue () {

--- a/app/views/landing-pages/parents-v2/FeaturesGrid.vue
+++ b/app/views/landing-pages/parents-v2/FeaturesGrid.vue
@@ -65,8 +65,11 @@ export default {
     },
   },
   watch: {
-    basicAnnualSubscriptionForCurrentUser () {
-      this.rows[2].content[1] = this.price
+    price: {
+      immediate: true,
+      handler (newPrice) {
+        this.updatePriceInRows(newPrice)
+      },
     },
   },
   created () {
@@ -83,6 +86,14 @@ export default {
     ...mapActions({
       loadProducts: 'products/loadProducts',
     }),
+    updatePriceInRows (newPrice) {
+      this.rows = this.rows.map(row => {
+        if (row.type === 'header') {
+          return { ...row, content: [row.content[0], newPrice, row.content[2], row.content[3]] }
+        }
+        return row
+      })
+    },
   },
 }
 </script>

--- a/app/views/landing-pages/parents-v2/FeaturesGrid.vue
+++ b/app/views/landing-pages/parents-v2/FeaturesGrid.vue
@@ -51,17 +51,22 @@ export default {
       const p = this.basicAnnualSubscriptionForCurrentUser
       let origPrice = 99
       if (p) {
-        origPrice = p.priceStringNoSymbol()
+        origPrice = (p.amount / 100).toFixed(2)
         if (origPrice % 1 === 0) {
           origPrice = Math.floor(origPrice)
         }
       }
       // we don't have coupon ID in parent page so no sale price here
-      if (p?.get('formattedAmmount')) {
-        return $.i18n.t('parents_v2.grid_self_paced_year_price_without_currencya', { price: p.get('formattedAmmount') })
+      if (p?.formattedAmmount) {
+        return $.i18n.t('parents_v2.grid_self_paced_year_price_without_currencya', { price: p.formattedAmmount })
       } else {
         return $.i18n.t('parents_v2.grid_self_paced_year_price', { price: origPrice })
       }
+    },
+  },
+  watch: {
+    basicAnnualSubscriptionForCurrentUser () {
+      this.rows[2].content[1] = this.price
     },
   },
   created () {

--- a/app/views/landing-pages/parents-v2/FeaturesGrid.vue
+++ b/app/views/landing-pages/parents-v2/FeaturesGrid.vue
@@ -15,6 +15,7 @@
 
 <script>
 import TableRow from './TableRow.vue'
+import { mapActions, mapGetters } from 'vuex'
 
 export default {
   components: {
@@ -41,9 +42,43 @@ export default {
       { content: [$.i18n.t('parents_v2.grid_class_recording'), null, '✓', '✓'] },
       { content: [$.i18n.t('parents_v2.grid_money_back'), null, '✓', '✓'] },
       { content: [$.i18n.t('parents_v2.grid_ai_hints_allowance'), 10, 20, 20] },
-      { content: [$.i18n.t('parents_v2.grid_prompts_allowance'), 50, 200, 200] }
-    ]
+      { content: [$.i18n.t('parents_v2.grid_prompts_allowance'), 50, 200, 200] },
+    ],
   }),
+  computed: {
+    ...mapGetters('products', ['basicAnnualSubscriptionForCurrentUser']),
+    price () {
+      const p = this.basicAnnualSubscriptionForCurrentUser
+      let origPrice = 99
+      if (p) {
+        origPrice = p.priceStringNoSymbol()
+        if (origPrice % 1 === 0) {
+          origPrice = Math.floor(origPrice)
+        }
+      }
+      // we don't have coupon ID in parent page so no sale price here
+      if (p?.get('formattedAmmount')) {
+        return $.i18n.t('parents_v2.grid_self_paced_year_price_without_currencya', { price: p.get('formattedAmmount') })
+      } else {
+        return $.i18n.t('parents_v2.grid_self_paced_year_price', { price: origPrice })
+      }
+    },
+  },
+  created () {
+    try {
+      this.loadProducts()
+    } catch (e) {
+      console.error('Error loading products in parents-v2', e)
+    }
+  },
+  mounted () {
+    this.rows[2].content[1] = this.price
+  },
+  methods: {
+    ...mapActions({
+      loadProducts: 'products/loadProducts',
+    }),
+  },
 }
 </script>
 

--- a/app/views/landing-pages/parents-v2/FeaturesGrid.vue
+++ b/app/views/landing-pages/parents-v2/FeaturesGrid.vue
@@ -80,7 +80,7 @@ export default {
     }
   },
   mounted () {
-    this.rows[2].content[1] = this.price
+    this.updatePriceInRows(this.price)
   },
   methods: {
     ...mapActions({


### PR DESCRIPTION
fix ENG-1213

i cannot test it since i'm not in corrily price 😂  but I think I follow the subscribe modal logic. anyone can test it ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified routing by removing the redundant `'parents-v2'` entry.
	- Updated routing for `/parents` to directly import the `parents-v2` version of the `PageParents` component.
	- Added new pricing placeholders for self-paced courses in the localization module.
	- Enhanced `FeaturesGrid` component to dynamically display subscription-based pricing.

- **Bug Fixes**
	- Removed outdated experiment logic related to the parents page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->