### PR TITLE
Fix empty nested loop JS->Python when at end of file

### DIFF
--- a/app/lib/translate-utils.coffee
+++ b/app/lib/translate-utils.coffee
@@ -401,7 +401,7 @@ translateJSWhitespace = (jsCode, language='lua') ->
     # Add `pass` statmeents to empty block bodies
     s = s.replace(/^([ ]*)(?![ ]*#)[^\n]+:[ ]*(?=\n+(?!\1[ ]+(?!#[^\n]*$)[^\n]+))/gm, '$&\n$1    pass')
     # ... and also when there's no trailing whitespace
-    s = s.replace(/([ ]*)(?![ ]*#)[^\n]+:$/g, '$&\n     pass')
+    s = s.replace(/([ ]*)(?![ ]*#)[^\n]+:$/g, '$&\n$1    pass')
   else if language is 'coffeescript'
     # Add indented empty block lines where they would be missing
     s = s.replace(/^([ ]*)(?![ ]*#).*(?:->|\b(?:if|then|else|unless|while|for|in)\b)(?![^\n]*(?:->|\b(?:if|then|else|unless|while|for|in)\b))[^\n]*(?=\n(?!\1[ ]+(?!#[^\n]*$)[^\n]+))/gm, '$&\n$1    ')

--- a/test/app/lib/translate_utils.spec.js
+++ b/test/app/lib/translate_utils.spec.js
@@ -1095,11 +1095,9 @@ describe('Aether / code transpilation utility library', () => {
     })
 
     describe('if JS code does not use semicolons (automatic semicolon insertion)', () => {
-      // TODO: make this one work
       it('in a simple statement', () =>
-        expect(translateUtils.translateJS('hero.moveRight()'), 'cpp').toBe('int main() {\n    hero.moveRight();\n    return 0;\n}'))
+        expect(translateUtils.translateJS('hero.moveRight()', 'cpp')).toBe('int main() {\n    hero.moveRight();\n    return 0;\n}'))
 
-      // TODO: make this one work
       it('in a complicated program', () =>
         expect(translateUtils.translateJS('function a(b, c) {\n    var d = b + c\n}\na()', 'cpp')).toBe('auto a(auto b, auto c) {\n    auto d = b + c;\n}\n\nint main() {\n    a();\n    return 0;\n}'))
 

--- a/test/app/lib/translate_utils.spec.js
+++ b/test/app/lib/translate_utils.spec.js
@@ -1433,4 +1433,74 @@ end`,
       })
     }
   })
+
+  describe('translateJS can handle empty indented blocks at end of file', () => {
+    const sourceByLanguage = {
+      javascript: `\
+for (let i = 0; i < 5; ++i) {
+    for (let j = 0; j < 5; ++j) {
+        if (look('right') == 'crab') {
+            while (health < 4) {
+                
+            }
+        }
+    }
+}`,
+      cpp: `\
+for (int i = 0; i < 5; ++i) {
+    for (int j = 0; j < 5; ++j) {
+        if (look("right") == "crab") {
+            while (health < 4) {
+                
+            }
+        }
+    }
+}`,
+      java: `\
+for (int i = 0; i < 5; ++i) {
+    for (int j = 0; j < 5; ++j) {
+        if (look("right") == "crab") {
+            while (health < 4) {
+                
+            }
+        }
+    }
+}`,
+      python: `\
+for i in range(0, 5):
+    for j in range(0, 5):
+        if look('right') == 'crab':
+            while health < 4:
+                pass`,
+      coffeescript: `\
+for i in [0...5]
+    for j in [0...5]
+        if look('right') is 'crab'
+            while health < 4
+                `,
+      lua: `\
+for i=1, 5 do
+    for j=1, 5 do
+        if look('right') == 'crab' then
+            while health < 4 do
+                
+            end
+        end
+    end
+end`,
+    }
+
+    for (const [language, targetSource] of Object.entries(sourceByLanguage)) {
+      it(`in ${language}`, () => {
+        const translated = translateUtils.translateJS(sourceByLanguage.javascript, language, false)
+        const editDistance = levenshteinDistance(translated, targetSource)
+        if (translated !== targetSource) {
+          console.log(`\n${translated}`)
+          console.log(`\n${targetSource}`)
+        }
+        expect(translated).toBe(targetSource)
+        expect(editDistance).toEqual(0)
+      })
+    }
+  })
 })


### PR DESCRIPTION
Previously, we fixed empty loops, then empty loops at end of file, but we didn't preserve whitespace properly when we did that, so now we update the regex slightly to do so.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced translation capabilities for JavaScript to Python, Lua, and CoffeeScript.
	- Improved handling of semicolons in C++ and Java.
	- Better whitespace management for function definitions across languages.
	- Logic adjustments for empty block bodies in Python and CoffeeScript.
	- New methods for translating whitespace and brackets in JavaScript.

- **Bug Fixes**
	- Refined regex patterns for accurate syntax conversion in for-loops and if-conditions.

- **Tests**
	- Expanded test coverage for the translation utility, including various JavaScript constructs and edge cases.
	- Added tests for handling of empty and indented blocks, variable declarations, and control flow structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->