### PR TITLE
Make generated Junior blocks always connect to each other

### DIFF
--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -618,7 +618,7 @@ module.exports = class LevelLoader extends CocoClass
     return if @headless and not @level.isType('web-dev')
     # This is a way (the way?) PUT /db/level.sessions/undefined was happening
     # See commit c242317d9
-    return if not @session.id
+    return if not @session?.id
     patch =
       'levelName': @level.get('name')
       'levelID': @level.get('slug') or @level.id


### PR DESCRIPTION
Previously, we would sometimes put them in separate stacks, and if they were inside another block, that would also involve adding a newline block.

I don't remember exactly why we did this, but I think it had something to do with CodeCombat and newlines and comments and such things being important.

In any case, we don't seem to need it in CodeCombat Junior, and this code change seems to do the trick, while not having any effect outside of Junior.

Able to remove a long function that was counteracting these newline blocks for maxBlocks counting in CCJ as well. (That I just added today.)

Fixes CCJ-285. Fixes CCJ-293. Fixes CCJ-284.

Before: example of auto-generated blocks having gaps and (newline) blocks:
<img width="676" alt="Screenshot 2024-11-07 at 15 16 31" src="https://github.com/user-attachments/assets/9c2dcc58-7cb2-4bb9-ba50-9e2f54229780">

After: everything's snug:
<img width="654" alt="Screenshot 2024-11-07 at 15 16 27" src="https://github.com/user-attachments/assets/ffff2a20-2278-4889-b347-b6f832079c00">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and session management in the LevelLoader, improving stability during loading processes.
	- Streamlined block linking and conversion for junior users, optimizing their experience with code-to-blocks functionality.

- **Bug Fixes**
	- Simplified logic in SpellView for determining maximum block counts, eliminating unnecessary complexity.

- **Refactor**
	- Removed outdated methods and language-specific logic in SpellView, focusing on a more generalized approach to block counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->