### PR TITLE
Yuqiang/more hero image not loading bug

### DIFF
--- a/app/views/play/level/modal/CourseVictoryComponent.vue
+++ b/app/views/play/level/modal/CourseVictoryComponent.vue
@@ -191,7 +191,7 @@
         juniorHeroReplacement = _.invert(thangTypeConstants.juniorHeroReplacements)[slug]
         if juniorHeroReplacement
           slug = juniorHeroReplacement
-        - heroesWithImg = ['stalwart', 'samurai', 'raider', 'guardian', 'goliath', 'duelist', 'champion', 'captain', 'knight']
+        heroesWithImg = ['stalwart', 'samurai', 'raider', 'guardian', 'goliath', 'duelist', 'champion', 'captain', 'knight']
         if slug in heroesWithImg
           return "/images/pages/play/modal/#{slug}.png"
         return "/images/pages/play/modal/captain.png"

--- a/app/views/play/level/modal/CourseVictoryComponent.vue
+++ b/app/views/play/level/modal/CourseVictoryComponent.vue
@@ -191,7 +191,8 @@
         juniorHeroReplacement = _.invert(thangTypeConstants.juniorHeroReplacements)[slug]
         if juniorHeroReplacement
           slug = juniorHeroReplacement
-        if slug in thangTypeConstants.heroClasses.Warrior
+        - heroesWithImg = ['stalwart', 'samurai', 'raider', 'guardian', 'goliath', 'duelist', 'champion', 'captain', 'knight']
+        if slug in heroesWithImg
           return "/images/pages/play/modal/#{slug}.png"
         return "/images/pages/play/modal/captain.png"
       comboImage: ->

--- a/ozaria/site/views/play/level/modal/CourseVictoryComponent.vue
+++ b/ozaria/site/views/play/level/modal/CourseVictoryComponent.vue
@@ -195,7 +195,7 @@
         juniorHeroReplacement = _.invert(thangTypeConstants.juniorHeroReplacements)[slug]
         if juniorHeroReplacement
           slug = juniorHeroReplacement
-        - heroesWithImg = ['stalwart', 'samurai', 'raider', 'guardian', 'goliath', 'duelist', 'champion', 'captain', 'knight']
+        heroesWithImg = ['stalwart', 'samurai', 'raider', 'guardian', 'goliath', 'duelist', 'champion', 'captain', 'knight']
         if slug in heroesWithImg
           return "/images/pages/play/modal/#{slug}.png"
         return "/images/pages/play/modal/captain.png"

--- a/ozaria/site/views/play/level/modal/CourseVictoryComponent.vue
+++ b/ozaria/site/views/play/level/modal/CourseVictoryComponent.vue
@@ -195,7 +195,8 @@
         juniorHeroReplacement = _.invert(thangTypeConstants.juniorHeroReplacements)[slug]
         if juniorHeroReplacement
           slug = juniorHeroReplacement
-        if slug in thangTypeConstants.heroClasses.Warrior
+        - heroesWithImg = ['stalwart', 'samurai', 'raider', 'guardian', 'goliath', 'duelist', 'champion', 'captain', 'knight']
+        if slug in heroesWithImg
           return "/images/pages/play/modal/#{slug}.png"
         return "/images/pages/play/modal/captain.png"
       comboImage: ->


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0fc63e69-7dc1-4c59-ac6f-3cd5f2ae71f3)
fix ENG-1703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the selection of hero images shown in the course victory modal to ensure accurate images are displayed for specific heroes. If a hero is not in the new supported list, the captain image will be shown by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->