### PR TITLE
add request quote button in top nav for teachers

### DIFF
--- a/app/components/common/Navigation.vue
+++ b/app/components/common/Navigation.vue
@@ -62,7 +62,12 @@ export default Vue.extend({
     AnnouncementModal,
     AnnouncementNav,
     'cta-button': CTAButton,
-    caret: CaretDown
+    caret: CaretDown,
+  },
+  data () {
+    return {
+      showContactModal: false,
+    }
   },
   computed: {
     ...mapGetters('announcements', [
@@ -552,6 +557,9 @@ export default Vue.extend({
                     //- string replaced in RootView
                     span.language-dropdown-current Language
                   ul(class="dropdown-menu language-dropdown")
+              ul.nav.navbar-nav(v-if="me.isTeacher() && !me.hideTopRightNav()")
+                li
+                  cta-button.request-demo-button(data-event-action="Header Request Demo CTA" size="small" href="/schools?openContactModal=true") {{ $t('new_home.request_quote') }}
 </template>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
fixes ENG-1509

<img width="1029" alt="Screenshot 2025-03-25 at 1 42 55 PM" src="https://github.com/user-attachments/assets/e3c4e63e-d683-4677-a2df-a17c515d6c84" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the top navigation bar: teachers now see a Request Demo button that opens a contact modal, streamlining the process for demo requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->