### PR TITLE
Fix CCJ-240: improve handling of var/let/const in translateJS

### DIFF
--- a/app/lib/translate-utils.coffee
+++ b/app/lib/translate-utils.coffee
@@ -165,8 +165,8 @@ translateJSBrackets = (jsCode, language='cpp', fullCode=true) ->
       s = s.replace /\ let /g, ' var '
       s = s.replace /\(let /g, '(var '
       s = s.replace /\nlet /g, '\var '
-      s = s.replace /\ const /g, ' const var '
-      s = s.replace /\nconst /g, '\nconst var '
+      s = s.replace /\ const /g, ' final var '
+      s = s.replace /\nconst /g, '\nfinal var '
 
     s = s.replace /TEMPCONST/g, constType
 

--- a/app/lib/translate-utils.coffee
+++ b/app/lib/translate-utils.coffee
@@ -164,10 +164,9 @@ translateJSBrackets = (jsCode, language='cpp', fullCode=true) ->
     else if language is 'java'
       s = s.replace /\ let /g, ' var '
       s = s.replace /\(let /g, '(var '
-      s = s.replace /\nlet /g, '\var '
+      s = s.replace /\nlet /g, '\nvar '
       s = s.replace /\ const /g, ' final var '
       s = s.replace /\nconst /g, '\nfinal var '
-
     s = s.replace /TEMPCONST/g, constType
 
     # TODO: figure out how we are going to call other methods in Java

--- a/app/lib/translate-utils.coffee
+++ b/app/lib/translate-utils.coffee
@@ -133,14 +133,18 @@ translateJSBrackets = (jsCode, language='cpp', fullCode=true) ->
 
   functionReturnType = if language is 'cpp' then 'auto' else 'public static var'  # TODO: figure out some auto return types for Java
   functionParamType = if language is 'cpp' then 'auto' else 'Object'  # TODO: figure out some auto/void param types for Java
+  constType = if language is 'cpp' then 'const' else 'final'
   for i in [0...len]
     s = jsCodes[i]
     s = s.replace /function (.+?)\((.*?)\)/g, (match, functionName, functionParams) ->
       typedParameters = _.filter(functionParams.split(/, ?/)).map((e) -> "#{functionParamType} #{e}").join(', ')
       "#{functionReturnType} #{functionName}(#{typedParameters})"
-    s = s.replace /var (x|y|z|dist)/g, 'float $1'
-    s = s.replace /var (\w+)Index/g, 'int $1Index'
-    s = s.replace /var (i|j|k)(?![a-zA-Z0-9_])/g, 'int $1'
+    s = s.replace /(var|let) (x|y|z|dist)/g, 'float $2'
+    s = s.replace /(var|let) (\w+)Index/g, 'int $2Index'
+    s = s.replace /(var|let) (i|j|k)(?![a-zA-Z0-9_])/g, 'int $2'
+    s = s.replace /const (x|y|z|dist)/g, 'TEMPCONST float $1'
+    s = s.replace /const (\w+)Index/g, 'TEMPCONST int $1Index'
+    s = s.replace /const (i|j|k)(?![a-zA-Z0-9_])/g, 'TEMPCONST int $1'
     s = s.replace /\ ===\ /g, ' == '
     s = s.replace /\ !== /g, ' != '
     s = s.replace /hero\.throw\(/g, 'hero.throwEnemy('
@@ -157,6 +161,14 @@ translateJSBrackets = (jsCode, language='cpp', fullCode=true) ->
       s = s.replace /\ const /g, ' const auto '
       s = s.replace /\nconst /g, '\nconst auto '
       s = s.replace /\ return \[([^;]*)\];/g, ' return {$1};'
+    else if language is 'java'
+      s = s.replace /\ let /g, ' var '
+      s = s.replace /\(let /g, '(var '
+      s = s.replace /\nlet /g, '\var '
+      s = s.replace /\ const /g, ' const var '
+      s = s.replace /\nconst /g, '\nconst var '
+
+    s = s.replace /TEMPCONST/g, constType
 
     # TODO: figure out how we are going to call other methods in Java
     # TODO: figure out how we are going to handle {x: 34, y: 30} object literals in Java
@@ -285,16 +297,16 @@ translateJSWhitespace = (jsCode, language='lua') ->
     s = s.replace /\.shift\(0?\)/g, '.remove(0)'
 
   if language is 'lua'
-    s = s.replace /\ var /g, ' local '
+    s = s.replace /\ (var|let|const) /g, ' local '
     s = s.replace /\ = \[([^;]*)\];/g, ' = {$1};'
-    s = s.replace /\(var /g, '(local '
-    s = s.replace /\nvar /g, '\nlocal '
+    s = s.replace /\((var|let|const) /g, '(local '
+    s = s.replace /\n(var|let|const) /g, '\nlocal '
     s = s.replace /\ return \[([^;]*)\];/g, ' return {$1};'
   else if language in ['python', 'coffeescript']
-    s = s.replace /^ *var [^=\n]*$\n/gm, ''  # Remove variable declarations without initialization
-    s = s.replace /\ var /g, ' '
-    s = s.replace /\(var /g, '('
-    s = s.replace /\nvar /g, '\n'
+    s = s.replace /^ *(var|let) [^=\n]*$\n/gm, ''  # Remove variable declarations without initialization
+    s = s.replace /\ (var|let|const) /g, ' '
+    s = s.replace /\((var|let|const) /g, '('
+    s = s.replace /\n(var|let|const) /g, '\n'
 
   # Don't substitute these within comments
   noComment = '^ *([^/\\r\\n]*?)'

--- a/test/app/lib/translate_utils.spec.js
+++ b/test/app/lib/translate_utils.spec.js
@@ -1172,4 +1172,155 @@ describe('Aether / code transpilation utility library', () => {
       }
     }
   })
+
+  describe('translateJS can handle var, let, and const', () => {
+    const sourceByLanguage = {
+      javascript: `\
+var a;
+var b = 1;
+var c = 2, d = 3;
+a = 5;
+
+let e;
+let f = 1;
+let g = 2, h = 3;
+e = 5;
+
+const h = 1;
+const m = 2, n = 3;
+
+var i = 1;
+let j = 2;
+const k = 3;
+
+var x = 4;
+let y = 5;
+const z = 6;
+`,
+      cpp: `\
+auto a;
+auto b = 1;
+auto c = 2, auto d = 3;
+a = 5;
+
+auto e;
+auto f = 1;
+auto g = 2, auto h = 3;
+e = 5;
+
+const auto h = 1;
+const auto m = 2, const auto n = 3;
+
+int i = 1;
+int j = 2;
+const int k = 3;
+
+float x = 4;
+float y = 5;
+const float z = 6;
+`,
+      java: `\
+var b = 1;
+var c = 2, var d = 3;
+var a = 5;
+
+var f = 1;
+var g = 2, var h = 3;
+var e = 5;
+
+final var h = 1;
+final var m = 2, final var n = 3;
+
+int i = 1;
+int j = 2;
+final int k = 3;
+
+float x = 4;
+float y = 5;
+final float z = 6;
+`,
+      python: `\
+b = 1
+c = 2, d = 3
+a = 5
+
+f = 1
+g = 2, h = 3
+e = 5
+
+h = 1
+m = 2, n = 3
+
+i = 1
+j = 2
+k = 3
+
+x = 4
+y = 5
+z = 6
+`,
+      coffeescript: `\
+b = 1
+c = 2, d = 3
+a = 5
+
+f = 1
+g = 2, h = 3
+e = 5
+
+h = 1
+m = 2, n = 3
+
+i = 1
+j = 2
+k = 3
+
+x = 4
+y = 5
+z = 6
+`,
+      lua: `\
+local a
+local b = 1
+local c = 2
+local d = 3
+a = 5
+
+local e
+local f = 1
+local g = 2
+local h = 3
+e = 5
+
+local h = 1
+local m = 2
+local n = 3
+
+local i = 1
+local j = 2
+local k = 3
+
+local x = 4
+local y = 5
+local z = 6
+`,
+    }
+
+    for (const [language, targetSource] of Object.entries(sourceByLanguage)) {
+      // At time of test writing, we don't yet properly handle:
+      // 1. java/cpp/lua multiple variable definitions on one line
+      // 2. java not able to use `var a` for uninitialized variables
+      const func = ['python', 'coffeescript', 'javascript'].includes(language) ? it : xit
+      func(`in ${language}`, () => {
+        const translated = translateUtils.translateJS(sourceByLanguage.javascript, language, false)
+        const editDistance = levenshteinDistance(translated, targetSource)
+        if (translated !== targetSource) {
+          console.log(`\n${translated}`)
+          console.log(`\n${targetSource}`)
+        }
+        expect(translated).toBe(targetSource)
+        expect(editDistance).toEqual(0)
+      })
+    }
+  })
 })

--- a/test/app/lib/translate_utils.spec.js
+++ b/test/app/lib/translate_utils.spec.js
@@ -1186,7 +1186,7 @@ let f = 1;
 let g = 2, h = 3;
 e = 5;
 
-const h = 1;
+const l = 1;
 const m = 2, n = 3;
 
 var i = 1;
@@ -1208,7 +1208,7 @@ auto f = 1;
 auto g = 2, auto h = 3;
 e = 5;
 
-const auto h = 1;
+const auto l = 1;
 const auto m = 2, const auto n = 3;
 
 int i = 1;
@@ -1228,7 +1228,7 @@ var f = 1;
 var g = 2, var h = 3;
 var e = 5;
 
-final var h = 1;
+final var l = 1;
 final var m = 2, final var n = 3;
 
 int i = 1;
@@ -1248,7 +1248,7 @@ f = 1
 g = 2, h = 3
 e = 5
 
-h = 1
+l = 1
 m = 2, n = 3
 
 i = 1
@@ -1268,7 +1268,7 @@ f = 1
 g = 2, h = 3
 e = 5
 
-h = 1
+l = 1
 m = 2, n = 3
 
 i = 1
@@ -1292,7 +1292,7 @@ local g = 2
 local h = 3
 e = 5
 
-local h = 1
+local l = 1
 local m = 2
 local n = 3
 


### PR DESCRIPTION
Before this, special handling that triggered on `var` would usually not trigger on `let` or `const`.

Still some cases that aren't handled in cpp/java/lua, but they are better than they were. xit on the new tests for those, but noted where the failures would be.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced translation utility to support variable declarations using `var`, `let`, and `const` for multiple target languages (C++, Java, Python, Lua, CoffeeScript).
	- Introduced refined logic for translating function signatures and control structures.
	- Added new methods for handling brackets and whitespace in translations.

- **Bug Fixes**
	- Improved whitespace handling and comment rewriting to comply with target language syntax.

- **Tests**
	- Added a comprehensive test suite for variable declaration handling across various programming languages, ensuring translation accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->