### PR TITLE
Fix CCJ-69: full-width play button in game dev mode

### DIFF
--- a/app/views/play/level/tome/CastButtonView.coffee
+++ b/app/views/play/level/tome/CastButtonView.coffee
@@ -182,7 +182,7 @@ module.exports = class CastButtonView extends CocoView
 
   updateButtonWidth: ->
     numVisibleButtons = @$el.find('.btn:visible').length
-    @castButton.toggleClass 'full-width', numVisibleButtons is 1
+    @castButton.add('.game-dev-play-btn').toggleClass 'full-width', numVisibleButtons is 1
 
   updateReplayability: =>
     return if @destroyed

--- a/app/views/play/level/tome/TomeView.coffee
+++ b/app/views/play/level/tome/TomeView.coffee
@@ -112,7 +112,7 @@ module.exports = class TomeView extends CocoView
 
   determineCodeFormat: ->
     language = @options.session.get('codeLanguage') ? me.get('aceConfig')?.language ? 'python'
-    if @options.level.isType('web-dev') or (language not in ['python', 'javascript', 'lua']) or @options.level.get('product') != 'codecombat-junior'
+    if @options.level.isType('web-dev', 'game-dev') or (language not in ['python', 'javascript', 'lua']) or @options.level.get('product') != 'codecombat-junior'
       # TODO: eventually we could get game-dev working, if we figure out how to list spawnables
       newCodeFormat = 'text-code'
     else


### PR DESCRIPTION
Also tweaking already-disabled extra disabling of game-dev levels, since they don't work at the moment.

Left is old, right is new:
<img width="979" alt="Screenshot 2024-10-18 at 12 27 33" src="https://github.com/user-attachments/assets/87dbadb6-92fb-42ca-82a2-0ff5929a2252">


When level is complete, half-width mode returns to make room for done button:
<img width="966" alt="Screenshot 2024-10-18 at 12 27 52" src="https://github.com/user-attachments/assets/c56d8140-6c2d-46fe-a174-57b9a482eada">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced button responsiveness and state management for improved user feedback during submissions.
	- Updated logic for determining code formats and spell creation based on level types.

- **Bug Fixes**
	- Improved handling of button width calculation to ensure accurate display in various scenarios.

- **Documentation**
	- Added warning comments regarding mirror session handling to guide users in specific scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->