### PR TITLE
better level chat

### DIFF
--- a/app/lib/user-utils.js
+++ b/app/lib/user-utils.js
@@ -93,17 +93,18 @@ async function levelChatCreditsString () {
     return $.i18n.t('user_credits.level_chat_no_credits_left')
   }
   const { creditsLeft, durationKey, durationAmount } = credits[0]
+  const i18nKey = $.i18n.t(`user_credits.level_chat_duration_${durationKey}`)
   if (creditsLeft > 0) {
     if (durationAmount > 1) {
-      return $.i18n.t('user_credits.level_chat_left_in_duration_multiple', { credits: creditsLeft, duration_key: durationKey, duration_amount: durationAmount })
+      return $.i18n.t('user_credits.level_chat_left_in_duration_multiple', { credits: creditsLeft, duration_key: i18nKey, duration_amount: durationAmount })
     } else {
-      return $.i18n.t('user_credits.level_chat_left_in_duration', { credits: creditsLeft, duration_key: durationKey })
+      return $.i18n.t('user_credits.level_chat_left_in_duration', { credits: creditsLeft, duration_key: i18nKey })
     }
   } else {
     if (durationAmount > 1) {
-      return $.i18n.t('user_credits.level_chat_no_credits_left_duration_multiple', { duration_key: durationKey, duration_amount: durationAmount })
+      return $.i18n.t('user_credits.level_chat_no_credits_left_duration_multiple', { duration_key: i18nKey, duration_amount: durationAmount })
     } else {
-      return $.i18n.t('user_credits.level_chat_no_credits_left_duration', { duration_key: durationKey })
+      return $.i18n.t('user_credits.level_chat_no_credits_left_duration', { duration_key: i18nKey })
     }
   }
 }

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -5483,6 +5483,10 @@ module.exports = {
       level_chat_no_credits_left_duration: 'No AI Bot queries left for the __duration_key__',
       level_chat_no_credits_left_duration_multiple: 'No AI Bot queries left for __duration_amount__ __duration_key__',
       level_chat_no_credits_left: 'No AI Bot queries left',
+      level_chat_duration_hour: 'hour',
+      level_chat_duration_day: 'day',
+      level_chat_duration_week: 'week',
+      level_chat_duration_month: 'month',
     },
     home_v3: {
       mission_title: 'Join us in our mission to make coding and AI accessible to all.',

--- a/app/locale/zh-HANS.js
+++ b/app/locale/zh-HANS.js
@@ -1047,7 +1047,7 @@ module.exports = {
       code_saved: '代码已保存',
       chat_placeholder: '[AI_TRANSLATION]需要编程帮助吗？和 AI 聊天。（实验性功能！）',
       chat_fix_show: '[AI_TRANSLATION]给我看',
-      //    chat_fix_hide: "Hide",
+      chat_fix_hide: '隐藏',
       skip_tutorial: '跳过（esc）',
       keyboard_shortcuts: '快捷键',
       loading_start: '开始',
@@ -5466,11 +5466,15 @@ module.exports = {
     },
 
     user_credits: {
-      level_chat_left_in_duration: '[AI_TRANSLATION]你有 __credits__ 次 AI Bot 查询次数剩余时间是 __duration_key__\n',
-      level_chat_left_in_duration_multiple: '[AI_TRANSLATION]你有 __credits__ 次 AI Bot 查询次数剩余时间是 __duration_amount__ __duration_key__\n',
-      level_chat_no_credits_left_duration: '[AI_TRANSLATION]没有 AI Bot 查询了 __duration_key__',
-      level_chat_no_credits_left_duration_multiple: '[AI_TRANSLATION]剩下没有 AI 机器人查询 __duration_amount__ __duration_key__  ',
-      level_chat_no_credits_left: '[AI_TRANSLATION]无 AI 机器人查询',
+      level_chat_left_in_duration: '你每 __duration_key__ 有 __credits__ 次 AI 问答次数',
+      level_chat_left_in_duration_multiple: '你每 __duration_amount__ __duration_key__ 有 __credits__ 次 AI 问答次数',
+      level_chat_no_credits_left_duration: '没有 AI 问答次数了( 这一__duration_key__)',
+      level_chat_no_credits_left_duration_multiple: '没有 AI 问答次数了( 这 __duration_amount__ __duration_key__)',
+      level_chat_no_credits_left: '没有 AI 问答次数了',
+      level_chat_duration_hour: '个小时',
+      level_chat_duration_day: '天',
+      level_chat_duration_week: '周',
+      level_chat_duration_month: '个月',
     },
 
     home_v3: {

--- a/app/views/play/level/LevelChatView.coffee
+++ b/app/views/play/level/LevelChatView.coffee
@@ -91,7 +91,7 @@ module.exports = class LevelChatView extends CocoView
     content = content.replace /^\|Free\|?:? ?(.*?)$/gm, '$1'
     content = content.replace /^\|Issue\|?:? ?(.*?)$/gm, '\n$1'
     content = content.replace /^\|Explanation\|?:? ?(.*?)$/gm, '\n*$1*\n'
-    #content = content.replace /\|Code\|?:? ?`{0,3}\n?((.|\n)*?)`{0,3}\n?$/g, '```$1```'
+    # content = content.replace /\|Code\|?:? ?`{0,3}\n?((.|\n)*?)`{0,3}\n?$/g, '|Code|: ```$1```'
     content = content.replace /\|Code\|?:? ?\n?```.*?\n((.|\n)*?)```\n?/g, (match, p1) =>
       @lastFixedCode = p1
       if p1

--- a/app/views/play/level/tome/ProblemAlertView.coffee
+++ b/app/views/play/level/tome/ProblemAlertView.coffee
@@ -67,7 +67,8 @@ module.exports = class ProblemAlertView extends CocoView
     super()
 
   afterRender: ->
-    @$('[data-toggle="popover"]').popover()
+    $('.chatbot-hint').popover().click () =>
+      setTimeout((() => $('.chatbot-hint').popover('hide')), 3000)
     unless me.showChinaResourceInfo()
       unless @creditMessage
         @handleUserCreditsMessage()

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -1846,6 +1846,7 @@ module.exports = class SpellView extends CocoView
     if solution.classList.contains('display')
       solution.classList.remove('display')
     else
+      solution.style.opacity = 1
       solution.classList.add('display')
       Backbone.Mediator.publish 'tome:hide-problem-alert', {}
     return if @solutionStreaming


### PR DESCRIPTION
fix ENG-1710
![image](https://github.com/user-attachments/assets/22a2fe12-1453-44cc-92f4-96cd876b8427)
the credit message popover can't closed if the user forget to click the question mark again and the problemAlert view auto hide. so I add a 3s auto close function. the double click still be able to close the popover, and if not, popover would auto closed in 3s. 

other updates are mainly about i18n. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced localization for credit duration messages with new time keys (hour, day, week, month) for greater clarity.
	- Updated language support to provide more detailed and user-friendly credit notifications.
	- Improved chat formatting for code snippets, offering a clearer and more distinctive presentation.
	- Refined hint interactions with popovers that now auto-hide after a short delay, and smoother solution display transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->