### PR TITLE
remove all time leaderboard for now

### DIFF
--- a/app/views/ai-league/PageLeagueTeachers.vue
+++ b/app/views/ai-league/PageLeagueTeachers.vue
@@ -345,7 +345,7 @@ export default {
       </section>
 
       <div class="row text-center">
-        <div class="col-lg-6">
+        <div class="col-lg-12">
           <content-box>
             <template #text>
               <div class="box-title">
@@ -397,24 +397,6 @@ export default {
                 :title="$t(`league.${regularArenaSlug.replace(/-/g, '_')}`)"
                 :player-count="selectedGlobalLeaderboardPlayerCount"
                 class="leaderboard-component"
-              />
-            </template>
-          </content-box>
-        </div>
-        <div class="col-lg-6">
-          <content-box>
-            <template #text>
-              <div class="box-title">
-                {{ $t('league.all_time') }}
-              </div>
-              <leaderboard
-                :key="`${clanIdSelected}-codepoints`"
-                :title="$t('league.codepoints')"
-                :rankings="selectedClanCodePointsRankings"
-                :clan-id="clanIdSelected"
-                score-type="codePoints"
-                class="leaderboard-component"
-                :player-count="codePointsPlayerCount"
               />
             </template>
           </content-box>


### PR DESCRIPTION
fix ENG-1238
![image](https://github.com/user-attachments/assets/abc853c4-9edd-4ecf-88ea-071920ac403e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified layout for the League Teachers page, expanding the content area to a full-width display.
  
- **Bug Fixes**
	- Removed the leaderboard component for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->