### PR TITLE
allow tournament owner to anonymize players

### DIFF
--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -5149,6 +5149,8 @@ module.exports = {
       error_results_date_too_early: 'The Results Time cannot be earlier than End Time',
       publish_results: 'Publish Results',
       publish_options: 'Publish Options',
+      anonymize_players: 'Anonymize Players',
+      anonymize_players_description: 'Players cannot see each other\'s name until tournament published.',
     },
 
     payments: {

--- a/app/schemas/models/clan.schema.js
+++ b/app/schemas/models/clan.schema.js
@@ -67,7 +67,8 @@ _.extend(ClanSchema.properties, {
     ncesId: c.shortString({ title: 'NCES' })
   }),
   displayName: { type: 'string', description: 'overwrites visual visual name of clan - used as name is tied to the slug' },
-  esportsImage: { type: 'string', format: 'image-file', title: 'Esports Image', description: 'Image to show for this team on league page.' }
+  esportsImage: { type: 'string', format: 'image-file', title: 'Esports Image', description: 'Image to show for this team on league page.' },
+  anonymizeTournament: { type: 'boolean', title: 'Anonymize Tournament', description: 'Anonymize the leaderboard of it\'s tournament.' },
 })
 
 c.extendBasicProperties(ClanSchema, 'Clan')

--- a/app/views/ladder/LadderPlayModal.js
+++ b/app/views/ladder/LadderPlayModal.js
@@ -132,7 +132,7 @@ module.exports = (LadderPlayModal = (function () {
         this.nameMap = nameMap
         if (this.destroyed) { return }
         for (challenger of _.values(this.challengers)) {
-          challenger.opponentName = this.nameMap[challenger.opponentID]?.name || 'Anonymous'
+          challenger.opponentName = this.nameMap[challenger.opponentID]?.fullName || this.nameMap[challenger.opponentID]?.name || 'Anonymous'
           challenger.opponentWizard = this.nameMap[challenger.opponentID]?.wizard || {}
         }
         return this.checkWizardLoaded()

--- a/app/views/ladder/components/EditTournamentModal.vue
+++ b/app/views/ladder/components/EditTournamentModal.vue
@@ -98,6 +98,17 @@
             class="form-control"
           >
         </template>
+        <label for="anonymize">
+          {{ $t('tournament.anonymize_players') }}
+        </label>
+        <span class="small text-navy">{{ $t('tournament.anonymize_players_description') }}</span>
+        <input
+          id="anonymize"
+          v-model="editableTournament.anonymize"
+          type="checkbox"
+          class="form-control"
+          :disabled="disableEdit"
+        >
       </div>
 
       <div class="form-group pull-right">

--- a/app/views/ladder/components/EditTournamentModal.vue
+++ b/app/views/ladder/components/EditTournamentModal.vue
@@ -4,7 +4,7 @@
     @close="$emit('close')"
   >
     <form
-      class="edit-tournament-form"
+      class="edit-tournament-form container"
       @submit.prevent="onFormSubmit"
     >
       <div class="form-group">
@@ -18,6 +18,8 @@
           class="form-control"
           disabled
         >
+      </div>
+      <div class="form-group">
         <template v-if="clanId">
           <!-- TODO i18n -->
           <label for="clan"> {{ $t('tournament.team') }} </label>
@@ -30,6 +32,8 @@
             @change="e => changeClanSelected(e)"
           />
         </template>
+      </div>
+      <div class="form-group">
         <label for="startDate">
           {{ $t('tournament.start_date_time') }}
         </label>
@@ -41,6 +45,8 @@
           class="form-control"
           :disabled="disableEdit"
         >
+      </div>
+      <div class="form-group">
         <label for="endDate">
           {{ $t('tournament.end_date_time') }}
         </label>
@@ -52,7 +58,8 @@
           class="form-control"
           :disabled="disableEdit"
         >
-
+      </div>
+      <div class="form-group">
         <label
           for="publish-options"
         >
@@ -98,17 +105,18 @@
             class="form-control"
           >
         </template>
-        <label for="anonymize">
-          {{ $t('tournament.anonymize_players') }}
-        </label>
-        <span class="small text-navy">{{ $t('tournament.anonymize_players_description') }}</span>
+      </div>
+      <div class="form-group">
         <input
           id="anonymize"
           v-model="editableTournament.anonymize"
           type="checkbox"
-          class="form-control"
           :disabled="disableEdit"
         >
+        <label for="anonymize">
+          {{ $t('tournament.anonymize_players') }}
+        </label>
+        <span class="small text-navy">{{ $t('tournament.anonymize_players_description') }}</span>
       </div>
 
       <div class="form-group pull-right">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a771d85c-98c6-4108-91a5-9a195153273e)
![image](https://github.com/user-attachments/assets/3e2c432b-9d2b-4123-a19a-df2188ed3415)
fix ENG-1839

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option in the tournament edit form to anonymize player identities until the tournament is published.
  - Introduced new interface text to support the anonymization feature for tournaments.
  - Enhanced opponent name display to prioritize full names, improving clarity during matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->