### PR TITLE
Fix CCJ-26: highlight actively running blocks

### DIFF
--- a/app/core/blocklyUtils.js
+++ b/app/core/blocklyUtils.js
@@ -1231,7 +1231,25 @@ module.exports.getBlockById = function ({ workspace, id }) {
 
 module.exports.blockToCode = function ({ block, codeLanguage }) {
   const generator = module.exports.getBlocklyGenerator(codeLanguage)
-  return generator.forBlock[block.type](block)
+  const code = generator.forBlock[block.type](block)
+  if (_.isArray(code)) {
+    // Sometimes the first element is the code and the second is... the operator priority, or something like this
+    return code[0]
+  }
+  return code
+}
+
+module.exports.getBlocksByCodeLine = function ({ workspace, codeLine, codeLanguage }) {
+  const matchedBlocks = []
+  const blocks = workspace.getAllBlocks()
+  for (const block of blocks) {
+    if (!/^Hero_/.test(block.type)) continue
+    const blockCode = module.exports.blockToCode({ block, codeLanguage })
+    if (blockCode?.trim() === codeLine) {
+      matchedBlocks.push(block)
+    }
+  }
+  return matchedBlocks
 }
 
 module.exports.blocklyMutationEvents = [Blockly.Events.CHANGE, Blockly.Events.CREATE, Blockly.Events.DELETE, Blockly.Events.BLOCK_CHANGE, Blockly.Events.BLOCK_CREATE, Blockly.Events.BLOCK_DELETE, Blockly.Events.BLOCK_DRAG, Blockly.Events.BLOCK_FIELD_INTERMEDIATE_CHANGE, Blockly.Events.BLOCK_MOVE, Blockly.Events.VAR_CREATE, Blockly.Events.VAR_DELETE, Blockly.Events.VAR_RENAME]

--- a/app/styles/play/common/blockly.sass
+++ b/app/styles/play/common/blockly.sass
@@ -60,3 +60,12 @@
         // Move the text over to center it, now that the dropdown arrow on the right is gone
         transform: translateX(10px)
 
+  .highlighted-block
+    & > path
+      fill: rgba(250, 248, 243, 1) !important
+      stroke: #0099FF !important
+      stroke-width: 2px !important
+
+    & > g > text.blocklyText
+      text-shadow: 0 2px black, 0 -2px black, 2px 0 black, -2px 0 black
+

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -1600,6 +1600,9 @@ module.exports = class SpellView extends CocoView
     showToolbarView = executed.length and @spellThang.castAether.metrics.statementsExecuted > 3 and not @options.level.get 'hidesCodeToolbar'  # Hide for a while
     showToolbarView = false  # TODO: fix toolbar styling in new design to have some space for it
 
+    if @blockly
+      @$el.find('.highlighted-block').attr('class', 'blocklyDraggable')
+
     if showToolbarView
       statementIndex = Math.max 0, lastExecuted.length - 1
       @toolbarView?.toggleFlow true
@@ -1639,6 +1642,15 @@ module.exports = class SpellView extends CocoView
           utils.replaceText $codeLineEl.find('.line-number'), if sourceLineNumber >= 0 then sourceLineNumber + 1 else ''
           utils.replaceText $codeLineEl.find('.indentation'), codeLine.match(/\s*/)[0]
           utils.replaceText $codeLineEl.find('.code-text'), _.string.trim(codeLine)
+
+      if clazz is 'executing' and @blockly
+        # Also highlight actively running block, by matching nth line of this type to nth block of this type
+        trimmedLines = @aceDoc.$lines.slice(0, end.row + 1).map (line) -> line.trim().replace(/.*(look\(.*?\))/, '$1')
+        codeLine = _.last(trimmedLines)
+        sameLineIndex = trimmedLines.filter((line) -> line is codeLine).length - 1
+        block = blocklyUtils.getBlocksByCodeLine({ workspace: @blockly, codeLine, codeLanguage: @spell.language })[sameLineIndex]
+        if block
+          $(block.svgGroup_).attr('class', 'blocklyDraggable highlighted-block')  # addClass doesn't work on svgs I guess
 
     @debugView?.setVariableStates {} unless gotVariableStates
     null


### PR DESCRIPTION
![2024-10-18 11 37 30](https://github.com/user-attachments/assets/52c5a9de-24ae-4c89-8f62-9fd418ecea2c)
![2024-10-18 11 49 06](https://github.com/user-attachments/assets/7a1a1f5e-dbc4-49ca-a4e3-56a878c91f3f)
![2024-10-18 11 51 29](https://github.com/user-attachments/assets/d341009b-4b7d-4f09-85d6-c3c6cd9358be)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to retrieve blocks based on specific lines of code in the Blockly environment.
	- Added new commands for step-by-step navigation in the ACE editor, enhancing code execution interaction.
	- Implemented visual highlighting of corresponding blocks in Blockly when hovering over lines in the ACE editor.

- **Style**
	- Added a new CSS class for improved visual representation of highlighted blocks in the Blockly interface.

- **Bug Fixes**
	- Enhanced existing methods to better handle array return types and improve integration between ACE editor and Blockly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->