### PR TITLE
ENG-1441 - Adamk/junior links from marketing pages

### DIFF
--- a/app/components/common/Navigation.vue
+++ b/app/components/common/Navigation.vue
@@ -7,7 +7,8 @@ import {
   isCodeCombat,
   isOzaria,
   OZARIA,
-  ozBaseURL
+  ozBaseURL,
+  getJuniorUrl,
 } from 'core/utils'
 import AnnouncementModal from '../../views/announcement/announcementModal'
 import AnnouncementNav from '../../views/announcement/AnnouncementNav'
@@ -36,7 +37,7 @@ export const items = {
   GRANTS: { url: cocoPath('/grants'), title: 'nav.grants_funding_resources' },
   DEMO: { url: '/teachers/quote', title: 'nav.request_quote_demo' },
   COCO_CLASSROOM: { url: cocoPath('/schools'), title: 'nav.codecombat_classroom' },
-  COCO_JUNIOR: { url: cocoPath('/play/junior'), title: 'nav.coco_junior' },
+  COCO_JUNIOR: { url: getJuniorUrl(), title: 'nav.coco_junior' },
   COCO_HOME: { url: cocoPath('/play'), title: 'nav.codecombat_home' },
   OZ_CLASSROOM: { url: ozPath('/'), title: 'nav.ozaria_classroom' },
   AP_CSP: { url: cocoPath('/apcsp'), title: 'nav.ap_csp' },

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -1699,6 +1699,14 @@ module.exports.secondsToMinutesAndSeconds = function (seconds) {
   return `${minutes}:${remainingSeconds < 10 ? '0' : ''}${remainingSeconds}`
 }
 
+module.exports.getJuniorUrl = function() {
+  let juniorPath = '/play/junior'
+  if(me && me.isTeacher() && !me.isAnonymous()) {
+    juniorPath = '/teachers/curriculum/junior'
+  }
+  return `${cocoBaseURL()}${juniorPath}`
+}
+
 module.exports = {
   ...module.exports,
   activeAndPastArenas,

--- a/app/views/home/ModalJunior.vue
+++ b/app/views/home/ModalJunior.vue
@@ -1,7 +1,7 @@
 <script>
 import ModalDynamicContent from 'ozaria/site/components/teacher-dashboard/modals/ModalDynamicContent'
 import trackable from 'app/components/mixins/trackable.js'
-import { cocoBaseURL } from 'core/utils'
+import { getJuniorUrl } from 'core/utils'
 
 import CTAButton from 'app/components/common/buttons/CTAButton.vue'
 
@@ -13,11 +13,7 @@ export default Vue.extend({
   mixins: [trackable],
   computed: {
     href () {
-      let path = '/play/junior'
-      if (me.isTeacher() && !me.isAnonymous()) {
-        path = '/teachers/curriculum'
-      }
-      return `${cocoBaseURL()}${path}`
+      return getJuniorUrl()
     },
     isBeforeEndOfSeptember () {
       const now = new Date()

--- a/app/views/home/PageHome.vue
+++ b/app/views/home/PageHome.vue
@@ -233,6 +233,7 @@ import BaseCloudflareVideo from '../../components/common/BaseCloudflareVideo.vue
 import HeaderComponent from '../../components/common/elements/HeaderComponent.vue'
 import ModalJunior from './ModalJunior'
 import HackstackAutoPromotion from '../ai/HackstackAutoPromotion'
+import { getJuniorUrl } from 'core/utils'
 
 const utils = require('core/utils')
 const paymentUtils = require('app/lib/paymentUtils')
@@ -374,7 +375,7 @@ export default Vue.extend({
         {
           title: this.$t('home_v3.young_learners_1_title'),
           text: this.$t('home_v3.young_learners_1_text'),
-          link: 'https://codecombat.com/play/junior',
+          link: getJuniorUrl(),
           linkText: this.$t('home_v3.try_it_now'),
           image: '/images/pages/home-v3/young-learners/box-bg-coco-jr.webp',
         },

--- a/app/views/landing-pages/hoc/PageHoc.vue
+++ b/app/views/landing-pages/hoc/PageHoc.vue
@@ -56,6 +56,7 @@ import PageParentsLanding from 'app/views/landing-pages/parents/PageParents'
 import CTAButton from 'app/components/common/buttons/CTAButton.vue'
 import MixedColorLabel from 'app/components/common/labels/MixedColorLabel.vue'
 import BoxPanel from 'app/components/common/elements/BoxPanel.vue'
+import { getJuniorUrl } from 'core/utils'
 
 export default {
   name: 'PageHoc',
@@ -95,7 +96,7 @@ export default {
           links: [
             {
               linkText: $.i18n.t('hoc_page.try_activity'),
-              link: 'https://codecombat.com/play/junior',
+              link: getJuniorUrl(),
             },
             {
               linkText: $.i18n.t('hoc_page.view_lesson'),

--- a/test/app/core/utils.spec.coco.js
+++ b/test/app/core/utils.spec.coco.js
@@ -1313,4 +1313,36 @@ describe('Utility library', function () {
       expect(utils.secondsToMinutesAndSeconds(9)).toEqual('0:09');
     });
   });
+
+  fdescribe('getJuniorUrl', () => {
+    let me;
+    let originalMe;
+  
+    beforeEach(() => {
+      // Save the original 'me' object
+      originalMe = global.me;
+  
+      me = {
+        isTeacher: jasmine.createSpy(),
+        isAnonymous: jasmine.createSpy()
+      };
+      global.me = me;
+    });
+  
+    afterEach(() => {
+      // Restore the original 'me' object after each test
+      global.me = originalMe;
+    });
+  
+    it('should return junior path for non-teacher or anonymous users', () => {
+      me.isTeacher.and.returnValue(false);
+      expect(utils.getJuniorUrl()).toEqual(`${utils.cocoBaseURL()}/play/junior`);
+    });
+  
+    it('should return teacher curriculum path for non-anonymous teachers', () => {
+      me.isTeacher.and.returnValue(true);
+      me.isAnonymous.and.returnValue(false);
+      expect(utils.getJuniorUrl()).toEqual(`${utils.cocoBaseURL()}/teachers/curriculum/junior`);
+    });
+  });
 })

--- a/test/app/core/utils.spec.coco.js
+++ b/test/app/core/utils.spec.coco.js
@@ -1314,7 +1314,7 @@ describe('Utility library', function () {
     });
   });
 
-  fdescribe('getJuniorUrl', () => {
+  describe('getJuniorUrl', () => {
     let me;
     let originalMe;
   


### PR DESCRIPTION
 - create utils method to figure out junior url
 - replace all pages where we had link to `/play/junior`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a dynamic URL generation for the junior section, enhancing accessibility based on user roles (teachers vs. anonymous users).
  
- **Bug Fixes**
  - Improved maintainability by replacing hardcoded URLs with the new `getJuniorUrl()` function across various components.

- **Tests**
  - Added a test suite for the `getJuniorUrl` function to ensure correct URL generation based on user roles, improving overall test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->