### PR TITLE
play page should count same levels as play/campaign

### DIFF
--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -811,6 +811,7 @@ class CampaignView extends RootView {
           if (me.freeOnly() && !me.isStudent()) {
             levels = levels.filter(level => !level.requiresSubscription)
           }
+          this.annotateLevels(levels)
           const count = this.countLevels(levels)
           campaign.levelsTotal = count.total
           campaign.levelsCompleted = count.completed


### PR DESCRIPTION
fix ENG-2050
in play/dungen : 
<img width="1086" height="226" alt="image" src="https://github.com/user-attachments/assets/ae6891a7-478d-4eda-a586-e6815e611f6f" />
in /play, before change: 
<img width="1393" height="688" alt="image" src="https://github.com/user-attachments/assets/986d23eb-c809-43f8-b6a9-12d063c34056" />

after:
<img width="1406" height="753" alt="image" src="https://github.com/user-attachments/assets/8103be51-98b5-43fd-875f-b000cf475153" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected campaign level annotations in public campaigns after filtering for free access, ensuring levels display accurate locked/next states and colors.
  * Fixed calculation of total and completed levels so progress counts reflect only the filtered levels, improving progress accuracy for players on free plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->