### PR TITLE
only allow china server to use old dashboard now

### DIFF
--- a/app/core/Router.js
+++ b/app/core/Router.js
@@ -463,7 +463,7 @@ module.exports = (CocoRouter = (function () {
           }
         },
         'teachers/classes' () {
-          if (utils.isCodeCombat && !me.isNewDashboardActive()) {
+          if (me.showChinaResourceInfo() && !me.isNewDashboardActive()) {
             return this.routeDirectly('courses/TeacherClassesView', [], { redirectStudents: true, teachersOnly: true })
           } else {
             return this.routeDirectly('core/SingletonAppVueComponentView', arguments, { redirectStudents: true, teachersOnly: true })

--- a/ozaria/site/components/teacher-dashboard/common/DashboardToggle.vue
+++ b/ozaria/site/components/teacher-dashboard/common/DashboardToggle.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    v-if="chinaInfra"
     id="dashboard-toggle"
     class="dashboard-toggle"
   >
@@ -73,7 +74,10 @@ export default Vue.extend({
     },
     isNewDashboard () {
       return this.dashboardStatus
-    }
+    },
+    chinaInfra () {
+      return me.showChinaResourceInfo()
+    },
   },
   watch: {
     dashboardStatus (newValue, oldValue) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d9106195-c7a6-4463-bd2f-58eeec79a762)

fix ENG-1851

this pr is enough ,but can also see https://github.com/codecombat/codecombat-server/pull/1266 if we want server logic too

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The teacher dashboard toggle is now only visible for users with access to China-specific resources.

* **Changes**
  * The "Teachers / Classes" page routing now considers China resource access, affecting which view is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->