### PR TITLE
Fix CCJ-131: rerun code after reload action

### DIFF
--- a/app/views/play/level/tome/TomeView.coffee
+++ b/app/views/play/level/tome/TomeView.coffee
@@ -276,7 +276,8 @@ module.exports = class TomeView extends CocoView
     if utils.getQueryVariable 'dev'
       @updateSpellPalette @spellView.thang, @spellView.spell if @spellView
     spell.view.reloadCode false for spellKey, spell of @spells when spell.view and (spell.team is me.team or (spell.team in ['common', 'neutral', null]))
-    @cast false, false
+    _.defer =>
+      @cast false, false unless @destroyed
 
   updateLanguageForAllSpells: (e) ->
     spell.updateLanguageAether e.language for spellKey, spell of @spells when spell.canWrite()


### PR DESCRIPTION
The code tried to rerun after reload, but a race condition made it run the old code, while players would have assumed it would be running the new (default) code.

Not sure what the race condition was, but deferring code execution a frame does the trick.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of spells in the TomeView, enhancing user interactions.
  
- **Bug Fixes**
	- Optimized toggling of the blocks UI to prevent unnecessary operations.
	- Enhanced reliability by ensuring methods only execute when appropriate, reducing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->