### PR TITLE
use auto name for sso sign up

### DIFF
--- a/app/styles/modal/create-account-modal/sso-confirm-view.sass
+++ b/app/styles/modal/create-account-modal/sso-confirm-view.sass
@@ -3,3 +3,6 @@
     display: flex
     flex-direction: column
     align-items: center
+
+    .m-y-3
+      width: 40px

--- a/app/templates/core/create-account-modal/single-sign-on-confirm-view.pug
+++ b/app/templates/core/create-account-modal/single-sign-on-confirm-view.pug
@@ -14,7 +14,6 @@ form#basic-info-form.modal-body
 
     .hr-text.m-y-3
       hr
-      span(data-i18n="common.next")
 
     .form-container
       input.hidden(name="email" value=view.signupState.get('email'))

--- a/app/templates/core/create-account-modal/single-sign-on-confirm-view.pug
+++ b/app/templates/core/create-account-modal/single-sign-on-confirm-view.pug
@@ -18,28 +18,7 @@ form#basic-info-form.modal-body
 
     .form-container
       input.hidden(name="email" value=view.signupState.get('email'))
-      .form-group
-        .row
-          .col-xs-7.col-xs-offset-3
-            label.control-label(for="username-input")
-              span(data-i18n="general.username")
-          .col-xs-5.col-xs-offset-3
-            input.form-control.input-lg#username-input(name="name" value=view.signupState.get('signupForm').name)
-          .col-xs-4.name-check
-            - var checkNameState = view.state.get('checkNameState');
-            if checkNameState === 'checking'
-              span.small(data-i18n="signup.checking")
-            if checkNameState === 'exists'
-              span.small
-                span.text-burgundy.glyphicon.glyphicon-remove-circle
-                =" "
-                span= view.state.get('suggestedNameText')
-            if checkNameState === 'available'
-              span.small
-                span.text-forest.glyphicon.glyphicon-ok-circle
-                =" "
-                span(data-i18n="signup.name_available")
-
+      input.hidden(name="name" value=view.signupState.get('autoName'))
       .form-group.subscribe
         .row
           .col-xs-7.col-xs-offset-3

--- a/app/views/core/CreateAccountModal/BasicInfoView.js
+++ b/app/views/core/CreateAccountModal/BasicInfoView.js
@@ -589,6 +589,8 @@ module.exports = (BasicInfoView = (function () {
                   ssoUsed,
                   email: ssoAttrs.email
                 })
+                const autoName = `${ssoAttrs.email.split('@')[0]}+${ssoUsed}`
+                this.signupState.set('autoName', autoName)
                 if (exists) {
                   return this.trigger('sso-connect:already-in-use')
                 } else {


### PR DESCRIPTION
fix ENG-1438
![image](https://github.com/user-attachments/assets/f9f4f06e-9b12-412b-8be8-f0e531e7e734)
i think gmail make sure the email name is unique, so adding +gplus should work fine. if we meet some case that name conflict, we can resolve it later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - The account creation process has been streamlined by removing the manual username entry.
  - An automatically generated username is now created using your email and sign-on method, simplifying the sign-up experience while maintaining essential functionality.
  
- **Style**
  - Added a new class to enhance the layout of the modal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->