### PR TITLE
Valentin/Refactor campaign routing and schema updates for Galaxy

### DIFF
--- a/app/core/Router.js
+++ b/app/core/Router.js
@@ -390,11 +390,11 @@ module.exports = (CocoRouter = (function () {
           return this.navigate(`play/web-dev-level/${sessionID}?${queryString}`, { trigger: true, replace: true })
         },
         'play/spectate/:levelID': go('play/SpectateView'),
-        'play/ai' () {
-          return this.routeDirectly('play/CampaignView', ['galaxy'], { redirectStudents: true, redirectTeachers: true })
-        },
         'play/:campaign' (campaign) {
           if (utils.isCodeCombat) {
+            if (campaign === 'ai') {
+              return this.routeDirectly('play/CampaignView', arguments, { redirectStudents: true, redirectTeachers: true })
+            }
             return this.routeDirectly('play/CampaignView', arguments)
           } else {
             const props = {

--- a/app/core/Router.js
+++ b/app/core/Router.js
@@ -392,8 +392,9 @@ module.exports = (CocoRouter = (function () {
         'play/spectate/:levelID': go('play/SpectateView'),
         'play/:campaign' (campaign) {
           if (utils.isCodeCombat) {
-            if (campaign === 'ai') {
-              return this.routeDirectly('play/CampaignView', arguments, { redirectStudents: true, redirectTeachers: true })
+            const slug = (campaign || '').toLowerCase()
+            if (slug === 'ai') {
+              return this.routeDirectly('play/CampaignView', [slug], { redirectStudents: true, redirectTeachers: true })
             }
             return this.routeDirectly('play/CampaignView', arguments)
           } else {

--- a/app/schemas/models/campaign.schema.js
+++ b/app/schemas/models/campaign.schema.js
@@ -3,8 +3,8 @@ const LevelSchema = require('./level')
 
 const CampaignSchema = c.object({
   default: {
-    type: 'hero'
-  }
+    type: 'hero',
+  },
 })
 c.extendNamedProperties(CampaignSchema) // name first
 
@@ -16,7 +16,7 @@ _.extend(CampaignSchema.properties, {
 
   ambientSound: c.object({}, {
     mp3: { type: 'string', format: 'sound-file' },
-    ogg: { type: 'string', format: 'sound-file' }
+    ogg: { type: 'string', format: 'sound-file' },
   }),
 
   backgroundImage: c.array({}, {
@@ -25,8 +25,8 @@ _.extend(CampaignSchema.properties, {
     properties: {
       image: { type: 'string', format: 'image-file' },
       width: { type: 'number' }, // - not required for ozaria campaigns
-      campaignPage: { type: 'number', title: 'Campaign page number', description: 'Give the page number if there are multiple pages in the campaign' } // Oz-only
-    }
+      campaignPage: { type: 'number', title: 'Campaign page number', description: 'Give the page number if there are multiple pages in the campaign' }, // Oz-only,
+    },
   }),
   backgroundColor: { type: 'string' },
   backgroundColorTransparent: { type: 'string' },
@@ -55,12 +55,12 @@ _.extend(CampaignSchema.properties, {
             { type: 'string', links: [{ rel: 'db', href: '/db/level/{($)}/version' }], format: 'latest-version-original-reference' },
             {
               type: 'array',
-              items: { type: 'string', links: [{ rel: 'db', href: '/db/level/{($)}/version' }], format: 'latest-version-original-reference' }
-            }
-          ]
-        }
-      }
-    }
+              items: { type: 'string', links: [{ rel: 'db', href: '/db/level/{($)}/version' }], format: 'latest-version-original-reference' },
+            },
+          ],
+        },
+      },
+    },
   },
   isOzaria: { type: 'boolean', description: 'Is this an ozaria campaign', default: false }, // TODO: migrate to using `product` instead
   product: c.singleProduct,
@@ -89,9 +89,9 @@ _.extend(CampaignSchema.properties, {
               item: { type: 'string', links: [{ rel: 'db', href: '/db/thang.type/{($)}/version' }], format: 'latest-version-original-reference' },
               hero: { type: 'string', links: [{ rel: 'db', href: '/db/thang.type/{($)}/version' }], format: 'latest-version-original-reference' },
               level: { type: 'string', links: [{ rel: 'db', href: '/db/level/{($)}/version' }], format: 'latest-version-original-reference' },
-              type: { enum: ['heroes', 'items', 'levels'] }
-            }
-          }
+              type: { enum: ['heroes', 'items', 'levels'] },
+            },
+          },
         },
 
         // - normal properties
@@ -108,20 +108,20 @@ _.extend(CampaignSchema.properties, {
             properties: {
               nextLevelStage: { type: 'number', title: 'Next Level Stage', description: 'Which capstone stage is unlocked' },
               conditions: c.object({}, {
-                afterCapstoneStage: { type: 'number', title: 'After Capstone Stage', description: 'What capstone stage needs to be completed to unlock this next level' }
-              })
-            }
-          }
+                afterCapstoneStage: { type: 'number', title: 'After Capstone Stage', description: 'What capstone stage needs to be completed to unlock this next level' },
+              }),
+            },
+          },
         },
         first: { type: 'boolean', description: 'Is it the first level in the campaign', default: true },
         campaignPage: { type: 'number', title: 'Campaign page number', description: 'Give the page number if there are multiple pages in the campaign' },
         releasePhase: { enum: ['beta', 'internalRelease', 'released'], title: 'Release status', description: 'Release status of the level, determining who sees it.', default: 'internalRelease' },
-        moduleNum: { type: 'number', title: 'Module number', default: 1 }
+        moduleNum: { type: 'number', title: 'Module number', default: 1 },
 
       // - denormalized properties from Levels are cloned below
-      }
+      },
 
-    }
+    },
   },
   scenarios: {
     type: 'array',
@@ -135,6 +135,7 @@ _.extend(CampaignSchema.properties, {
       },
     },
   },
+  isGalaxy: { type: 'boolean', description: 'Is this a galaxy campaign', default: false },
 })
 
 CampaignSchema.denormalizedLevelProperties = [
@@ -187,7 +188,7 @@ CampaignSchema.denormalizedLevelProperties = [
   'isPlayedInStages',
   'ozariaType',
   'introContent',
-  'displayName'
+  'displayName',
 ]
 const hiddenLevelProperties = ['name', 'description', 'i18n', 'replayable', 'slug', 'original', 'primerLanguage', 'shareable', 'concepts', 'scoreTypes']
 for (const prop of CampaignSchema.denormalizedLevelProperties) {

--- a/app/styles/play/campaign-view.sass
+++ b/app/styles/play/campaign-view.sass
@@ -911,7 +911,7 @@ $hackstackGlowSizeBase: 5px
         &.ai-league-menu-icon
           transform: scale(1.4) translateX(-10px)
         &.cchome-menu-icon
-          transform: scale(2)
+          transform: scale(2.3) translate(-5px, -1px)
 
         
         

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -57,6 +57,7 @@ const ROBLOX_MODAL_SHOWN = 'roblox-modal-shown'
 const PROMPTED_FOR_SIGNUP = 'prompted-for-signup'
 const PROMPTED_FOR_SUBSCRIPTION = 'prompted-for-subscription'
 const AI_LEAGUE_MODAL_SHOWN = 'ai-league-modal-shown'
+const GALAXY_TERRAIN = 'ai' // galaxy is the inner name, but in URL it is 'ai' for players
 
 class LevelSessionsCollection extends CocoCollection {
   static initClass () {
@@ -150,7 +151,7 @@ class CampaignView extends RootView {
     super(options)
     this.onMouseMovePortals = this.onMouseMovePortals.bind(this)
     this.onWindowResize = this.onWindowResize.bind(this)
-    if (terrain === 'ai') {
+    if (terrain === GALAXY_TERRAIN) {
       this.isGalaxy = true
       this.terrain = null
     } else {
@@ -262,7 +263,7 @@ class CampaignView extends RootView {
       this.campaign = this.supermodel.loadModel(this.campaign).model
 
       this.listenToOnce(this.campaign, 'sync', () => {
-        if (this.campaign?.get('isGalaxy')) {
+        if (this.campaign?.get('isGalaxy') && this.isGalaxy) {
           this.isGalaxy = true
           this.isCatalyst = true
           this.render() // Re-render to update the UI with the new isGalaxy state

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -2172,7 +2172,7 @@ class CampaignView extends RootView {
     }
 
     if (what === 'junior-original-choice') {
-      return this.isCatalyst && !me.finishedAnyLevels() && !this.terrain && !storage.load('junior-original-choice-seen')
+      return this.isCatalyst && !this.isGalaxy && !me.finishedAnyLevels() && !this.terrain && !storage.load('junior-original-choice-seen')
     }
 
     if (['status-line'].includes(what)) {

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -152,9 +152,10 @@ class CampaignView extends RootView {
     this.onWindowResize = this.onWindowResize.bind(this)
     if (terrain === 'ai') {
       this.isGalaxy = true
-      terrain = null
+      this.terrain = null
+    } else {
+      this.terrain = terrain
     }
-    this.terrain = terrain
     if (/^classCode/.test(this.terrain)) {
       this.terrain = '' // Stop /play?classCode= from making us try to play a classCode campaign
     }

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -257,17 +257,18 @@ class CampaignView extends RootView {
         return
       }
     }
+    if (this.terrain) {
+      this.campaign = new Campaign({ _id: this.terrain })
+      this.campaign = this.supermodel.loadModel(this.campaign).model
 
-    this.campaign = new Campaign({ _id: this.terrain })
-    this.campaign = this.supermodel.loadModel(this.campaign).model
-
-    this.listenToOnce(this.campaign, 'sync', () => {
-      if (this.campaign?.get('isGalaxy')) {
-        this.isGalaxy = true
-        this.isCatalyst = true
-        this.render() // Re-render to update the UI with the new isGalaxy state
-      }
-    })
+      this.listenToOnce(this.campaign, 'sync', () => {
+        if (this.campaign?.get('isGalaxy')) {
+          this.isGalaxy = true
+          this.isCatalyst = true
+          this.render() // Re-render to update the UI with the new isGalaxy state
+        }
+      })
+    }
     // Temporary attempt to make sure all earned rewards are accounted for. Figure out a better solution...
     this.earnedAchievements = new CocoCollection([], { url: '/db/earned_achievement', model: EarnedAchievement, project: ['earnedRewards'] })
     this.listenToOnce(this.earnedAchievements, 'sync', function () {


### PR DESCRIPTION
- Updated Router.js to handle 'ai' campaign routing directly.
- Modified campaign.schema.js to ensure proper schema structure and added 'isGalaxy' property.
- Adjusted CampaignView.js to manage galaxy campaign state and improve navigation logic.
- Enhanced campaign-view.sass for better UI scaling of menu icons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI/Galaxy campaigns are now auto-detected via a new campaign flag and served under the unified play route (dedicated play/ai route removed).
  * Returning from a Galaxy campaign routes you back to the AI/Galaxy play path when applicable.

* **Bug Fixes**
  * Campaign view UI and behavior consistently reflect Galaxy/AI state using dynamic detection.

* **Style**
  * Campaign menu icon enlarged and slightly repositioned for improved visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->