### PR TITLE
support google imagen 4 icon

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -1597,7 +1597,8 @@ const aiToolToImage = {
   'stable-diffusion': '/images/ai/Stable_Diffusion.png',
   'dall-e-3': '/images/ai/DALL-E.webp',
   'claude': '/images/ai/claude.webp',
-  'gemini': '/images/ai/gemini.svg'
+  'gemini': '/images/ai/gemini.svg',
+  'imagen': '/images/ai/gemini.svg',
 }
 
 module.exports.getImageFromAiTool = (tool) => {
@@ -1611,6 +1612,8 @@ module.exports.getImageFromAiTool = (tool) => {
     return aiToolToImage.gpt
   } else if (tool.includes('gemini')) {
     return aiToolToImage.gemini
+  } else if (tool.includes('imagen')) {
+    return aiToolToImage.imagen
   } else {
     return '/images/ai/IconHackStack_Gray.svg'
   }


### PR DESCRIPTION
imagen can use gemini icon first 
fix ENG-2031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added icon support for the “Imagen” AI tool, ensuring it displays consistently in the interface.

* **Bug Fixes**
  * Improved image selection to correctly recognize tool names containing “imagen,” preventing missing or incorrect icons in listings and detail views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->