### PR TITLE
Add requiredThangTypes to Systems

### DIFF
--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -443,9 +443,10 @@ module.exports = class LevelLoader extends CocoClass
       @loadThangsRequiredByLevelThang(thang)
       for comp in thang.components or []
         componentVersions.push _.pick(comp, ['original', 'majorVersion'])
-
-    for system in @level.get('systems') or []
+    systems = @level.get('systems') or []
+    for system in systems
       systemVersions.push _.pick(system, ['original', 'majorVersion'])
+      @loadThangsRequiredFromSystemObject(system)
       if indieSprites = system?.config?.indieSprites
         for indieSprite in indieSprites
           thangIDs.push indieSprite.thangType
@@ -470,7 +471,7 @@ module.exports = class LevelLoader extends CocoClass
       worldNecessities.push @maybeLoadURL(url, LevelComponent, 'component')
     for obj in objUniq systemVersions
       url = "/db/level.system/#{obj.original}/version/#{obj.majorVersion}"
-      worldNecessities.push @maybeLoadURL(url, LevelSystem, 'system')
+      worldNecessities.push(@maybeLoadURL(url, LevelSystem, 'system'))
     for obj in objUniq articleVersions
       url = "/db/article/#{obj.original}/version/#{obj.majorVersion}"
       @maybeLoadURL url, Article, 'article'
@@ -486,6 +487,10 @@ module.exports = class LevelLoader extends CocoClass
   loadThangsRequiredByThangType: (thangType) ->
     @loadThangsRequiredFromComponentList thangType.get('components')
 
+  loadThangTypeData: (thangType) ->
+    url = "/db/thang.type/#{thangType}/version?project=name,components,original,rasterIcon,kind,prerenderedSpriteSheetData"
+    @worldNecessities.push @maybeLoadURL(url, ThangType, 'thang')
+
   loadThangsRequiredFromComponentList: (components) ->
     return unless components
     requiredThangTypes = []
@@ -499,10 +504,33 @@ module.exports = class LevelLoader extends CocoClass
       console.error "Some Thang had a blank required ThangType in components list:", components
     for thangType in extantRequiredThangTypes
       if thangType + '' is '[object Object]'
-        console.error "Some Thang had an improperly stringified required ThangType in components list:", thangType, components
+        console.error("Some Thang had an improperly stringified required ThangType in components list:", thangType, components) 
       else
-        url = "/db/thang.type/#{thangType}/version?project=name,components,original,rasterIcon,kind,prerenderedSpriteSheetData"
-        @worldNecessities.push @maybeLoadURL(url, ThangType, 'thang')
+        @loadThangTypeData(thangType)
+
+  loadThangsRequiredFromSystemDefaults: (systemModel) ->
+    config = systemModel.get('configSchema')
+    if not config
+      return
+    configDefault = config.default
+    @loadThangsRequiredFromSystemConfig(configDefault)
+  
+  loadThangsRequiredFromSystemObject: (system) ->
+    if system.config
+      @loadThangsRequiredFromSystemConfig(system.config)
+
+
+  loadThangsRequiredFromSystemConfig: (config) ->
+    if not config
+      return
+    requiredThangTypes = config.requiredThangTypes
+    if not requiredThangTypes
+      return
+    for thangType in requiredThangTypes
+      if thangType + '' is '[object Object]'
+        console.error("Some System had an improperly stringified required ThangType:", thangType, system.name)
+      else
+        @loadThangTypeData(thangType)
 
   onThangNamesLoaded: (thangNames) ->
     for thangType in thangNames.models
@@ -520,6 +548,10 @@ module.exports = class LevelLoader extends CocoClass
   onWorldNecessityLoaded: (resource) ->
     # Note: this can also be called when session, opponentSession, or other resources with dedicated load handlers are loaded, before those handlers
     index = @worldNecessities.indexOf(resource)
+    if resource.name is 'system'
+      @loadThangsRequiredFromSystemDefaults(resource.model)
+      
+
     if resource.name is 'thang'
       @loadDefaultComponentsForThangType(resource.model)
       @loadThangsRequiredByThangType(resource.model)


### PR DESCRIPTION
Closes GD-339

https://linear.app/codecombat/issue/GD-339/add-requiredthangtypes-to-systems

We are using `requiredThangTypes` in Thangs to preload things that can be spawned dynamically in a level. For some mass levels, such as CCJ, we need to move some spawn logic to systems and populate it with all levels. For that, we need to preload some things from systems.

Now we are loadinf requiredThangTypes from defaults even if they are redefined. This way, we can be sure we have a safe default because we use such spawning for a large number of levels. For specific levels, we don't use systems anyway, so system defaults are used only for " must-haves."


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced level loading mechanism with improved system and ThangType data processing
  - Added new methods to support more robust resource loading during game initialization

- **Refactor**
  - Restructured loading logic to improve code readability and maintainability
  - Updated error logging and resource management processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->