### PR TITLE
Fix CCJ-288: fix bugs with heart vs. chicken goal icons

### DIFF
--- a/app/views/play/level/LevelGoal.vue
+++ b/app/views/play/level/LevelGoal.vue
@@ -58,7 +58,7 @@
         result = []
         return result unless @product is 'codecombat-junior'
         for key, icon of goalIconImageMap when @goal[key]
-          if key is 'saveThangs' and not (_.values(@state.killed).length > 1) and @$store.state.game.heroHealth.max and @goal.saveThangs?[0] in ['Hero Placeholder', 'humans']
+          if key is 'saveThangs' and @$store.state.game.heroHealth.max and @goal.saveThangs?[0] in ['Hero Placeholder', 'humans']
             # saveThangs with just the hero; show hearts
             fullHearts = Math.max 0, @$store.state.game.heroHealth.current || 0
             emptyHearts = (@$store.state.game.heroHealth.max || 1) - fullHearts
@@ -85,7 +85,8 @@
             else
               completed = targeted - dead
             if @product is 'codecombat-junior'
-              text = text + "#{completed}/#{targeted}"
+              if @goal.saveThangs?[0] not in ['Hero Placeholder', 'humans']
+                text = text + "#{completed}/#{targeted}"
             else
               text = text + " (#{completed}/#{targeted})"
         if @state.collected and @product is 'codecombat-junior'


### PR DESCRIPTION
I had started with a `saveThangs` length condition and kept making it more specific, but actually the `saveThangs` condition was problematic in the first place, and the later conditions were sufficient.

This also makes it such that we don't show a "current / total" suffix on the health goal using a similar condition.

### Busted
<img width="889" alt="Screenshot 2024-11-04 at 15 21 20" src="https://github.com/user-attachments/assets/2ec7e41a-07cf-43fc-8b8d-6caa83aeb27f">

### Trusted
<img width="752" alt="Screenshot 2024-11-04 at 15 21 08" src="https://github.com/user-attachments/assets/e8407801-63f4-4fc6-b6ba-71939496c7f6">

### And if you die
<img width="328" alt="Screenshot 2024-11-04 at 15 20 23" src="https://github.com/user-attachments/assets/7ef81642-a035-446e-858a-8b4f82096dff">
