### PR TITLE
web-dev should go with game-dev

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
@@ -235,7 +235,7 @@ export default {
               practiceLevels,
             }
 
-            if (content.type === 'game-dev') {
+            if (content.type === 'game-dev' || content.type === 'web-dev') {
               defaultProgressDot.normalizedType = 'capstone'
             } else if (content.type === undefined) {
               defaultProgressDot.normalizedType = 'practicelvl'

--- a/ozaria/site/store/TeacherDashboardPanel.js
+++ b/ozaria/site/store/TeacherDashboardPanel.js
@@ -337,6 +337,9 @@ export default {
       if (!ozariaType) {
         icon = type
         url = `/play/intro/${fromIntroLevelOriginal}?course=${selectedCourseId}&codeLanguage=${classroomLanguage}&intro-content=${introContent || 0}&original=true`
+        if (utils.isCodeCombat) {
+          url = `/play/level/${content.slug}?course=${selectedCourseId}&codeLanguage=${classroomLanguage}`
+        }
       } else if (ozariaType) {
         if (ozariaType === 'practice') {
           icon = 'practicelvl'
@@ -365,7 +368,7 @@ export default {
 
       const panelHeader = `Module ${moduleNum} | ${getGameContentDisplayNameWithType(content)}`
 
-      if (['hero', 'course', undefined, 'web-dev'].includes(content.type)) {
+      if (['hero', 'course', undefined].includes(content.type)) {
         // For practice levels and challenge levels
 
         commit('setTimeSpent', utils.secondsToMinutesAndSeconds(Math.ceil(studentSessions[normalizedOriginal].playtime)))
@@ -377,7 +380,7 @@ export default {
           dateFirstCompleted: studentSessions[normalizedOriginal].dateFirstCompleted,
           sessionContentObjects: [practiceLevelData(content, studentSessions)],
         })
-      } else if (content.type === 'game-dev') {
+      } else if (content.type === 'game-dev' || content.type === 'web-dev') {
         const language = studentSessions[normalizedOriginal]?.codeLanguage || 'python'
         const gameGoals = [
           ...(content.goals || []), ...(content.additionalGoals || []).map(({ goals }) => goals).flat(),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1d61dc41-f97c-4523-a136-79eadc57fc88)

web-dev should also use project panel to show `view students project` URL.

also fix the `view level` button
![image](https://github.com/user-attachments/assets/bd6e00e2-32d5-4f0e-8834-3c247822267d)

fix ENG-1299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced content type handling for progress tracking in the teacher dashboard, now including 'web-dev' alongside 'game-dev'.
	- Improved display of completion status with the addition of a new parameter in the session content display.

- **Bug Fixes**
	- Resolved issues with URL construction for specific content types based on user conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->