### PR TITLE
Remove Ned Fulmer (Patch)

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -1406,8 +1406,7 @@ const activeAndPastArenas = () => (() => {
 const teamSpells = { humans: ['hero-placeholder/plan'], ogres: ['hero-placeholder-1/plan'] }
 
 const clanHeroes = [
-  { clanId: '601351bb4b79b4013e198fbe', clanSlug: 'team-derbezt', thangTypeOriginal: '6037ed81ad0ac000f5e9f0b5', thangTypeSlug: 'armando-hoyos' },
-  { clanId: '6137aab4e0bae40025bed266', clanSlug: 'team-ned', thangTypeOriginal: '6136fe7e9f1147002c1316b4', thangTypeSlug: 'ned-fulmer' }
+  { clanId: '601351bb4b79b4013e198fbe', clanSlug: 'team-derbezt', thangTypeOriginal: '6037ed81ad0ac000f5e9f0b5', thangTypeSlug: 'armando-hoyos' }
 ]
 
 const freeAccessLevels = [


### PR DESCRIPTION
It seems like those still in the clan can access the Ned Fulmer hero (which was meant to be removed a while ago) . This fix would no longer grant the hero to any users in the Ned Fulmer clan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the list of available clans by removing one entry from the clan selection options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->