### PR TITLE
Move junior's next level button

### DIFF
--- a/app/schemas/subscriptions/play.js
+++ b/app/schemas/subscriptions/play.js
@@ -23,6 +23,10 @@ module.exports = {
   }
   ),
 
+  'level:overallStatus-changed': c.object({ required: ['overallStatus'] },
+    { overallStatus: { type: ['string', 'null', 'undefined'] } },
+  ),
+
   'level:set-letterbox': c.object({},
     { on: { type: 'boolean' } }),
 

--- a/app/styles/play/level/control-bar-view.sass
+++ b/app/styles/play/level/control-bar-view.sass
@@ -172,13 +172,22 @@
         .hamburger span.icon-bar
           background-color: $control-yellow-highlight
 
-    #level-done-button, #next-game-button, #control-bar-sign-up-button
+    #next-game-button, #control-bar-sign-up-button
       top: 7px
       font-size: 13px
       height: 24px
 
     #level-done-button
-      display: none
+      top: 3px
+      font-size: 13px
+      height: 40px  
+      width: 40px  
+      align-items: center
+      justify-content: center
+
+    img.success-icon
+      width: 24px  
+      height: 24px  
 
   .hints-button
     float: right

--- a/app/styles/play/level/control-bar-view.sass
+++ b/app/styles/play/level/control-bar-view.sass
@@ -172,18 +172,22 @@
         .hamburger span.icon-bar
           background-color: $control-yellow-highlight
 
-    #next-game-button, #control-bar-sign-up-button
+    #next-game-button, #control-bar-sign-up-button, #level-done-button
       top: 7px
       font-size: 13px
       height: 24px
-
+    
     #level-done-button
+      display: none
+
+    #level-done-button.junior
       top: 3px
       font-size: 13px
       height: 40px  
       width: 40px  
       align-items: center
       justify-content: center
+      display: flex
 
     img.success-icon
       width: 24px  

--- a/app/templates/play/level/control-bar-view.pug
+++ b/app/templates/play/level/control-bar-view.pug
@@ -45,10 +45,11 @@ if includeHomeLink
   if spectateGame
     button.btn.btn-xs.btn-inverse.banner#next-game-button(data-i18n="play_level.next_game") Next game
 
-  //- if !observing
-  //-   button.btn.btn-xs.btn-primary.banner#level-done-button(data-i18n="play_level.done") Done
+  if !observing && product != 'codecombat-junior'
+    button.btn.btn-xs.btn-primary.banner#level-done-button(data-i18n="play_level.done") Done
+
   if lastOverallStatus == 'success' && product == 'codecombat-junior'
-    button.btn.btn-xs.btn-success.btn-illustrated#level-done-button(title="$t('play_level.next_level')")
+    button.btn.btn-xs.btn-success.btn-illustrated#level-done-button(title="$t('play_level.next_level')", class="junior")
       img.success-icon(src="/images/level/goal-icons/next-level.png" alt="")
       
   if me.get('anonymous') && !features.noAuth

--- a/app/templates/play/level/control-bar-view.pug
+++ b/app/templates/play/level/control-bar-view.pug
@@ -45,9 +45,12 @@ if includeHomeLink
   if spectateGame
     button.btn.btn-xs.btn-inverse.banner#next-game-button(data-i18n="play_level.next_game") Next game
 
-  if !observing
-    button.btn.btn-xs.btn-primary.banner#level-done-button(data-i18n="play_level.done") Done
-
+  //- if !observing
+  //-   button.btn.btn-xs.btn-primary.banner#level-done-button(data-i18n="play_level.done") Done
+  if lastOverallStatus == 'success' && product == 'codecombat-junior'
+    button.btn.btn-xs.btn-success.btn-illustrated#level-done-button(title="$t('play_level.next_level')")
+      img.success-icon(src="/images/level/goal-icons/next-level.png" alt="")
+      
   if me.get('anonymous') && !features.noAuth
     button.btn.btn-xs.btn-primary.banner#control-bar-sign-up-button(data-toggle='coco-modal', data-target='core/CreateAccountModal', data-i18n="signup.sign_up")
 

--- a/app/views/play/level/ControlBarView.coffee
+++ b/app/views/play/level/ControlBarView.coffee
@@ -22,6 +22,7 @@ module.exports = class ControlBarView extends CocoView
   subscriptions:
     'level:disable-controls': 'onDisableControls'
     'level:enable-controls': 'onEnableControls'
+    'level:overallStatus-changed': 'onOverallStatusChanged'
     'ipad:memory-warning': 'onIPadMemoryWarning'
 
   events:
@@ -46,6 +47,8 @@ module.exports = class ControlBarView extends CocoView
     @levelID = @levelSlug or @level.id
     @spectateGame = options.spectateGame ? false
     @observing = options.session.get('creator') isnt me.id
+    @product = @level.attributes.product
+    @lastOverallStatus = null
 
     exam = userUtils.getStorageExam()
     if exam
@@ -119,6 +122,8 @@ module.exports = class ControlBarView extends CocoView
       @lastDifficulty = c.levelDifficulty
     c.spectateGame = @spectateGame
     c.observing = @observing
+    c.product = @product
+    c.lastOverallStatus = @lastOverallStatus
     @homeViewArgs = [{supermodel: if @hasReceivedMemoryWarning then null else @supermodel}]
     gameDevCampaign = application.getHocCampaign()
     if gameDevCampaign and not @level.isLadder()
@@ -187,6 +192,11 @@ module.exports = class ControlBarView extends CocoView
     Backbone.Mediator.publish 'level:hints-button', {state: @options.hintsState.get('hidden')}
     @options.hintsState.set('hidden', not @options.hintsState.get('hidden'))
     window.tracker?.trackEvent 'Hints Clicked', category: 'Students', levelSlug: @levelSlug, hintCount: @options.hintsState.get('hints')?.length ? 0
+
+  onOverallStatusChanged: (e) ->
+    return if e?.overallStatus == @lastOverallStatus 
+    @lastOverallStatus = e.overallStatus
+    @render()
 
   onDisableControls: (e) -> @toggleControls e, false
   onEnableControls: (e) -> @toggleControls e, true

--- a/app/views/play/level/LevelGoals.vue
+++ b/app/views/play/level/LevelGoals.vue
@@ -9,10 +9,10 @@
         :state="goalStates[goal.id]",
         :product="product",
       )
-      li.goals-status.rtl-allowed(v-if="showStatus && product === 'codecombat-junior' && classToShow === 'success'")
-        span(v-if="classToShow === 'success'" :title="$t('play_level.next_level')").goal-status.success
-          button.btn.btn-xs.btn-success.btn-illustrated#level-done-button
-            img.success-icon(src="/images/level/goal-icons/next-level.png" alt="")
+      //-li.goals-status.rtl-allowed(v-if="showStatus && product === 'codecombat-junior' && classToShow === 'success'")
+      //-  span(v-if="classToShow === 'success'" :title="$t('play_level.next_level')").goal-status.success
+      //-    button.btn.btn-xs.btn-success.btn-illustrated#level-done-button
+      //-      img.success-icon(src="/images/level/goal-icons/next-level.png" alt="")
     level-goal(
       v-if="conceptGoals.length",
       :goal="{ name: $t('play_level.use_at_least_one_concept') }",
@@ -74,6 +74,11 @@
             return 'success'
         return 'incomplete'
     }
+
+    watch:
+      overallStatus:
+        handler: (newVal, oldVal) ->
+          Backbone.Mediator.publish 'level:overallStatus-changed', {overallStatus: newVal}
 
     components: {
       LevelGoal

--- a/app/views/play/level/LevelGoals.vue
+++ b/app/views/play/level/LevelGoals.vue
@@ -9,10 +9,7 @@
         :state="goalStates[goal.id]",
         :product="product",
       )
-      //-li.goals-status.rtl-allowed(v-if="showStatus && product === 'codecombat-junior' && classToShow === 'success'")
-      //-  span(v-if="classToShow === 'success'" :title="$t('play_level.next_level')").goal-status.success
-      //-    button.btn.btn-xs.btn-success.btn-illustrated#level-done-button
-      //-      img.success-icon(src="/images/level/goal-icons/next-level.png" alt="")
+      
     level-goal(
       v-if="conceptGoals.length",
       :goal="{ name: $t('play_level.use_at_least_one_concept') }",


### PR DESCRIPTION
Move junior's next level button to buttons area at controlBarView
closes [CCJ-335 ](https://linear.app/codecombat/issue/CCJ-335/modify-the-location-of-the-next-level-button)
<img width="1662" alt="image" src="https://github.com/user-attachments/assets/c607e58a-5a9e-4f32-97d9-4cb865255de5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new event handler for overall status changes, enhancing responsiveness to status updates.
	- Added a new button in the control bar that conditionally renders based on overall status.
	- Implemented a watcher for overall status changes in the LevelGoals component.
  
- **Bug Fixes**
	- Removed outdated success status button for 'codecombat-junior' product.

- **Style**
	- Updated styles for control bar buttons and layout, improving visual organization.
	- Adjusted button visibility and layout within the control bar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->