### PR TITLE
Valentin / Auto play modals video and hackstack Icon

### DIFF
--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -56,9 +56,9 @@ $hackstackGlowSizeBase: 5px
 
 @keyframes hackstackIconGlow
   0%, 100%
-    filter: drop-shadow(0 0 $hackstackGlowSizeBase #222) drop-shadow(0 0 (2 * $hackstackGlowSizeBase) $hackstackGlowColor) drop-shadow(0 0 (4 * $hackstackGlowSizeBase) $hackstackGlowColor)
+    filter: drop-shadow(0 0 $hackstackGlowSizeBase #555) drop-shadow(0 0 (2 * $hackstackGlowSizeBase) $hackstackGlowColor) drop-shadow(0 0 (4 * $hackstackGlowSizeBase) $hackstackGlowColor)
   50%
-    filter: drop-shadow(0 0 (1.5 * $hackstackGlowSizeBase) #222) drop-shadow(0 0 (3 * $hackstackGlowSizeBase) $hackstackGlowColor) drop-shadow(0 0 (6 * $hackstackGlowSizeBase) $hackstackGlowColor)
+    filter: drop-shadow(0 0 (1.5 * $hackstackGlowSizeBase) #555) drop-shadow(0 0 (3 * $hackstackGlowSizeBase) $hackstackGlowColor) drop-shadow(0 0 (6 * $hackstackGlowSizeBase) $hackstackGlowColor)
 
 
 #campaign-view

--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -21,6 +21,10 @@ $levelDotShadowHeight: 0.8 * $levelDotHeight
 $levelClickRadius: 20px
 $gameControlSize: 80px
 $gameControlMargin: 30px
+$glowingPortalColor: #E57F15
+$glowingPortalSizeBase: 5px
+$hackstackGlowColor: #2E231F
+$hackstackGlowSizeBase: 5px
 
 +keyframes(levelStartedPulse)
   from
@@ -32,6 +36,30 @@ $gameControlMargin: 30px
   to
     @include box-shadow(0px 0px 4px #333)
     margin-bottom: math.div(-$levelDotHeight, 3) + $levelDotZ
+
++keyframes(portalGlow)
+  from
+    filter: drop-shadow(0 0 $glowingPortalSizeBase #fff) drop-shadow(0 0 (3 * $glowingPortalSizeBase) $glowingPortalColor) drop-shadow(0 0 (6 * $glowingPortalSizeBase) $glowingPortalColor)
+  50%
+    filter: drop-shadow(0 0 (2 * $glowingPortalSizeBase) #fff) drop-shadow(0 0 (4 * $glowingPortalSizeBase) $glowingPortalColor) drop-shadow(0 0 (8 * $glowingPortalSizeBase) $glowingPortalColor)
+  to
+    filter: drop-shadow(0 0 $glowingPortalSizeBase #fff) drop-shadow(0 0 (3 * $glowingPortalSizeBase) $glowingPortalColor) drop-shadow(0 0 (6 * $glowingPortalSizeBase) $glowingPortalColor)
+
+// Reusable portal glow class
+.portal-glow
+  @include animation(portalGlow 2s infinite)
+  transform-style: preserve-3d
+  will-change: filter
+  
+  &:hover
+    @include animation(portalGlow 1s infinite)
+
+@keyframes hackstackIconGlow
+  0%, 100%
+    filter: drop-shadow(0 0 $hackstackGlowSizeBase #222) drop-shadow(0 0 (2 * $hackstackGlowSizeBase) $hackstackGlowColor) drop-shadow(0 0 (4 * $hackstackGlowSizeBase) $hackstackGlowColor)
+  50%
+    filter: drop-shadow(0 0 (1.5 * $hackstackGlowSizeBase) #222) drop-shadow(0 0 (3 * $hackstackGlowSizeBase) $hackstackGlowColor) drop-shadow(0 0 (6 * $hackstackGlowSizeBase) $hackstackGlowColor)
+
 
 #campaign-view
   top: 0
@@ -120,6 +148,10 @@ $gameControlMargin: 30px
         transform: translate(-50%, 100%) scale(1.8) scaleY(1.3)
         left: 50%
         top: -80%
+        animation: hackstackIconGlow 2s infinite
+        filter: drop-shadow(0 0 #{$hackstackGlowSizeBase} #222) drop-shadow(0 0 #{2 * $hackstackGlowSizeBase} #{$hackstackGlowColor}) drop-shadow(0 0 #{4 * $hackstackGlowSizeBase} #{$hackstackGlowColor})
+        &:hover
+          filter: drop-shadow(0 0 #{1.5 * $hackstackGlowSizeBase} #222) drop-shadow(0 0 #{3 * $hackstackGlowSizeBase} #{$hackstackGlowColor}) drop-shadow(0 0 #{6 * $hackstackGlowSizeBase} #{$hackstackGlowColor})
         
     .map-background
       width: 100%
@@ -1736,27 +1768,3 @@ body[lang^="en"] #campaign-view .user-status-catalyst .user-status-line .languag
 
     &.language-dropdown
       width: 112px
-
-// glowing color constants
-$glowingColor: #E57F15
-$glowingSizeBase: 5px
-+keyframes(portalGlow)
-  from
-    filter: drop-shadow(0 0 $glowingSizeBase #fff) drop-shadow(0 0 (3 * $glowingSizeBase) $glowingColor) drop-shadow(0 0 (6 * $glowingSizeBase) $glowingColor)
-  50%
-    filter: drop-shadow(0 0 (2 * $glowingSizeBase) #fff) drop-shadow(0 0 (4 * $glowingSizeBase) $glowingColor) drop-shadow(0 0 (8 * $glowingSizeBase) $glowingColor)
-  to
-    filter: drop-shadow(0 0 $glowingSizeBase #fff) drop-shadow(0 0 (3 * $glowingSizeBase) $glowingColor) drop-shadow(0 0 (6 * $glowingSizeBase) $glowingColor)
-
-// Reusable portal glow class
-.portal-glow
-  @include animation(portalGlow 2s infinite)
-  transform-style: preserve-3d
-  will-change: filter
-  
-  &:hover
-    @include animation(portalGlow 1s infinite)
-
-
-
-

--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -104,22 +104,23 @@ $gameControlMargin: 30px
     // HackStack modal
     #hackstack-level-container
       position: absolute
-      left: 61%
-      top: 66%
+      left: 57.5%
+      top: 62.1%
       background-color: rgb(80, 130, 200)
       a
         display: inline
+      
       .hackstack-icon
-        background: url('/images/pages/hackstack/hackstack-logo-square-transparent-256.png')
+        background: url('/images/pages/hackstack/Code-Combat-AI-Hack-Stack-Full-Colour-Small.png')
         width: 200%
         aspect-ratio: 1
         background-size: contain
         position: relative
         background-repeat: no-repeat
-        transform: translate(-50%, -50%) scaleY(calc(4/3))
+        transform: translate(-50%, 100%) scale(1.8) scaleY(1.3)
         left: 50%
         top: -80%
-
+        
     .map-background
       width: 100%
       height: 100%
@@ -1755,5 +1756,7 @@ $glowingSizeBase: 5px
   
   &:hover
     @include animation(portalGlow 1s infinite)
+
+
 
 

--- a/app/templates/core/ai-league-promotion-modal.pug
+++ b/app/templates/core/ai-league-promotion-modal.pug
@@ -11,7 +11,7 @@
       div.paper-area
         div.big-text.text-center(data-i18n="league.promotion_blurb")
 
-        iframe(src="https://www.youtube.com/embed/dM3fUjqLpnI", frameborder="0", allowfullscreen="true", width="70%", height="250px")
+        iframe(src="https://www.youtube.com/embed/dM3fUjqLpnI?autoplay=1&mute=1", frameborder="0", allowfullscreen="true", width="70%", height="250px")
 
         hr
 

--- a/app/templates/core/cchome-promotion-modal.pug
+++ b/app/templates/core/cchome-promotion-modal.pug
@@ -13,7 +13,7 @@
 
         div.modal-video-container(style="width: 80%; margin: 0 auto;")
           div.video-aspect-ratio
-            iframe(src="https://www.youtube.com/embed/rOXRBQIXvlI")
+            iframe(src="https://www.youtube.com/embed/rOXRBQIXvlI?autoplay=1&mute=1")
         
         hr
         div.med-text.modal-text.text-center!= marked($.i18n.t("new_home.promo_modal_text"))

--- a/app/templates/core/hackstack-promotion-modal.pug
+++ b/app/templates/core/hackstack-promotion-modal.pug
@@ -13,7 +13,7 @@
 
         div.modal-video-container(style="width: 80%; margin: 0 auto;")
           div.video-aspect-ratio
-            iframe(src="https://www.youtube.com/embed/c1PpGqP9VA8")
+            iframe(src="https://www.youtube.com/embed/c1PpGqP9VA8?autoplay=1&mute=1")
         
         hr
         div.med-text.modal-text.text-center!= marked($.i18n.t("hackstack_page.promo_modal_text"))

--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -291,7 +291,7 @@ if showGameDevAlert
         .level.hackstack-level#hackstack-level-container(title="CodeCombat AI HackStack")
            span
             .hackstack-icon
-        .hackstack-level#hackstack-level-shadow(style="left: 61%; top: 67.5%;", class="level-shadow")
+        .hackstack-level#hackstack-level-shadow(style="left: 57.5%; top: 62.1%;", class="level-shadow")
   else if view.isCatalyst
     .portal-catalyst
       .portals


### PR DESCRIPTION
- Videos in promo modals are autoplay now (muted ,of course, otherwise chrome can complain and prevent)
- updated the icon for Hackstack in the dungeon (with glowing)

https://github.com/user-attachments/assets/6739256f-ebae-4e2a-a009-b835d2b367b0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added animated glowing effects to portal and Hackstack icons for enhanced visual appeal.

- **Style**
  - Updated Hackstack icon and portal glow animations for a more dynamic appearance.
  - Improved positioning of Hackstack elements in the campaign view for better alignment.

- **Bug Fixes**
  - Removed duplicate and outdated animation definitions to streamline styles.

- **Chores**
  - Updated promotional modal videos to autoplay muted for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->