### PR TITLE
ENG-1205 - Level number missing

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
@@ -16,7 +16,7 @@ import utils from 'core/utils'
 
 import storage from 'core/storage'
 
-import { mapMutations, mapGetters } from 'vuex'
+import { mapMutations, mapGetters, mapActions } from 'vuex'
 import { FIRST_CLASS_STEPS, CREATE_CLASS_STEPS } from './teacherDashboardTours'
 import ModalTeacherDetails from '../modals/ModalTeacherDetails'
 import { hasSeenTeacherDetailModalRecently, markTeacherDetailsModalAsSeen } from '../../../common/utils'
@@ -173,7 +173,11 @@ export default {
       setClassroomId: 'teacherDashboard/setClassroomId',
       setTeacherId: 'teacherDashboard/setTeacherId',
       setSelectedCourseId: 'teacherDashboard/setSelectedCourseIdCurrentClassroom',
-      setTeacherPagesTrackCategory: 'teacherDashboard/setTrackCategory'
+      setTeacherPagesTrackCategory: 'teacherDashboard/setTrackCategory',
+    }),
+
+    ...mapActions({
+      generateLevelNumberMap: 'gameContent/generateLevelNumberMap',
     }),
 
     getMostCommonLanguage () {
@@ -325,6 +329,12 @@ export default {
 
     onChangeCourse (courseId) {
       this.setSelectedCourseId({ courseId })
+
+      const course = this.classroomCourses.find(({ _id }) => _id === this.selectedCourseId)
+      this.generateLevelNumberMap({
+        campaignId: course.campaignID,
+        language: this.classroom.aceConfig.language,
+      }).catch(console.error)
     },
 
     closeTeacherDetailsModal () {

--- a/ozaria/site/store/BaseSingleClass.js
+++ b/ozaria/site/store/BaseSingleClass.js
@@ -153,7 +153,7 @@ export default {
       if (options?.componentName) {
         cmptName = options.componentName
       }
-      dispatch('teacherDashboard/fetchData', { componentName: cmptName, options: _.assign({ data: projectionData }, options) }, { root: true })
+      return dispatch('teacherDashboard/fetchData', { componentName: cmptName, options: _.assign({ data: projectionData }, options) }, { root: true })
     },
 
     async applyLicenses ({ state, rootGetters, dispatch, getters }) {


### PR DESCRIPTION
Use `gameContent` as source for level numbers on classroom view tooltips:

| before | after | 
| --- | --- | 
| <img width="309" alt="Screenshot 2024-09-19 at 2 36 19 PM" src="https://github.com/user-attachments/assets/07a2d119-971b-4110-99e7-a3694aa85529"> | ![Ozaria_Teacher_Dashboard](https://github.com/user-attachments/assets/67146d81-36b4-45f4-abec-4aa0d6f13c52) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `BaseSingleClass` and `BaseTeacherDashboard` components for improved level name and tooltip generation.
	- Added functionality to generate a level number map based on selected course details.

- **Bug Fixes**
	- Updated `fetchData` action in the Vuex store to return a promise, improving asynchronous handling.

- **Refactor**
	- Simplified lifecycle methods and optimized data fetching logic in components for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->