### PR TITLE
Catalyst in-campaign ui and polishing

### DIFF
--- a/app/styles/common/common.sass
+++ b/app/styles/common/common.sass
@@ -223,7 +223,7 @@ kbd
     width: 60px
     height: 60px
 
-.star
+.achievements-star
   display: inline-block
   background: transparent url(/images/achievements/star.png) no-repeat center
   background-size: contain
@@ -231,19 +231,19 @@ kbd
   height: 80px
   margin: 0px 2px
 
-  &.star-20
+  &.achievements-star-20
     width: 20px
     height: 20px
 
-  &.star-30
+  &.achievements-star-30
     width: 30px
     height: 30px
 
-  &.star-40
+  &.achievements-star-40
     width: 40px
     height: 40px
 
-  &.star-50
+  &.achievements-star-50
     width: 50px
     height: 50px
 .popover

--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -842,9 +842,32 @@ $gameControlMargin: 30px
 
         &.highlighted
           @include animation(jiggle .3s 20)
+          
 
-      
+    &.in-campaign
+      flex-direction: row
+      bottom: 2%
+      right: 50%
+      top: auto
+      transform: translateY(0) translateX(100%)
 
+      .btn
+        margin-top: 0
+        height: 40px
+        width: 40px
+        &:not(:first-child)
+          margin-left: 20px
+
+        &.hackstack-menu-icon
+          transform: scale(2) translateY(-5px)
+          margin-right: 20px
+
+        &.roblox-menu-icon
+          transform: scale(2) translateY(-5px) translateX(10px)
+
+        &.ai-league-menu-icon
+          transform: scale(1.5) translateY(-5px)
+        
     .tooltip
       font-size: 24px
 

--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -194,7 +194,7 @@ $gameControlMargin: 30px
         width: 170%
         left: -35%
 
-      img.star
+      img.level-star
         width: 100%
         bottom: 4%
         position: absolute

--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -925,24 +925,26 @@ $gameControlMargin: 30px
     top: 10px
     right: 30px
     text-align: right
-    font-size: 24px
+    font-size: 26px
     color: white
     text-shadow: 0px 2px 1px black, 0px -2px 1px black, -2px 0px 1px black, 2px 0px 1px black
-    height: 33px
-    line-height: 33px
+    height: 40px
+    line-height: 40px
 
-    
     .stats-row
       margin-bottom: 10px
       margin-top: 10px
     
     .user-status-line
       position: relative
+      display: flex
+      align-items: center
+      justify-content: flex-end
 
       .btn.btn-illustrated
         margin-left: 10px
         min-width: 90px
-        height: 33px
+        height: 40px
         color: white
 
         option
@@ -953,18 +955,24 @@ $gameControlMargin: 30px
         margin-right: 10px
 
       .gem, .player-hero-icon
-        position: absolute
-        top: 1px
+        position: relative
+        top: auto
 
       #gems-count
-        margin-left: 40px
+        margin-left: 5px
+        display: inline-flex
+        align-items: center
 
       .player-level
         margin-left: 5px
+        display: inline-flex
+        align-items: center
 
       .player-name
-        margin-left: 45px
+        margin-left: 5px
         margin-right: 10px
+        display: inline-flex
+        align-items: center
 
       a
         color: white
@@ -981,15 +989,9 @@ $gameControlMargin: 30px
         display: inline-block
         width: 30px
         height: 30px
-        margin: 0px 2px
-
-      .level-indicator
-        margin-left: 15px
-        color: white
-        display: inline-block
-        margin: 0 2px
-
-      .player-hero-icon
+        margin: 0px 4px
+        transform: scale(1.33)  // Scale up by 1.33 to get from 30px to ~40px
+        transform-origin: center center
         margin-left: 10px
         background-position: (-4 * $spriteSheetSize) 0
 
@@ -1009,8 +1011,13 @@ $gameControlMargin: 30px
           background-position: (-11 * $spriteSheetSize) 0
         &.sorcerer
           background-position: (-12 * $spriteSheetSize) 0
-            
-      
+
+      .level-indicator
+        margin-left: 15px
+        color: white
+        display: inline-block
+        margin: 0 2px
+
 
   .campaign-control-button
     position: absolute

--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -616,6 +616,7 @@ $gameControlMargin: 30px
     flex-direction: column
     gap: 10px
 
+    
     .btn
       &:not(:first-child)
         margin-left: 0
@@ -707,6 +708,16 @@ $gameControlMargin: 30px
 
         &.highlighted
           @include animation(jiggle .3s 20)
+      
+    &.in-campaign
+      flex-direction: row
+      bottom: 2%
+      top: auto
+      transform: translateY(0)
+      .btn
+        margin-top: 0
+        &:not(:first-child)
+          margin-left: 10px
 
     .tooltip
       font-size: 24px

--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -1698,7 +1698,7 @@ body[lang^="en"] #campaign-view .user-status-catalyst .user-status-line .languag
 
 .utility-controls-catalyst
   position: absolute
-  left: 20px
+  right: 20px
   bottom: 20px
   z-index: 10
   display: flex

--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -549,9 +549,8 @@ if showGameDevAlert
             span.gem.gem-30
             span#gems-count.spr= me.gems()
           if view.shouldShow('level')
-            .rtl-allowed
-              span.star.star-30
-              span.player-level.spr= me.level()
+            span.star.star-30
+            span.player-level.spr= me.level()
           if me.get('anonymous')
             button.btn.btn-illustrated.login-button.btn-warning(data-i18n="login.log_in")
             button.btn.btn-illustrated.signup-button.btn-danger(data-i18n="signup.sign_up")

--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -482,8 +482,8 @@ if showGameDevAlert
                       span.campaign-age-description(data-i18n="play.age_description_" + campaignProductName)
                       br
                     span= i18n(campaign.attributes, 'description')
-  if view.isCatalyst && !campaign
-    .game-controls-catalyst.header-font.picoctf-hide
+  if view.isCatalyst
+    .game-controls-catalyst.header-font.picoctf-hide(class=campaign != null ? "in-campaign" : "")
       if !(features.picoCtf || features.brainPop)
         if view.shouldShow('premium')
           button.btn.premium-menu-icon(data-i18n="[title]subscribe.subscribe_modal_title")

--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -70,7 +70,7 @@ if showGameDevAlert
     if view.shouldShow('videos')
       a.btn.btn-illustrated.btn-block.btn-lg.text-uppercase#videos-button(data-i18n="play_level.videos")
 
-    if view.shouldShow('league-arena')
+    if view.shouldShow('league-arena') && !view.isCatalyst
       for arena in view.activeArenas()
         // TODO: change from play to view standings if new Date() > arena.end
         - var playArenaText = $.t('league.play_arena_short', {arenaName: $.t('league.' + arena.slug.replace(/-/g, '_')), interpolation: {escapeValue: false}})
@@ -533,7 +533,7 @@ if showGameDevAlert
         if !me.get('anonymous', true) && view.shouldShow('settings')
           a.btn.account(href="/account/settings", data-i18n="[title]play.settings")
 
-  if view.isCatalyst && !campaign
+  if view.isCatalyst
     .user-status-catalyst.header-font.picoctf-hide
       .user-status-line
         if view.shouldShow('status-line')
@@ -610,7 +610,7 @@ if showGameDevAlert
       .glyphicon.glyphicon-volume-down
       .glyphicon.glyphicon-volume-up
 
-  if campaign && campaign.get('type') !== 'hoc' && !editorMode && view.shouldShow('back-to-campaigns')
+  if !view.isCatalyst && campaign && campaign.get('type') !== 'hoc' && !editorMode && view.shouldShow('back-to-campaigns')
     button.btn.btn-lg.btn-inverse.campaign-control-button.picoctf-hide#back-button(data-i18n="[title]resources.campaigns", title="Campaigns")
       .glyphicon.glyphicon-globe
 

--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -567,11 +567,11 @@ if showGameDevAlert
               span.m7-off(data-i18n="play.beta_levels_turn_off")
 
     .utility-controls-catalyst.header-font.picoctf-hide
+      select.language-dropdown.btn.btn-inverse#language-button(data-i18n="[title]play_level.language", title="Languages")
       button.btn.btn-lg.btn-inverse.picoctf-hide#volume-button(data-i18n="[title]play.adjust_volume", title="Adjust volume")
         .glyphicon.glyphicon-volume-off
         .glyphicon.glyphicon-volume-down
         .glyphicon.glyphicon-volume-up
-      select.language-dropdown.btn.btn-inverse#language-button(data-i18n="[title]play_level.language", title="Languages")
   else
     .user-status.header-font.picoctf-hide
       .user-status-line

--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -497,7 +497,7 @@ if showGameDevAlert
           button.btn.gems(data-toggle='coco-modal', data-target='play/modal/BuyGemsModal', data-i18n="[title]play.buy_gems")
         if !me.get('anonymous', true) && view.shouldShow('settings')
           a.btn.account(href="/account/settings", data-i18n="[title]play.settings")
-    .other-products-catalyst.header-font.picoctf-hide
+    .other-products-catalyst.header-font.picoctf-hide(class=campaign != null ? "in-campaign" : "")
       if !(features.picoCtf || features.brainPop)
         if view.shouldShow('hackstack')
           span.btn.hackstack-menu-icon(title='CodeCombat AI HackStack')

--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -142,7 +142,7 @@ if showGameDevAlert
             img.hero-portrait(src="/file/db/thang.type/" + level.unlocksHero + "/portrait.png")
           a(href=level.type == 'hero' ? '#' : level.disabled ? "/play" : "/play/" + (level.levelPath || 'level') + "/" + level.slug, disabled=level.disabled, data-level-slug=level.slug, data-level-path=level.levelPath || 'level', data-level-name=level.name)
           if levelStatus === 'complete'
-            img.star(src="/images/pages/play/star.png")
+            img.level-star(src="/images/pages/play/star.png")
           if editorMode
             - var kindKey = ((level.kind && level.kind[0]) || "").toUpperCase();
             //if kindKey
@@ -549,7 +549,7 @@ if showGameDevAlert
             span.gem.gem-30
             span#gems-count.spr= me.gems()
           if view.shouldShow('level')
-            span.star.star-30
+            span.achievements-star.achievements-star-30
             span.player-level.spr= me.level()
           if me.get('anonymous')
             button.btn.btn-illustrated.login-button.btn-warning(data-i18n="login.log_in")

--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -66,6 +66,8 @@ if showGameDevAlert
 
     if view.shouldShow('back-to-classroom')
       a.btn.btn-illustrated.btn-success.btn-block.btn-lg.text-uppercase(href='/play', data-i18n="play.back_to_classroom")
+    if view.isCatalyst && campaign != null
+      a.btn.btn-illustrated.btn-success.btn-block.btn-lg.text-uppercase#back-button-catalyst(data-i18n="play_level.back_to_map", title="Back to Map")
 
     if view.shouldShow('videos')
       a.btn.btn-illustrated.btn-block.btn-lg.text-uppercase#videos-button(data-i18n="play_level.videos")

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -2174,7 +2174,9 @@ class CampaignView extends RootView {
     }
 
     if (what === 'anonymous-classroom-signup') {
-      return me.isAnonymous() && (me.level() < 8) && me.promptForClassroomSignup() && !this.editorMode && this.terrain !== 'junior' && !storage.load('hid-anonymous-classroom-signup-dialog')
+      return me.isAnonymous() && !this.isCatalyst &&
+        (me.level() < 8) && me.promptForClassroomSignup() &&
+        !this.editorMode && this.terrain !== 'junior' && !storage.load('hid-anonymous-classroom-signup-dialog')
     }
 
     if (what === 'amazon-campaign') {

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -1997,6 +1997,7 @@ class CampaignView extends RootView {
     if (application.getHocCampaign()) { return false }
     if (me.isInHourOfCode()) { return false }
     if (userUtils.isInLibraryNetwork() || userUtils.libraryName()) { return false }
+    if (this.isCatalyst) { return false }
     const latest = window.serverConfig.latestAnnouncement
     const myLatest = me.get('lastAnnouncementSeen')
     if (typeof latest !== 'number') { return }

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -106,6 +106,7 @@ class CampaignView extends RootView {
       'click .level-info-container .course-version button': 'onClickCourseVersion',
       'click #volume-button': 'onToggleVolume',
       'click #back-button': 'onClickBack',
+      'click #back-button-catalyst': 'onClickBack',
       'click #clear-storage-button': 'onClickClearStorage',
       'click .portal .campaign': 'onClickPortalCampaign',
       'click .portal .beta-campaign': 'onClickPortalCampaign',


### PR DESCRIPTION
Closes GD-446, GD-567, GD-458

- Removed teacher pop up for catalyst
- Improved alignment for top panel (see screenshot)
- Removed announcement modals for catalyst
- Reorganized in-campaign UI

![Screenshot 2025-03-31 at 16 42 34](https://github.com/user-attachments/assets/9f55a11c-86b3-411f-a3c2-87aebb85e41c)
![Screenshot 2025-04-02 at 09 51 44](https://github.com/user-attachments/assets/fab5097d-8458-413c-bf24-e3c7b77c0914)

![Screenshot 2025-04-02 at 09 52 03](https://github.com/user-attachments/assets/6b4f5398-99e1-484b-b4fe-bd38915d785a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new navigation button to return to the map during campaign mode.
  - Enhanced the display of campaign-related elements based on active campaign status.

- **Style**
  - Updated achievement icon styling for clearer visual cues.
  - Refined the layout in campaign views with improved spacing, button sizing, and enhanced alignment for user status and game controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->