### PR TITLE
CCJ level generation updates

### DIFF
--- a/app/lib/level-generation.js
+++ b/app/lib/level-generation.js
@@ -312,7 +312,7 @@ const defaultHeroComponentIDs = {
 }
 
 const defaultHeroComponentConfig = {
-  Attackable: { maxHealth: 3 },
+  Attackable: { maxHealth: 4 },
   JuniorPlayer: {
     programmableSnippets: [],
     requiredThangTypes: ['5467beaf69d1ba0000fb91fb']
@@ -706,7 +706,7 @@ generateProperty(null, function (level, parameters) {
     juniorPlayer.config = _.find(heroSource.components, (component) => component.original === defaultHeroComponentIDs.JuniorPlayer).config
   } else {
     juniorPlayer.config = {
-      programmableSnippets: ['for-loop', 'if', '=='],
+      programmableSnippets: ['for-loop', 'if', '==', 'while-loop'],
       requiredThangTypes: ['5467beaf69d1ba0000fb91fb'],
     }
   }
@@ -744,7 +744,7 @@ generateProperty(null, async function (level, parameters) {
   if (sourceLevel) {
     apis = programmableSource.config.programmableProperties
   } else {
-    apis = ['go', 'hit', 'spin', 'zap', 'look']
+    apis = ['go', 'hit', 'spin', 'zap', 'look', 'heal', 'health', 'dist']
   }
 
   let solutionCode, starterCode

--- a/app/views/editor/campaign/CampaignEditorView.js
+++ b/app/views/editor/campaign/CampaignEditorView.js
@@ -67,6 +67,7 @@ module.exports = (CampaignEditorView = (function () {
         'shift+7': function (e) { this.assignModuleToSelectedLevels(7) },
         'shift+8': function (e) { this.assignModuleToSelectedLevels(8) },
         'shift+9': function (e) { this.assignModuleToSelectedLevels(9) },
+        'shift+0': function (e) { this.assignModuleToSelectedLevels(10) },
       }
     }
 

--- a/app/views/editor/verifier/VerifierTest.js
+++ b/app/views/editor/verifier/VerifierTest.js
@@ -81,7 +81,15 @@ module.exports = class VerifierTest extends CocoClass {
     me.team = (this.team = 'humans')
     this.setupGod()
     this.initGoalManager()
-    aetherUtils.fetchToken(this.solution.source, this.language)
+    let solutionSource = this.solution.source
+    if (this.level.get('product') === 'codecombat-junior') {
+      // Rewrite blank `health` calls to `hero.health`, otherwise global value assignment isn't dynamically updated
+      solutionSource = solutionSource.replace(/(^|[^a-zA-Z.])health(?!\w)/g, (match, prefix) => {
+        if (prefix.endsWith('hero.')) return match
+        return `${prefix}hero.health`
+      })
+    }
+    aetherUtils.fetchToken(solutionSource, this.language)
       .then(token => this.register(token))
   }
 

--- a/app/views/editor/verifier/VerifierView.js
+++ b/app/views/editor/verifier/VerifierView.js
@@ -104,7 +104,7 @@ module.exports = (VerifierView = (function () {
               const object = campaign.get('levels')
               for (const levelID in object) { // Would use isType, but it's not a Level model
                 const level = object[levelID]
-                if (!['hero-ladder', 'course-ladder', 'web-dev', 'ladder'].includes(level.type)) {
+                if (!['hero-ladder', 'course-ladder', 'web-dev', 'ladder'].includes(level.type) && !(campaign.get('slug') === 'junior' && /-[a-z]$/.test(level.slug))) {
                   result1.push(campaignInfo.levels.push(level.slug))
                 }
               }

--- a/app/views/play/level/tome/Spell.coffee
+++ b/app/views/play/level/tome/Spell.coffee
@@ -184,6 +184,11 @@ module.exports = class Spell
       @source = source
     else
       source = @getSource()
+    if @level.get('product') is 'codecombat-junior'
+      # Rewrite blank `health` calls to `hero.health`, otherwise global value assignment isn't dynamically updated
+      source = source.replace /(^|[^a-zA-Z.])health(?!\w)/g, (match, prefix) ->
+        return match if prefix.endsWith('hero.')
+        return "#{prefix}hero.health"
     unless @language is 'html'
       @thang?.aether.transpile source
       @session.lastAST = @thang?.aether.ast


### PR DESCRIPTION
### Update default CCJ level generation parameters 
These are the usual defaults for levels at the point in the course we're making them at.

### Add campaign editor shortcut to assign module 10 
Press Shift+0 to do it (already have Shift+1-9). I guess modules 11 and 12 will just get done by hand ;)

### Make verifier work for CCJ 
Skips practice levels, otherwise it would probably crash.

### Hack to support dynamic health global in CCJ levels 
Instead of assigning `health` -> `hero.health` statically at the start of the program, like is done in the programming.Programmable Component, we instead rewrite any bare instances of `health` to
`hero.health` in a way that's hopefully invisible to the player, so that references to `health` will get the current value.

Otherwise, code like `while health < 4:` does not work, because `health` is initialized to `4` and never updated as the hero takes damage.

Couldn't find another way around this given all the voodoo we do around making these globals work for CCJ, but seems to do fine in my testing, and should be strictly scoped to CCJ and the `health` property.