### PR TITLE
Fix CCJ-175: make replay also rerun in Junior

### DIFF
--- a/app/views/play/level/LevelPlaybackView.coffee
+++ b/app/views/play/level/LevelPlaybackView.coffee
@@ -352,7 +352,12 @@ module.exports = class LevelPlaybackView extends CocoView
     return if @shouldIgnore()
     button = $('#play-button')
     willPlay = button.hasClass('paused') or button.hasClass('ended')
-    Backbone.Mediator.publish 'level:set-playing', playing: willPlay
+    if @options.level.get('product') is 'codecombat-junior' and (button.hasClass('ended') or button.hasClass('paused') and @getScrubRatio() < 0.05)
+      # Just rewind and rerun the level for Junior so students don't have to understand difference between play button here and in code editor
+      Backbone.Mediator.publish 'level:set-time', ratio: 0, scrubDuration: 0
+      Backbone.Mediator.publish 'tome:manual-cast', realTime: false
+    else
+      Backbone.Mediator.publish 'level:set-playing', playing: willPlay
     $(document.activeElement).blur()
 
   onToggleVolume: (e) ->


### PR DESCRIPTION
This makes it so that when you press this button when the playback is stopped at end or beginning, it reruns the code. That way both "play" buttons do the same thing instead of different things. Useful for Junior players who we don't expect to have a mental model of the difference, since in Junior the "RUN" button in the code editor is just a play triangle icon.

<img width="580" alt="Screenshot 2024-10-15 at 14 26 47" src="https://github.com/user-attachments/assets/f95c5197-8f1c-4f49-a2c7-0d5b447b160c">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced playback control for 'codecombat-junior' levels, allowing a reset to the beginning of the level under specific conditions.
	- Improved volume control button to accurately reflect the current volume state after toggling.

- **Bug Fixes**
	- Streamlined logic for the volume button's class update to ensure correct state representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->