### PR TITLE
disable auto promotion in mobile

### DIFF
--- a/app/views/home/PageHome.vue
+++ b/app/views/home/PageHome.vue
@@ -210,7 +210,7 @@
       </div>
     </div>
     <ModalJunior />
-    <HackstackAutoPromotion />
+    <HackstackAutoPromotion v-if="!isMobile" />
   </div>
 </template>
 
@@ -445,6 +445,10 @@ export default Vue.extend({
     }
   },
   computed: {
+    isMobile () {
+      return utils.isMobile()
+    },
+
     me () {
       return me
     },


### PR DESCRIPTION
fix ENG-1384
auto promotion modal isn't working good in mobile view, so disable it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a responsive design for the `HackstackAutoPromotion` component, which now only displays on non-mobile devices.

- **Bug Fixes**
	- Improved visibility control for the `HackstackAutoPromotion` component based on device type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->