### PR TITLE
Fix CCJ-146: disallow toolbox direction dropdowns in early levels

### DIFF
--- a/app/core/blocklyUtils.js
+++ b/app/core/blocklyUtils.js
@@ -657,8 +657,7 @@ const createBlock = function ({ owner, prop, generator, codeLanguage, codeFormat
 
   if (codeFormat === 'blocks-icons' && setup.message0.startsWith('hit ')) {
     // Use an image instead of text
-    setup.message0 = setup.message0.replace(/hit %1 %2/, '%1%2 %3') // With times
-    setup.message0 = setup.message0.replace(/hit %1/, '%1%2') // Without times
+    setup.message0 = setup.message0.replace(/hit %1/, '%1%2')
     setup.args0.unshift({
       type: 'field_image',
       src: '/images/level/blocks/block-hit.png',
@@ -671,8 +670,7 @@ const createBlock = function ({ owner, prop, generator, codeLanguage, codeFormat
 
   if (codeFormat === 'blocks-icons' && setup.message0.startsWith('spin ')) {
     // Use an image instead of text
-    setup.message0 = setup.message0.replace(/spin %1/, '%1 %2') // With times
-    setup.message0 = setup.message0.replace(/spin/, '%1') // Without times
+    setup.message0 = setup.message0.replace(/spin/, '%1')
     setup.args0.unshift({
       type: 'field_image',
       src: '/images/level/blocks/block-spin.png',
@@ -685,8 +683,7 @@ const createBlock = function ({ owner, prop, generator, codeLanguage, codeFormat
 
   if (codeFormat === 'blocks-icons' && setup.message0.startsWith('zap ')) {
     // Use an image instead of text
-    setup.message0 = setup.message0.replace(/zap %1 %2/, '%1%2 %3') // With times
-    setup.message0 = setup.message0.replace(/zap %1/, '%1%2') // Without times
+    setup.message0 = setup.message0.replace(/zap %1/, '%1%2')
     setup.args0.unshift({
       type: 'field_image',
       src: '/images/level/blocks/block-zap.png',

--- a/app/styles/play/common/blockly.sass
+++ b/app/styles/play/common/blockly.sass
@@ -44,3 +44,19 @@
   .blocklyDropdownRect
     fill: rgba(33, 88, 233, 0.75)
 
+  &.static-toolbox-dropdowns .blocklyFlyout
+    .blocklyEditableText:nth-child(3)
+      // This prevents clicks on dropdown elements like "up" or "right" from going through.
+      // We do this in early levels where we provide four go blocks, one for each direction.
+      // We don't want players to mess around changing dropdwon arguments in toolbox, only workspace.
+      // :nth-child(3) happens to be the direction argument (so we don't apply to steps argument)
+      pointer-events: none
+
+      image:last-child
+        // Hide the dropdown arrow next to the block label
+        display: none
+
+      .blocklyDropdownText, image[*|href*="/images/level/blocks/block"]
+        // Move the text over to center it, now that the dropdown arrow on the right is gone
+        transform: translateX(10px)
+

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -475,6 +475,9 @@ module.exports = class SpellView extends CocoView
     if @onCodeChangeMetaHandler
       @blockly.addChangeListener @onBlocklyEvent
 
+    hasFourGoBlocks = _.filter(@propertyEntryGroups.Hero?.props, (prop) -> /^go/.test(prop.name)).length is 4
+    targetDiv.toggleClass 'static-toolbox-dropdowns', hasFourGoBlocks
+
     @lastBlocklyState = if PERSIST_BLOCK_STATE and not @session.fake then storage.load "lastBlocklyState_#{@options.level.get('original')}_#{@session.id}" else null
     if @lastBlocklyState
       @awaitingBlocklySerialization = true


### PR DESCRIPTION
Players can still use dropdowns to change `go()` block directional arguments in the workspace, but not in the toolbox (was confusing to do it there with four direction-specific `go()` blocks already configured). Steps argument dropdowns are still changeable.

### No toolbox dropdown for directions (text)
<img width="501" alt="Screenshot 2024-10-17 at 10 22 37" src="https://github.com/user-attachments/assets/60b350bd-6cf4-4cab-b2cc-e048a8e232da">

### No toolbox dropdown for directions (icons)
<img width="386" alt="Screenshot 2024-10-17 at 10 29 01" src="https://github.com/user-attachments/assets/8aad531b-252d-4311-9a04-f590292037e7">

### Steps dropdown but not direction dropdown (text)
<img width="480" alt="Screenshot 2024-10-17 at 10 44 14" src="https://github.com/user-attachments/assets/01b19235-efc4-4101-b7d9-065a8872bc2b">

### Steps dropdown but not direction dropdown (icons)
<img width="465" alt="Screenshot 2024-10-17 at 10 44 29" src="https://github.com/user-attachments/assets/cbe06667-23bb-4219-88bc-5bc395cdd7a5">

### Dropdown appears when we go from four blocks to one block
<img width="452" alt="Screenshot 2024-10-17 at 10 29 40" src="https://github.com/user-attachments/assets/923968b1-bdab-4989-b7c9-b7e9c4cd8113">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Blockly integration in the spell editor, allowing toggling of static toolbox dropdowns based on block presence.
- **Bug Fixes**
	- Simplified message formatting for specific Blockly commands, improving clarity in the user interface.
- **Style**
	- Introduced new styles for dropdown elements in the Blockly interface to enhance user interaction.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->