### PR TITLE
add played on in progress dot tooltip

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
@@ -176,11 +176,13 @@ export default {
           const levelOriginalCompletionMap = {}
           const playTimeMap = {}
           const completionDateMap = {}
+          const playedOnMap = {}
 
           for (const session of Object.values(studentSessions)) {
             levelOriginalCompletionMap[session.level.original] = session.state
             playTimeMap[session.level.original] = session.playtime
-            completionDateMap[session.level.original] = session.state.complete && session.changed
+            playedOnMap[session.level.original] = session.changed
+            completionDateMap[session.level.original] = session.state.complete && session.dateFirstCompleted
           }
 
           moduleStatsForTable.studentSessions[student._id] = translatedModuleContent.map((content) => {
@@ -225,6 +227,7 @@ export default {
               isPlayable: isPlayableForStudent[student._id],
               isPractice,
               playTime: playTimeMap[normalizedOriginal],
+              playedOn: playedOnMap[normalizedOriginal],
               completionDate: completionDateMap[normalizedOriginal],
               tooltipName: levelNameMap[content._id].levelName,
               practiceLevels,

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/TableModuleGrid.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/TableModuleGrid.vue
@@ -141,7 +141,7 @@ export default {
   >
     <!-- FLAT REPRESENTATION OF ALL SESSIONS -->
     <div
-      v-for="({studentId, status, playTime, tooltipName, completionDate, flag, clickHandler, selectedKey, normalizedType, isLocked, isSkipped, lockDate, lastLockDate, original, normalizedOriginal,fromIntroLevelOriginal, isPlayable, isOptional }, index) of allStudentSessionsLinear"
+      v-for="({studentId, status, playTime, tooltipName, playedOn, completionDate, flag, clickHandler, selectedKey, normalizedType, isLocked, isSkipped, lockDate, lastLockDate, original, normalizedOriginal,fromIntroLevelOriginal, isPlayable, isOptional }, index) of allStudentSessionsLinear"
       :key="selectedKey"
       :class="cellClass(index)"
     >
@@ -161,6 +161,7 @@ export default {
         :selected="selectedOriginals.includes(normalizedOriginal) && selectedStudentIds.includes(studentId)"
         :hovered="hoveredLevels.includes(normalizedOriginal) && selectedStudentIds.includes(studentId)"
         :play-time="playTime"
+        :played-on="playedOn"
         :completion-date="completionDate"
         :tooltip-name="tooltipName"
         :normalized-original="normalizedOriginal"

--- a/ozaria/site/components/teacher-dashboard/Panel/components/ConceptCheckInfo.vue
+++ b/ozaria/site/components/teacher-dashboard/Panel/components/ConceptCheckInfo.vue
@@ -53,6 +53,16 @@ export default {
       </p>
     </div>
     <div
+      v-if="conceptCheck.lastPlayed !== ''"
+      class="row-icon"
+    >
+      <img src="/images/ozaria/teachers/dashboard/svg_icons/Icon_TimeSpent.svg">
+      <p>
+        <b>{{ $t('user.last_played') }}:</b>
+        {{ `${conceptCheck.lastPlayed}` }}
+      </p>
+    </div>
+    <div
       v-if="conceptCheck.classAverage !== -1"
       class="row-icon"
     >

--- a/ozaria/site/components/teacher-dashboard/common/progress/progressDot.vue
+++ b/ozaria/site/components/teacher-dashboard/common/progress/progressDot.vue
@@ -84,6 +84,10 @@ export default {
       type: Number,
       default: 0,
     },
+    playedOn: {
+      type: String,
+      default: '',
+    },
     completionDate: {
       type: [Boolean, String],
       default: null,
@@ -181,9 +185,12 @@ export default {
       return `
         ${status}
         ${this.tooltipName ? `<br><strong>${this.tooltipName}</strong>` : ''}
+        ${this.playedOn ? `<br>${$.i18n.t('user.last_played')}: ${moment(this.playedOn).format('lll')}` : ''}
         ${this.status === 'complete' && this.completionDate ? `<br>${$.i18n.t('teacher.completed')}: ${moment(this.completionDate).format('lll')}` : ''}
         ${this.playTime ? `<br>${$.i18n.t('teacher.time_played_label')} ${moment.duration({ seconds: this.playTime }).humanize()}` : ''}
+
         ${this.extraPracticeLevels?.length ? '<br><br>' : ''}
+
         ${this.filterPracticeLevelsToDisplay(this.extraPracticeLevels).map(({ name, status }) => `${$.i18n.t('teacher_dashboard.practice_level')}: ${name} - ${$.i18n.t(`teacher_dashboard.${status}`)}`).join('<br>')}`
     },
 

--- a/ozaria/site/store/TeacherDashboardPanel.js
+++ b/ozaria/site/store/TeacherDashboardPanel.js
@@ -130,6 +130,7 @@ export default {
       learningGoal: undefined,
       totalSubmissions: -1,
       timeSpent: -1,
+      lastPlayed: '',
       classAverage: -1, // TODO: Punt this temporarily.
     },
     //     panelSessionContent: practiceLevelData({
@@ -260,6 +261,9 @@ export default {
     setTimeSpent (state, timeSpent) {
       Vue.set(state.conceptCheck, 'timeSpent', timeSpent)
     },
+    setLastPlayed (state, lastPlayed) {
+      Vue.set(state.conceptCheck, 'lastPlayed', lastPlayed)
+    },
     setTotalSubmissions (state, totalSubmissions) {
       Vue.set(state.conceptCheck, 'totalSubmissions', totalSubmissions)
     },
@@ -372,6 +376,7 @@ export default {
         // For practice levels and challenge levels
 
         commit('setTimeSpent', utils.secondsToMinutesAndSeconds(Math.ceil(studentSessions[normalizedOriginal].playtime)))
+        commit('setLastPlayed', moment(studentSessions[normalizedOriginal].changed).format('lll'))
 
         dispatch('setPanelSessionContent', {
           header: panelHeader,


### PR DESCRIPTION
fix ENG-1522
![image](https://github.com/user-attachments/assets/5ae10a8b-e360-42d7-a6e4-5a1d25f71194)
![image](https://github.com/user-attachments/assets/d74bb907-4ba9-4126-8774-62fa91f25baa)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced student progress tracking by adding a new `playedOn` property to show when levels were played.
	- Improved tooltip in progress dots to display the last played date for each level.
	- Added display of the last played date in the concept check information.

- **Bug Fixes**
	- Updated logic for tracking student level interactions and completion dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->