### PR TITLE
ENG-1198 - fix modal scroll on small screens

### DIFF
--- a/app/components/common/BaseModalContainer.vue
+++ b/app/components/common/BaseModalContainer.vue
@@ -20,15 +20,14 @@
 
         display: flex;
 
-        align-items: center;
-        justify-content: center;
+        align-items: safe center;
+        justify-content: safe center;
 
         transition: opacity .3s ease;
     }
 
     .modal-container {
         background: #FFF;
-
         transition: all .3s ease;
     }
 


### PR DESCRIPTION
Modal didn't scroll to top before the fix:

| before | after | 
| --- | --- |
| ![scroll-old](https://github.com/user-attachments/assets/8e4ad10a-8227-4dc9-a7c7-30728793314e) | ![scroll](https://github.com/user-attachments/assets/674bb55a-7da6-4b20-9990-87a57ebd24e9) | 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated CSS properties for improved alignment of modal content in responsive layouts. 
	- Removed a transition property from the modal container, ensuring consistent functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->