### PR TITLE
use code language passed in the parameter and disable selection in th…

### DIFF
--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -440,7 +440,7 @@ export default function getVueRouter () {
               path: 'start',
               name: 'ExamStartPage',
               component: () => import(/* webpackChunkName: "examPage" */'app/views/exams/StartPage'),
-              props: true,
+              props: (route) => ({ ...route.query, ...route.params }),
             },
             {
               path: 'progress',

--- a/app/views/exams/ExamPage.vue
+++ b/app/views/exams/ExamPage.vue
@@ -24,6 +24,11 @@ export default {
       type: String,
       default: 'start',
     },
+    codeLang: {
+      type: String,
+      required: false,
+      default: '',
+    },
   },
   data () {
     return {

--- a/app/views/exams/StartPage.vue
+++ b/app/views/exams/StartPage.vue
@@ -8,7 +8,7 @@
         <select
           id="language-select"
           v-model="codeLanguage"
-          :disabled="!isNewUser"
+          :disabled="!isNewUser || disableCodeLang"
           class="form-control"
         >
           <option
@@ -67,12 +67,18 @@ export default {
       type: String,
       required: true,
     },
+    codeLang: {
+      type: String,
+      required: false,
+      default: '',
+    },
   },
   data () {
     return {
       codeLanguage: 'python',
       timer: false,
       loading: false,
+      disableCodeLang: false,
     }
   },
   computed: {
@@ -119,6 +125,9 @@ export default {
     this.checkingUserExam()
     if (this.userExam?.codeLanguage) {
       this.codeLanguage = this.userExam.codeLanguage
+    } else if (this.codeLang && this.avaliableLanguages.includes(this.codeLang)) {
+      this.codeLanguage = this.codeLang
+      this.disableCodeLang = true
     }
   },
   methods: {


### PR DESCRIPTION
…at case

fixes ENG-1450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional prop `codeLang` in both the `ExamPage` and `StartPage` components to enhance programming language selection.
	- Enhanced control over route parameters for the `ExamStartPage` route, allowing for more explicit handling of route data.

- **Bug Fixes**
	- Improved logic for disabling the language selection dropdown based on the presence of the `codeLang` prop.

- **Documentation**
	- Updated prop definitions for `ExamPage` and `StartPage` components to include the new `codeLang` prop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->