### PR TITLE
Fix CCJ-164: go to next level and skip CourseVictoryComponent in CCJ

### DIFF
--- a/app/views/play/level/modal/CourseVictoryModal.js
+++ b/app/views/play/level/modal/CourseVictoryModal.js
@@ -221,6 +221,11 @@ module.exports = (CourseVictoryModal = (function () {
       if (this.level.isLadder() || this.level.isProject()) {
         const index = _.indexOf(this.views, this.currentView)
         return this.showView(this.views[index + 1])
+      } else if (this.level.get('product') === 'codecombat-junior') {
+        // Skip the victory component, which has a lot of text and choices, and just keep it simple by going to the next level.
+        // If we want to present the choice between the next level and the practice level here, or allow easy "back to map" button, then we show it.
+        // But if we did, we would probably want to simplify the CourseVictoryComponent in Junior mode, because it's a bit complicated and has too much text.
+        return this.onNextLevel()
       } else {
         return this.showVictoryComponent()
       }


### PR DESCRIPTION
In classroom mode, when it's CCJ or when items and gems are on, student accounts see two modal screens on completing a level:

### RewardsView
<img width="828" alt="Screenshot 2024-11-08 at 15 39 24" src="https://github.com/user-attachments/assets/e711f028-37f5-41ed-af2c-9e6fd0b4c8ab">

### CourseVictoryComponent
<img width="772" alt="Screenshot 2024-11-08 at 15 39 58" src="https://github.com/user-attachments/assets/4ede8bb5-feb7-40ac-af45-f163eb6299d7">

For CodeCombat Junior, seeing two screens is a bit slow-paced, and the second one also has too much text. This just skips it and goes to the next level.

If we want to present the choice between the next level and the practice level here, or allow easy "back to map" button, then we could show the CourseVictoryComponent. But if we did, we would probably want to simplify it when in Junior mode, because it's a bit complicated and has too much text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Course Victory modal for junior users, simplifying their experience by streamlining the flow upon victory.
  
- **Bug Fixes**
	- Improved error handling for fetching the next level, ensuring appropriate logging for 404 errors.

- **Refactor**
	- Updated code for improved clarity and performance, including the removal of unnecessary constructs and modernization of practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->