### PR TITLE
Removed predefined hero Captain for assessment levels in classrooms

### DIFF
--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -337,9 +337,6 @@ module.exports = class LevelLoader extends CocoClass
       when utils.isOzaria
         # Use configured Ozaria hero
         me.get('ozariaUserOptions')?.isometricThangTypeOriginal or ThangType.heroes['hero-b']
-      when @level.isAssessment() and me.showHeroAndInventoryModalsToStudents()
-        # Set default hero for assessment levels in class if classroomItems is on
-        ThangType.heroes.captain
       when session.get('heroConfig')?.thangType
         # Use the hero set in the session
         session.get('heroConfig').thangType

--- a/app/models/Level.js
+++ b/app/models/Level.js
@@ -313,10 +313,6 @@ module.exports = (Level = (function () {
           if (!heroThangType) {
             heroThangType = ThangTypeConstants.heroes.knight
           }
-          // For assessments, use default hero in class if classroomItems is on
-          if (this.isAssessment() && me.showHeroAndInventoryModalsToStudents()) {
-            heroThangType = ThangTypeConstants.heroes.captain
-          }
           if (heroThangType) {
             let juniorHeroReplacement
             if (this.get('product', true) === 'codecombat-junior') {


### PR DESCRIPTION
Closes [GD-281](https://linear.app/codecombat/issue/GD-281/check-for-challenge-level-type-levels)

I tested locally through a proxy, and it looks like there are no problems. I have no idea where, but the hero size and speed are set correctly somewhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced loading mechanism for levels and sessions, improving flexibility and robustness.
	- Improved error handling and logging during level loading processes.
  
- **Bug Fixes**
	- Adjusted hero selection logic during assessments to allow for varied configurations.

- **Refactor**
	- Streamlined code by removing unnecessary conditions and comments related to assessment logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->