### PR TITLE
hide simulate leaderboard for non-admin

### DIFF
--- a/app/templates/play/ladder/ladder.pug
+++ b/app/templates/play/ladder/ladder.pug
@@ -203,13 +203,16 @@ block content
       .inline-simulation-stats
         #simulate-tab-view
   else
+    if !me.isAdmin()
+      .inline-simulation-stats
+        #simulate-tab-view
     ul.nav.nav-pills
       li.active
         a(href="#ladder", data-toggle="tab", data-i18n="general.ladder") Ladder
       if !me.get('anonymous')
         li
           a(href="#my-matches", data-toggle="tab", data-i18n="ladder.my_matches") My Matches
-        if view.leagueType !== 'course'
+        if view.leagueType !== 'course' && me.isAdmin()
           li
             a(href="#simulate", data-toggle="tab", data-i18n="ladder.simulate") Simulate
       if view.winners
@@ -285,8 +288,9 @@ block content
         #new-leaderboard-view
       .tab-pane.well#my-matches
         #my-matches-tab-view
-      .tab-pane.well#simulate
-        #simulate-tab-view
+      if me.isAdmin()
+        .tab-pane.well#simulate
+          #simulate-tab-view
 
       if view.level.get('name') === 'Greed' || view.level.get('name') === 'Criss-Cross' || view.level.get('name') === 'Zero Sum'
         .tab-pane.well#winners

--- a/app/views/ladder/SimulateTabView.js
+++ b/app/views/ladder/SimulateTabView.js
@@ -178,7 +178,7 @@ class SimulatorsLeaderboardData extends CocoClass {
       }
       promises.push($.ajax('/db/level/-/ladder-match-queue-count', { success: queueSuccess, cache: false }))
     }
-    if (!this.level.isType('ladder')) {
+    if (!this.level.isType('ladder') && me.isAdmin()) {
       this.topSimulators = new SimulatorsLeaderboardCollection({ order: -1, scoreOffset: -1, limit: 20 })
       promises.push(this.topSimulators.fetch())
       const score = this.me.get('simulatedBy') || 0


### PR DESCRIPTION
result: 
![image](https://github.com/user-attachments/assets/a931196d-b517-4e03-86a6-35debfa74924)


acutally i notice that course-ladder doesn't show up the simulate leaderboard but actually load it. that's why we have so many hits I think. and also notice that most of hero-ladders are closed, so most of home user may already turn to ai-league. i think hide this leaderboard make sense. let's see if anyone complain about it.

fix ENG-1679

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Refined the ladder view so that simulation statistics and the "Simulate" tab are displayed based on user permissions. Non-admin users see a streamlined view while simulation details and controls are available only to admins.
	- Adjusted the data fetching for simulation metrics to ensure that leaderboard data is retrieved exclusively for authorized users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->