### PR TITLE
Change teacher level preview back button to redirect them into new dashboard

### DIFF
--- a/app/templates/teachers/teacher-course-solution-view.pug
+++ b/app/templates/teachers/teacher-course-solution-view.pug
@@ -4,7 +4,7 @@ block page_nav
   include ../courses/teacher-dashboard-nav
   .do-not-print.container
     span.backlink
-      a(href='/teachers/courses')
+      a(href='/teachers/guide/codecombat')
         |&lt;
         span= ' '
         spna(data-i18n="teacher.back_to_course_guides")


### PR DESCRIPTION
Fixes eng-2065

Sends them to the new curriculum guide + dashboard instead of the old one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the back navigation in the Teacher Course Solution view to return to the Teachers Guide (CodeCombat) instead of the Courses page. This ensures users land on the expected guide section after viewing a solution, improving navigation clarity and reducing confusion. No other UI or behavior changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->