### PR TITLE
Fix CCJ-273: use chicken goal icon for save-friends, not peasant

### DIFF
--- a/app/views/play/level/LevelGoal.vue
+++ b/app/views/play/level/LevelGoal.vue
@@ -26,8 +26,7 @@
   goalIconImageMap =
     heart: '/images/level/goal-icons/heart.png'
     heartEmpty: '/images/level/goal-icons/heart-empty.png'
-    # saveThangs: '/images/level/goal-icons/save-thangs.png'
-    saveThangs: '/file/db/thang.type/529f9026dacd325127000005/portrait.png'  # Peasant for now, until we have chicken
+    saveThangs: '/images/level/goal-icons/save-thangs.png'
     killThangs: '/images/level/goal-icons/kill-thangs.png'
     collectThangs: '/images/level/goal-icons/collect-thangs.png'
     getToLocations: '/images/level/goal-icons/get-to-locations.png'


### PR DESCRIPTION
Peasant icon was temporary until we put the chickens in.
<img width="509" alt="Screenshot 2024-10-14 at 11 27 05" src="https://github.com/user-attachments/assets/2b3db187-6235-4956-a68a-dd355236db26">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Restored the correct icon for the `saveThangs` goal, ensuring the appropriate image is displayed in the Level Goal component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->