### PR TITLE
Fix CCJ-43: add TTS pronouncing blocks on insert

### DIFF
--- a/app/core/blocklyUtils.js
+++ b/app/core/blocklyUtils.js
@@ -1228,5 +1228,14 @@ module.exports.createBlockById = function ({ workspace, id, codeLanguage }) {
   return newWorkspaceBlock
 }
 
+module.exports.getBlockById = function ({ workspace, id }) {
+  return workspace.getBlockById(id)
+}
+
+module.exports.blockToCode = function ({ block, codeLanguage }) {
+  const generator = module.exports.getBlocklyGenerator(codeLanguage)
+  return generator.forBlock[block.type](block)
+}
+
 module.exports.blocklyMutationEvents = [Blockly.Events.CHANGE, Blockly.Events.CREATE, Blockly.Events.DELETE, Blockly.Events.BLOCK_CHANGE, Blockly.Events.BLOCK_CREATE, Blockly.Events.BLOCK_DELETE, Blockly.Events.BLOCK_DRAG, Blockly.Events.BLOCK_FIELD_INTERMEDIATE_CHANGE, Blockly.Events.BLOCK_MOVE, Blockly.Events.VAR_CREATE, Blockly.Events.VAR_DELETE, Blockly.Events.VAR_RENAME]
 module.exports.blocklyFinishedMutationEvents = _.without(module.exports.blocklyMutationEvents, Blockly.Events.CREATE, Blockly.Events.BLOCK_CREATE, Blockly.Events.BLOCK_DRAG, Blockly.Events.VAR_CREATE, Blockly.Events.VAR_DELETE, Blockly.Events.VAR_RENAME)

--- a/app/lib/AudioPlayer.coffee
+++ b/app/lib/AudioPlayer.coffee
@@ -132,12 +132,12 @@ class AudioPlayer extends CocoClass
   nameForSoundReference: (sound) ->
     sound[@ext.slice(1)]  # mp3 or ogg
 
-  preloadSound: (filename, name) ->
+  preloadSound: (filename, name, channels=1) ->
     return unless filename
     return if filename of cache
     name ?= filename
     # SoundJS flips out if you try to register the same file twice
-    result = createjs.Sound.registerSound(filename, name, 1)  # 1: 1 channel
+    result = createjs.Sound.registerSound(filename, name, channels)
     cache[filename] = new Media(name)
 
   # PROGRESS CALLBACKS

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -617,7 +617,7 @@ module.exports = class SpellView extends CocoView
     code = blocklyUtils.blockToCode({ block, codeLanguage: @spell.language })?.trim()
     docsCode = block?.docFormatter?.doc?.name
     return unless code or docsCode
-    lang = me.get('preferedLanguage', true) or 'en-US'
+    lang = me.get('preferredLanguage', true) or 'en-US'
     if docsCode and (not code or code.replace(/[^a-zA-Z0-9_-]/g, '') is docsCode.replace(/[^a-zA-Z0-9_-]/g, ''))
       # We can internationalize
       text = utils.i18n block.docFormatter.doc, 'name'


### PR DESCRIPTION
When you add a new block to the workspace, it uses TTS to pronounce the block, for CodeCombat Junior.

Probably there are some blocks which aren't pronounced well, and need to see how this interactions with the block i18n thing to get that working.

It would be good to preload this a bit so that they happen faster on first insertion.

TBD on whether players like this, but could be good for low-readers, especially with directional arrow confusions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced audio feedback for block interactions in the spell editor.
	- Added functionality to retrieve blocks by ID and convert blocks to code.
	- Enhanced audio playback capabilities with customizable channel settings.

- **Bug Fixes**
	- Updated audio file handling to ensure correct formats are used based on settings.

- **Documentation**
	- Improved clarity on audio playback methods and block management functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->