### PR TITLE
Fix CCJ-278: restore block limits by fixing block expression counts

### DIFF
--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -2030,12 +2030,86 @@ module.exports = class SpellView extends CocoView
 
   determineMaxBlocks: ->
     return Infinity unless @options.level.get('product') is 'codecombat-junior'
-    return Infinity if _.find(Object.values(@propertyEntryGroups || {}), (peg) -> _.find(peg.props, name: 'look'))  # TODO: find a way to not include expression blocks in our limit, once we get to conditionals
     goals = @options.level.get('goals') || []
     lineGoal = _.find goals, (g) -> g.linesOfCode
-    if lineGoal
-      return lineGoal.linesOfCode.humans
-    return Infinity
+    return Infinity unless lineGoal
+    maxBlocks = lineGoal.linesOfCode.humans
+    hasLook = _.find(Object.values(@propertyEntryGroups || {}), (peg) -> _.find(peg.props, name: 'look'))
+    hasDist = _.find(Object.values(@propertyEntryGroups || {}), (peg) -> _.find(peg.props, name: 'dist'))
+    if hasLook
+      # Need to allow extra blocks for the `look(dir)`, `dist(dir)`, and `health` expressions the solution will need
+      solution = store.getters['game/getSolutionSrc'](@spell.language) or ''
+      extraExpressionCount = solution.match(/(look\(|dist\(|health)/g)?.length || 0
+
+      # Also count any if and while conditions (there is a wrapper block for (A, OP, B)
+      # In blocks, we want to count the wrapper, but in source it's easier to count the operator (which actually isn't a block but rather a field)
+      extraExpressionCount += solution.match(/^ *(if|while).*?(===|==|!==|!=|~=|<|<=|>|>=).+$/gm)?.length || 0
+
+      # Also count any numeric or string literal value blocks in if and while conditions
+      extraExpressionCount += solution.match(/^ *(if|while).*?(===|==|!==|!=|~=|<|<=|>|>=).*?['"]?[a-zA-Z0-9_$]+['"]?/gm)?.length || 0
+
+      if @spell.language is 'python'
+        # Add count of same-level blocks after control structures, because we will have to insert newline blocks for those
+        extraExpressionCount += @countSameLevelBlocks(solution)
+
+      if hasDist
+        # Also need to allow extra blocks for the 3 in go(dir, 3) expressions now that dist is an extra block
+        extraExpressionCount += solution.match(/go\(.(up|down|left|right)., \d/g)?.length || 0
+
+      maxBlocks += extraExpressionCount
+
+    return maxBlocks
+
+  countSameLevelBlocks: (code) ->
+    lines = code.split '\n'
+    stack = []  # Stack to keep track of blocks
+    count = 0
+    n = lines.length
+
+    i = 0
+    while i < n
+      line = lines[i]
+      trimmedLine = line.trim()
+
+      # Skip empty lines and comments
+      if trimmedLine == '' or trimmedLine.indexOf('#') is 0
+        i += 1
+        continue
+
+      # Get current line's indentation level
+      match = line.match /^(\s*)/
+      currentIndentation = if match then match[1].length else 0
+
+      # Handle block endings
+      while stack.length > 0 and currentIndentation <= stack[stack.length - 1].indentation
+        block = stack.pop()
+
+        # Look ahead for the next non-empty, non-comment line
+        j = i
+        found = false
+        while j < n
+          nextLine = lines[j]
+          nextTrimmedLine = nextLine.trim()
+
+          if nextTrimmedLine == '' or nextTrimmedLine.indexOf('#') is 0
+            j += 1
+            continue
+
+          matchNext = nextLine.match /^(\s*)/
+          nextIndentation = if matchNext then matchNext[1].length else 0
+
+          if nextIndentation == block.indentation
+            # Found code at the same indentation level after the block ends
+            count += 1
+          break  # Only consider the immediate next code line
+
+      # Check if the line starts a new block
+      if /^\s*(if|while|for)\b/.test trimmedLine
+        stack.push indentation: currentIndentation, lineNumber: i
+
+      i += 1
+
+    return count
 
   destroy: ->
     $(@ace?.container).find('.ace_gutter').off 'click mouseenter', '.ace_error, .ace_warning, .ace_info'


### PR DESCRIPTION
We start with limits on number of SLOC in the physical source code, then apply appropriate transformations to get to the actual expected number of blocks in the final solution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced block limit calculations in the SpellView for a more dynamic and context-aware user experience.
	- Added a method to count blocks at the same indentation level, improving code structure analysis.

- **Documentation**
	- Included comments to clarify the purpose of new logic and counting mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->