### PR TITLE
Fix Languag Dropdown in Settings view

### DIFF
--- a/app/views/account/AccountSettingsView.js
+++ b/app/views/account/AccountSettingsView.js
@@ -20,7 +20,6 @@ const forms = require('core/forms')
 const User = require('models/User')
 const ConfirmModal = require('views/core/ConfirmModal')
 const { logoutUser, me } = require('core/auth')
-const RootView = require('views/core/RootView')
 const CreateAccountModal = require('views/core/CreateAccountModal')
 const globalVar = require('core/globalVar')
 const utils = require('core/utils')
@@ -28,7 +27,7 @@ const RobloxButton = require('./robloxButton.vue').default
 const DashboardToggle = require('ozaria/site/components/teacher-dashboard/common/DashboardToggle.vue').default
 
 module.exports = (AccountSettingsView = (function () {
-  AccountSettingsView = class AccountSettingsView extends RootView {
+  AccountSettingsView = class AccountSettingsView extends CocoView {
     static initClass () {
       this.prototype.id = 'account-settings-view'
       this.prototype.template = template


### PR DESCRIPTION
If `AccountSettingsView` is inherited from `RootView`, it'll call the `buildLanguages` method, but [$el](https://github.com/codecombat/codecombat/blob/8b089c9d30eb6ee93ab1425954eaf358c8f7f653/app/views/core/RootView.coffee#L204) won't contain the language dropdown, since it is in the header. Thus languages won't be initialised because [condition](https://github.com/codecombat/codecombat/blob/8b089c9d30eb6ee93ab1425954eaf358c8f7f653/app/views/core/RootView.coffee#L225-L226) will fail.

I don't know why it was inherited from `RootView`, and not from `CocoView`, but as far as I tested, I didn't find any issues. 

![Account_Settings___CodeCombat_and_Fiókbeállítások___CodeCombat_and_Comparing_master___adamk_fix-settings-languag-dropdown_·_codecombat_codecombat](https://github.com/user-attachments/assets/686c02ee-69db-4b2c-862d-fd9044110561)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved user object management for enhanced data handling in account settings.
  
- **Bug Fixes**
	- Adjusted class inheritance to ensure better functionality and properties for the `AccountSettingsView`.

- **Refactor**
	- Minor refactor of the `validateCredentialsForDestruction` method for improved behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->