### PR TITLE
Catalyst campaign description only on hover

### DIFF
--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -1345,6 +1345,7 @@ $gameControlMargin: 30px
     background: transparent url(/images/pages/play/portal-background.png)
     overflow-y: auto
     padding: 20px
+    $description-transition-time: 0.4s
 
     .portals
       display: flex
@@ -1387,6 +1388,10 @@ $gameControlMargin: 30px
             top: 45%
             width: 100%
             text-align: center
+
+            .play-button
+              margin: 15px 0
+              min-width: 100px
             
             // Text styling
             .campaign-name, .levels-completed, .campaign-locked
@@ -1397,6 +1402,10 @@ $gameControlMargin: 30px
             .campaign-description-container
               margin: 10px auto
               width: 80%
+              opacity: 0
+              visibility: hidden
+              transition: opacity $description-transition-time ease, visibility $description-transition-time ease
+              transition-delay: 0.15s
               
               .campaign-description
                 background: transparent url(/images/level/popover_border_background.png) no-repeat
@@ -1406,11 +1415,11 @@ $gameControlMargin: 30px
                 font-size: 14px
                 line-height: 1.2
                 margin: 0
-              
-            .play-button
-              margin: 15px 0
-              min-width: 100px
-        
+          
+          &:hover .campaign-label .campaign-description-container
+            opacity: 1
+            visibility: visible
+
       .campaign-rows
         display: flex
         flex-direction: column
@@ -1466,7 +1475,10 @@ $gameControlMargin: 30px
               width: 100%
               text-align: center
               
-              // Text styling
+              .play-button
+                margin: 15px 0
+                min-width: 100px
+              
               .campaign-name, .levels-completed, .campaign-locked
                 margin: 0
                 color: white
@@ -1475,6 +1487,10 @@ $gameControlMargin: 30px
               .campaign-description-container
                 margin: 10px auto
                 width: 80%
+                opacity: 0
+                visibility: hidden
+                transition: opacity $description-transition-time ease, visibility $description-transition-time ease
+                transition-delay: 0.15s
                 
                 .campaign-description
                   background: transparent url(/images/level/popover_border_background.png) no-repeat
@@ -1484,10 +1500,10 @@ $gameControlMargin: 30px
                   font-size: 14px
                   line-height: 1.2
                   margin: 0
-                
-              .play-button
-                margin: 15px 0
-                min-width: 100px
+            
+            &:hover .campaign-label .campaign-description-container
+              opacity: 1
+              visibility: visible
             
           .side-campaign-container
             position: absolute
@@ -1533,6 +1549,10 @@ $gameControlMargin: 30px
                 text-align: center
                 z-index: 1
                 
+                .play-button
+                  margin: 15px 0
+                  min-width: 100px
+
                 .campaign-name, .levels-completed, .campaign-locked
                   margin: 0
                   color: white
@@ -1545,12 +1565,15 @@ $gameControlMargin: 30px
                   padding: 12px
                   color: black
                   font-size: 12px
-                
-                .play-button
-                  margin: 10px 0
-                  min-width: 100px
-                  color: white
+                  opacity: 0
+                  visibility: hidden
+                  transition: opacity $description-transition-time ease, visibility $description-transition-time ease
+                  transition-delay: 0.15s
               
+              &:hover .campaign-label .campaign-description
+                opacity: 1
+                visibility: visible
+
               .background-container
                 position: absolute
                 top: 0

--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -1416,7 +1416,7 @@ $gameControlMargin: 30px
                 line-height: 1.2
                 margin: 0
           
-          &:hover .campaign-label .campaign-description-container
+          &:hover .campaign-description-container
             opacity: 1
             visibility: visible
 

--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -1501,7 +1501,7 @@ $gameControlMargin: 30px
                   line-height: 1.2
                   margin: 0
             
-            &:hover .campaign-label .campaign-description-container
+            &:hover .campaign-description-container
               opacity: 1
               visibility: visible
             
@@ -1570,7 +1570,7 @@ $gameControlMargin: 30px
                   transition: opacity $description-transition-time ease, visibility $description-transition-time ease
                   transition-delay: 0.15s
               
-              &:hover .campaign-label .campaign-description
+              &:hover .campaign-description
                 opacity: 1
                 visibility: visible
 


### PR DESCRIPTION
Closes GD-450

![image](https://github.com/user-attachments/assets/340327cd-1e89-4382-8a9d-dc1996e90a7b)
![image](https://github.com/user-attachments/assets/2c781599-eac1-48fb-9b08-2db48976b137)
![image](https://github.com/user-attachments/assets/def30442-78f9-4b11-ae3e-60ace2af26ba)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Enhanced campaign descriptions with smooth fade-in and fade-out effects on hover for an improved viewing experience.
  - Standardized play button styling across campaign sections to ensure a consistent, polished visual appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->