### PR TITLE
reduce unneccessary render in /students view

### DIFF
--- a/app/templates/courses/courses-view.pug
+++ b/app/templates/courses/courses-view.pug
@@ -146,7 +146,7 @@ mixin classrooms_content()
               span.spr= classroom.get('name')
               - var languageMap = {javascript: 'JavaScript', python: 'Python', cpp: 'C++', java: 'Java'}
               span.spr (#{languageMap[(classroom.get('aceConfig') || {}).language]})
-            p
+            p.teacher-name
               span(data-i18n="courses.teacher")
               span :
               if view.ownerNameMap && view.ownerNameMap[classroom.get('ownerID')]
@@ -160,7 +160,7 @@ mixin classrooms_content()
               span.spr= classroom.get('name')
               - var languageMap = {javascript: 'JavaScript', python: 'Python', cpp: 'C++', java: 'Java'}
               span.spr (#{languageMap[(classroom.get('aceConfig') || {}).language]})
-            p
+            p.teacher-name
               span(data-i18n="courses.teacher")
               span :
               if view.ownerNameMap && view.ownerNameMap[classroom.get('ownerID')]

--- a/app/views/courses/CoursesView.js
+++ b/app/views/courses/CoursesView.js
@@ -370,7 +370,7 @@ module.exports = (CoursesView = (function () {
         .then(() => {
           this.ownerNameMap = {}
           for (const ownerID of Array.from(ownerIDs)) { this.ownerNameMap[ownerID] = NameLoader.getName(ownerID) }
-          return (typeof this.render === 'function' ? this.render() : undefined)
+          return this.renderSelectors('.teacher-name')
         })
       if (utils.useWebsocket) {
         this.useWebsocket = true
@@ -448,7 +448,10 @@ module.exports = (CoursesView = (function () {
         }, this)
       }
 
-      _.forEach(_.unique(_.pluck(this.classrooms.models, 'id')), classroomID => {
+      // now we use same levels in each classrooms
+      const latestClassroom = this.classrooms.models?.[0]
+      if (latestClassroom) {
+        const classroomID = latestClassroom.get('_id')
         const levels = new Levels()
         this.listenTo(levels, 'sync', () => {
           if (this.destroyed) { return }
@@ -456,7 +459,7 @@ module.exports = (CoursesView = (function () {
           return this.render()
         })
         return this.supermodel.trackRequest(levels.fetchForClassroom(classroomID, { data: { project: `original,primerLanguage,slug,name,i18n.${me.get('preferredLanguage', true)},displayName` } }))
-      })
+      }
 
       if (utils.isOzaria && this.showHocProgress()) {
         return this.calculateHocStats()


### PR DESCRIPTION
for my testing student (20+classrooms)
reduce isStudentOnLockedCourse calls from 1000+ to 200+

for normal students in 2-3 classrooms, the overall calls is about 30~40 times.

not sure why more classrooms still increase the calls (before it's related to fetching classroom levels, now I fix that part). but I don't think it worth more time to dig in. current behaviors looks good to me.

fix ENG-1737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved consistency by adding a specific CSS class to teacher name elements in classroom views.

- **Refactor**
  - Optimized rendering to update only teacher name elements instead of the entire view when owner names are loaded.
  - Adjusted data fetching to load levels for only the most recent classroom, reducing unnecessary requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->