### PR TITLE
use fetch options correctly

### DIFF
--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -1894,6 +1894,7 @@ module.exports = {
       courses_suffix: '',
       course_prefix: 'Course',
       course_suffix: '',
+      activate_license: 'Activate License',
       licenses_activated_success: 'Licenses have been Activated Successfully!',
       license_code_used: 'License Code used.',
     },

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -1818,6 +1818,8 @@ module.exports = {
       initial_free_courses_description: '*Courses can be updated using Assign Content after creating class too.',
       junior_code_format_only: 'Blocks (Icons) only available for Junior',
       hackstack_no_code_language_format: 'AI HackStack does not need a programming language or code format',
+      licenses_activated_success: 'Licenses have been Activated Successfully!',
+      license_code_used: 'License Code used.',
     },
 
     no_licenses_page: {
@@ -1894,9 +1896,6 @@ module.exports = {
       courses_suffix: '',
       course_prefix: 'Course',
       course_suffix: '',
-      activate_license: 'Activate License',
-      licenses_activated_success: 'Licenses have been Activated Successfully!',
-      license_code_used: 'License Code used.',
     },
 
     teachers_quote: {
@@ -4717,6 +4716,7 @@ module.exports = {
       ai_league_curriculum_blurb: 'Access our comprehensive curriculum guides designed specifically for AI League arenas. These resources help you introduce competitive coding concepts and teach strategic thinking.',
       ai_league_custom_title: 'Custom AI League Tournaments',
       ai_league_custom_blurb: "Create your own customized tournaments to engage your students! Select from our library of coding arenas and set competition dates, whether it's a classroom challenge or a school-wide competition.",
+      activate_license: 'Activate License',
     },
 
     outcomes: {

--- a/app/views/teachers/JoinLicensesByCode.vue
+++ b/app/views/teachers/JoinLicensesByCode.vue
@@ -1,12 +1,12 @@
 <script>
-import { mapActions } from 'vuex'
-import { COMPONENT_NAMES, PAGE_TITLES } from '../common/constants.js'
+import { mapActions, mapMutations } from 'vuex'
+import { COMPONENT_NAMES, PAGE_TITLES } from 'ozaria/site/components/teacher-dashboard/common/constants.js'
 export default {
-  name: COMPONENT_NAMES.ACTIVATE_LICENSES,
+  name: COMPONENT_NAMES.ACTIVATE_LICENSE,
   data () {
     return {
       state: 'loading',
-      result: {}
+      result: {},
     }
   },
   mounted () {
@@ -19,7 +19,10 @@ export default {
   },
   methods: {
     ...mapActions({
-      joinByCodes: 'prepaids/joinPrepaidByCodes'
+      joinByCodes: 'prepaids/joinPrepaidByCodes',
+    }),
+    ...mapMutations({
+      setPageTitle: 'teacherDashboard/setPageTitle',
     }),
     post () {
       this.joinByCodes(this.$route.query).then((res) => {
@@ -36,7 +39,7 @@ export default {
         if (state === 'success') {
           setTimeout(() => {
             application.router.navigate('/teachers/licenses', { trigger: true })
-          }, 3000)
+          }, 5000)
         }
       })
     }

--- a/app/views/teachers/JoinLicensesByCode.vue
+++ b/app/views/teachers/JoinLicensesByCode.vue
@@ -19,10 +19,7 @@ export default {
       joinByCodes: 'prepaids/joinPrepaidByCodes'
     }),
     post () {
-      this.joinByCodes({
-        method: 'POST',
-        json: this.$route.query
-      }).then((res) => {
+      this.joinByCodes(this.$route.query).then((res) => {
         let state = 'success'
         for (const code in res) {
           if (!res[code] || typeof res[code] === 'string') {

--- a/app/views/teachers/JoinLicensesByCode.vue
+++ b/app/views/teachers/JoinLicensesByCode.vue
@@ -1,6 +1,8 @@
 <script>
 import { mapActions } from 'vuex'
+import { COMPONENT_NAMES, PAGE_TITLES } from '../common/constants.js'
 export default {
+  name: COMPONENT_NAMES.ACTIVATE_LICENSES,
   data () {
     return {
       state: 'loading',
@@ -8,6 +10,7 @@ export default {
     }
   },
   mounted () {
+    this.setPageTitle(PAGE_TITLES[this.$options.name])
     if (this.$route.query.codes) {
       this.post()
     } else {
@@ -22,7 +25,7 @@ export default {
       this.joinByCodes(this.$route.query).then((res) => {
         let state = 'success'
         for (const code in res) {
-          if (!res[code] || typeof res[code] === 'string') {
+          if (!res[code] || res[code] !== 'success') {
             state = 'partly-failed'
             break
           }

--- a/ozaria/site/components/teacher-dashboard/common/constants.js
+++ b/ozaria/site/components/teacher-dashboard/common/constants.js
@@ -12,6 +12,7 @@ export const COMPONENT_NAMES = {
   AI_LEAGUE: 'AILeague',
   CURRICULUM_GUIDE: 'BaseCurriculumGuide',
   APCSP: 'APCSPPage',
+  ACTIVATE_LICENSE: 'ActivateLicense',
 }
 
 export const PAGE_TITLES = {
@@ -21,5 +22,6 @@ export const PAGE_TITLES = {
   [COMPONENT_NAMES.PD]: 'pd',
   [COMPONENT_NAMES.AI_LEAGUE]: 'ai_league',
   [COMPONENT_NAMES.APCSP]: 'apcsp',
-  [COMPONENT_NAMES.CURRICULUM_GUIDE]: 'curriculum_guide'
+  [COMPONENT_NAMES.CURRICULUM_GUIDE]: 'curriculum_guide',
+  [COMPONENT_NAMES.ACTIVATE_LICENSE]: 'activate_license',
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9534713c-bc87-4473-a717-45fde3f77da8)
fix ENG-1423

the `joinByCodes` function uses the options as `json`  and ready make the `method: POST` so should only use query as options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the license joining process with streamlined data handling.
	- Improved English localization with new sections and refined descriptions for educational offerings.

- **Bug Fixes**
	- Maintained existing control flow and error handling logic for processing results from the join operation.

- **Chores**
	- Updated method signature for clarity and improved functionality.
	- Added new constants for component names and page titles in the teacher dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->