### PR TITLE
do not show premium modal when user is premium

### DIFF
--- a/app/views/landing-pages/premium/PagePremium.vue
+++ b/app/views/landing-pages/premium/PagePremium.vue
@@ -19,7 +19,7 @@
                 <CTAButton
                   @clickedCTA="onClickMainCta"
                 >
-                  {{ $t('subscribe.subscribe_title') }}
+                  {{ me.isPremium() ? $t('courses.continue_playing') : $t('subscribe.subscribe_title') }}
                 </CTAButton>
               </p>
             </template>
@@ -109,7 +109,7 @@
               <CTAButton
                 @clickedCTA="onClickMainCta"
               >
-                {{ $t('subscribe.subscribe_title') }}
+                {{ me.isPremium() ? $t('courses.continue_playing') : $t('subscribe.subscribe_title') }}
               </CTAButton>
             </div>
           </div>
@@ -234,7 +234,7 @@
               <CTAButton
                 @clickedCTA="onClickMainCta"
               >
-                {{ $t('subscribe.subscribe_title') }}
+                {{ me.isPremium() ? $t('courses.continue_playing') : $t('subscribe.subscribe_title') }}
               </CTAButton>
             </div>
           </div>
@@ -582,7 +582,11 @@ export default {
 
   methods: {
     onClickMainCta () {
-      this.isSubscribeModalOpen = true
+      if (me.isPremium()) {
+        application.router.navigate('/play', { trigger: true })
+      } else {
+        this.isSubscribeModalOpen = true
+      }
     },
   },
 


### PR DESCRIPTION
fix ENG-1933
<img width="1517" height="714" alt="image" src="https://github.com/user-attachments/assets/2f430e99-3e24-4411-bcb0-dc9a002108a3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The main call-to-action button on the premium landing page now displays "Continue Playing" for premium users and "Subscribe" for non-premium users.
  * Premium users clicking the main CTA are taken directly to the play page, while non-premium users see the subscription modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->