### PR TITLE
Fix CCJ-110: delete blocks by dragging off screen

### DIFF
--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -534,6 +534,19 @@ module.exports = class SpellView extends CocoView
     return unless e.type in blocklyUtils.blocklyMutationEvents
     { blocklySource, blocklySourceRaw } = @blocklyToAce e
 
+    # If a block is moved too far off the screen, then let's delete it
+    metrics = @blockly.getMetricsManager().getViewMetrics(true)
+    if e.type is Blockly.Events.BLOCK_MOVE and
+      ('drag' in (e.reason or [])) and
+      e.newCoordinate and
+      (e.newCoordinate.x < metrics.left - 25 or
+       # Right side is handled by dragging onto the toolbox, which shows a little animation
+       e.newCoordinate.y < metrics.top - 15 or
+       e.newCoordinate.y > metrics.top + metrics.height - 10)
+      block = @blockly.getBlockById e.blockId
+      block.dispose()
+      return
+
     return unless blocklySource and e.type in blocklyUtils.blocklyFinishedMutationEvents and blocklySource.trim().replace(/\n\s*\n/g, '\n') isnt @spell.source.trim().replace(/\n\s*\n/g, '\n')
     # Sometimes move event happens when blocks are moving around during a drag, but the drag isn't done. e.reason including 'drag' means it's done, 'connect' happens when clicked-to-insert.
     return if e.type is Blockly.Events.BLOCK_MOVE and not ('drag' in (e.reason or [])) and not ('connect' in (e.reason or []))


### PR DESCRIPTION
By default, Blockly just deletes blocks that you drag back to the workspace on the right side, or to the trashcan (which we are not using). If you drag off the other three sides, the blocks just kinda live out there, invisible, in the void, until something snaps the blocks back to the center. Confusing!

Now, we check if the dragged block would be (close to) off the screen, so you can drag off the other three sides and delete the block.

![2024-10-18 05 46 44](https://github.com/user-attachments/assets/948bd51f-dd28-4796-90d7-f86468d09022)

![2024-10-18 05 49 55](https://github.com/user-attachments/assets/8f117c7c-730d-4e09-8a84-c394ccba0366)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced spell editor interface with improved block deletion functionality during drag operations.
	- Updated event handling for block movements to ensure only completed actions trigger updates.
	- Improved autocomplete feature for user snippets.

- **Bug Fixes**
	- Refined logic for managing the state of the editor and interactions with the Blockly interface.

- **Refactor**
	- Minor adjustments for code clarity and maintainability, including the introduction of utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->