### PR TITLE
add another close button to close the level chat

### DIFF
--- a/app/styles/play/level/chat.sass
+++ b/app/styles/play/level/chat.sass
@@ -129,7 +129,17 @@
     max-height: 600px
     //max-height: Max(600px, calc(100vh - calc(#{$game-view-width}) * (589 / 924) - 50px - 80px - 60px - 30px - 25px))
     max-height: Max(600px, calc(100vh - (100vw * 0.57 - 200px - 17px) * 589 / 924 - 50px - 60px - 80px - 30px - 25px))
-    
+
+
+    .close-level-chat
+      position: absolute
+      top: 0
+      right: 0
+      font-size: 36px
+      line-height: 20px
+      color: white
+      cursor: pointer
+
   tr
     line-height: 18px // space between multiple lines within messages
     strong

--- a/app/templates/play/level/chat.pug
+++ b/app/templates/play/level/chat.pug
@@ -3,8 +3,9 @@
     tbody
 
 .open-chat-area.chat-area.secret
+  .close-level-chat
+    | x
   .table
 
 //textarea(data-i18n="[placeholder]play_level.chat_placeholder")
 i.icon-comment.icon-white
-

--- a/app/views/play/level/LevelChatView.coffee
+++ b/app/views/play/level/LevelChatView.coffee
@@ -21,6 +21,7 @@ module.exports = class LevelChatView extends CocoView
     'keydown textarea': 'onChatKeydown'
     'keypress textarea': 'onChatKeypress'
     'click i': 'onIconClick'
+    'click .close-level-chat': 'onIconClick'
     'click .fix-code-button': 'onFixCodeClick'
 
   subscriptions:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8e66117c-f370-48a3-9e1e-29a2dbcd46a7)
fix ENG-1788

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visible "x" close button to the chat area, allowing users to easily close the chat panel.
- **Style**
  - Updated chat area styling to position and style the new close button for better visibility and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->