### PR TITLE
ENG-1419 - Solution guide print not working

### DIFF
--- a/app/templates/teachers/teacher-course-solution-view.pug
+++ b/app/templates/teachers/teacher-course-solution-view.pug
@@ -47,8 +47,7 @@ block content
       each level, index in view.levels.models
         .small
           if !view.isJunior || !level.get('practice')
-            - let selected = view.shownLevelModels.indexOf(level) !== -1;
-            a.show-level-data(class=selected ? 'selected' : '' data-slug=`${level.get('slug')}` href=`#${level.get('slug')}`) #{view.levelNumberMap[level.get('original')]}. #{i18n(level.attributes, 'displayName') || i18n(level.attributes, 'name')}
+            a.show-level-data(data-slug=`${level.get('slug')}` href=`#${level.get('slug')}`) #{view.levelNumberMap[level.get('original')]}. #{i18n(level.attributes, 'displayName') || i18n(level.attributes, 'name')}
             if view.isJunior
               - let practiceLevels = view.levels.models.filter(l => l.get('practice') &&  l.get('name').match(level.get('name')))
               if practiceLevels.length > 0

--- a/app/views/teachers/TeacherCourseSolutionView.js
+++ b/app/views/teachers/TeacherCourseSolutionView.js
@@ -49,14 +49,25 @@ module.exports = (TeacherCourseSolutionView = (function () {
       const button = $(e.target).closest('.show-practice-levels-button')
       const shown = this.showPracticeLevelsForSlug === button.data().slug
       this.showPracticeLevelsForSlug = shown ? null : button.data().slug
+      if (!this.showPracticeLevelsForSlug) {
+        this.updateShownLevels()
+      }
       this.render()
     }
 
     onClickShowLevelData (e) {
       const levelData = $(e.target).closest('.show-level-data')
       const slug = $(levelData[0]).data('slug')
-      this.shownLevelModels = this.levels.models.filter(l => l.get('slug') === slug)
+      this.updateShownLevels(slug)
       this.render()
+    }
+
+    updateShownLevels (slug) {
+      this.shownLevelModels = this.isJunior
+        ? this.levels.models.filter(l =>
+          this.showPracticeLevelsForSlug ? slug === l.get('slug') : !l.get('practice'),
+        )
+        : this.levels.models
     }
 
     onClickPrint () {
@@ -230,6 +241,8 @@ ${translateUtils.translateJS(a.slice(13, +(a.length - 4) + 1 || undefined), this
         // Filter out non numbered levels.
         this.levels.models = this.levels.models.filter(l => l.get('original') in this.levelNumberMap)
       }
+
+      this.updateShownLevels(this.levels.models[0].get('slug'))
       return (typeof this.render === 'function' ? this.render() : undefined)
     }
 

--- a/test/app/views/teachers/TeacherCourseSolutionView.spec.js
+++ b/test/app/views/teachers/TeacherCourseSolutionView.spec.js
@@ -1,0 +1,44 @@
+
+const TeacherCourseSolution = require('views/teachers/TeacherCourseSolutionView.js')
+const Level = require('models/Level')
+
+describe('TeacherCourseSolution', function () {
+  let view
+  beforeEach(function () {
+    view = new TeacherCourseSolution()
+  })
+
+  describe('updateShownLevels', function () {
+    let mockLevels
+    beforeEach(() => {
+      mockLevels = [
+        new Level({ slug: 'level1', practice: false }),
+        new Level({ slug: 'level2', practice: true }),
+        new Level({ slug: 'level3', practice: false }),
+      ]
+      view.levels = { models: mockLevels }
+    })
+
+    it('should update shownLevelModels to all levels when isJunior is false', () => {
+      view.isJunior = false
+      view.updateShownLevels('level1')
+      expect(JSON.stringify(view.shownLevelModels)).toEqual(JSON.stringify(mockLevels))
+    })
+
+    it('should update shownLevelModels to non-practice levels when isJunior is true and showPracticeLevelsForSlug is false', () => {
+      view.isJunior = true
+      view.showPracticeLevelsForSlug = false
+      view.updateShownLevels('level1')
+      const expectedModels = mockLevels.filter(l => !l.get('practice'))
+      expect(view.shownLevelModels.map(i => i.get('slug'))).toEqual(expectedModels.map(i => i.get('slug')))
+    })
+
+    it('should update shownLevelModels to specified level when isJunior is true and showPracticeLevelsForSlug is true', () => {
+      view.isJunior = true
+      view.showPracticeLevelsForSlug = true
+      view.updateShownLevels('level1')
+      const expectedModel = mockLevels.find(l => l.get('slug') === 'level1')
+      expect(view.shownLevelModels.map(i => i.get('slug'))).toEqual([expectedModel].map(i => i.get('slug')))
+    })
+  })
+})


### PR DESCRIPTION
### Changes:

- Non junior courses: go back to old way ( show solution for all levels)
- Junior course: 
  - Show only non-practice levels by default. (so users can print all the solutions for the non-practice ones). 
  - When a practice level is selected, show solution only for the selected one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new method `updateShownLevels` to manage level data display in the Teacher Course Solution view
	- Improved logic for filtering and displaying levels based on user context

- **Bug Fixes**
	- Refined level data selection and visibility mechanism
	- Streamlined level filtering process

- **Tests**
	- Added comprehensive test suite for `updateShownLevels` method
	- Implemented test cases covering different level display scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->