### PR TITLE
sometimes the campaignId isn't update but we need fetch levelNumber a…

### DIFF
--- a/ozaria/site/components/play/PagePlayLevel/index.vue
+++ b/ozaria/site/components/play/PagePlayLevel/index.vue
@@ -69,12 +69,23 @@ module.exports = Vue.extend({
     campaignId () {
       return (store.state.game.level || {}).campaign
     },
+    levelOriginal () {
+      return store.state?.game?.level?.original
+    },
   },
   watch: {
     campaignId (newCampaign) {
       if (newCampaign) {
         this.fetchLevelNumber()
       }
+    },
+    levelOriginal () {
+      this.fetchLevelNumber()
+    },
+  },
+  mounted () {
+    if (this.campaignId) {
+      this.fetchLevelNumber()
     }
   },
   methods: {


### PR DESCRIPTION
…nyway

fix ENG-1333
![image](https://github.com/user-attachments/assets/c9c5e81f-afdd-48a6-9825-461afacd6c4c)

i didn't record a gif but testing can be easy to spy any student and try several levels (esp. practice levels) can see the updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a computed property, `levelOriginal`, for enhanced level data handling.
	- Added a watcher for `levelOriginal` to trigger updates when the level changes.
	- Updated lifecycle behavior to fetch level number based on the original level data when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->