### PR TITLE
base modal uses many places, add option to diff new and old modal style

### DIFF
--- a/app/views/home/ModalHackStack.vue
+++ b/app/views/home/ModalHackStack.vue
@@ -33,6 +33,7 @@ export default Vue.extend({
   <ModalDynamicContent
     v-if="showPromotion"
     ref="modal"
+    modal-type="newModal"
     seen-promotions-property="summer-2025-hackstack-promotion"
   >
     <template #content>

--- a/ozaria/site/components/common/BaseModal.vue
+++ b/ozaria/site/components/common/BaseModal.vue
@@ -41,7 +41,7 @@ export default {
       width: 60%
 
       padding: 25px
-      border-radius: 25px
+      border-radius: 10px
 
       // transition: all .3s ease;
 

--- a/ozaria/site/components/common/Modal.vue
+++ b/ozaria/site/components/common/Modal.vue
@@ -18,6 +18,10 @@ export default Vue.extend({
       type: Boolean,
       default: false,
     },
+    modalType: {
+      type: String,
+      default: 'oldModal',
+    },
   },
   computed: {
     backboneClose () {
@@ -35,12 +39,21 @@ export default Vue.extend({
 </script>
 
 <template>
-  <base-modal>
+  <base-modal :class="{'new-modal': modalType === 'newModal'}">
     <template #header>
       <div class="teacher-modal-header">
         <span class="title"> {{ title }} </span>
         <!-- NOTE: The ID #ozaria-modal-header-close-button may be used elsewhere to trigger closing from Backbone -->
+        <img
+          v-if="modalType === 'oldModal'"
+          id="ozaria-modal-header-close-button"
+          class="close-icon"
+          src="/images/ozaria/common/IconClose.svg"
+          :data-dismiss="backboneClose"
+          @[vueClose]="$emit('close')"
+        >
         <span
+          v-else
           class="close-icon fake-icon"
           :data-dismiss="backboneClose"
           @[vueClose]="$emit('close')"
@@ -56,25 +69,23 @@ export default Vue.extend({
   </base-modal>
 </template>
 
-<style lang="scss">
-.modal-container {
-  border-radius: 25px;
-}
-.ozaria-modal-header {
-  padding: 0;
-  border: unset;
-  box-sizing: border-box;
-  box-shadow: unset;
-  border-top-left-radius: 25px;
-  border-top-right-radius: 25px;
-}
-</style>
-
 <style lang="scss" scoped>
 @import "app/styles/bootstrap/variables";
 @import "ozaria/site/styles/common/variables.scss";
 @import "app/styles/ozaria/_ozaria-style-params.scss";
 @import "app/styles/component_variables.scss";
+
+::v-deep .modal-container {
+  border-radius: 10px;
+}
+::v-deep .ozaria-modal-header {
+  background: #FFFFFF;
+  border: 1px solid rgba(0, 0, 0, 0.13);
+  box-sizing: border-box;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.06);
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+}
 
 .title {
   @include font-h-2-subtitle-black-24;
@@ -84,8 +95,7 @@ export default Vue.extend({
 .teacher-modal-header {
   display: flex;
   flex-direction: row;
-  position: relative;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
   width: 100%;
   margin: 0px 10px;
@@ -95,18 +105,39 @@ export default Vue.extend({
   cursor: pointer;
 }
 
-.fake-icon {
-  position: absolute;
-  right: -40px;
-  top: -40px;
-  background: $purple;
-  width: 50px;
-  height: 50px;
-  text-align: center;
-  line-height: 35px;
-  font-size: 50px;
-  color: white;
-  font-weight: 400;
-  border-radius: 10px;
+.new-modal {
+  ::v-deep {
+  .modal-container {
+    border-radius: 25px !important;
+  }
+  .ozaria-modal-header {
+    background: unset;
+    padding: 0;
+    border: unset;
+    box-shadow: unset;
+    border-top-left-radius: 25px;
+    border-top-right-radius: 25px;
+  }
+  }
+
+  .teacher-modal-header {
+    justify-content: center;
+    position: relative;
+  }
+
+  .fake-icon {
+    position: absolute;
+    right: -35px;
+    top: -25px;
+    background: $purple;
+    width: 50px;
+    height: 50px;
+    text-align: center;
+    line-height: 35px;
+    font-size: 50px;
+    color: white;
+    font-weight: 400;
+    border-radius: 10px;
+  }
 }
 </style>

--- a/ozaria/site/components/teacher-dashboard/modals/ModalDynamicContent.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalDynamicContent.vue
@@ -16,7 +16,11 @@ export default Vue.extend({
       required: false,
       default () {
         return `modal-${Math.random().toString(36).substring(7)}`
-      }
+      },
+    },
+    modalType: {
+      type: String,
+      default: 'oldModal',
     },
     title: {
       type: String,
@@ -131,6 +135,7 @@ export default Vue.extend({
   <div>
     <modal
       v-if="modalVisible"
+      :modal-type="modalType"
       :title="title"
       role="dialog"
       aria-modal="true"


### PR DESCRIPTION
fix ENG-1830

![image](https://github.com/user-attachments/assets/641738c3-353b-4b96-b838-7e96409175fb)
![image](https://github.com/user-attachments/assets/fe2169a7-76ce-443d-b219-c55ba442ce4b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for two visually distinct modal styles, allowing modals to switch between "old" and "new" appearances.

- **Style**
  - Updated modal border-radius for improved visual consistency across modal types.
  - Enhanced modal header and close button styling for the new modal type, providing a refreshed look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->