### PR TITLE
ENG-1562 - Fix HS Sign Up issue

### DIFF
--- a/app/views/ai/AIView.js
+++ b/app/views/ai/AIView.js
@@ -31,8 +31,8 @@ module.exports = (AIView = (function () {
       // Undo our 62.5% default HTML font-size here
       $('html').css('font-size', '16px')
       ai.AI({ domElement: this.$el.find('#ai-root')[0] })
-      window.handleAICreditLimitReached = this.handleAICreditLimitReached
-      window.AICreditLimitReachedMsg = this.AICreditLimitReachedMsg
+      window.handleAICreditLimitReached = this.handleAICreditLimitReached.bind(this)
+      window.AICreditLimitReachedMsg = this.AICreditLimitReachedMsg.bind(this)
       return super.afterInsert()
     }
 
@@ -54,14 +54,14 @@ module.exports = (AIView = (function () {
       const interval = creditObj.durationKey
       const amount = creditObj.durationAmount
       if (me.isTeacher()) {
-        super.openModalView(new DirectContactModal())
+        this.openModalView(new DirectContactModal())
       } else if (me.isAnonymous()) {
-        super.openModalView(new CreateAccountModal({ mode: 'signup' }))
+        this.openModalView(new CreateAccountModal({ mode: 'signup' }))
       } else if (me.isHomeUser()) {
         if (me.hasSubscription()) {
           message = $.i18n.t('play_level.not_enough_credits_interval', { interval, amount })
         } else {
-          super.openModalView(new SubscribeModal())
+          this.openModalView(new SubscribeModal())
         }
       } else if (me.isStudent()) {
         if (me.isEnrolled()) {


### PR DESCRIPTION
When exporting the methods to `window.` from `AIView`, it was forgotten to bind the methods on the actual instance of `AIView`. 
It was somehow fixed by the hack to call `super` instead of `this`, but it somehow ended in dark magic that disabled all click listeners in the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated method bindings in the AI view to ensure proper context preservation
	- Modified method calls to use current instance context instead of parent class context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->