### PR TITLE
need to use jquery-i18next in popover content formatter

### DIFF
--- a/app/views/play/level/tome/DocFormatter.coffee
+++ b/app/views/play/level/tome/DocFormatter.coffee
@@ -201,6 +201,7 @@ module.exports = class DocFormatter
       if language is @options.language then return text
       if language is 'javascript' and @options.language in ['java', 'cpp'] then return text
       return ''
+    $("<div>#{content}</div>").i18n().html()
 
   replaceSpriteName: (s) ->
     # Prefer type, and excluded the quotes we'd get with @formatValue


### PR DESCRIPTION
fix ENG-1310
![image](https://github.com/user-attachments/assets/3b30e1c4-4cd8-4d7b-9658-c65714de0b31)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced documentation generation with improved handling for various documentation types (e.g., function, event, property).
	- Added better integration for displaying formatted content in popovers.

- **Bug Fixes**
	- Improved error handling for language-specific translations and documentation examples.

- **Refactor**
	- Refined logic for generating names and formatting output based on user language preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->