### PR TITLE
Fix CCJ-277: fix line counting for for-loops

### DIFF
--- a/app/lib/level-generation.js
+++ b/app/lib/level-generation.js
@@ -167,9 +167,9 @@ generateProperty('goals', function (level, parameters) {
 
     shortCode: {
       optional: false,
-      linesOfCode: { humans: 5 },
+      linesOfCode: { humans: 6 },
       id: 'short-code',
-      name: 'Under 6 statements.'
+      name: 'Only 6 lines of code'
     },
 
     moveToTarget: {


### PR DESCRIPTION
The way we parse the AST to count how many lines of code are being used was failing to take into account temp variable declarations that transpilation added to Python, Lua, C++, and Java. Now we recognize these temp variables and extra variable declarations inside the for-loop condition and reduce the count accordingly, so that the lines of code counted for goals corresponds better with the number of SLOC.

Left is before (counting 2 extra lines for the for-loop), right is after.
<img width="1026" alt="Screenshot 2024-11-07 at 11 28 38" src="https://github.com/user-attachments/assets/ec1b7d56-efa7-4010-ae8c-0871a9654dc2">
