### PR TITLE
Fix CCJ-27: limit number of addable blocks for limited-line levels

### DIFF
--- a/app/core/blocklyUtils.js
+++ b/app/core/blocklyUtils.js
@@ -913,7 +913,10 @@ module.exports.initializeBlocklyLanguage = function () {
   }
 }
 
-module.exports.createBlocklyOptions = function ({ toolbox, renderer, codeLanguage, codeFormat, product }) {
+module.exports.createBlocklyOptions = function ({ toolbox, renderer, codeLanguage, codeFormat, product, maxBlocks }) {
+  if (maxBlocks && maxBlocks !== Infinity && product === 'codecombat-junior') {
+    ++maxBlocks // Allow for start block
+  }
   module.exports.initializeBlocklyLanguage()
   return {
     toolbox,
@@ -926,8 +929,6 @@ module.exports.createBlocklyOptions = function ({ toolbox, renderer, codeLanguag
     },
     sounds: me.get('volume') > 0,
     // Renderer choices: 'geras': default, 'thrasos': more modern take on geras, 'zelos': Scratch-like
-    // renderer: 'zelos',
-    // renderer: 'thrasos',
     renderer: renderer || ($(window).innerHeight() > 500 && product === 'codecombat-junior' ? 'zelos' : 'thrasos'),
     zoom: {
       // Hide so that we don't mess with width of toolbox
@@ -937,7 +938,7 @@ module.exports.createBlocklyOptions = function ({ toolbox, renderer, codeLanguag
       maxScale: 1.5,
     },
     trashcan: false,
-    // oneBasedIndex: codeLanguage === 'lua' // TODO: Need to test. Default is true.
+    oneBasedIndex: codeLanguage === 'lua',
     move: {
       scrollbars: true,
       drag: true,
@@ -952,6 +953,7 @@ module.exports.createBlocklyOptions = function ({ toolbox, renderer, codeLanguag
     // },
     collapse: codeFormat !== 'blocks-icons', // Don't let blocks be collapsed in icon mode
     disable: true, // Do let blocks be disabled
+    maxBlocks, // Defaults to Infinity
   }
 }
 

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -468,7 +468,8 @@ module.exports = class SpellView extends CocoView
     # codeToBlocks prepareBlockIntelligence function needs the JavaScript version of the toolbox
     @blocklyToolboxJS = if codeLanguage is 'javascript' then @blocklyToolbox else blocklyUtils.createBlocklyToolbox({ @propertyEntryGroups, codeLanguage: 'javascript', codeFormat: @options.codeFormat, level: @options.level })
     targetDiv = @$('.blockly-container')
-    blocklyOptions = blocklyUtils.createBlocklyOptions({ toolbox: @blocklyToolbox, codeLanguage, codeFormat: @options.codeFormat, product: @options.level.get('product') or 'codecombat' })
+    maxBlocks = @determineMaxBlocks()
+    blocklyOptions = blocklyUtils.createBlocklyOptions({ toolbox: @blocklyToolbox, codeLanguage, codeFormat: @options.codeFormat, product: @options.level.get('product') or 'codecombat', maxBlocks })
     @blockly = Blockly.inject targetDiv[0], blocklyOptions
     @blocklyActive = true
     blocklyUtils.initializeBlocklyTooltips()
@@ -1966,6 +1967,14 @@ module.exports = class SpellView extends CocoView
     @blockly?.getToolbox()?.setVisible true
     @blockly?.getFlyout()?.setVisible true
     null
+
+  determineMaxBlocks: ->
+    return Infinity unless @options.level.get('product') is 'codecombat-junior'
+    goals = @options.level.get('goals') || []
+    lineGoal = _.find goals, (g) -> g.linesOfCode
+    if lineGoal
+      return lineGoal.linesOfCode.humans
+    return Infinity
 
   destroy: ->
     $(@ace?.container).find('.ace_gutter').off 'click mouseenter', '.ace_error, .ace_warning, .ace_info'


### PR DESCRIPTION
Some levels have statement limits, like under 6 lines of code, which is a soft limit that causes goal failure if you exceed it. Here we implement the same as a hard limit for blocks, using Blockly's `maxBlocks` limitation in the blocks that can be added from the toolbox. You can still click to insert blocks beyond the maximum, but they show as disabled, and you can't drag to insert them.

![2024-10-18 09 51 37](https://github.com/user-attachments/assets/9e73568f-c5fb-4165-bb86-c357dd563dd5)

![2024-10-18 09 50 11](https://github.com/user-attachments/assets/3e1041f9-5eb4-47f3-9af1-42106ee457f4)
