### PR TITLE
update hs tour content

### DIFF
--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -6310,7 +6310,7 @@ module.exports = {
       learning_modules: 'Learning Modules',
       level_complete: 'You did it! Level complete. Continue your AI journey with the next level.',
       run_code_tour_title: 'Ready to see the magic?',
-      run_code_tour_text: 'Press “Run Code” and watch your project come to life. No experience required!',
+      run_code_tour_text: 'Press “Output” and watch your project come to life. No experience required!',
       ready_to_review_helptext: 'Mark this when your project is complete. Your teacher will then see it as ready to review on their side.',
     },
     new_premium: {


### PR DESCRIPTION
fix ENG-1997

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated user-facing English copy in the product tour. The instruction now reads: “Press ‘Output’ and watch your project come to life. No experience required!” (previously referenced “Run Code”). The tour title remains the same. This is a text-only change; no functional behavior is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->