### PR TITLE
add is clone to ai-project

### DIFF
--- a/app/schemas/models/ai_project.schema.js
+++ b/app/schemas/models/ai_project.schema.js
@@ -72,6 +72,11 @@ _.extend(AIProjectSchema.properties, {
     title: 'Changed',
     readOnly: true,
   }),
+  isPublic: {
+    title: 'Is Public',
+    type: 'boolean',
+    description: 'Whether this project is public',
+  },
 })
 
 AIProjectSchema.required = ['visibility', 'user', 'scenario', 'actionQueue']


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property, `isPublic`, to the AI project schema, allowing users to specify if a project is public.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->