### PR TITLE
Adjust block code to handle variable blocks

### DIFF
--- a/app/core/blocklyUtils.js
+++ b/app/core/blocklyUtils.js
@@ -43,7 +43,7 @@ module.exports.createBlocklyToolbox = function ({ propertyEntryGroups, generator
       propNames.add(prop.name)
     }
     if (/programmaticon/i.test(owner)) continue
-    const userBlocks = mergedPropertyEntryGroups[owner].props.filter(prop => !(['for-loop', 'if', '==', '!=', 'while-loop', '<', '>'].includes(prop.name))).map(prop =>
+    const userBlocks = mergedPropertyEntryGroups[owner].props.filter(prop => !(['for-loop', 'if', '==', '!=', 'while-loop', '<', '>', 'variable'].includes(prop.name))).map(prop =>
       createBlock({ owner, prop, generator, codeLanguage, codeFormat, level, superBasicLevels, propNames })
     )
     userBlockCategories.push({ kind: 'category', name: owner === 'Hero' ? '' : owner, colour: '190', contents: userBlocks })
@@ -639,7 +639,13 @@ module.exports.createBlocklyToolbox = function ({ propertyEntryGroups, generator
       name: 'Variables',
       colour: '50',
       custom: 'VARIABLE',
-      include () { return (propNames.has('while-true loop') || propNames.has('while-loop')) && level?.get('product') !== 'codecombat-junior' } // TODO: better targeting of when we introduce this logic? It's after while-true loops, but doesn't have own 'variables' entry in Programmaticon
+      include () {
+        if (level?.get('product') === 'codecombat-junior') {
+          return propNames.has('variable')
+        }
+        // TODO: better targeting of when we introduce this logic? It's after while-true loops, but doesn't have own 'variables' entry in Programmaticon
+        return (propNames.has('while-true loop') || propNames.has('while-loop'))
+      },
     },
     {
       kind: 'category',

--- a/app/lib/code-to-blocks.js
+++ b/app/lib/code-to-blocks.js
@@ -477,7 +477,7 @@ class Converters {
         // TODO: make general, not just based on callee.name being one of the methods where we do this
         const toArg = args.splice(0, 1)
         out.fields = { to: toArg[0].fields.TEXT }
-        const convertsSquaresToFields = !/dist\(/.test(ctx.code) // Don't do this once we start using `dist` function
+        const convertsSquaresToFields = !_.find(ctx.plan, (entry) => entry[0].type === 'Hero_dist') // Don't do this once we start using `dist` function or variables
         if (args.length && convertsSquaresToFields) {
           // Remove second argument; convert to field
           const squaresArg = args.splice(0, 1)

--- a/app/lib/level-generation.js
+++ b/app/lib/level-generation.js
@@ -706,7 +706,7 @@ generateProperty(null, function (level, parameters) {
     juniorPlayer.config = _.find(heroSource.components, (component) => component.original === defaultHeroComponentIDs.JuniorPlayer).config
   } else {
     juniorPlayer.config = {
-      programmableSnippets: ['for-loop', 'if', '==', 'while-loop'],
+      programmableSnippets: ['for-loop', 'if', '==', 'while-loop', 'variable'],
       requiredThangTypes: ['66873b397eff730c9e750994', '62050186cb069a0023866b0d'],
     }
   }

--- a/app/lib/level-generation.js
+++ b/app/lib/level-generation.js
@@ -706,7 +706,7 @@ generateProperty(null, function (level, parameters) {
     juniorPlayer.config = _.find(heroSource.components, (component) => component.original === defaultHeroComponentIDs.JuniorPlayer).config
   } else {
     juniorPlayer.config = {
-      programmableSnippets: ['for-loop', 'if', '==', 'while-loop', 'variable'],
+      programmableSnippets: ['for-loop', 'if', '==', 'while-loop', '<', '>', 'variable'],
       requiredThangTypes: ['66873b397eff730c9e750994', '62050186cb069a0023866b0d'],
     }
   }

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -2036,6 +2036,7 @@ module.exports = class SpellView extends CocoView
     maxBlocks = lineGoal.linesOfCode.humans
     hasLook = _.find(Object.values(@propertyEntryGroups || {}), (peg) -> _.find(peg.props, name: 'look'))
     hasDist = _.find(Object.values(@propertyEntryGroups || {}), (peg) -> _.find(peg.props, name: 'dist'))
+    hasVars = _.find(Object.values(@propertyEntryGroups || {}), (peg) -> _.find(peg.props, name: 'variable'))
     if hasLook
       # Need to allow extra blocks for the `look(dir)`, `dist(dir)`, and `health` expressions the solution will need
       solution = store.getters['game/getSolutionSrc'](@spell.language) or ''
@@ -2051,6 +2052,9 @@ module.exports = class SpellView extends CocoView
       if hasDist
         # Also need to allow extra blocks for the 3 in go(dir, 3) expressions now that dist is an extra block
         extraExpressionCount += solution.match(/go\(.(up|down|left|right)., \d/g)?.length || 0
+
+      if hasVars
+        return Infinity  # TODO: figure out how to count the var blocks
 
       maxBlocks += extraExpressionCount
 


### PR DESCRIPTION
Didn't figure out how to count blocks for max blocks limit for variables yet, but that's not a big deal at this point in the campaign–just disabled the block-side limits. (Not many levels have line-of-code limits once variables are included, and the goals still limit them, just not the blocks.)

<img width="1033" alt="Screenshot 2024-11-14 at 15 31 07" src="https://github.com/user-attachments/assets/ceeffb9d-fb5b-4055-9f03-97dfaadb864c">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced filtering logic for user-defined blocks, now excluding blocks named 'variable.'
  - Added support for user-defined variables in the Blockly interface, allowing for more flexible programming tasks.
  - Introduced new programmable snippets, including '<', '>', and 'variable,' to improve the hero component's capabilities.

- **Bug Fixes**
  - Improved error handling and validation in level generation to ensure compliance with defined criteria.

- **Documentation**
  - Updated comments and documentation for clarity on new functionalities and logic changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->