### PR TITLE
Treema ThangType Search pagination problem

### DIFF
--- a/app/views/editor/level/treema_nodes.js
+++ b/app/views/editor/level/treema_nodes.js
@@ -391,7 +391,6 @@ module.exports.ThangTypeNode = (ThangTypeNode = (ThangTypeNode = (function () {
       ThangTypeNode.thangTypesCollection.fetch({ data: { limit: PAGE_SIZE } })
       ThangTypeNode.thangTypesCollection.skip = 0
       ThangTypeNode.thangTypesCollection.once('sync', () => this.onThangCollectionSynced(ThangTypeNode.thangTypesCollection))
-      // return ThangTypeNode.thangTypesCollection.once('sync', () => this.processThangTypes(ThangTypeNode.thangTypesCollection))
     }
 
     onThangCollectionSynced (collection) {


### PR DESCRIPTION
Closes GD-343

# Problem

Go to any level on prod where we have Spawns and requiredThangTypes and try to add "Skeleton". You can not.

![image](https://github.com/user-attachments/assets/c4e584d3-dc7a-4b77-bccc-75783b86aa05)

So before GD had to use copy-edit-paste json-treema trick to fulfill some values there.

# Solution

In treema nodes we need to use the similar solution what we are using for AddThangs or SearchThangs and combine several fetch with skip.

# Test

Proxy mode and try to add "skeleton"

![image](https://github.com/user-attachments/assets/9f5d299c-c251-4620-adfd-198462bdfd06)

# Side Effect (good)

It fixes a problem for Equips for inventory, we can add "Short Sword" now.
![image](https://github.com/user-attachments/assets/050375b1-9fce-4ef8-b828-c47704082386)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced data fetching mechanism for ThangTypeNode with improved pagination support.
	- Implemented recursive data retrieval when collection size reaches maximum limit.

- **Performance**
	- Optimized data loading by fetching up to 1000 items per request.
	- Improved error handling during data fetching operations. 
	- Prevented unnecessary data overwriting during collection synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->