### PR TITLE
add ai league tournament enddate clearly

### DIFF
--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -3383,6 +3383,7 @@ module.exports = {
       difficulty_beginner: 'Beginner',
       difficulty_intermediate: 'Intermediate',
       difficulty_advanced: 'Advanced',
+      ai_league_ends: 'Global AI League ends at __time__',
     },
 
     user: {

--- a/app/styles/play/ladder/ladder.sass
+++ b/app/styles/play/ladder/ladder.sass
@@ -253,6 +253,9 @@
   justify-content: center
   font-size: 36px
 
+  .ai-league-info
+    font-size: 14px
+
 @media only screen and (max-width: 800px)
   #ladder-view
     #level-column img

--- a/app/templates/play/ladder/ladder.pug
+++ b/app/templates/play/ladder/ladder.pug
@@ -105,6 +105,8 @@ block content
 
 
     #tournament-status
+      if !view.tournamentState && view.globalAILeagueEnds
+         .ai-league-info(data-i18n="ladder.ai_league_ends", data-i18n-options={ time: view.globalAILeagueEnds })
       if view.tournamentState == 'initializing'
         #tournament-status
           p

--- a/app/views/ladder/LadderView.js
+++ b/app/views/ladder/LadderView.js
@@ -122,6 +122,17 @@ module.exports = (LadderView = (function () {
         this.checkTournamentCloseInterval = setInterval(this.checkTournamentClose.bind(this), 3000)
         this.checkTournamentClose()
       }
+
+      if (!this.leagueID) {
+        // global arena, check is current AI League
+
+        const currentArena = _.find(utils.activeArenas(), { slug: this.levelID })
+        if (currentArena) {
+          this.globalAILeagueEnds = moment(currentArena.end).format('LLL')
+        } else {
+          this.globalAILeagueEnds = null
+        }
+      }
     }
 
     static initClass () {

--- a/app/views/ladder/components/LadderPanel.vue
+++ b/app/views/ladder/components/LadderPanel.vue
@@ -173,7 +173,11 @@ export default {
       return difficulties[index]
     },
     difficultyI18n () {
-      return $.i18n.t(`ladder.difficulty_${this.difficulty}`)
+      if (this.difficulty) {
+        return $.i18n.t(`ladder.difficulty_${this.difficulty}`)
+      } else {
+        return ''
+      }
     },
   },
   methods: {


### PR DESCRIPTION
fix ENG-1978

<img width="701" height="237" alt="image" src="https://github.com/user-attachments/assets/287f41c0-912a-4857-9d2c-ffb2e2212216" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a message displaying the end time of the Global AI League on the ladder page when no tournament is active.
* **Style**
  * Introduced new styling for the AI League end message to ensure consistent font size.
* **Bug Fixes**
  * Improved handling of difficulty localization to prevent issues when difficulty data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->