### PR TITLE
Fix CCJ-127: auto close error messages on block edits

### DIFF
--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -545,6 +545,7 @@ module.exports = class SpellView extends CocoView
 
     if @options.level.get('product') is 'codecombat-junior'
       # Immediate code execution on each significant block change that produces a program that differs by more than newlines
+      @hideProblemAlert()
       @recompile()
     else
       @notifySpellChanged()


### PR DESCRIPTION
Previously, some block edits would not hide error messages even as the code reran. It's not so easy to get error messages in CodeCombat Junior, but here's an example that now works, whereas before the error would stay up even as the code was "fixed" by the block-based code reasserting correct arguments and rewriting the text code.
![2024-10-18 04 32 11](https://github.com/user-attachments/assets/cb5071eb-642d-4246-aad4-8c10d56852b4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced event handling for user interactions with the spell editing interface.
  - Improved management of user code problems and error handling.
  - Enhanced integration with Blockly, including dynamic visibility of the toolbox during cinematic playback.
  - Introduced new methods for cinematic playback handling and solution display updates.

- **Performance Improvements**
  - Optimized methods for resizing and updating the editor for faster response times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->