### PR TITLE
catch an ai translation error

### DIFF
--- a/app/locale/vi.js
+++ b/app/locale/vi.js
@@ -2223,7 +2223,7 @@ module.exports = {
       //    play_now_learn_3: "strings & variables to customize actions",
       play_now_learn_4: '[AI_TRANSLATION]làm sao để đánh bại một con quỷ ogre (kỹ năng sống quan trọng!)',
       welcome_to_page: 'Chào mừng bạn đến với trang quản lý khóa học!',
-      my_classes: '[AI_TRANSLATION]Tấn công `"#{_.string.titleize(target)}"`, không phải `"#{target}"`. (Chữ cái in hoa là quan trọng.)',
+      my_classes: 'Lớp của tôi',
       class_added: '[AI_TRANSLATION]Đã thêm lớp học thành công!',
       view_map: '[AI_TRANSLATION]xem bản đồ',
       view_videos: '[AI_TRANSLATION]xem video',


### PR DESCRIPTION
ai translation sometimes split the translation error and make the wrong mapping. it is hard to catch it, so can only fix one if we met one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated localization files for Vietnamese language support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->