### PR TITLE
ENG-1195 - Practice Levels: Hover content changes

### DIFF
--- a/ozaria/site/components/teacher-dashboard/common/progress/progressDot.vue
+++ b/ozaria/site/components/teacher-dashboard/common/progress/progressDot.vue
@@ -251,12 +251,18 @@ export default {
         return levels.slice(0, 3)
       }
 
-      return [
+      const selectedLevels = [
         levels[mainIndex - 2],
         levels[mainIndex - 1],
         levels[mainIndex],
         levels[mainIndex + 1],
-      ].filter(Boolean).slice(-3)
+      ].filter(Boolean)
+
+      if (mainIndex === firstAssignedLevelIndex) {
+        return selectedLevels.slice(0, 3)
+      }
+
+      return selectedLevels.slice(-3)
     },
 
     getStatus (level) {

--- a/test/ozaria/site/components/teacher-dashboard/progressDot.spec.js
+++ b/test/ozaria/site/components/teacher-dashboard/progressDot.spec.js
@@ -8,7 +8,7 @@ describe('ProgressDot', () => {
     wrapper = shallowMount(ProgressDot)
   })
 
-  fdescribe('filterPracticeLevelsToDisplay', () => {
+  describe('filterPracticeLevelsToDisplay', () => {
     it('returns last three levels including first "assigned" one from end', () => {
       const practiceLevels = [
         { name: 'Level 1', isCompleted: true, inProgress: true }, // complete

--- a/test/ozaria/site/components/teacher-dashboard/progressDot.spec.js
+++ b/test/ozaria/site/components/teacher-dashboard/progressDot.spec.js
@@ -1,0 +1,106 @@
+import { shallowMount } from '@vue/test-utils'
+import ProgressDot from 'ozaria/site/components/teacher-dashboard/common/progress/progressDot.vue' // replace with your actual component path
+
+describe('ProgressDot', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = shallowMount(ProgressDot)
+  })
+
+  describe('filterPracticeLevelsToDisplay', () => {
+    it('returns last three levels including first "assigned" one from end', () => {
+      const practiceLevels = [
+        { name: 'Level 1', isCompleted: true, inProgress: true }, // complete
+        { name: 'Level 2', isCompleted: false, inProgress: true }, // progress
+        { name: 'Level 3', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 4', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 5', isCompleted: false, inProgress: false }, // assigned
+      ]
+
+      const result = wrapper.vm.filterPracticeLevelsToDisplay(practiceLevels)
+
+      expect(result).toEqual([
+        { name: 'Level 1', status: 'complete' },
+        { name: 'Level 2', status: 'progress' },
+        { name: 'Level 3', status: 'assigned' },
+      ])
+    })
+
+    it('returns last three levels if no "assigned" level is found', () => {
+      const practiceLevels = [
+        { name: 'Level 1', isCompleted: true, inProgress: true }, // complete
+        { name: 'Level 2', isCompleted: true, inProgress: true }, // complete
+        { name: 'Level 3', isCompleted: true, inProgress: true }, // complete
+        { name: 'Level 4', isCompleted: true, inProgress: true }, // complete
+        { name: 'Level 5', isCompleted: true, inProgress: true }, // complete
+      ]
+
+      const result = wrapper.vm.filterPracticeLevelsToDisplay(practiceLevels)
+
+      expect(result).toEqual([
+        { name: 'Level 3', status: 'complete' },
+        { name: 'Level 4', status: 'complete' },
+        { name: 'Level 5', status: 'complete' },
+      ])
+    })
+
+    it('shows the first three levels if all are "assigned"', () => {
+      const practiceLevels = [
+        { name: 'Level 1', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 2', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 3', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 4', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 5', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 6', isCompleted: false, inProgress: false }, // assigned
+      ]
+
+      const result = wrapper.vm.filterPracticeLevelsToDisplay(practiceLevels)
+
+      expect(result).toEqual([
+        { name: 'Level 1', status: 'assigned' },
+        { name: 'Level 2', status: 'assigned' },
+        { name: 'Level 3', status: 'assigned' },
+      ])
+    })
+
+    it('shows all levels if there are only three and they are complete, in-progress, assigned', () => {
+      const practiceLevels = [
+        { name: 'Level 1', isCompleted: true, inProgress: true }, // complete
+        { name: 'Level 2', isCompleted: false, inProgress: true }, // progress
+        { name: 'Level 3', isCompleted: false, inProgress: false }, // assigned
+      ]
+
+      const result = wrapper.vm.filterPracticeLevelsToDisplay(practiceLevels)
+
+      expect(result).toEqual([
+        { name: 'Level 1', status: 'complete' },
+        { name: 'Level 2', status: 'progress' },
+        { name: 'Level 3', status: 'assigned' },
+      ])
+    })
+
+    it('returns last three levels including first "inProgress" one from end', () => {
+      const practiceLevels = [
+        { name: 'Level 1', isCompleted: true, inProgress: false }, // complete
+        { name: 'Level 2', isCompleted: true, inProgress: false }, // complete
+        { name: 'Level 3', isCompleted: true, inProgress: false }, // complete
+        { name: 'Level 4', isCompleted: true, inProgress: false }, // complete
+        { name: 'Level 5', isCompleted: false, inProgress: true }, // in progress
+        { name: 'Level 6', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 7', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 8', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 9', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 10', isCompleted: false, inProgress: false }, // assigned
+      ]
+
+      const result = wrapper.vm.filterPracticeLevelsToDisplay(practiceLevels)
+
+      expect(result).toEqual([
+        { name: 'Level 4', status: 'complete' },
+        { name: 'Level 5', status: 'progress' },
+        { name: 'Level 6', status: 'assigned' },
+      ])
+    })
+  })
+})

--- a/test/ozaria/site/components/teacher-dashboard/progressDot.spec.js
+++ b/test/ozaria/site/components/teacher-dashboard/progressDot.spec.js
@@ -8,7 +8,7 @@ describe('ProgressDot', () => {
     wrapper = shallowMount(ProgressDot)
   })
 
-  describe('filterPracticeLevelsToDisplay', () => {
+  fdescribe('filterPracticeLevelsToDisplay', () => {
     it('returns last three levels including first "assigned" one from end', () => {
       const practiceLevels = [
         { name: 'Level 1', isCompleted: true, inProgress: true }, // complete
@@ -100,6 +100,29 @@ describe('ProgressDot', () => {
         { name: 'Level 4', status: 'complete' },
         { name: 'Level 5', status: 'progress' },
         { name: 'Level 6', status: 'assigned' },
+      ])
+    })
+
+    it('returns last completed ones and first assigned if there is no in-progress one.', () => {
+      const practiceLevels = [
+        { name: 'Level 1', isCompleted: true, inProgress: false }, // complete
+        { name: 'Level 2', isCompleted: true, inProgress: false }, // complete
+        { name: 'Level 3', isCompleted: true, inProgress: false }, // complete
+        { name: 'Level 4', isCompleted: true, inProgress: false }, // complete
+        { name: 'Level 5', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 6', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 7', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 8', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 9', isCompleted: false, inProgress: false }, // assigned
+        { name: 'Level 10', isCompleted: false, inProgress: false }, // assigned
+      ]
+
+      const result = wrapper.vm.filterPracticeLevelsToDisplay(practiceLevels)
+
+      expect(result).toEqual([
+        { name: 'Level 3', status: 'complete' },
+        { name: 'Level 4', status: 'complete' },
+        { name: 'Level 5', status: 'assigned' },
       ])
     })
   })


### PR DESCRIPTION
| before | after | 
| --- | --- | 
| ![CodeCombat_Teacher_Dashboard](https://github.com/user-attachments/assets/04f9b7cd-e431-44f0-88b3-c724353b02aa) | ![CodeCombat_Teacher_Dashboard](https://github.com/user-attachments/assets/76dc0982-6fb4-4648-a4c4-516ab7254749) | 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced tooltip content for practice levels in the Progress Dot component.
	- New method to determine the status of practice levels.
	- Default value set for `extraPracticeLevels` prop.

- **Bug Fixes**
	- Improved organization and readability of component properties.

- **Tests**
	- Introduced unit tests for the Progress Dot component, covering various scenarios for practice level filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->