### PR TITLE
Valentin/Catalyst updates

### DIFF
--- a/app/core/Tracker2/FullStoryTracker.js
+++ b/app/core/Tracker2/FullStoryTracker.js
@@ -109,7 +109,7 @@ export default class FullstoryTracker extends BaseTracker {
     } else if (me.anonymous && Math.random() < 0.0015) {
       this.log('decide enabled', 'anon user')
       return true
-    } else if (window.me.getCatalystExperimentValue() == 'beta' && Math.random() < 0.05) {
+    } else if (window.me.getCatalystExperimentValue() == 'control' && Math.random() < 0.05) {
       this.log('decide enabled', 'catalyst experiment')
       return true
     } else if (this.store.getters['me/isTeacher'] && !this.store.getters['me/isParent'] && Math.random() < 0.01) {

--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -67,7 +67,7 @@ if showGameDevAlert
     if view.shouldShow('back-to-classroom')
       a.btn.btn-illustrated.btn-success.btn-block.btn-lg.text-uppercase(href='/play', data-i18n="play.back_to_classroom")
     if view.isCatalyst && campaign != null && campaign.get('slug') != 'junior'
-      a.btn.btn-illustrated.btn-success.btn-block.btn-lg.text-uppercase#back-button-catalyst(data-i18n="play_level.back_to_map", title="Back to Map")
+      a.btn.btn-illustrated.btn-block.btn-lg.text-uppercase#back-button-catalyst(data-i18n="play_level.back_to_map", title="Back to Map")
 
     if view.shouldShow('videos')
       a.btn.btn-illustrated.btn-block.btn-lg.text-uppercase#videos-button(data-i18n="play_level.videos")

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -2197,7 +2197,7 @@ class CampaignView extends RootView {
     }
 
     if (what === 'anonymous-classroom-signup') {
-      return me.isAnonymous() && (me.level() < 8) && me.promptForClassroomSignup() && !this.isCatalyst &&
+      return me.isAnonymous() && (me.level() < 8) && me.promptForClassroomSignup() &&
         !this.editorMode && this.terrain !== 'junior' && !storage.load('hid-anonymous-classroom-signup-dialog')
     }
 


### PR DESCRIPTION
- returned teacher pop-up
- back to map button color
- more stats for fullstory (need to look into control group)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted experiment tracking conditions to ensure correct user groups are included.
  - Updated button styling in campaign view for consistency by removing the green success color from a specific button.
  - Modified signup prompt logic so that anonymous users in the Catalyst experiment can now see the classroom signup prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->