### PR TITLE
ENG-1255 - Stop access to paid junior levels from curriculum guide

### DIFF
--- a/app/core/store/modules/me.js
+++ b/app/core/store/modules/me.js
@@ -77,6 +77,18 @@ export default {
       return me.isPremium()
     },
 
+    isContentAccessible (state, getters) {
+      return (accessLevel) => {
+        const userAccessLevel = getters.isPaidTeacher ? 'paid' : 'free'
+        const userAccessMap = {
+          free: ['free'],
+          'sales-call': ['free', 'sales-call'],
+          paid: ['free', 'sales-call', 'paid'],
+        }
+        return userAccessMap[userAccessLevel].includes(accessLevel)
+      }
+    },
+
     /**
      * @returns {object|undefined} avatar schema object or undefined if not defined.
      */
@@ -114,14 +126,14 @@ export default {
 
     isPremium (state, getters) {
       return getters.isAdmin || getters.hasSubscription || getters.isInGodMode
-    }
+    },
   },
 
   mutations: {
     updateUser (state, updates) {
       // deep copy, since nested data may be changed, and vuex store restricts mutations
       return _.assign(state, $.extend(true, {}, updates))
-    }
+    },
   },
 
   actions: {
@@ -143,12 +155,12 @@ export default {
       const ozariaConfig = state.ozariaUserOptions || {}
       commit('updateUser', {
         ozariaUserOptions:
-        { ...ozariaConfig, avatar: { cinematicThangTypeId, cinematicPetThangId, avatarCodeString } }
+        { ...ozariaConfig, avatar: { cinematicThangTypeId, cinematicPetThangId, avatarCodeString } },
       })
     },
 
     authenticated ({ commit }, user) {
       commit('updateUser', user)
-    }
-  }
+    },
+  },
 }

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleContent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleContent.vue
@@ -56,6 +56,8 @@ export default {
       classroomId: 'teacherDashboard/classroomId',
       getLevelNumber: 'gameContent/getLevelNumber',
       levelNumberMap: 'gameContent/levelNumberMap',
+      getCurrentModuleHeadingInfo: 'baseCurriculumGuide/getCurrentModuleHeadingInfo',
+      isContentAccessible: 'me/isContentAccessible',
     }),
 
     classroomInstance () {
@@ -170,6 +172,13 @@ export default {
     isOzariaNoCodeLevel (icon) {
       return ['cutscene', 'cinematic', 'interactive'].includes(icon)
     },
+    isAccessible (moduleNum) {
+      if (this.isOnLockedCampaign) {
+        return false
+      }
+      const moduleInfo = this.getCurrentModuleHeadingInfo(moduleNum)
+      return this.isContentAccessible(moduleInfo.access)
+    },
   },
 }
 </script>
@@ -182,10 +191,11 @@ export default {
     />
 
     <div class="content-rows">
-      <a
+      <component
+        :is="isAccessible(moduleNum)? 'a' : 'span'"
         v-for="{ icon, name, _id, url, description, isPartOfIntro, isIntroHeadingRow, original, assessment, slug, fromIntroLevelOriginal }, key in getContentTypes"
         :key="_id"
-        :href="isOnLockedCampaign ? '#' : url"
+        :href="isAccessible(moduleNum) ? url : null"
         target="_blank"
         rel="noreferrer"
       >
@@ -206,6 +216,7 @@ export default {
             :is-part-of-intro="isPartOfIntro"
             :show-code-btn="!isOzariaNoCodeLevel(icon) && !(isJunior && icon === 'practicelvl')"
             :identifier="slug"
+            :locked="!isAccessible(moduleNum)"
             @click.native="trackEvent('Curriculum Guide: Individual content row clicked')"
             @showCodeClicked="onShowCodeClicked"
           />
@@ -218,7 +229,7 @@ export default {
           :code-left="sampleCodeByLevel[slug]"
           @click.native="onClickedCodeDiff"
         />
-      </a>
+      </component>
     </div>
   </div>
 </template>

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleRow.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleRow.vue
@@ -1,6 +1,5 @@
 <script>
 import ContentIcon from '../../common/icons/ContentIcon'
-import { mapGetters } from 'vuex'
 import { getGameContentDisplayType } from 'ozaria/site/common/ozariaUtils.js'
 import marked from 'marked'
 
@@ -62,7 +61,11 @@ export default {
     },
     identifier: {
       type: String
-    }
+    },
+    locked: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   data () {
@@ -72,9 +75,6 @@ export default {
   },
 
   computed: {
-    ...mapGetters({
-      isOnLockedCampaign: 'baseCurriculumGuide/isOnLockedCampaign'
-    }),
 
     clearDescription () {
       const description = marked(this.description).replace(/<[^>]*>/g, '')
@@ -84,7 +84,7 @@ export default {
 
     moduleRowClass () {
       return {
-        locked: this.isOnLockedCampaign,
+        locked: this.locked,
         'part-of-intro': this.isPartOfIntro,
         'show-progress-dot': this.showProgressDot
       }

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/TableModuleHeader.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/TableModuleHeader.vue
@@ -108,6 +108,7 @@ export default {
       selectedCourseId: 'teacherDashboard/getSelectedCourseIdCurrentClassroom',
       getCourseInstancesOfClass: 'courseInstances/getCourseInstancesOfClass',
       classroom: 'teacherDashboard/getCurrentClassroom',
+      isContentAccessible: 'me/isContentAccessible',
     }),
 
     isCodeCombat () {
@@ -283,7 +284,7 @@ export default {
             >
               <dynamic-link
                 target="_blank"
-                :href="getLevelUrl({ozariaType, introLevelSlug, courseId: selectedCourseId, codeLanguage: classroom.aceConfig.language, slug, introContent})"
+                :href="isContentAccessible(access) ? getLevelUrl({ozariaType, introLevelSlug, courseId: selectedCourseId, codeLanguage: classroom.aceConfig.language, slug, introContent}) : null"
               >
                 {{ tooltipName }}
               </dynamic-link>


### PR DESCRIPTION
links removed to non-accessible levels from classroom view and curriculum guide

| curriculum guide | classroom | 
| --- | --- | 
| ![accesslevel](https://github.com/user-attachments/assets/636cacbb-1159-4b74-b5a5-398b3c0cb45b) | ![accesslevel2](https://github.com/user-attachments/assets/c787584a-1050-4602-8c59-5c30a1be0c6a) | 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `isContentAccessible` functionality to enhance content visibility based on user access levels.
	- Added computed properties and methods in the module content components to streamline accessibility checks and improve user experience.
	- Enhanced link generation logic in the dashboard components to ensure links only appear for accessible content.

- **Bug Fixes**
	- Updated existing methods to ensure accurate checks for user payment status and module accessibility.

- **Refactor**
	- Simplified component logic by reducing reliance on external state management for determining module locked states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->