### PR TITLE
Lower interpreter statement execution limit for CCJ levels

### DIFF
--- a/app/lib/aether_utils.coffee
+++ b/app/lib/aether_utils.coffee
@@ -28,7 +28,7 @@ module.exports.createAetherOptions = (options) ->
       aether_MissingThis: {level: 'error'}
     problemContext: options.problemContext
     #functionParameters: # TODOOOOO
-    executionLimit: 3 * 1000 * 1000
+    executionLimit: options.executionLimit or 3 * 1000 * 1000
     language: options.codeLanguage
     useInterpreter: true
   parameters = functionParameters[options.functionName]
@@ -72,8 +72,9 @@ module.exports.fetchToken = (source, language) =>
 
 module.exports.generateSpellsObject = (options) ->
   {level, levelSession, token} = options
-  {createAetherOptions} = require 'lib/aether_utils'
-  aetherOptions = createAetherOptions functionName: 'plan', codeLanguage: levelSession.get('codeLanguage'), skipProtectAPI: options.level?.isType('game-dev')
+  aetherOptions = module.exports.createAetherOptions functionName: 'plan', codeLanguage: levelSession.get('codeLanguage'), skipProtectAPI: options.level?.isType('game-dev')
+  if level?.get('product') is 'codecombat-junior'
+    aetherOptions.executionLimit = 100 * 1000  # Junior levels shouldn't use as many statements, can exceed execution limit earlier (100K) than normal levels (default 3M)
   spellThang = thang: {id: 'Hero Placeholder'}, aether: new Aether aetherOptions
   spells = "hero-placeholder/plan": thang: spellThang, name: 'plan'
   source = token or levelSession.get('code')?['hero-placeholder']?.plan ? ''

--- a/app/views/artisans/StudentSolutionsView.js
+++ b/app/views/artisans/StudentSolutionsView.js
@@ -25,7 +25,6 @@ const LevelSessions = require('collections/LevelSessions')
 const LevelComponent = require('models/LevelComponent')
 const ace = require('lib/aceContainer')
 const aceUtils = require('core/aceUtils')
-const { createAetherOptions } = require('lib/aether_utils')
 const loadAetherLanguage = require('lib/loadAetherLanguage')
 
 if (utils.isOzaria) {

--- a/app/views/editor/verifier/VerifierTest.js
+++ b/app/views/editor/verifier/VerifierTest.js
@@ -189,7 +189,7 @@ module.exports = class VerifierTest extends CocoClass {
     this.listenToOnce(this.god, 'infinite-loop', this.fail)
     this.listenToOnce(this.god, 'user-code-problem', this.onUserCodeProblem)
     this.listenToOnce(this.god, 'goals-calculated', this.processSingleGameResults)
-    this.god.createWorld({ spells: aetherUtils.generateSpellsObject({ levelSession: this.session, token: tokenSource }) })
+    this.god.createWorld({ spells: aetherUtils.generateSpellsObject({ level: this.level, levelSession: this.session, token: tokenSource }) })
     this.state = 'running'
     this.reportResults()
   }

--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -7,7 +7,6 @@ template = require 'app/templates/play/play-level-view'
 ThangType = require 'models/ThangType'
 utils = require 'core/utils'
 storage = require 'core/storage'
-{createAetherOptions} = require 'lib/aether_utils'
 loadAetherLanguage = require 'lib/loadAetherLanguage'
 
 # tools

--- a/app/views/play/level/tome/Spell.coffee
+++ b/app/views/play/level/tome/Spell.coffee
@@ -227,6 +227,8 @@ module.exports = class Spell
       includeFlow: includeFlow
       problemContext: problemContext
       useInterpreter: true
+    if @level.get('product') is 'codecombat-junior'
+      aetherOptions.executionLimit = 100 * 1000  # Junior levels shouldn't use as many statements, can exceed execution limit earlier (100K) than normal levels (default 3M)
     aether = new Aether aetherOptions
     if @worker
       workerMessage =


### PR DESCRIPTION
CodeCombat levels interpret a max of 3M statements before throwing an error, which can take a while to trigger on infinite loops withs slower hardware.

CodeCombat Junior levels should be much simpler as a rule, and are fairly prone to infinite loops that don't have automatic yields inserted in them once we get into the later modules that use while loops, so this sets the limit to 100K statements, which should trigger on an infinite loop quite quickly.