### PR TITLE
license with different endDate should be separately displayed

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseTeacherDashboard/index.vue
@@ -136,15 +136,15 @@ export default {
 
     allLicensesTypes () {
       const prepaidTypes = this.getPrepaids(me.id)?.available?.map(prepaid => {
+        let baseType = 'full_license'
         if (prepaid.type === 'starter_license') {
-          return 'starter_license'
+          baseType = 'starter_license'
         }
         const includedCourseIDs = prepaid.includedCourseIDs
         if (includedCourseIDs) {
-          return 'customized_license:' + (includedCourseIDs.join('+'))
-        } else {
-          return 'full_license'
+          baseType = 'customized_license:' + (includedCourseIDs.join('+'))
         }
+        return `${baseType}:${prepaid.endDate}` // Licenses of different endDate should be displayed separately
       })
       return Array.from(new Set(prepaidTypes))
     },

--- a/ozaria/site/components/teacher-dashboard/modals/ModalApplyLicenses/ModalApplyLicense.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalApplyLicenses/ModalApplyLicense.vue
@@ -222,7 +222,7 @@ export default {
           name += $.i18n.t('teacher.full_license')
         }
       }
-      name += `(${license.maxRedeemers - (license.redeemers?.length || 0)})`
+      name += ` (${license.maxRedeemers - (license.redeemers?.length || 0)})`
       return name
     },
     numericalCourses (object, oType) {


### PR DESCRIPTION
<img width="1241" height="527" alt="image" src="https://github.com/user-attachments/assets/4f839cb6-4e07-48d0-8512-4ef6eaf0b63f" />
fix ENG-1970

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved license type handling to ensure licenses with different end dates are displayed as distinct entries in the dashboard.
  * Adjusted license name formatting in the license application modal for clearer display of remaining redeemers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->