### PR TITLE
Fix CCJ-229: implement new health bar styles for Junior

### DIFF
--- a/app/lib/surface/Lank.coffee
+++ b/app/lib/surface/Lank.coffee
@@ -17,6 +17,11 @@ healthColors =
   humans: [255, 0, 0]
   neutral: [64, 212, 128]
 
+juniorHealthColors =
+  ogres: [0, 240, 255]
+  humans: [253, 20, 48]
+  neutral: [64, 212, 128]
+
 # Sprite: EaselJS-based view/controller for Thang model
 module.exports = Lank = class Lank extends CocoClass
   thangType: null # ThangType instance
@@ -559,9 +564,14 @@ module.exports = Lank = class Lank extends CocoClass
   updateStats: ->
     return unless @thang and @thang.health isnt @lastHealth
     @lastHealth = @thang.health
-    if bar = @healthBar
-      healthPct = Math.max(@thang.health / @thang.maxHealth, 0)
-      bar.scaleX = healthPct / @options.floatingLayer.resolutionFactor
+    if @healthBar
+      if @thang.healthBarStyle is 'pill-with-ticks'
+        # We have to redraw the health bar
+        @addHealthBar()
+      else
+        # We can just scale the health bar
+        healthPct = Math.max(@thang.health / @thang.maxHealth, 0)
+        @healthBar.scaleX = healthPct / @options.floatingLayer.resolutionFactor
       if @thang.id is 'Hero Placeholder'
         Backbone.Mediator.publish 'sprite:hero-health-updated', health: @thang.health, maxHealth: @thang.maxHealth
     if @thang.showsName
@@ -589,16 +599,22 @@ module.exports = Lank = class Lank extends CocoClass
     @gameUIState.trigger(ourEventName, newEvent)
 
   addHealthBar: ->
-    return unless @thang?.health? and 'health' in (@thang?.hudProperties ? []) and @options.floatingLayer
-    team = @thang?.team or 'neutral'
+    return unless @thang?.health? and 'health' in (@thang.hudProperties || []) and @options.floatingLayer
+    team = @thang.team or 'neutral'
     key = "#{team}-health-bar"
+    if (@thang.healthBarStyle is 'pill-with-ticks') and @thang.maxHealth <= 10
+      health = Math.max(0, Math.ceil(@thang.health))
+      maxHealth = Math.ceil(@thang.maxHealth || @thang.health)
+      key = "#{key}-#{health}-#{maxHealth}"
 
     unless key in @options.floatingLayer.spriteSheet.animations
-      healthColor = healthColors[team]
-      bar = createProgressBar(healthColor)
+      healthColor = (if @thang.healthBarStyle is 'pill-with-ticks' then juniorHealthColors else healthColors)[team]
+      bar = createProgressBar(healthColor, health, maxHealth)
       @options.floatingLayer.addCustomGraphic(key, bar, bar.bounds)
 
     hadHealthBar = @healthBar
+    if hadHealthBar
+      @options.floatingLayer.removeChild @healthBar
     @healthBar = new createjs.Sprite(@options.floatingLayer.spriteSheet)
     @healthBar.gotoAndStop(key)
     offset = @getOffset 'aboveHead'

--- a/app/lib/surface/sprite_utils.coffee
+++ b/app/lib/surface/sprite_utils.coffee
@@ -1,16 +1,82 @@
 createjs = require 'lib/createjs-parts'
 
-WIDTH = 20
-HEIGHT = 2
-EDGE = 0.3
-
-module.exports.createProgressBar = createProgressBar = (color) ->
+module.exports.createProgressBar = createProgressBar = (color, ticks, maxTicks) ->
   g = new createjs.Graphics()
-  g.setStrokeStyle(1)
-  g.beginFill(createjs.Graphics.getRGB(0, 0, 0))
-  g.drawRect(0, -HEIGHT/2, WIDTH, HEIGHT, HEIGHT)
-  g.beginFill(createjs.Graphics.getRGB(color...))
-  g.drawRoundRect(EDGE, EDGE - HEIGHT/2, WIDTH-EDGE*2, HEIGHT-EDGE*2, HEIGHT-EDGE*2)
+
+  unless maxTicks
+    # Simple rectangular bar style
+    WIDTH = 20
+    HEIGHT = 2
+    EDGE = 0.3
+    TICK_WIDTH = 2
+    g.setStrokeStyle(1)
+    g.beginFill(createjs.Graphics.getRGB(0, 0, 0))
+    g.drawRect(0, -HEIGHT/2, WIDTH, HEIGHT, HEIGHT)
+    g.beginFill(createjs.Graphics.getRGB(color...))
+    g.drawRoundRect(EDGE, EDGE - HEIGHT/2, WIDTH-EDGE*2, HEIGHT-EDGE*2, HEIGHT-EDGE*2)
+  else if not ticks
+    # Draw no bar if health is 0
+  else
+    # Dimensions and settings
+    # Scale width from 12 (1 health) to 34 (10+ health)
+    WIDTH = 8 + 4 * Math.min(maxTicks, 3) + 2 * Math.max(0, Math.min(maxTicks - 3, 7))
+    HEIGHT = 6
+    STROKE_WIDTH = 1
+    TICK_WIDTH = 1
+    EDGE = STROKE_WIDTH / 2  # Adjust EDGE to be half the stroke width
+
+    # Calculate dimensions
+    pieceWidth = (WIDTH - (maxTicks - 1) * TICK_WIDTH) / maxTicks
+    radius = HEIGHT / 2
+
+    # Draw background
+    g.setStrokeStyle(STROKE_WIDTH)
+    g.beginStroke(createjs.Graphics.getRGB(59, 39, 34, 1))
+    g.beginFill(createjs.Graphics.getRGB(28, 14, 83, 0.4))
+
+    # Draw background shape with precise curvature
+    g.moveTo(radius, -HEIGHT/2)
+    g.lineTo(WIDTH - radius, -HEIGHT/2)
+    g.arc(WIDTH - radius, 0, radius, -Math.PI/2, Math.PI/2, false)
+    g.lineTo(radius, HEIGHT/2)
+    g.arc(radius, 0, radius, Math.PI/2, -Math.PI/2, false)
+    g.closePath()
+    g.endStroke()
+
+    # Draw filled pieces
+    if ticks > 0
+      g.setStrokeStyle(0)  # No stroke for filled pieces
+      g.beginFill(createjs.Graphics.getRGB(color...))
+
+      filledWidth = Math.min(ticks * (pieceWidth + TICK_WIDTH) - TICK_WIDTH, WIDTH - STROKE_WIDTH)
+
+      # Calculate the inset for the progress bar
+      inset = EDGE
+
+      # Left cap (outset)
+      g.moveTo(radius, -HEIGHT/2 + inset)
+      g.arcTo(inset, -HEIGHT/2 + inset, inset, 0, radius - inset)
+      g.arcTo(inset, HEIGHT/2 - inset, radius, HEIGHT/2 - inset, radius - inset)
+      g.lineTo(filledWidth, HEIGHT/2 - inset)
+
+      # Right cap (full outset if full, straight line if not)
+      if ticks == maxTicks
+        g.lineTo(WIDTH - radius, HEIGHT/2 - inset)
+        g.arc(WIDTH - radius, 0, radius - inset, Math.PI/2, -Math.PI/2, true)
+        g.lineTo(inset, -HEIGHT/2 + inset)
+      else
+        g.lineTo(filledWidth, -HEIGHT/2 + inset)
+
+      g.closePath()
+
+    # Add vertical tick marks
+    g.setStrokeStyle(TICK_WIDTH)
+    g.beginStroke(createjs.Graphics.getRGB(147, 129, 107, 1))
+    for i in [1...maxTicks]
+      tickX = i * (pieceWidth + TICK_WIDTH) - TICK_WIDTH/2
+      g.moveTo(tickX, -HEIGHT/2 - 5)
+      g.lineTo(tickX, HEIGHT/2 + 5)
+
   s = new createjs.Shape(g)
   s.z = 100
   s.bounds = [0, -HEIGHT/2, WIDTH, HEIGHT]


### PR DESCRIPTION
Allows us to set a new `healthBarStyle = 'pill-with-ticks'`, which shows rounded corners, a semi-transparent background, and discrete sections instead of displaying just a continuous rectangle. Also updates the colors used a little bit.

### Design Exploration
<img width="654" alt="Screenshot 2024-10-14 at 13 43 26" src="https://github.com/user-attachments/assets/56bc0a48-43ab-43dc-9165-608bd9c99aa5">

### Implementation Close-Up
<img width="622" alt="Screenshot 2024-10-14 at 13 43 35" src="https://github.com/user-attachments/assets/0da9711c-1042-413f-9dfb-d906cc47b69d">

*The scaling/resolution isn't great, but it wasn't on the original health bars, either.*

### Implementation Zoomed Out
<img width="1032" alt="Screenshot 2024-10-14 at 13 43 41" src="https://github.com/user-attachments/assets/b63ab97f-4e24-4d30-bfd0-299558548d1a">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced health bar rendering with new color configurations for different teams.
	- Improved progress bar functionality with tick marks and dynamic sizing.

- **Bug Fixes**
	- Adjusted health bar logic to ensure proper rendering based on health styles.

- **Documentation**
	- Updated method signatures to reflect new parameters and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->