### PR TITLE
fake language too for code points rankings

### DIFF
--- a/app/core/store/modules/clans.js
+++ b/app/core/store/modules/clans.js
@@ -4,9 +4,9 @@ const _ = require('lodash')
 
 const sortClan = (clns) => {
   const clans = clns.filter(c => c)
-  const firstClassClan = _.findIndex(clans, (clan) => clan.slug.startsWith('autoclan-classroom'))
-  const classClans = clans.filter((clan) => clan.slug.startsWith('autoclan-classroom'))
-  const otherClans = clans.filter((clan) => !clan.slug.startsWith('autoclan-classroom'))
+  const firstClassClan = _.findIndex(clans, (clan) => clan?.slug?.startsWith('autoclan-classroom'))
+  const classClans = clans.filter((clan) => clan?.slug?.startsWith('autoclan-classroom'))
+  const otherClans = clans.filter((clan) => !clan?.slug?.startsWith('autoclan-classroom'))
   classClans.sort((a, b) => b._id.localeCompare(a._id))
   otherClans.splice(firstClassClan, 0, ...classClans)
   return otherClans

--- a/app/core/store/modules/seasonalLeague.js
+++ b/app/core/store/modules/seasonalLeague.js
@@ -606,7 +606,8 @@ export default {
           creatorName: me.broadName(),
           rank: parseInt(myRank, 10),
           totalScore: me.get('stats').codePoints,
-          creator: me.id
+          creator: me.id,
+          submittedCodeLanguage: me.get('aceConfig')?.language,
         }
 
         codePointsRankingInfo.playersAbove = playersAbove

--- a/app/views/ladder/components/Leaderboard.vue
+++ b/app/views/ladder/components/Leaderboard.vue
@@ -204,7 +204,7 @@ export default Vue.extend({
       }
     },
     computeStyle (item, index) {
-      if (this.tableTitles[index].slug === 'language') {
+      if (this.tableTitles[index].slug === 'language' && item) {
         return { 'background-image': `url(/images/common/code_languages/${item}_icon.png)` }
       }
     },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d18d562f-a14e-4277-a36f-2dd2db23e424)

now in code points leaderboard we also have language for user. and if it's still undefined we also ignore it instead of query an `undefined_icon` 