### PR TITLE
Yuqiang/copy message route limit fix

### DIFF
--- a/app/views/editor/ai-chat-message/AIChatMessageCloneModal.js
+++ b/app/views/editor/ai-chat-message/AIChatMessageCloneModal.js
@@ -100,7 +100,7 @@ class ScenarioNode extends treemaExt.IDReferenceNode {
     // TODO: fix the term search
     this.getSearchResultsEl().empty().append('Searching')
     this.collections = new CocoCollection([], { model: AIScenario })
-    this.collections.url = '/db/ai_scenario?project[]=_id&project[]=name&limit=1000'
+    this.collections.url = '/db/ai_scenario?project[]=_id&project[]=name&limit=1000&sort=-_id'
     this.collections.fetch()
     this.collections.once('sync', this.loadAIScenarios, this)
   }


### PR DESCRIPTION
we have default limit as 100 so in global server (217 scenarios) cannot be fetched full.
let use max limit here and also sort scenarios with latest one so that new scenarios can be easy found.
fix ENG-1947


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved the loading of AI scenarios by limiting results to the most recent 1000 entries, ensuring faster access and better performance when searching or filtering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->