### PR TITLE
use object-id default schema instead of original treema extension

### DIFF
--- a/app/schemas/models/campaign.schema.js
+++ b/app/schemas/models/campaign.schema.js
@@ -130,7 +130,7 @@ _.extend(CampaignSchema.properties, {
       type: 'object',
       properties: {
         // scenario original
-        scenario: c.objectId({ links: [{ rel: 'db', href: '/db/ai_scenario/{($)}/version' }], format: 'latest-version-original-reference' }),
+        scenario: c.objectId({ title: 'AI Scenario Original' }),
         moduleNum: { type: 'number', title: 'Module number', default: 5 },
       },
     },


### PR DESCRIPTION
fixes eng-2068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified how campaign scenarios are referenced, removing external version-linking to streamline usage.

* **Documentation**
  * Updated the visible label for the scenario field to “AI Scenario Original,” improving clarity in generated forms and API docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->