### PR TITLE
hide revoke button for lebanon users

### DIFF
--- a/app/templates/courses/manage-licenses-modal.pug
+++ b/app/templates/courses/manage-licenses-modal.pug
@@ -160,9 +160,10 @@ block modal-body-content
     .col-sm-4
       .text-center
         span.change-tab(data-i18n='teacher.apply_licenses', data-tab='apply', class=(activeTab == 'apply' ? 'focus' : ''))
-    .col-sm-4
-      .text-center
-        span.change-tab(data-i18n='teacher.check_and_revoke_license', data-tab='revoke', class=(activeTab == 'revoke'? 'focus': ''))
+    if me.get('country') !== 'lebanon'
+      .col-sm-4
+        .text-center
+          span.change-tab(data-i18n='teacher.check_and_revoke_license', data-tab='revoke', class=(activeTab == 'revoke'? 'focus': ''))
     .col-sm-2
       | .
 

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/ViewAndManage.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/ViewAndManage.vue
@@ -61,6 +61,10 @@ export default {
 
     sortBy () {
       return storage.load('sortMethod') || 'Last Name'
+    },
+
+    me () {
+      return window.me
     }
   },
   methods: {
@@ -162,7 +166,7 @@ export default {
           @click="applyLicenses"
         />
         <icon-button-with-text
-          v-if="showLicenses"
+          v-if="showLicenses && me.get('country') !== 'lebanon'"
           class="icon-with-text larger-icon"
           :icon-name="displayOnly ? 'IconLicenseRevoke_Gray' : 'IconLicenseRevoke'"
           :text="$t('teacher_dashboard.revoke_licenses')"


### PR DESCRIPTION
simply hide the revoke button to forbid lebanon teachers revoke their license.
fix ENG-1730

![image](https://github.com/user-attachments/assets/c5853ea1-a551-4516-ac60-7d4c2ed39237)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated license management options: The "check and revoke license" functionality now appears only for users outside of Lebanon.
	- Enhanced teacher dashboard: License revocation controls are now tailored based on your geographical location, providing a more refined user interface experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->