### PR TITLE
add npm scripts for easier test running

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "scripts": {
     "start": "node ./index.js",
     "test": "COCO_TRAVIS_TEST=1 NODE_OPTIONS='--max-old-space-size=4096' npm run webpack && ./node_modules/.bin/karma start --single-run --reporters dots",
+    "test:single": "COCO_TRAVIS_TEST=1 NODE_OPTIONS='--max-old-space-size=4096' ./node_modules/.bin/karma start --single-run --reporters dots",
     "test-ubuntu": "(Xvfb :99 &) && COCO_TRAVIS_TEST=1 NODE_OPTIONS='--max-old-space-size=4096' npm run webpack && DISPLAY=:99.0 ./node_modules/karma/bin/karma start --browsers Firefox --single-run --reporters dots",
     "test-china": "COCO_CHINA_INFRASTRUCTURE=true npm run test",
     "postinstall": "patch-package",
@@ -43,6 +44,7 @@
     "webpack": "NODE_OPTIONS='--max-old-space-size=4096' webpack",
     "bower": "bower",
     "dev": "NODE_OPTIONS='--max-old-space-size=4096' webpack --watch",
+    "dev:test": "COCO_TRAVIS_TEST=1 NODE_OPTIONS='--max-old-space-size=4096' webpack --watch",
     "dev:ozaria": "COCO_PRODUCT=ozaria npm run dev",
     "dev-container": "DEV_CONTAINER=1 NODE_OPTIONS='--max-old-space-size=4096' webpack --watch",
     "proxy": "COCO_PROXY='true' nodemon",


### PR DESCRIPTION
new test npm scripts added: 

- `npm run dev:test`: it'll run webpack with watch for the test runner environment
- `npm run test:single`: when the other command is running (webpack is up), this will run the tests 

Just open two terminals, let the `dev:test` run in one, and while development run the `test:single` when needed in the other teminal window.
At the beginning `dev:test` will last long, but once it was set up, it'll compile the modifications quickly.
You should use `fdescribe` and/or `fit` to run your specific test cases. `dev:test` takes about 8-10 seconds which is pretty reasonable time I think. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new testing scripts to enhance testing capabilities:
		- `test:single`: Run tests in single mode using Karma.
		- `dev:test`: Enable development testing with Webpack in watch mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->