### PR TITLE
Restart playback on code run when hero's dead or code's unchanged

### DIFF
--- a/app/lib/surface/Surface.coffee
+++ b/app/lib/surface/Surface.coffee
@@ -519,16 +519,16 @@ module.exports = Surface = class Surface extends CocoClass
     @setPlayingCalled = false  # Don't overwrite playing settings if they changed by, say, scripts.
     @frameBeforeCast = @currentFrame
     # This is where I wanted to trigger a rewind, but it turned out to be pretty complicated, since the new world gets updated everywhere, and you don't want to rewind through that.
-    shouldRestart = @options.level?.get('product') isnt 'codecombat-junior'
-    if not shouldRestart and e.spellsAreUnchanged
+    preservePlaybackPosition = @options.level?.get('product') is 'codecombat-junior'
+    if preservePlaybackPosition and e.spellsAreUnchanged
       # If we are rerunning the same code, we probably want to see what happens instead of just fast-forwarding through the same execution
-      shouldRestart = true
+      preservePlaybackPosition = false
       @frameBeforeCast = 0  # Don't fast-forward in this case
-    if not shouldRestart and @world.getThangByID('Hero Placeholder')?.health <= 0
+    if preservePlaybackPosition and @world.getThangByID('Hero Placeholder')?.health <= 0
       # If hero is currently dead, actually go back 3s: 2s before death (since world ends 1s after death)
       # That way we don't just restart playback from dead hero state at the end and not learn anything
       @frameBeforeCast = Math.max 0, Math.round(@frameBeforeCast - 3 * @world.frameRate)
-    @setProgress 0, 0 if shouldRestart
+    @setProgress 0, 0 unless preservePlaybackPosition
 
   onNewWorld: (event) ->
     return unless event.world.name is @world.name

--- a/app/schemas/subscriptions/tome.js
+++ b/app/schemas/subscriptions/tome.js
@@ -23,7 +23,8 @@ module.exports = {
     justBegin: { type: 'boolean' },
     cinematic: { type: 'boolean' },
     keyValueDb: { type: 'object' },
-    spellJustLoaded: { type: 'boolean' }
+    spellJustLoaded: { type: 'boolean' },
+    spellsAreUnchanged: { type: 'boolean', description: 'Whether the code has is the same as it was on the last cast' },
   }),
 
   'tome:manual-cast': c.object({ title: 'Manually Cast Spells', description: 'Published when you wish to manually recast all spells', required: [] },

--- a/app/views/play/level/tome/TomeView.coffee
+++ b/app/views/play/level/tome/TomeView.coffee
@@ -221,6 +221,7 @@ module.exports = class TomeView extends CocoView
     if @options.observing
       difficulty = Math.max 0, difficulty - 1  # Show the difficulty they won, not the next one.
     Backbone.Mediator.publish 'level:set-playing', {playing: false}
+    newCastSpellCode = @spells['hero-placeholder/plan']?.source
     Backbone.Mediator.publish 'tome:cast-spells', {
       @spells,
       preload,
@@ -233,8 +234,11 @@ module.exports = class TomeView extends CocoView
       flagHistory: sessionState.flagHistory ? [],
       god: @options.god,
       fixedSeed: @options.fixedSeed,
-      keyValueDb: @options.session.get('keyValueDb') ? {}
+      keyValueDb: @options.session.get('keyValueDb') ? {},
+      spellsAreUnchanged: _.isEqual(newCastSpellCode, @lastCastSpellCode)
     }
+    @lastCastSpellCode = newCastSpellCode
+    null
 
   onClick: (e) ->
     Backbone.Mediator.publish 'tome:focus-editor', {} unless $(e.target).parents('.popover').length


### PR DESCRIPTION
Fix CCJ-296: replay from beginning when you run CCJ code that you had already run before.

Fix CCJ-297: replay from t-3 when you run CCJ code when your hero is already dead.

## Old confusing behavior with no restarts/rewinds
https://github.com/user-attachments/assets/4a8e3d47-6799-4b0a-90c6-6ce318c35e29

## New behavior with smarter restarts/rewinds
https://github.com/user-attachments/assets/00c81009-7bbd-4f8f-b549-e7430429d386




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced spell casting functionality with improved state management and playback controls.
	- Added a new property to track if spells have changed, improving responsiveness during gameplay.
	- Introduced a mechanism to monitor the last cast spell's code for better spell state management.

- **Bug Fixes**
	- Improved handling of playback state based on spell conditions and world context.

- **Documentation**
	- Updated schema to include a new property for tracking spell state during casting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->