### PR TITLE
ENG-1250 - load level only if it is not locked

### DIFF
--- a/app/schemas/subscriptions/play.js
+++ b/app/schemas/subscriptions/play.js
@@ -265,8 +265,7 @@ module.exports = {
   'level:click-ai-hint': c.object({}),
 
   'level:locked': c.object({}, {
-    session: { type: 'object' },
-    level: { type: 'object' }
+    level: { type: 'object' },
   }),
 
   'ladder:refresh': c.object({})


### PR DESCRIPTION
The problem was that `onLevelLoaded` was called regardless if level was locked or not.
In this pr the old `onLevelLoaded` method was renamed to `onAccessibleLevelLoaded`, and this method is called only if the level is not locked, or accessible because of other reasons regardless if it is locked or not. (accessible if no classroom is provided or we're in headless mode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to handle logic for accessible levels.
  
- **Bug Fixes**
	- Simplified event publishing for locked levels by removing unnecessary session data.
  
- **Refactor**
	- Improved the loading process for classrooms and levels, enhancing readability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->