### PR TITLE
Fix empty block code generation

### DIFF
--- a/test/app/lib/translate_utils.spec.js
+++ b/test/app/lib/translate_utils.spec.js
@@ -1323,4 +1323,98 @@ local z = 6
       })
     }
   })
+
+  describe('translateJS can handle empty blocks', () => {
+    const sourceByLanguage = {
+      javascript: `\
+for (let i = 0; i < 5; ++i) {
+    
+}
+
+for (let j = 0; j < 5; ++j) {
+    if (look('right') == 'crab') {
+        
+    }
+    if (look('left') == 'gem') {
+        
+    }
+}
+`,
+      cpp: `\
+for (int i = 0; i < 5; ++i) {
+    
+}
+
+for (int j = 0; j < 5; ++j) {
+    if (look("right") == "crab") {
+        
+    }
+    if (look("left") == "gem") {
+        
+    }
+}
+`,
+      java: `\
+for (int i = 0; i < 5; ++i) {
+    
+}
+
+for (int j = 0; j < 5; ++j) {
+    if (look("right") == "crab") {
+        
+    }
+    if (look("left") == "gem") {
+        
+    }
+}
+`,
+      python: `\
+for i in range(0, 5):
+    pass
+
+for j in range(0, 5):
+    if look('right') == 'crab':
+        pass
+    if look('left') == 'gem':
+        pass
+`,
+      coffeescript: `\
+for i in [0...5]
+    
+
+for j in [0...5]
+    if look('right') is 'crab'
+        
+    if look('left') is 'gem'
+        
+`,
+      lua: `\
+for i=1, 5 do
+    
+end
+
+for j=1, 5 do
+    if look('right') == 'crab' then
+        
+    end
+    if look('left') == 'gem' then
+        
+    end
+end
+`,
+    }
+
+    for (const [language, targetSource] of Object.entries(sourceByLanguage)) {
+      it(`in ${language}`, () => {
+        const translated = translateUtils.translateJS(sourceByLanguage.javascript, language, false)
+        const editDistance = levenshteinDistance(translated, targetSource)
+        if (translated !== targetSource) {
+          console.log(`\n${translated}`)
+          console.log(`\n${targetSource}`)
+        }
+        expect(translated).toBe(targetSource)
+        expect(editDistance).toEqual(0)
+      })
+    }
+  })
 })


### PR DESCRIPTION
Automatically adds `pass` statements to Python empty loops and indented empty line to CoffeeScript empty loops.

Also fixes Lua numeric for-loop indexing by starting at 1 instead of 0. I _think_ this is better, but Lua indexing is a mess.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of empty block bodies in Python and CoffeeScript translations, including automatic insertion of `pass` statements and indented empty lines.
	- Updated regex patterns for translating JavaScript for-loops, adjusting starting indices as necessary.

- **Bug Fixes**
	- Improved translation accuracy for empty for-loops and conditional statements across multiple languages.

- **Tests**
	- Introduced a new test suite validating the handling of empty blocks in various programming languages during translation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->