### PR TITLE
let's update UI after click play

### DIFF
--- a/app/views/play/level/PlayGameDevLevelView.coffee
+++ b/app/views/play/level/PlayGameDevLevelView.coffee
@@ -192,6 +192,7 @@ module.exports = class PlayGameDevLevelView extends RootView
     action = if @state.get('playing') then 'Play GameDev Level - Restart Level' else 'Play GameDev Level - Start Level'
     window.tracker?.trackEvent(action, @eventProperties)
     @state.set('playing', true)
+    @willUpdateFrontEnd = true
 
   onClickCopyURLButton: ->
     @$('#copy-url-input').val(@state.get('shareURL')).select()
@@ -217,7 +218,7 @@ module.exports = class PlayGameDevLevelView extends RootView
       modal.once 'replay', @onClickPlayButton, @
 
   updateStudentGoals: ->
-    return if @studentGoals
+    return if @studentGoals?.length
     # Set by users. Defined in `game.GameUI` component in the level editor.
     if @world.uiText?.directions?.length
       @studentGoals = @world.uiText.directions.map((direction) -> {type: "user_defined", direction})


### PR DESCRIPTION
seems we don't pre-load user code in /play/game-dev-levels (someone else playing other players' game dev projects) so the @world.uiText isn't update until we click `play` button. 
maybe I'm not 100% correct but anyway update frontend and students' goal when we click `play` button won't be wrong. 
![image](https://github.com/user-attachments/assets/c381eae5-17c2-42ac-82f7-2d5f5d6b1bdf)

fix ENG-1684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the play button functionality to ensure the interface updates promptly when starting a play session.
  - Refined goal management so updates occur only when there are active targets, contributing to a more efficient and reliable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->