### PR TITLE
ENG-1451 - Replace US flag with English (US)

### DIFF
--- a/app/components/common/Navigation.vue
+++ b/app/components/common/Navigation.vue
@@ -563,10 +563,6 @@ export default Vue.extend({
 #main-nav.navbar {
   background: white;
 
-  ::v-deep .emoji-flag {
-    font-size: 30px
-  }
-
   // Add dark mode styles
   &.dark-mode {
 

--- a/app/views/core/RootView.coffee
+++ b/app/views/core/RootView.coffee
@@ -207,10 +207,7 @@ module.exports = class RootView extends CocoView
     $('body').attr('lang', preferred)
 
   initializeLanguageDropdown: (newLang) ->
-    if newLang isnt 'en-US'
-      @$el.find('.language-dropdown-current')?.text(locale[newLang].nativeDescription)
-    else
-      @$el.find('.language-dropdown-current')?.html("<span class=\"emoji-flag\">🇺🇸</span>")
+    @$el.find('.language-dropdown-current')?.text(locale[newLang].nativeDescription)
 
   addLanguagesToSelect: ($select, initialVal) ->
     # For now, we only want to support a few languages for Ozaria that we have people working to translate.


### PR DESCRIPTION
<img width="2280" alt="CodeCombat_AI_and_CodeCombat_-_Coding_games_to_learn_Python_and_JavaScript___CodeCombat_and_eng__Channel__-_CodeCombat_Core_-_Slack" src="https://github.com/user-attachments/assets/a00b6113-6bfe-45b3-b609-97af35f67d8a">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for URL generation in the navigation component, enhancing consistency.
  
- **Bug Fixes**
	- Simplified the language dropdown initialization to always display the correct language description without conditional checks.

- **Refactor**
	- Removed specific style rules in the navigation component for a cleaner design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->