### PR TITLE
should hide AI icon when disable levelChat in level

### DIFF
--- a/app/views/play/level/PlayLevelView.coffee
+++ b/app/views/play/level/PlayLevelView.coffee
@@ -443,7 +443,8 @@ module.exports = class PlayLevelView extends RootView
     @insertSubView new GameDevTrackView {} if @level.isType('game-dev')
     @insertSubView new HUDView {@level} unless @level.isType('web-dev')
     @insertSubView new LevelDialogueView {@level, sessionID: @session.id}
-    @insertSubView new ChatView({@levelID, sessionID: @session.id, @session, aceConfig: @classroomAceConfig, aiChatKind: @level.get('aiChatKind'), levelRealID: @level.id})
+    if (@classroomAceConfig.levelChat and @classroomAceConfig.levelChat != 'none') or @level.isLadder()
+      @insertSubView new ChatView({@levelID, sessionID: @session.id, @session, aceConfig: @classroomAceConfig, aiChatKind: @level.get('aiChatKind'), levelRealID: @level.id})
     @insertSubView new ProblemAlertView {@session, @level, @supermodel, aceConfig: @classroomAceConfig}
     @insertSubView new SurfaceContextMenuView {@session, @level}
     @insertSubView new DuelStatsView {@level, @session, @otherSession, @supermodel, thangs: @world.thangs, showsGold: goldInDuelStatsView} if @level.isLadder()


### PR DESCRIPTION
<img width="1512" height="813" alt="image" src="https://github.com/user-attachments/assets/8f485bf4-64f8-42ae-b130-00feedea17d2" />
<img width="1512" height="813" alt="image" src="https://github.com/user-attachments/assets/22e597b9-3787-4290-a3d6-0383fabd9cca" />

all AI entry should show or hide at the same time
fix ENG-2028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat panel now appears only in ladder levels or when explicitly enabled in classroom settings.
  * Chat is hidden for levels where level chat is disabled or not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->