### PR TITLE
Fix turbo track (S15 AILeague) ending and publish dates

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -1347,7 +1347,7 @@ const arenas = [
   { season: 13, slug: 'kings-gambit', type: 'championship', start: new Date('2025-04-01T00:00:00.000-07:00'), end: new Date('2025-05-01T00:00:00.000-07:00'), results: new Date('2025-05-10T07:00:00.000-07:00'), levelOriginal: '', image: '' },
   { season: 14, slug: 'strikers-stadium', type: 'regular', start: new Date('2025-05-01T00:00:00.000-07:00'), end: new Date('2025-09-01T00:00:00.000-07:00'), results: new Date('2025-09-14T07:00:00.000-07:00'), levelOriginal: '', image: '' },
   { season: 14, slug: 'golden-goal', type: 'championship', start: new Date('2025-07-01T00:00:00.000-07:00'), end: new Date('2025-09-01T00:00:00.000-07:00'), results: new Date('2025-09-14T07:00:00.000-07:00'), levelOriginal: '', image: '' },
-  { season: 15, slug: 'turbo-track', type: 'regular', start: new Date('2025-09-01T00:00:00.000-07:00'), end: new Date('2025-01-01T00:00:00.000-08:00'), results: new Date('2025-01-10T07:00:00.000-08:00'), levelOriginal: '', image: '' },
+  { season: 15, slug: 'turbo-track', type: 'regular', start: new Date('2025-09-01T00:00:00.000-07:00'), end: new Date('2026-01-01T00:00:00.000-08:00'), results: new Date('2026-01-10T07:00:00.000-08:00'), levelOriginal: '', image: '' },
   { season: 15, slug: 'grand-prix', type: 'championship', start: new Date('2025-12-01T00:00:00.000-08:00'), end: new Date('2026-01-01T00:00:00.000-08:00'), results: new Date('2026-01-10T07:00:00.000-08:00'), levelOriginal: '', image: '' },
 ]
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dbc25787-ac2e-4c98-8fd5-882e4175580e)
League was not showing system shock as the correct regular season arena for S12, this might fix it, the end and publish dates for S15 Turbo Track was not correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated date configurations for the "turbo-track" arena in the system configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->