### PR TITLE
Fix CCJ-317: show Junior damage numbers

### DIFF
--- a/app/lib/surface/Lank.coffee
+++ b/app/lib/surface/Lank.coffee
@@ -286,7 +286,7 @@ module.exports = Lank = class Lank extends CocoClass
       @handledDisplayEvents[event] = true
       options = JSON.parse(event[5...])
       label = new createjs.Text options.text, "bold #{options.size or 16}px Arial", options.color or '#FFF'
-      shadowColor = {humans: '#F00', ogres: '#00F', neutral: '#0F0', common: '#0F0'}[@thang.team] ? '#000'
+      shadowColor = options.shadowColor or {humans: '#F00', ogres: '#00F', neutral: '#0F0', common: '#0F0'}[@thang.team] or '#000'
       label.shadow = new createjs.Shadow shadowColor, 1, 1, 3
       offset = @getOffset 'aboveHead'
       [label.x, label.y] = [@sprite.x + offset.x - label.getMeasuredWidth() / 2, @sprite.y + offset.y]
@@ -294,10 +294,11 @@ module.exports = Lank = class Lank extends CocoClass
       window.labels ?= []
       window.labels.push label
       label.alpha = 0
+      duration = options.duration or 2200
       createjs.Tween.get(label)
-        .to({y: label.y-2, alpha: 1}, 200, createjs.Ease.linear)
-        .to({y: label.y-12}, 1000, createjs.Ease.linear)
-        .to({y: label.y-22, alpha: 0}, 1000, createjs.Ease.linear)
+        .to({y: label.y-2, alpha: 1}, duration * 200 / 2200, createjs.Ease.linear)
+        .to({y: label.y-12}, duration * 1000 / 2200, createjs.Ease.linear)
+        .to({y: label.y-22, alpha: 0}, duration * 1000 / 2200, createjs.Ease.linear)
         .call =>
           return if @destroyed
           @options.textLayer.removeChild label


### PR DESCRIPTION
Actually, most of the code is in JuniorPlayer and already live, but this customizes the display to make it look a bit better.

![2024-11-07 14 44 26](https://github.com/user-attachments/assets/b70aa6c3-3184-4a6b-b675-d4c511cb6435)
![2024-11-07 14 44 54](https://github.com/user-attachments/assets/98ed9d3f-6649-4eca-8958-c77e7a3bf56a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced text event handling with configurable shadow colors and animation durations.
	- Improved flexibility for varied animation speeds based on context.

- **Bug Fixes**
	- Streamlined logic for text event animations to ensure timing aligns with specified durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->