### PR TITLE
Fix CCJ-123: add "close" button to victory modal

### DIFF
--- a/app/styles/play/level/modal/course-victory-modal.sass
+++ b/app/styles/play/level/modal/course-victory-modal.sass
@@ -18,6 +18,7 @@
     .modal-content
       position: relative
       margin-top: -251px
+      box-shadow: none
 
   //- Header
 

--- a/app/styles/play/level/modal/hero-victory-modal.sass
+++ b/app/styles/play/level/modal/hero-victory-modal.sass
@@ -97,6 +97,12 @@
     min-height: 30px
     margin-top: 160px
 
+  .close-button
+    position: absolute
+    right: -15px
+    top: -37px
+    font-size: 50px
+
   .achievement-panel
     background: transparent url("/images/pages/play/level/modal/victory_modal_shelf.png") no-repeat center 73px
     width: 824px

--- a/app/templates/play/level/modal/hero-victory-modal.pug
+++ b/app/templates/play/level/modal/hero-victory-modal.pug
@@ -10,6 +10,8 @@ block modal-header-content
         h1(data-i18n="play_level.victory") Victory
 
 block modal-body-content
+  button.close-button.btn.btn-illustrated.btn-lg.btn-warning(type="button", data-dismiss="modal", aria-hidden="true", tabindex=-1) &times;
+
   if victoryText
     #victory-text(dir="auto")= victoryText
 

--- a/app/views/core/ModalView.js
+++ b/app/views/core/ModalView.js
@@ -51,7 +51,7 @@ module.exports = (ModalView = (function () {
     render () {
       __guardMethod__(this.focusTrap, 'deactivate', o => o.deactivate())
       super.render()
-      return this.trapFocus()
+      this.trapFocus()
     }
 
     afterRender () {
@@ -83,12 +83,14 @@ module.exports = (ModalView = (function () {
 
     trapFocus () {
       if (!this.trapsFocus) { return }
-      console.log(this.constructor != null ? this.constructor.name : undefined, 'trapping focus within modal')
-      if (this.focusTrap == null) { this.focusTrap = focusTrap.createFocusTrap(this.el) }
+      if (!this.focusTrap) {
+        this.focusTrap = focusTrap.createFocusTrap(this.el)
+      }
       try {
-        return (this.focusTrap != null ? this.focusTrap.activate() : undefined)
+        this.focusTrap?.activate()
+        console.log(this.constructor?.name, 'trapping focus within modal')
       } catch (e) {
-        return console.log(this.constructor != null ? this.constructor.name : undefined, 'not trapping focus for modal with no focusable elements')
+        console.log(this.constructor?.name, 'not trapping focus for modal with no focusable elements')
       }
     }
 

--- a/app/views/play/level/modal/HeroVictoryModal.js
+++ b/app/views/play/level/modal/HeroVictoryModal.js
@@ -327,6 +327,7 @@ module.exports = (HeroVictoryModal = (function () {
       for (const original in this.thangTypes) { const hero = this.thangTypes[original]; this.playSelectionSound(hero, true) } // Preload them
       this.updateSavingProgressStatus()
       this.initializeAnimations()
+      _.delay(() => this.$el?.find('button.btn-success').last()?.focus(), 200)
       if (this.level.isLadder()) {
         this.ladderSubmissionView = new LadderSubmissionView({ session: this.session, level: this.level })
         return this.insertSubView(this.ladderSubmissionView, this.$el.find('.ladder-submission-view'))


### PR DESCRIPTION
<img width="855" alt="Screenshot 2024-10-15 at 10 50 02" src="https://github.com/user-attachments/assets/7d8953ba-40c4-4ec7-90d6-bcc90241014d">

Also makes it so that keyboard focus goes to "continue" button in victory modal, which lets you press escape to close the modal, instead of staying in the ace editor.

Fixes a random extra box shadow in CourseVictoryModal that was causing minor visual glitching.

Trivial refactor to some logging code that was decaffeinated poorly and logging in two cases instead of one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a close button in the hero victory modal for improved user interaction.
	- Added keyframe animations for enhanced visual feedback.
  
- **Style Updates**
	- Updated styles for the course and hero victory modals, including adjustments for responsiveness and layout.

- **Bug Fixes**
	- Streamlined error handling and event management in the modal views for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->