### PR TITLE
Fix ENG-957: specify aspect ratios for more campaign maps

### DIFF
--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -1541,7 +1541,30 @@ class CampaignView extends RootView {
 
   onWindowResize (e) {
     const mapHeight = 1536
-    const mapWidth = { dungeon: 2350, forest: 2500, auditions: 2500, desert: 2411, mountain: 2422, glacier: 2421, junior: 2214 }[this.terrain] || 2350
+    const mapWidths = {
+      dungeon: 2350,
+      forest: 2500,
+      auditions: 2500,
+      desert: 2411,
+      mountain: 2421,
+      glacier: 2413,
+      junior: 2214,
+      'campaign-game-dev-1': 2500,
+      'campaign-game-dev-2': 2500,
+      'campaign-game-dev-3': 2500,
+      'campaign-web-dev-1': 2500,
+      'campaign-web-dev-2': 2500,
+      'game-dev-1': 2500,
+      'game-dev-2': 2500,
+      'game-dev-3': 2500,
+      'web-dev-1': 2500,
+      'web-dev-2': 2500,
+      'course-3': 2500,
+      'course-4': 2411,
+      'course-5': 2421,
+      'course-6': 2413,
+    }
+    const mapWidth = mapWidths[this.terrain] || 2350
     const aspectRatio = mapWidth / mapHeight
     const pageWidth = this.$el.width()
     const pageHeight = this.$el.height()


### PR DESCRIPTION
This fixes vertical or horizontal wrapping at certain window sizes.
![Screenshot 2024-10-14 at 11 28 10](https://github.com/user-attachments/assets/9454e3f0-2461-4e6d-a795-ce9f3e0b35c5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced the Campaign View for better handling of different terrain types through a new mapping system.
	- Updated the window resize functionality to ensure accurate width adjustments for various terrains.
- **Code Maintenance**
	- Improved code organization and clarity, making it easier to manage and expand terrain types in the future.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->