### PR TITLE
let's skip junior when loading classroom if possible

### DIFF
--- a/app/core/store/modules/teacherDashboard.js
+++ b/app/core/store/modules/teacherDashboard.js
@@ -214,6 +214,9 @@ export default {
 
         const classroomCourses = getters.getCoursesCurrentClassroom || []
         if (classroomCourses.length > 0) {
+          if (classroomCourses?.[0]?.slug === 'junior' && classroomCourses.length > 1) {
+            return (classroomCourses[1] || {})._id
+          }
           return (classroomCourses[0] || {})._id
         }
       }


### PR DESCRIPTION
let's load junior as default course-id if only the junior is the only course in classroom.
fix ENG-1972

