### PR TITLE
message text should format in markdown to be easy edit

### DIFF
--- a/app/schemas/models/ai_chat_message.schema.js
+++ b/app/schemas/models/ai_chat_message.schema.js
@@ -27,7 +27,7 @@ _.extend(AIChatMessageSchema.properties, {
     enum: ['scenario', 'project'],
   },
   sentAt: { title: 'Sent At', type: 'number' },
-  text: { title: 'Text', type: 'string', description: 'The content text of the chat message' },
+  text: { title: 'Text', type: 'string', description: 'The content text of the chat message', format: 'markdown' },
   documents: {
     title: 'Documents',
     type: 'array',


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f04557fc-f10f-4130-accf-8efc769d4bf6)
fix eNG-1882

Not sure do we have other chat message editor, but this change should work in screenshot anyway

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat message content now supports markdown formatting for improved text display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->