### PR TITLE
Fix CCJ-275: differentiate between saveThangs hero and friends

### DIFF
--- a/app/views/play/level/LevelGoal.vue
+++ b/app/views/play/level/LevelGoal.vue
@@ -58,7 +58,7 @@
         result = []
         return result unless @product is 'codecombat-junior'
         for key, icon of goalIconImageMap when @goal[key]
-          if key is 'saveThangs' and not (_.values(@state.killed).length > 1) and @$store.state.game.heroHealth.max
+          if key is 'saveThangs' and not (_.values(@state.killed).length > 1) and @$store.state.game.heroHealth.max and @goal.saveThangs?[0] in ['Hero Placeholder', 'humans']
             # saveThangs with just the hero; show hearts
             fullHearts = Math.max 0, @$store.state.game.heroHealth.current || 0
             emptyHearts = (@$store.state.game.heroHealth.max || 1) - fullHearts


### PR DESCRIPTION
With one friend, it thought both cases were the hero. This makes it more specific so we can show hero hearts when it's the hero and the friend icons when it's the friends.

Before: hearts are duplicated
<img width="534" alt="Screenshot 2024-10-14 at 13 06 58" src="https://github.com/user-attachments/assets/5e648864-5679-43a6-ad72-6b0913b7bcf5">

After: second set of hearts is proper friend icon
<img width="546" alt="Screenshot 2024-10-14 at 15 36 58" src="https://github.com/user-attachments/assets/f8db5255-cd92-47a9-b86a-73bcced452ad">
*note that that will turn into a chicken with the other icon fix today*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced display logic for heart icons based on specific conditions related to the `saveThangs` goal, improving user experience by ensuring icons are only shown when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->