### PR TITLE
Lock home version campaign islands when no levels are unlocked

### DIFF
--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -550,6 +550,7 @@ module.exports = {
       owned: 'Owned', // For items you own
       locked: 'Locked',
       locked_by_teacher: 'Locked By Teacher',
+      locked_campaign: 'Complete previous world to unlock',
       available: 'Available',
       skills_granted: 'Skills Granted', // Property documentation details
       heroes: 'Heroes', // Tooltip on hero shop button from /play

--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -827,7 +827,7 @@ $gameControlMargin: 30px
 
         &.locked
           @include filter(contrast(80%) brightness(80%))
-          pointer-events: none
+          cursor: default
 
         &.forest
           background-position: (-1 * $campaignWidth) 0
@@ -906,7 +906,7 @@ $gameControlMargin: 30px
 
           &.locked
             @include filter(contrast(80%) brightness(80%))
-            pointer-events: none
+            cursor: default
 
           .campaign-label
             position: absolute

--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -304,7 +304,7 @@ if showGameDevAlert
                 - var campaign = campaigns[campaignSlug];
                 if !campaign
                   - continue;
-                div(class="beta-campaign" + (campaign ? "" : " silhouette") + (campaign && campaign.locked && !godmode ? " locked" : ""), data-campaign-slug=campaignSlug)
+                div(class="beta-campaign" + (campaign ? "" : " silhouette") + (campaign && campaign.locked && !godmode ? " locked" : ""), data-campaign-slug=campaignSlug, data-i18n="[title]play.locked_campaign" : "", data-placement="bottom")
                   .background-container(class=campaignSlug)
                   .campaign-label
                     h3.campaign-name
@@ -328,7 +328,7 @@ if showGameDevAlert
                         span= i18n(campaign.attributes, 'description')
           else
             - var campaign = campaigns[campaignSlug];
-            div(class="campaign " + campaignSlug + (campaign ? "" : " silhouette") + (campaign && campaign.locked && !godmode ? " locked" : ""), data-campaign-slug=campaignSlug)
+            div(class="campaign " + campaignSlug + (campaign ? "" : " silhouette") + (campaign && campaign.locked && !godmode ? " locked" : ""), data-campaign-slug=campaignSlug, data-i18n="[title]play.locked_campaign" : "")
               .campaign-label
                 h2.campaign-name
                   if campaign


### PR DESCRIPTION
Previously, you could click on them and then be taken to an empty map with nothing to do. Now, you can't click on them, and hovering over them shows a basic message to complete the previous world to unlock.
![Screenshot 2025-03-23 at 15 50 24](https://github.com/user-attachments/assets/76e175a2-1b74-4d1a-9b35-af78ad11b558)
