### PR TITLE
show language and code format picker whenever playing first level of …

### DIFF
--- a/app/lib/LevelSetupManager.coffee
+++ b/app/lib/LevelSetupManager.coffee
@@ -92,9 +92,8 @@ module.exports = class LevelSetupManager extends CocoClass
   open: ->
     return @waitingToOpen = true unless @modalsLoaded
     firstModal = if @options.hadEverChosenHero then @inventoryModal else @heroesModal
-    if @options.levelID is 'the-gem' && not me.isStudent()
+    if @options.levelID is 'the-gem'
       # show hero picker for the first level (the-gem) in junior to default to blocks-text
-      console.log 'Showing hero picker for the-gem in junior to default to blocks-text'
       firstModal = @heroesModal
     else if ((not _.isEqual(lastHeroesEarned, me.get('earned')?.heroes ? []) or
         not _.isEqual(lastHeroesPurchased, me.get('purchased')?.heroes ? [])) and

--- a/app/lib/LevelSetupManager.coffee
+++ b/app/lib/LevelSetupManager.coffee
@@ -92,7 +92,11 @@ module.exports = class LevelSetupManager extends CocoClass
   open: ->
     return @waitingToOpen = true unless @modalsLoaded
     firstModal = if @options.hadEverChosenHero then @inventoryModal else @heroesModal
-    if ((not _.isEqual(lastHeroesEarned, me.get('earned')?.heroes ? []) or
+    if @options.levelID is 'the-gem' && not me.isStudent()
+      # show hero picker for the first level (the-gem) in junior to default to blocks-text
+      console.log 'Showing hero picker for the-gem in junior to default to blocks-text'
+      firstModal = @heroesModal
+    else if ((not _.isEqual(lastHeroesEarned, me.get('earned')?.heroes ? []) or
         not _.isEqual(lastHeroesPurchased, me.get('purchased')?.heroes ? [])) and
         (utils.isOzaria or not (me.isAnonymous() and me.isInHourOfCode())))
       console.log 'Showing hero picker because heroes earned/purchased has changed.'

--- a/app/views/play/common/ChangeLanguageTab.js
+++ b/app/views/play/common/ChangeLanguageTab.js
@@ -40,7 +40,14 @@ module.exports = (ChangeLanguageTab = (function () {
       this.codeFormat = this.options.codeFormat || me.get('aceConfig')?.codeFormat || defaultCodeFormat
       if (this.isJunior && options.level?.get('slug') === 'the-gem') {
         // let's default to blocks-text for the-gem (first level) in junior so that users can see the blocks
-        this.codeFormat = 'blocks-text'
+        const blockFormat = 'blocks-text'
+        if (me.isStudent()) {
+          if (this.classroomAceConfig?.codeFormats?.includes(blockFormat)) {
+            this.codeFormat = blockFormat
+          }
+        } else {
+          this.codeFormat = blockFormat
+        }
       }
       this.codeLanguage = this.options?.session?.get('codeLanguage') || me.get('aceConfig')?.language || 'python'
 

--- a/app/views/play/common/ChangeLanguageTab.js
+++ b/app/views/play/common/ChangeLanguageTab.js
@@ -40,7 +40,7 @@ module.exports = (ChangeLanguageTab = (function () {
       this.codeFormat = this.options.codeFormat || me.get('aceConfig')?.codeFormat || defaultCodeFormat
       if (this.isJunior && options.level?.get('slug') === 'the-gem') {
         // let's default to blocks-text for the-gem (first level) in junior so that users can see the blocks
-        const blockFormat = 'blocks-text'
+        const blockFormat = 'blocks-icons'
         if (me.isStudent()) {
           if (this.classroomAceConfig?.codeFormats?.includes(blockFormat)) {
             this.codeFormat = blockFormat

--- a/app/views/play/common/ChangeLanguageTab.js
+++ b/app/views/play/common/ChangeLanguageTab.js
@@ -36,7 +36,12 @@ module.exports = (ChangeLanguageTab = (function () {
       this.utils = utils
       this.codeLanguageObject = utils.getCodeLanguages()
       this.codeFormatObject = utils.getCodeFormats()
-      this.codeFormat = this.options.codeFormat || me.get('aceConfig')?.codeFormat || 'text-code'
+      const defaultCodeFormat = 'text-code'
+      this.codeFormat = this.options.codeFormat || me.get('aceConfig')?.codeFormat || defaultCodeFormat
+      if (this.isJunior && options.level?.get('slug') === 'the-gem') {
+        // let's default to blocks-text for the-gem (first level) in junior so that users can see the blocks
+        this.codeFormat = 'blocks-text'
+      }
       this.codeLanguage = this.options?.session?.get('codeLanguage') || me.get('aceConfig')?.language || 'python'
 
       this.updateCodeFormatList()


### PR DESCRIPTION
…junior, default to blocks on picker when level is the-gem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced modal handling for user sessions, including new conditions for displaying modals based on user context.
	- Improved language selection functionality with refined conditions based on user roles and device types.

- **Bug Fixes**
	- Adjusted logic to ensure appropriate code formats and languages are available based on user status and device constraints.

- **Refactor**
	- Streamlined code structure for better clarity and maintainability in modal and language handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->