### PR TITLE
show discontinued soon message in old dashboard

### DIFF
--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -2890,6 +2890,7 @@ module.exports = {
       stop_spying_student: 'You can return to the teacher account by clicking `Stop Spying` in the user dropdown',
       show_practice_levels: 'Show Practice Levels',
       hide_practice_levels: 'Hide Practice Levels',
+      dashboard_deprecation_message: 'This legacy dashboard will be discontinued soon. To ensure uninterrupted access to all features and the best teaching tools, please transition to our new and improved Teacher Dashboard.',
     },
 
     teacher_licenses: {

--- a/app/templates/courses/teacher-classes-view.pug
+++ b/app/templates/courses/teacher-classes-view.pug
@@ -70,6 +70,9 @@ block content
     .container.top-container
       div#classes-nag-subview
 
+      .alert.alert-warning
+        strong(data-i18n='teacher.dashboard_deprecation_message')
+
       h3
         span(data-i18n='teacher.current_classes')
         #dashboard-toggle(:show-title="true", size="sm")

--- a/app/templates/courses/teacher-classes-view.pug
+++ b/app/templates/courses/teacher-classes-view.pug
@@ -70,8 +70,9 @@ block content
     .container.top-container
       div#classes-nag-subview
 
-      .alert.alert-warning
-        strong(data-i18n='teacher.dashboard_deprecation_message')
+      if !view.chinaInfra
+        .alert.alert-warning
+          strong(data-i18n='teacher.dashboard_deprecation_message')
 
       h3
         span(data-i18n='teacher.current_classes')

--- a/app/views/courses/TeacherClassesView.js
+++ b/app/views/courses/TeacherClassesView.js
@@ -153,6 +153,8 @@ module.exports = (TeacherClassesView = (function () {
       this.trialRequests = new TrialRequests()
       this.trialRequests.fetchOwn()
       this.supermodel.trackCollection(this.trialRequests)
+
+      this.chinaInfra = features?.chinaInfra
     }
 
     static initClass () {


### PR DESCRIPTION
fixes ENG-1735

<img width="1182" alt="Screenshot 2025-04-02 at 4 10 07 PM" src="https://github.com/user-attachments/assets/01f2380b-06d0-4481-b95b-e89335a0b8f0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a deprecation warning that informs teachers the legacy dashboard will soon be discontinued.
  - Displayed an alert on the teacher view urging users to transition to the new Teacher Dashboard for uninterrupted access and improved tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->