### PR TITLE
Fix ENG-1371: Fix level editor display of null stats

### DIFF
--- a/app/views/editor/level/LevelEditView.js
+++ b/app/views/editor/level/LevelEditView.js
@@ -736,6 +736,9 @@ module.exports = (LevelEditView = (function () {
     async getLevelCompletionRate () {
       if (!me.isAdmin()) { return }
       this.levelStats = await fetchLevelStats(this.level.get('original'))
+      if (this.levelStats.completionRate == null || !this.levelStats.playtime?.p50) {
+        return // No stats yet
+      }
       const rateDisplay = (this.levelStats.completionRate * 100).toFixed(1) + '%'
       this.$('#completion-rate').text(rateDisplay).removeClass('hide')
       this.$('#completion-time').text(this.levelStats.playtime.p50 + 's').attr('title', JSON.stringify(this.levelStats.playtime)).removeClass('hide')


### PR DESCRIPTION
Before, levels with no (completed) sessions yet would show "0% undefineds" in the header. Now they don't show anything unless stats appear.

### Problem
<img width="346" alt="Screenshot 2024-11-04 at 10 47 17" src="https://github.com/user-attachments/assets/f9d0dbb1-012f-4952-9962-fb89bd8134b8">

### No data format
<img width="321" alt="Screenshot 2024-11-04 at 10 47 20" src="https://github.com/user-attachments/assets/cac138a3-1737-4d92-a936-2cbfd6bbb89c">

### Fixed
<img width="193" alt="Screenshot 2024-11-04 at 10 48 34" src="https://github.com/user-attachments/assets/6db568a7-c19c-451b-bb27-d555b611ca48">

### Levels with stats still work
<img width="306" alt="Screenshot 2024-11-04 at 10 49 38" src="https://github.com/user-attachments/assets/904ef50e-30f4-4809-9bbe-037a37aba438">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling in the Level Edit View for improved stability.
	- Improved event management to prevent errors during level data transmission.

- **Bug Fixes**
	- Fixed issues with level statistics display by ensuring necessary data is available before processing.

- **Refactor**
	- Updated methods to handle parameters more robustly and refined logic for title construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->