### PR TITLE
summary all stats for old api dashboard

### DIFF
--- a/app/views/api/components/ApiData.vue
+++ b/app/views/api/components/ApiData.vue
@@ -117,8 +117,20 @@ module.exports = Vue.extend({
     },
     licenseDaysByMonth () {
       const byMonth = []
-      let totalUsed = 0
       const months = _.keys(this.licenseStats.licenseDaysByMonth).sort().reverse()
+      const summary = {
+        month: 'Total',
+        licenseDaysUsed: 0,
+        activeLicenses: 0,
+        progress: {
+          linesOfCode: 0,
+          programs: 0,
+          playtime: 0,
+        },
+        newSignups: 0,
+        ageStats: 0,
+        licensesUsed: 0,
+      }
       for (const month of months) {
         const stat = this.licenseStats.licenseDaysByMonth[month]
         byMonth.push({
@@ -130,10 +142,16 @@ module.exports = Vue.extend({
           ageStats: stat.ageStats,
           licensesUsed: stat.licensesUsed,
         })
-        totalUsed += stat.daysUsed
+        summary.licenseDaysUsed += stat.daysUsed || 0
+        summary.activeLicenses += stat.noOfRedeemers || 0
+        summary.progress.linesOfCode += stat.progress?.linesOfCode || 0
+        summary.progress.programs += stat.progress?.programs || 0
+        summary.progress.playtime += stat.progress?.playtime || 0
+        summary.newSignups += stat.newSignups || 0
+        summary.licensesUsed += stat.licensesUsed || 0
       }
       if (byMonth.length) {
-        byMonth.push({ month: 'Total', licenseDaysUsed: totalUsed })
+        byMonth.push(summary)
       }
       return byMonth
     },

--- a/app/views/api/components/ApiData.vue
+++ b/app/views/api/components/ApiData.vue
@@ -121,7 +121,6 @@ module.exports = Vue.extend({
       const summary = {
         month: 'Total',
         licenseDaysUsed: 0,
-        activeLicenses: 0,
         progress: {
           linesOfCode: 0,
           programs: 0,
@@ -143,7 +142,6 @@ module.exports = Vue.extend({
           licensesUsed: stat.licensesUsed,
         })
         summary.licenseDaysUsed += stat.daysUsed || 0
-        summary.activeLicenses += stat.noOfRedeemers || 0
         summary.progress.linesOfCode += stat.progress?.linesOfCode || 0
         summary.progress.programs += stat.progress?.programs || 0
         summary.progress.playtime += stat.progress?.playtime || 0


### PR DESCRIPTION
fix ENG-1665

![image](https://github.com/user-attachments/assets/65a3cef9-13ca-4b16-ad16-0414f35d28d1)

didn't find a better api in china staging db. but this should show the results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the license statistics display to include additional key metrics such as usage days, active licenses, progress indicators, signups, and age-related data for a more comprehensive overview.

- **Refactor**
  - Consolidated multiple metric updates into a unified summary structure to streamline data presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->