### PR TITLE
locking changes

### DIFF
--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -92,7 +92,7 @@ module.exports = class LevelLoader extends CocoClass
 
 
   loadClassroomIfNecessary: ->
-    if not @classroomId and not @courseInstanceId
+    if not @classroomId and not @courseInstanceID
       @onAccessibleLevelLoaded()
       return
     if @headless and not @level?.isType('web-dev')

--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -97,7 +97,7 @@ module.exports = class LevelLoader extends CocoClass
       return
 
     if not @classroomId and not @courseInstanceID
-      if me.isAdmin()
+      if me.isAdmin() or !me.isStudent()
         @onAccessibleLevelLoaded()
       noty({
         text: 'Classroom not found',

--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -92,12 +92,20 @@ module.exports = class LevelLoader extends CocoClass
 
 
   loadClassroomIfNecessary: ->
-    if not @classroomId and not @courseInstanceID
-      @onAccessibleLevelLoaded()
-      return
     if @headless and not @level?.isType('web-dev')
       @onAccessibleLevelLoaded()
       return
+
+    if not @classroomId and not @courseInstanceID
+      if me.isAdmin()
+        @onAccessibleLevelLoaded()
+      noty({
+        text: 'Classroom not found',
+        type: 'error',
+        timeout: 5000,
+      })
+      return
+
     if @courseInstanceID and not @classroomId
       @courseInstance = new CourseInstance({_id: @courseInstanceID})
       @courseInstance.fetch().then =>

--- a/app/models/ClassroomLib.js
+++ b/app/models/ClassroomLib.js
@@ -78,19 +78,14 @@ const ClassroomLib = {
 
     if (typeof value === 'undefined' && modifier === 'locked') {
       // Legacy behavior.
-      return ClassroomLib.isStudentOnLockedLevel(classroomAttributes, studentId, courseIdToCheck, level)
+      return ClassroomLib.isStudentOnLockedLevelLegacy(classroomAttributes, studentId, courseIdToCheck, level)
     }
 
     // If we have a modifier expiry date, then we check if the modifier will expire at the given date.
     if (modifierExpiryDate) {
-      if (new Date(value).toString() === modifierExpiryDate.toString()) {
+      if (value && new Date(value).toString() === modifierExpiryDate.toString()) {
         return true
       }
-      return false
-    }
-
-    if (!value) {
-      // If we have not tracked a locked course, then assume unlocked.
       return false
     }
 
@@ -101,9 +96,12 @@ const ClassroomLib = {
     if (new Date(value) > new Date()) {
       return true
     }
+
+    return false
   },
 
-  isStudentOnLockedLevel: (classroom, studentId, courseIdToCheck, levelOriginal) => {
+  // this is deprecated and will be removed in the future
+  isStudentOnLockedLevelLegacy: (classroom, studentId, courseIdToCheck, levelOriginal) => {
     const studentCourseLocked = classroom?.studentLockMap?.[studentId]?.courseId
     if (!studentCourseLocked) {
       // If we have not tracked a locked course, then assume unlocked.

--- a/app/schemas/models/classroom.schema.js
+++ b/app/schemas/models/classroom.schema.js
@@ -113,7 +113,7 @@ _.extend(ClassroomSchema.properties, {
     additionalProperties: c.object(
       { title: 'Student Lock Object', description: 'Key value of student id tied to the lock data.' }, {
         courseId: c.objectId(),
-        levelOriginal: c.objectId(),
+        levelOriginal: c.objectId({ description: 'Deprecated: use lockedLevels instead' }),
         lockedScenarioLevels: c.object({
           description: 'AI Scenario levels that can be locked or unlocked',
           additionalProperties: ['boolean', c.stringDate()]

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/ViewAndManage.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/ViewAndManage.vue
@@ -207,7 +207,9 @@ export default {
           />
           <!-- The tooltip -->
           <template slot="popover">
-            <lock-or-skip :shown="lockOrSkipShown" />
+            <lock-or-skip
+              :shown="lockOrSkipShown"
+            />
           </template>
         </v-popover>
       </div>

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/LockOrSkip.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/LockOrSkip.vue
@@ -42,7 +42,8 @@ export default {
       SKIP: { modifiers: ['locked', 'optional'], value: true },
       UNSKIP: { modifiers: ['locked', 'optional'], value: false },
       MAKE_OPTIONAL: { modifiers: ['optional'], value: true },
-      REMOVE_OPTIONAL: { modifiers: ['optional'], value: false }
+      REMOVE_OPTIONAL: { modifiers: ['optional'], value: false },
+      inProgress: false,
     }
   },
 
@@ -112,13 +113,14 @@ export default {
       this.showDatepicker = !this.showDatepicker
     },
 
-    submit () {
-      this.updateLevelAccessStatus()
+    async submit () {
+      await this.updateLevelAccessStatus()
       this.deselectAllOriginals()
       this.deselectAllStudentIds()
     },
 
-    updateLevelAccessStatus () {
+    async updateLevelAccessStatus () {
+      this.inProgress = true
       const date = (this.action === this.LOCK && this.showDatepicker && this.selectedDate) || null
       const args = {
         classroom: this.classroom,
@@ -135,10 +137,11 @@ export default {
         date
       }
       if (this.isHackStack) {
-        this.updateScenarioAccessStatusForSelectedStudents(args)
+        await this.updateScenarioAccessStatusForSelectedStudents(args)
       } else {
-        this.updateLevelAccessStatusForSelectedStudents(args)
+        await this.updateLevelAccessStatusForSelectedStudents(args)
       }
+      this.inProgress = false
     },
     selectAllOriginals () {
       this.replaceSelectedOriginals(this.allOriginals || this.selectableOriginals)
@@ -232,6 +235,9 @@ export default {
         href="#"
         @click="submit"
       >{{ $t('common.submit') }}</a>
+      <div v-if="inProgress">
+        {{ $t('teacher.in_progress') }}..
+      </div>
     </div>
 
     <div

--- a/ozaria/site/components/teacher-dashboard/common/progress/progressDot.vue
+++ b/ozaria/site/components/teacher-dashboard/common/progress/progressDot.vue
@@ -197,8 +197,6 @@ export default {
     levelAccessStatus () {
       if (this.isLocked && !this.lockDate && !this.isOptional) {
         return 'locked'
-      } else if (!this.isLocked && !this.isPlayable && !this.lockDate) {
-        return 'locked-by-previous'
       } else if (this.lockDate && this.lockDate > new Date()) {
         return 'locked-with-timeframe'
       } else if (this.isSkipped) {
@@ -211,9 +209,6 @@ export default {
 
     hasClockIcon () {
       if (this.levelAccessStatus === 'locked-with-timeframe') {
-        return true
-      }
-      if (this.levelAccessStatus === 'locked-by-previous' && this.lastLockDate > new Date()) {
         return true
       }
       return false

--- a/ozaria/site/store/BaseSingleClass.js
+++ b/ozaria/site/store/BaseSingleClass.js
@@ -320,7 +320,7 @@ export default {
       }
 
       onSuccess?.()
-      dispatch('classrooms/updateClassroom', {
+      return dispatch('classrooms/updateClassroom', {
         classroom,
         updates: {
           studentLockMap: clonedClass.studentLockMap
@@ -403,7 +403,7 @@ export default {
       }
 
       onSuccess?.()
-      dispatch('classrooms/updateClassroom', {
+      return dispatch('classrooms/updateClassroom', {
         classroom,
         updates: {
           studentLockMap: clonedClass.studentLockMap


### PR DESCRIPTION
fixes ENG-1734, ENG-1733


- Remove locked by previous feature on teacher to avoid confusion
- Fix a bug on student side causing level to load even though it is locked
- Show in progress identifer during locking save on teacher

No locked by previous like before to avoid confusion:
<img width="724" alt="Screenshot 2025-04-01 at 4 34 54 PM" src="https://github.com/user-attachments/assets/65cd2479-ad76-4135-9b92-9c36d3841e94" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Non-admin users now receive a clear notification when classroom data is unavailable.
	- The teacher dashboard shows a loading indicator while access updates are processed.
	- Progress displays have been streamlined for a cleaner view of level access status.
	- A legacy method for checking student level access has been introduced, signaling a transition in functionality.

- **Bug Fixes**
	- Removed unnecessary conditions in the access status logic, simplifying the display of level access statuses.

- **Chores**
	- Adjusted formatting in the component templates for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->