### PR TITLE
remove version attribute from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   proxy:
     build:


### PR DESCRIPTION
The `version` attribute is deprecated:

```
WARN[0000] /Users/.../codecombat/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

It was removed with v2 of docker compose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container orchestration configuration by removing the top-level version declaration.
  * No changes to features, UI, or performance.
  * Deployment and local development behavior remain unchanged.
  * No action required from end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->