### PR TITLE
curr guide changes

### DIFF
--- a/app/core/Router.js
+++ b/app/core/Router.js
@@ -511,6 +511,7 @@ module.exports = (CocoRouter = (function () {
         'teachers/resources_new': go('core/SingletonAppVueComponentView'),
         'teachers/curriculum': teacherProxyRoute(go('teachers/curriculum', { redirectStudents: true })),
         'teachers/curriculum/:campaign': teacherProxyRoute(go('teachers/curriculum', { redirectStudents: true })),
+        'teachers/guide/:product': teacherProxyRoute(go('core/SingletonAppVueComponentView'), { redirectStudents: true }),
         'teachers/resources/ap-cs-principles': go('teachers/ApCsPrinciplesView', { redirectStudents: true }),
         'teachers/resources/:name': go('teachers/MarkdownResourceView', { redirectStudents: true }),
         'teachers/professional-development': teacherProxyRoute(go('pd/PDView', { redirectStudents: true })),

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -367,6 +367,13 @@ if (isCodeCombat) {
   }
 }
 
+const JUNIOR_COURSE_IDS = [
+  courseIDs.JUNIOR,
+]
+const HACKSTACK_COURSE_IDS = [
+  courseIDs.HACKSTACK,
+]
+
 const allCourseIDs = _.assign(courseIDs, otherCourseIDs)
 
 const freeCocoCourseIDs = [allCourseIDs.JUNIOR, allCourseIDs.INTRODUCTION_TO_COMPUTER_SCIENCE, allCourseIDs.HACKSTACK]
@@ -1840,7 +1847,9 @@ module.exports = {
   ozBaseURL,
   useWebsocket,
   getProductUrl,
-  shaTag
+  shaTag,
+  JUNIOR_COURSE_IDS,
+  HACKSTACK_COURSE_IDS,
 }
 
 function __guard__ (value, transform) {

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -325,6 +325,11 @@ export default function getVueRouter () {
               ],
             },
             { path: 'apcsp', component: () => import(/* webpackChunkName: "apcsp" */ '../views/apcsp/PageMarketing.vue') },
+            {
+              path: 'guide/:product',
+              component: () => import(/* webpackChunkName: "guide" */ '../../ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/index.vue'),
+              props: true,
+            },
           ],
 
         },

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterContent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterContent.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="chapter-content">
+    <div class="fluid-container">
+      <div class="row">
+        <div class="col-md-9">
+          <module-content
+            v-for="num in moduleNumbers"
+            :key="num"
+            :module-num="num"
+            :is-capstone="isCapstoneModule(num)"
+          />
+          <div
+            v-if="moduleNumbers.length==0"
+            class="spinner-container"
+          >
+            <LoadingSpinner />
+          </div>
+        </div>
+        <div class="col-md-3">
+          <concepts-covered :concept-list="conceptsCovered" />
+          <csta-standards :csta-list="cstaStandards" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import ConceptsCovered from './ConceptsCovered'
+import CstaStandards from './CstaStandards'
+import ModuleContent from './ModuleContent'
+import LoadingSpinner from 'app/components/common/elements/LoadingSpinner'
+import { mapGetters } from 'vuex'
+import utils from 'core/utils'
+
+export default {
+  name: 'ChapterContent',
+  components: {
+    ConceptsCovered,
+    CstaStandards,
+    ModuleContent,
+    LoadingSpinner,
+  },
+  computed: {
+    ...mapGetters({
+      getModuleInfo: 'baseCurriculumGuide/getModuleInfo',
+      getCurrentCourse: 'baseCurriculumGuide/getCurrentCourse',
+    }),
+    moduleNumbers () {
+      return Object.keys(this.getModuleInfo || {})
+    },
+    conceptsCovered () {
+      return this.getCurrentCourse?.concepts || []
+    },
+
+    cstaStandards () {
+      return this.getCurrentCourse?.cstaStandards || []
+    },
+  },
+  methods: {
+    isCapstoneModule (moduleNum) {
+      if (utils.isCodeCombat) {
+        return false
+      }
+      // Assuming that last module is the capstone module, TODO store `isCapstoneModule` with module details in the course schema.
+      return moduleNum === this.moduleNumbers[this.moduleNumbers.length - 1]
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.fluid-container {
+  padding: 30px 25px;
+}
+</style>

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterInfo.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterInfo.vue
@@ -182,7 +182,12 @@ export default {
     const campaigns = new Campaigns([], { forceCourseNumbering: true })
     campaigns.fetchByType('course', { data: { project: 'levels,levelsUpdated' } })
     campaigns.on('sync', () => {
-      const campaign = campaigns.get(this.getCurrentCourse.campaignID)
+      const currentCourse = this.getCurrentCourse
+      if (!currentCourse) {
+        console.log('no current course')
+        return
+      }
+      const campaign = campaigns.get(currentCourse.campaignID)
       if (campaign) {
         this.levelsNameMap = campaign.getLevelNameMap()
       } else {

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterNav.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterNav.vue
@@ -28,13 +28,20 @@ export default {
     }
   },
 
-  created () {
-    this.setDefaultCampaign()
+  watch: {
+    chapters: {
+      immediate: true,
+      handler (newChapters) {
+        if (newChapters?.length > 0) {
+          this.setSelectedCampaign(newChapters[0].campaignID)
+        }
+      },
+    },
   },
 
   methods: {
     ...mapActions({
-      setSelectedCampaign: 'baseCurriculumGuide/setSelectedCampaign'
+      setSelectedCampaign: 'baseCurriculumGuide/setSelectedCampaign',
     }),
 
     classForButton (campaignID) {
@@ -47,21 +54,6 @@ export default {
     clickChapterNav (campaignID) {
       this.setSelectedCampaign(campaignID)
       window.tracker?.trackEvent('Curriculum Guide: Chapter Nav Clicked', { category: this.getTrackCategory, label: this.courseName })
-    },
-
-    setDefaultCampaign () {
-      // open the related campaign if course was selected on teacher dashboard
-      const classroomCourseId = this.classroomCourseId
-      if (!classroomCourseId) return
-
-      const courses = this.courses
-      if (!courses) return
-
-      const course = courses.find(course => course._id === classroomCourseId)
-
-      if (course && course.campaignID) {
-        this.setSelectedCampaign(course.campaignID)
-      }
     },
 
     showNewIcon (campaignID) {

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterNav.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterNav.vue
@@ -7,7 +7,12 @@ export default {
   components: {
     IconNew,
   },
-
+  props: {
+    chapters: {
+      type: Array,
+      required: true,
+    },
+  },
   computed: {
     ...mapGetters({
       chapterNavBar: 'baseCurriculumGuide/chapterNavBar',
@@ -17,21 +22,6 @@ export default {
       classroomCourseId: 'teacherDashboard/getSelectedCourseIdCurrentClassroom',
       courses: 'courses/sorted'
     }),
-
-    chapterNav () {
-      // This ensures released chapters are correctly placed, with internal chapters added after.
-      return (this.chapterNavBar || [])
-        .filter(({ releasePhase }) => releasePhase !== 'internalRelease')
-        .concat(
-          (this.chapterNavBar || [])
-            .filter(({ releasePhase }) => releasePhase === 'internalRelease')
-        ).map(({ campaignID, free, _id }, idx) => {
-          return ({
-            campaignID,
-            heading: utils.isCodeCombat ? utils.courseAcronyms[_id] : this.$t('teacher_dashboard.chapter_num', { num: idx + 1 })
-          })
-        })
-    },
 
     courseName () {
       return this.getCurrentCourse?.name || ''
@@ -84,7 +74,7 @@ export default {
 <template>
   <div id="chapter-nav">
     <div
-      v-for="{ campaignID, heading } in chapterNav"
+      v-for="{ campaignID, heading } in chapters"
       :key="campaignID"
       :class="classForButton(campaignID)"
       @click="() => clickChapterNav(campaignID)"

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/HeaderComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/HeaderComponent.vue
@@ -1,0 +1,127 @@
+<template>
+  <div class="header">
+    <div class="header-icon">
+      <img src="/images/ozaria/teachers/dashboard/svg_icons/IconCurriculumGuide.svg">
+      <h2>{{ $t('teacher_dashboard.curriculum_guide') }}</h2>
+    </div>
+    <div
+      class="header-right"
+    >
+      <div class="code-language-dropdown">
+        <span class="select-language">{{ $t('courses.select_language') }}</span>
+        <select @change="changeLanguage">
+          <option
+            value="python"
+            :selected="getSelectedLanguage === 'python'"
+          >
+            Python
+          </option>
+          <option
+            value="javascript"
+            :selected="getSelectedLanguage === 'javascript'"
+          >
+            JavaScript
+          </option>
+        </select>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapMutations, mapGetters } from 'vuex'
+export default {
+  name: 'HeaderComponent',
+  computed: {
+    ...mapGetters({
+      getSelectedLanguage: 'baseCurriculumGuide/getSelectedLanguage',
+    }),
+  },
+  methods: {
+    ...mapMutations({
+      setSelectedLanguage: 'baseCurriculumGuide/setSelectedLanguage',
+    }),
+    changeLanguage (e) {
+      window.tracker?.trackEvent('Curriculum Guide: Language Changed from dropdown', { category: this.getTrackCategory, label: this.courseName })
+      this.setSelectedLanguage(e.target.value)
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+@import "app/styles/bootstrap/variables";
+@import "ozaria/site/styles/common/variables.scss";
+@import "app/styles/ozaria/_ozaria-style-params.scss";
+
+.header {
+  height: 60px;
+
+  background-color: #f2f2f2;
+  border: 1px solid #d8d8d8;
+  /* Drop shadow bottom ref: https://css-tricks.com/snippets/css/css-box-shadow/ */
+  -webkit-box-shadow: 0 8px 6px -6px #D2D2D2;
+    -moz-box-shadow: 0 8px 6px -6px #D2D2D2;
+        box-shadow: 0 8px 6px -6px #D2D2D2;
+
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+
+  .header-icon {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    img {
+      margin-left: 25px;
+      margin-right: 10px;
+    }
+  }
+
+  h2 {
+    @include font-h-2-subtitle-white-24;
+    color: black;
+    line-height: 28px;
+    letter-spacing: 0.56px;
+  }
+
+  .header-right {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-right: 12px;
+  }
+
+  .code-language-dropdown {
+    select {
+      background: $twilight;
+      border: 1.5px solid #355EA0;
+      border-radius: 4px;
+      color: $moon;
+      width: 150px;
+      padding: 8px 5px;
+      font-family: Work Sans;
+      font-style: normal;
+      font-weight: 600;
+      font-size: 14px;
+      line-height: 20px;
+    }
+  }
+
+  .select-language {
+    font-family: Work Sans;
+    font-weight: 600;
+    font-size: 12px;
+    line-height: 16px;
+    color: #545B64;
+    padding: 8px;
+  }
+
+  .close-btn {
+    cursor: pointer;
+    margin-left: 30px;
+    padding: 10px;
+  }
+}
+</style>

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/HeaderComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/HeaderComponent.vue
@@ -35,7 +35,12 @@ export default {
   computed: {
     ...mapGetters({
       getSelectedLanguage: 'baseCurriculumGuide/getSelectedLanguage',
+      getTrackCategory: 'teacherDashboard/getTrackCategory',
+      getCurrentCourse: 'baseCurriculumGuide/getCurrentCourse',
     }),
+    courseName () {
+      return this.getCurrentCourse?.name || ''
+    },
   },
   methods: {
     ...mapMutations({

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue
@@ -43,7 +43,8 @@ export default {
       getCurrentCourse: 'baseCurriculumGuide/getCurrentCourse',
       getModuleInfo: 'baseCurriculumGuide/getModuleInfo',
       getSelectedLanguage: 'baseCurriculumGuide/getSelectedLanguage',
-      getTrackCategory: 'teacherDashboard/getTrackCategory'
+      getTrackCategory: 'teacherDashboard/getTrackCategory',
+      chapterNavBar: 'baseCurriculumGuide/chapterNavBar',
     }),
 
     courseName () {
@@ -60,7 +61,20 @@ export default {
 
     moduleNumbers () {
       return Object.keys(this.getModuleInfo || {})
-    }
+    },
+    chapterNav () {
+      // This ensures released chapters are correctly placed, with internal chapters added after.
+      const chapters = this.chapterNavBar || []
+      const internalChapters = chapters.filter(({ releasePhase }) => releasePhase === 'internalRelease')
+      const releasedChapters = chapters.filter(({ releasePhase }) => releasePhase !== 'internalRelease')
+      return releasedChapters.concat(internalChapters)
+        .map(({ campaignID, free, _id }, idx) => {
+          return ({
+            campaignID,
+            heading: utils.isCodeCombat ? utils.courseAcronyms[_id] : this.$t('teacher_dashboard.chapter_num', { num: idx + 1 }),
+          })
+        })
+    },
   },
 
   mounted () {
@@ -132,7 +146,9 @@ export default {
         </div>
       </div>
 
-      <chapter-nav />
+      <chapter-nav
+        :chapters="chapterNav"
+      />
       <chapter-info />
 
       <div class="fluid-container">

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue
@@ -7,6 +7,7 @@ import utils from 'core/utils'
 import ChapterNav from './components/ChapterNav'
 import ChapterInfo from './components/ChapterInfo'
 import ChapterContent from './components/ChapterContent'
+import HeaderComponent from './components/HeaderComponent'
 
 export default {
   name: COMPONENT_NAMES.CURRICULUM_GUIDE,
@@ -14,6 +15,7 @@ export default {
     ChapterNav,
     ChapterInfo,
     ChapterContent,
+    HeaderComponent,
   },
 
   props: {
@@ -76,10 +78,6 @@ export default {
       setTeacherId: 'teacherDashboard/setTeacherId',
       setPageTitle: 'teacherDashboard/setPageTitle'
     }),
-    changeLanguage (e) {
-      window.tracker?.trackEvent('Curriculum Guide: Language Changed from dropdown', { category: this.getTrackCategory, label: this.courseName })
-      this.setSelectedLanguage(e.target.value)
-    },
   },
   watch: {
     defaultLanguage: {
@@ -94,34 +92,7 @@ export default {
 <template>
   <div>
     <div>
-      <div class="header">
-        <div class="header-icon">
-          <img src="/images/ozaria/teachers/dashboard/svg_icons/IconCurriculumGuide.svg">
-          <h2>{{ $t('teacher_dashboard.curriculum_guide') }}</h2>
-        </div>
-        <div
-          class="header-right"
-        >
-          <div class="code-language-dropdown">
-            <span class="select-language">{{ $t('courses.select_language') }}</span>
-            <select @change="changeLanguage">
-              <option
-                value="python"
-                :selected="getSelectedLanguage === 'python'"
-              >
-                Python
-              </option>
-              <option
-                value="javascript"
-                :selected="getSelectedLanguage === 'javascript'"
-              >
-                JavaScript
-              </option>
-            </select>
-          </div>
-        </div>
-      </div>
-
+      <header-component />
       <chapter-nav
         :chapters="chapterNav"
       />
@@ -133,84 +104,9 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  @import "app/styles/bootstrap/variables";
-  @import "ozaria/site/styles/common/variables.scss";
-  @import "app/styles/ozaria/_ozaria-style-params.scss";
-
 /* TODO: use app/styles/common/transition? */
   #curriculum-guide {
     background-color: white;
-  }
-
-  .header {
-    height: 60px;
-
-    background-color: #f2f2f2;
-    border: 1px solid #d8d8d8;
-    /* Drop shadow bottom ref: https://css-tricks.com/snippets/css/css-box-shadow/ */
-    -webkit-box-shadow: 0 8px 6px -6px #D2D2D2;
-      -moz-box-shadow: 0 8px 6px -6px #D2D2D2;
-          box-shadow: 0 8px 6px -6px #D2D2D2;
-
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-
-    .header-icon {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-
-      img {
-        margin-left: 25px;
-        margin-right: 10px;
-      }
-    }
-
-    h2 {
-      @include font-h-2-subtitle-white-24;
-      color: black;
-      line-height: 28px;
-      letter-spacing: 0.56px;
-    }
-
-    .header-right {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      margin-right: 12px;
-    }
-
-    .code-language-dropdown {
-      select {
-        background: $twilight;
-        border: 1.5px solid #355EA0;
-        border-radius: 4px;
-        color: $moon;
-        width: 150px;
-        padding: 8px 5px;
-        font-family: Work Sans;
-        font-style: normal;
-        font-weight: 600;
-        font-size: 14px;
-        line-height: 20px;
-      }
-    }
-
-    .select-language {
-      font-family: Work Sans;
-      font-weight: 600;
-      font-size: 12px;
-      line-height: 16px;
-      color: #545B64;
-      padding: 8px;
-    }
-
-    .close-btn {
-      cursor: pointer;
-      margin-left: 30px;
-      padding: 10px;
-    }
   }
 
   .clickable-hide-area {

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue
@@ -6,20 +6,14 @@ import utils from 'core/utils'
 
 import ChapterNav from './components/ChapterNav'
 import ChapterInfo from './components/ChapterInfo'
-import ConceptsCovered from './components/ConceptsCovered'
-import CstaStandards from './components/CstaStandards'
-import ModuleContent from './components/ModuleContent'
-import LoadingSpinner from 'app/components/common/elements/LoadingSpinner'
+import ChapterContent from './components/ChapterContent'
 
 export default {
   name: COMPONENT_NAMES.CURRICULUM_GUIDE,
   components: {
     ChapterNav,
     ChapterInfo,
-    ConceptsCovered,
-    CstaStandards,
-    ModuleContent,
-    LoadingSpinner
+    ChapterContent,
   },
 
   props: {
@@ -51,17 +45,6 @@ export default {
       return this.getCurrentCourse?.name || ''
     },
 
-    conceptsCovered () {
-      return this.getCurrentCourse?.concepts || []
-    },
-
-    cstaStandards () {
-      return this.getCurrentCourse?.cstaStandards || []
-    },
-
-    moduleNumbers () {
-      return Object.keys(this.getModuleInfo || {})
-    },
     chapterNav () {
       // This ensures released chapters are correctly placed, with internal chapters added after.
       const chapters = this.chapterNavBar || []
@@ -97,13 +80,6 @@ export default {
       window.tracker?.trackEvent('Curriculum Guide: Language Changed from dropdown', { category: this.getTrackCategory, label: this.courseName })
       this.setSelectedLanguage(e.target.value)
     },
-    isCapstoneModule (moduleNum) {
-      if (utils.isCodeCombat) {
-        return false
-      }
-      // Assuming that last module is the capstone module, TODO store `isCapstoneModule` with module details in the course schema.
-      return moduleNum === this.moduleNumbers[this.moduleNumbers.length - 1]
-    }
   },
   watch: {
     defaultLanguage: {
@@ -151,28 +127,7 @@ export default {
       />
       <chapter-info />
 
-      <div class="fluid-container">
-        <div class="row">
-          <div class="col-md-9">
-            <module-content
-              v-for="num in moduleNumbers"
-              :key="num"
-              :module-num="num"
-              :is-capstone="isCapstoneModule(num)"
-            />
-            <div
-              v-if="moduleNumbers.length==0"
-              class="spinner-container"
-            >
-              <LoadingSpinner />
-            </div>
-          </div>
-          <div class="col-md-3">
-            <concepts-covered :concept-list="conceptsCovered" />
-            <csta-standards :csta-list="cstaStandards" />
-          </div>
-        </div>
-      </div>
+      <chapter-content />
     </div>
   </div>
 </template>
@@ -185,10 +140,6 @@ export default {
 /* TODO: use app/styles/common/transition? */
   #curriculum-guide {
     background-color: white;
-  }
-
-  .fluid-container {
-    padding: 30px 25px;
   }
 
   .header {

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/index.vue
@@ -36,16 +36,10 @@ export default {
     }),
 
     ...mapGetters({
-      getCurrentCourse: 'baseCurriculumGuide/getCurrentCourse',
       getModuleInfo: 'baseCurriculumGuide/getModuleInfo',
       getSelectedLanguage: 'baseCurriculumGuide/getSelectedLanguage',
-      getTrackCategory: 'teacherDashboard/getTrackCategory',
       chapterNavBar: 'baseCurriculumGuide/chapterNavBar',
     }),
-
-    courseName () {
-      return this.getCurrentCourse?.name || ''
-    },
 
     chapterNav () {
       // This ensures released chapters are correctly placed, with internal chapters added after.

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/ExploreComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/ExploreComponent.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="explore">
+    <page-junior v-if="product === 'junior'" />
+    <page-hack-stack v-if="product === 'hackstack'" />
+    <page-schools v-else />
+  </div>
+</template>
+
+<script>
+import PageJunior from 'app/views/junior/PageJunior.vue'
+import PageSchools from 'app/views/schools/PageSchools.vue'
+import PageHackStack from 'app/views/landing-pages/hackstack/PageHackStack.vue'
+export default {
+  name: 'ExploreComponent',
+  components: {
+    PageJunior,
+    PageSchools,
+    PageHackStack,
+  },
+  props: {
+    product: {
+      type: String,
+      required: true,
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.explore {
+  background: #fff;
+}
+</style>

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/GuideContentComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/GuideContentComponent.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="guide-content">
+    <chapter-nav :chapters="chaptersNavData" />
+  </div>
+</template>
+
+<script>
+import ChapterNav from 'ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterNav.vue'
+import { mapActions, mapGetters } from 'vuex'
+import utils from 'core/utils'
+export default {
+  name: 'GuideContentComponent',
+  components: {
+    ChapterNav,
+  },
+  props: {
+    product: {
+      type: String,
+      required: true,
+    },
+  },
+  computed: {
+    ...mapGetters({
+      chapterNavBar: 'baseCurriculumGuide/chapterNavBar',
+    }),
+    chaptersNavData () {
+      const chapters = (this.chapterNavBar || []).filter(({ releasePhase }) => releasePhase === 'released')
+      const hackstackCourseIds = utils.HACKSTACK_COURSE_IDS
+      const juniorCourseIds = utils.JUNIOR_COURSE_IDS
+      let result
+      if (this.product === 'hackstack') {
+        result = chapters.filter(({ _id }) => hackstackCourseIds.includes(_id))
+      } else if (this.product === 'junior') {
+        result = chapters.filter(({ _id }) => juniorCourseIds.includes(_id))
+      } else {
+        result = chapters.filter(({ _id }) => !hackstackCourseIds.includes(_id) && !juniorCourseIds.includes(_id))
+      }
+      return result
+        .map(({ campaignID, _id }, idx) => {
+          return ({
+            campaignID,
+            heading: utils.isCodeCombat ? utils.courseAcronyms[_id] : this.$t('teacher_dashboard.chapter_num', { num: idx + 1 }),
+          })
+        })
+    },
+  },
+  async mounted () {
+    await this.fetchData()
+  },
+  methods: {
+    ...mapActions({
+      fetchReleasedCourses: 'courses/fetchReleased',
+    }),
+    async fetchData () {
+      await this.fetchReleasedCourses()
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/GuideContentComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/GuideContentComponent.vue
@@ -1,17 +1,20 @@
 <template>
   <div class="guide-content">
     <chapter-nav :chapters="chaptersNavData" />
+    <chapter-info />
   </div>
 </template>
 
 <script>
 import ChapterNav from 'ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterNav.vue'
+import ChapterInfo from 'ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterInfo.vue'
 import { mapActions, mapGetters } from 'vuex'
 import utils from 'core/utils'
 export default {
   name: 'GuideContentComponent',
   components: {
     ChapterNav,
+    ChapterInfo,
   },
   props: {
     product: {

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/GuideContentComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/GuideContentComponent.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="guide-content">
     <chapter-nav :chapters="chaptersNavData" />
+    <div class="separator" />
     <chapter-info />
     <chapter-content />
   </div>
@@ -65,4 +66,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.separator {
+  border: 1px solid #E6E6E6;
+  box-shadow: inset 0px -2px 10px rgba(0, 0, 0, 0.15);
+}
 </style>

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/GuideContentComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/GuideContentComponent.vue
@@ -32,8 +32,8 @@ export default {
     }),
     chaptersNavData () {
       const chapters = (this.chapterNavBar || []).filter(({ releasePhase }) => releasePhase === 'released')
-      const hackstackCourseIds = utils.HACKSTACK_COURSE_IDS
-      const juniorCourseIds = utils.JUNIOR_COURSE_IDS
+      const hackstackCourseIds = utils.HACKSTACK_COURSE_IDS || []
+      const juniorCourseIds = utils.JUNIOR_COURSE_IDS || []
       let result
       if (this.product === 'hackstack') {
         result = chapters.filter(({ _id }) => hackstackCourseIds.includes(_id))
@@ -59,7 +59,11 @@ export default {
       fetchReleasedCourses: 'courses/fetchReleased',
     }),
     async fetchData () {
-      await this.fetchReleasedCourses()
+      try {
+        await this.fetchReleasedCourses()
+      } catch (err) {
+        console.error('Error fetching released courses', err)
+      }
     },
   },
 }

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/GuideContentComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/GuideContentComponent.vue
@@ -2,12 +2,14 @@
   <div class="guide-content">
     <chapter-nav :chapters="chaptersNavData" />
     <chapter-info />
+    <chapter-content />
   </div>
 </template>
 
 <script>
 import ChapterNav from 'ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterNav.vue'
 import ChapterInfo from 'ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterInfo.vue'
+import ChapterContent from 'ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ChapterContent.vue'
 import { mapActions, mapGetters } from 'vuex'
 import utils from 'core/utils'
 export default {
@@ -15,6 +17,7 @@ export default {
   components: {
     ChapterNav,
     ChapterInfo,
+    ChapterContent,
   },
   props: {
     product: {

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/HeaderComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/HeaderComponent.vue
@@ -5,13 +5,13 @@
         :class="{ header__product: true, header__product__selected: defaultTab === 'guide' }"
         @click.prevent="() => onTabClicked('guide')"
       >
-        {{ product }}
+        {{ displayProductName }}
       </div>
       <div
         :class="{ header__product: true, header__product__selected: defaultTab === 'explore' }"
         @click.prevent="() => onTabClicked('explore')"
       >
-        {{ $t('general.learn_more') }}!
+        {{ $t('general.learn_more') }}
       </div>
     </div>
     <old-header-component
@@ -37,6 +37,20 @@ export default {
       default: 'guide',
     },
   },
+  computed: {
+    displayProductName () {
+      if (this.product === 'codecombat') {
+        return 'CodeCombat'
+      } else if (this.product === 'ozaria') {
+        return 'Ozaria'
+      } else if (this.product === 'hackstack') {
+        return 'AI HackStack'
+      } else if (this.product === 'junior') {
+        return 'Junior'
+      }
+      return this.product
+    },
+  },
   methods: {
     onTabClicked (tab) {
       this.$emit('onSelectedTabChange', tab)
@@ -58,7 +72,7 @@ export default {
 
   &__products {
     display: flex;
-    padding-top: 2px;
+    padding-top: 10px;
 
     @media (max-width: $screen-lg) {
       flex-direction: column;
@@ -66,11 +80,13 @@ export default {
   }
 
   &__product {
-    background: $color-green-1;
-    border: 1px solid $color-green-1;
+    background: $color-blue-1;
+    border: 1px solid $color-blue-1;
     box-shadow: 4px 0 7px rgba(0, 0, 0, 0.2), 0px -2px 5px rgba(0, 0, 0, 0.1);
+    color: $color-yellow-1;
 
-    margin-right: 1rem;
+    margin-right: 10px;
+    margin-left: 10px;
 
     border-top-left-radius: 5px;
     border-top-right-radius: 5px;
@@ -78,17 +94,17 @@ export default {
     padding: 5px 15px;
     cursor: pointer;
 
-    text-transform: uppercase;
-
     &:not(:last-child) {
       @media (max-width: $screen-lg) {
-        margin-bottom: 1rem;
+        margin-bottom: 10px;
       }
     }
 
     &__selected {
       background: $color-grey-2;
       border: 1px solid #E6E6E6;
+      color: black;
+      font-weight: bold;
     }
   }
 

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/HeaderComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/HeaderComponent.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="header">
+    <div class="header__products">
+      <div
+        :class="{ header__product: true, header__product__selected: selectedTab === 'guide' }"
+        @click.prevent="() => onTabClicked('guide')"
+      >
+        {{ product }}
+      </div>
+      <div
+        :class="{ header__product: true, header__product__selected: selectedTab === 'explore' }"
+        @click.prevent="() => onTabClicked('explore')"
+      >
+        {{ $t('parents_v2.step_box_2_subtitle') }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'HeaderComponent',
+  props: {
+    product: {
+      type: String,
+      required: true,
+    },
+    defaultTab: {
+      type: String,
+      default: 'guide',
+      required: true,
+    },
+  },
+  data () {
+    return {
+      selectedTab: this.defaultTab,
+    }
+  },
+  methods: {
+    onTabClicked (tab) {
+      this.selectedTab = tab
+      this.$emit('onSelectedTabChange', tab)
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+@import "app/styles/bootstrap/variables";
+@import "app/views/parents/css-mixins/variables";
+
+.header {
+  &__products {
+    display: flex;
+    padding-top: .5rem;
+
+    @media (max-width: $screen-lg) {
+      flex-direction: column;
+    }
+  }
+
+  &__product {
+    background: $color-green-1;
+    border: 1px solid $color-green-1;
+    box-shadow: 4px 0 7px rgba(0, 0, 0, 0.2), 0px -2px 5px rgba(0, 0, 0, 0.1);
+
+    margin-left: 1rem;
+    margin-right: 1rem;
+
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+
+    padding: 2px 1rem;
+    cursor: pointer;
+
+    text-transform: uppercase;
+
+    &:not(:last-child) {
+      @media (max-width: $screen-lg) {
+        margin-bottom: 1rem;
+      }
+    }
+
+    &__selected {
+      background: $color-grey-2;
+      border: 1px solid #E6E6E6;
+    }
+  }
+
+  &__logos {
+    height: 2rem;
+  }
+}
+</style>

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/HeaderComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/HeaderComponent.vue
@@ -2,24 +2,31 @@
   <div class="header">
     <div class="header__products">
       <div
-        :class="{ header__product: true, header__product__selected: selectedTab === 'guide' }"
+        :class="{ header__product: true, header__product__selected: defaultTab === 'guide' }"
         @click.prevent="() => onTabClicked('guide')"
       >
         {{ product }}
       </div>
       <div
-        :class="{ header__product: true, header__product__selected: selectedTab === 'explore' }"
+        :class="{ header__product: true, header__product__selected: defaultTab === 'explore' }"
         @click.prevent="() => onTabClicked('explore')"
       >
-        {{ $t('parents_v2.step_box_2_subtitle') }}
+        {{ $t('general.learn_more') }}!
       </div>
     </div>
+    <old-header-component
+      v-if="showGuideHeader()"
+    />
   </div>
 </template>
 
 <script>
+import OldHeaderComponent from '../../components/HeaderComponent'
 export default {
-  name: 'HeaderComponent',
+  name: 'HeaderComponentV2',
+  components: {
+    OldHeaderComponent,
+  },
   props: {
     product: {
       type: String,
@@ -31,15 +38,12 @@ export default {
       required: true,
     },
   },
-  data () {
-    return {
-      selectedTab: this.defaultTab,
-    }
-  },
   methods: {
     onTabClicked (tab) {
-      this.selectedTab = tab
       this.$emit('onSelectedTabChange', tab)
+    },
+    showGuideHeader () {
+      return this.selectedTab === 'guide'
     },
   },
 }
@@ -50,9 +54,12 @@ export default {
 @import "app/views/parents/css-mixins/variables";
 
 .header {
+  border: 1px solid #E6E6E6;
+  box-shadow: inset 0px -2px 10px rgba(0, 0, 0, 0.15);
+
   &__products {
     display: flex;
-    padding-top: .5rem;
+    padding-top: 2px;
 
     @media (max-width: $screen-lg) {
       flex-direction: column;
@@ -64,13 +71,12 @@ export default {
     border: 1px solid $color-green-1;
     box-shadow: 4px 0 7px rgba(0, 0, 0, 0.2), 0px -2px 5px rgba(0, 0, 0, 0.1);
 
-    margin-left: 1rem;
     margin-right: 1rem;
 
     border-top-left-radius: 5px;
     border-top-right-radius: 5px;
 
-    padding: 2px 1rem;
+    padding: 5px 15px;
     cursor: pointer;
 
     text-transform: uppercase;

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/HeaderComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/HeaderComponent.vue
@@ -43,7 +43,7 @@ export default {
       this.$emit('onSelectedTabChange', tab)
     },
     showGuideHeader () {
-      return this.selectedTab === 'guide'
+      return this.defaultTab === 'guide'
     },
   },
 }

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/HeaderComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/components/HeaderComponent.vue
@@ -35,7 +35,6 @@ export default {
     defaultTab: {
       type: String,
       default: 'guide',
-      required: true,
     },
   },
   methods: {

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="guide">
+  <div class="curr-guide">
     <header-component
       :product="product"
       :default-tab="selectedTab"
@@ -9,17 +9,23 @@
       v-if="selectedTab === 'explore'"
       :product="product"
     />
+    <guide-content-component
+      v-if="selectedTab === 'guide'"
+      :product="product"
+    />
   </div>
 </template>
 
 <script>
 import HeaderComponent from './components/HeaderComponent.vue'
 import ExploreComponent from './components/ExploreComponent.vue'
+import GuideContentComponent from './components/GuideContentComponent.vue'
 export default {
   name: 'BaseCurriculumGuideV2',
   components: {
     HeaderComponent,
     ExploreComponent,
+    GuideContentComponent,
   },
   props: {
     product: {
@@ -41,7 +47,4 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.guide {
-
-}
 </style>

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/index.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="guide">
+    <header-component
+      :product="product"
+      :default-tab="selectedTab"
+      @onSelectedTabChange="onSelectedTabChange"
+    />
+    <explore-component
+      v-if="selectedTab === 'explore'"
+      :product="product"
+    />
+  </div>
+</template>
+
+<script>
+import HeaderComponent from './components/HeaderComponent.vue'
+import ExploreComponent from './components/ExploreComponent.vue'
+export default {
+  name: 'BaseCurriculumGuideV2',
+  components: {
+    HeaderComponent,
+    ExploreComponent,
+  },
+  props: {
+    product: {
+      type: String,
+      required: true,
+    },
+  },
+  data () {
+    return {
+      selectedTab: 'guide',
+    }
+  },
+  methods: {
+    onSelectedTabChange (tab) {
+      this.selectedTab = tab
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.guide {
+
+}
+</style>

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/v2/index.vue
@@ -20,6 +20,8 @@
 import HeaderComponent from './components/HeaderComponent.vue'
 import ExploreComponent from './components/ExploreComponent.vue'
 import GuideContentComponent from './components/GuideContentComponent.vue'
+import { PAGE_TITLES, COMPONENT_NAMES } from '../../common/constants'
+import { mapMutations } from 'vuex'
 export default {
   name: 'BaseCurriculumGuideV2',
   components: {
@@ -38,7 +40,23 @@ export default {
       selectedTab: 'guide',
     }
   },
+  watch: {
+    product: {
+      handler () {
+        // when product changes, set the default selected tab to guide
+        this.selectedTab = 'guide'
+      },
+    },
+  },
+  mounted () {
+    this.setTeacherId(me.get('_id'))
+    this.setPageTitle(PAGE_TITLES[COMPONENT_NAMES.CURRICULUM_GUIDE])
+  },
   methods: {
+    ...mapMutations({
+      setTeacherId: 'teacherDashboard/setTeacherId',
+      setPageTitle: 'teacherDashboard/setPageTitle',
+    }),
     onSelectedTabChange (tab) {
       this.selectedTab = tab
     },

--- a/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
+++ b/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
@@ -40,13 +40,13 @@ export default {
     let guideOptions
     if (utils.isCodeCombat) {
       guideOptions = [
-        { id: 1, name: 'CodeCombat Junior', path: '/teachers/guide/junior' },
-        { id: 2, name: 'CodeCombat Classroom', path: '/teachers/guide/codecombat' },
-        { id: 3, name: 'AI HackStack', path: '/teachers/guide/hackstack' },
+        { id: 'junior', name: 'CodeCombat Junior', path: '/teachers/guide/junior' },
+        { id: 'codecombat', name: 'CodeCombat Classroom', path: '/teachers/guide/codecombat' },
+        { id: 'hackstack', name: 'AI HackStack', path: '/teachers/guide/hackstack' },
       ]
     } else {
       guideOptions = [
-        { id: 1, name: 'Ozaria Classroom', path: '/teachers/guide/ozaria' },
+        { id: 'ozaria', name: 'Ozaria Classroom', path: '/teachers/guide/ozaria' },
       ]
     }
     return {
@@ -322,7 +322,7 @@ export default {
         <li
           v-for="option in guideOptions"
           :key="option.id"
-          :class="isGuideTabSelected && $route.params.id === option.id ? 'selected' : null"
+          :class="isGuideTabSelected && $route.params.product === option.id ? 'selected' : null"
         >
           <router-link
             tag="a"
@@ -331,7 +331,6 @@ export default {
             data-action="Guide: Nav Clicked"
             data-toggle="dropdown"
             :data-label="$route.path"
-            @click.native="trackEvent"
           >
             {{ option.name }}
           </router-link>

--- a/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
+++ b/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
@@ -42,7 +42,7 @@ export default {
       guideOptions = [
         { id: 1, name: 'CodeCombat Junior', path: '/teachers/guide/junior' },
         { id: 2, name: 'CodeCombat Classroom', path: '/teachers/guide/codecombat' },
-        { id: 3, name: 'AI HackStack', path: '/teachers/guide/ai-hackstack' },
+        { id: 3, name: 'AI HackStack', path: '/teachers/guide/hackstack' },
       ]
     } else {
       guideOptions = [

--- a/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
+++ b/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
@@ -37,8 +37,21 @@ export default {
   },
 
   data: () => {
+    let guideOptions
+    if (utils.isCodeCombat) {
+      guideOptions = [
+        { id: 1, name: 'CodeCombat Junior', path: '/teachers/guide/junior' },
+        { id: 2, name: 'CodeCombat Classroom', path: '/teachers/guide/codecombat' },
+        { id: 3, name: 'AI HackStack', path: '/teachers/guide/ai-hackstack' },
+      ]
+    } else {
+      guideOptions = [
+        { id: 1, name: 'Ozaria Classroom', path: '/teachers/guide/ozaria' },
+      ]
+    }
     return {
       curriculumPromoClicked: false,
+      guideOptions,
     }
   },
 
@@ -123,7 +136,11 @@ export default {
 
     isCurriculumModalVisible () {
       return this.topModal?.name === 'curriculum-sidebar-promotion-modal'
-    }
+    },
+
+    isGuideTabSelected () {
+      return this.$route.path.startsWith('/teachers/guide')
+    },
   },
 
   methods: {
@@ -280,6 +297,48 @@ export default {
         </li>
       </ul>
     </li>
+
+    <li
+      role="presentation"
+      class="dropdown"
+    >
+      <a
+        id="GuideDropdown"
+        :class="['dropdown-toggle', isGuideTabSelected ? 'current-route' : '']"
+        href="#"
+        role="button"
+        data-toggle="dropdown"
+        aria-haspopup="true"
+        aria-expanded="false"
+      >
+        <div id="IconCurriculum" />
+        <span>{{ $t('teacher_dashboard.curriculum') }}</span>
+        <span class="caret" />
+      </a>
+      <ul
+        class="dropdown-menu"
+        aria-labelledby="GuideDropdown"
+      >
+        <li
+          v-for="option in guideOptions"
+          :key="option.id"
+          :class="isGuideTabSelected && $route.params.id === option.id ? 'selected' : null"
+        >
+          <router-link
+            tag="a"
+            :to="option.path"
+            class="dropdown-item"
+            data-action="Guide: Nav Clicked"
+            data-toggle="dropdown"
+            :data-label="$route.path"
+            @click.native="trackEvent"
+          >
+            {{ option.name }}
+          </router-link>
+        </li>
+      </ul>
+    </li>
+
     <li :class="{ 'modal-highlight': isCurriculumModalVisible }">
       <router-link
         id="CurriculumAnchor"

--- a/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
+++ b/ozaria/site/components/teacher-dashboard/common/SecondaryTeacherNavigation.vue
@@ -339,18 +339,6 @@ export default {
       </ul>
     </li>
 
-    <li :class="{ 'modal-highlight': isCurriculumModalVisible }">
-      <router-link
-        id="CurriculumAnchor"
-        to="/teachers/curriculum"
-        :class="{ 'current-route': isCurrentRoute('/teachers/curriculum') || isCurriculumModalVisible }"
-        data-action="Curriculum Guide: Nav Clicked"
-        @click.native="onCurriculumClicked"
-      >
-        <div id="IconCurriculum" />
-        {{ $t('teacher_dashboard.curriculum') }}
-      </router-link>
-    </li>
     <li>
       <router-link
         id="ResourceAnchor"

--- a/ozaria/site/components/teacher-dashboard/common/TitleBar.vue
+++ b/ozaria/site/components/teacher-dashboard/common/TitleBar.vue
@@ -112,7 +112,7 @@ export default {
     },
 
     inCurriculum () {
-      return this.$route.path.startsWith('/teachers/curriculum')
+      return this.$route.path.startsWith('/teachers/curriculum') || this.$route.path.startsWith('/teachers/guide')
     },
 
     classroomCreationDate () {


### PR DESCRIPTION
fixes ENG-1760
<img width="795" alt="Screenshot 2025-04-29 at 2 06 35 PM" src="https://github.com/user-attachments/assets/3e9ad361-36e2-418a-8ed0-8e0888fc17d7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new curriculum guide page for teachers, accessible via a dedicated route under the teachers section.
  - Added a tabbed curriculum guide interface with product-specific views (Junior, Hackstack, Schools) and an explore section.
  - Implemented new components for curriculum navigation, chapter content, and a language selection header.
  - Enhanced teacher navigation with a dropdown for selecting different curriculum guides.

- **Improvements**
  - Updated navigation and title bar to recognize and highlight the new curriculum guide routes.
  - Improved curriculum chapter filtering and navigation based on product and release phase.
  - Enhanced error handling in chapter information display.

- **Refactor**
  - Simplified component structure by delegating header, navigation, and content logic to new subcomponents.
  - Refactored chapter navigation to receive data via props for better flexibility and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->