### PR TITLE
should set original for scenario format

### DIFF
--- a/app/schemas/models/ai_project.schema.js
+++ b/app/schemas/models/ai_project.schema.js
@@ -35,7 +35,8 @@ _.extend(AIProjectSchema.properties, {
     title: 'Scenario',
     type: ['object', 'string'],
     description: 'The scenario Original of the project',
-    links: [{ rel: 'db', href: '/db/ai_scenario/{($)}/version' }],
+    format: 'scenario',
+    links: [{ rel: 'db', href: '/db/ai_scenario/{($)}/version', model: 'AIScenario' }],
   },
   actionQueue: {
     title: 'Action Queue',

--- a/app/schemas/models/campaign.schema.js
+++ b/app/schemas/models/campaign.schema.js
@@ -130,7 +130,7 @@ _.extend(CampaignSchema.properties, {
       type: 'object',
       properties: {
         // scenario original
-        scenario: c.objectId({ title: 'AI Scenario Original' }),
+        scenario: c.objectId({ title: 'AI Scenario Original', format: 'scenario', links: [{ rel: 'db', href: '/db/ai_scenario/{{$}}/version', model: 'AIScenario' }] }),
         moduleNum: { type: 'number', title: 'Module number', default: 5 },
       },
     },

--- a/app/views/editor/ai-chat-message/AIChatMessageCloneModal.js
+++ b/app/views/editor/ai-chat-message/AIChatMessageCloneModal.js
@@ -1,10 +1,8 @@
 const ModalView = require('views/core/ModalView')
 const template = require('app/templates/editor/ai-chat-message/clone')
-const CocoCollection = require('collections/CocoCollection')
-const AIScenario = require('models/AIScenario')
-require('lib/setupTreema')
-const treemaExt = require('core/treema-ext')
+const ScenarioNode = require('views/editor/ai-scenario/AIScenarioNode')
 const fetchJson = require('core/api/fetch-json')
+require('lib/setupTreema')
 
 const cloneSchema = {
   additionalProperties: false,
@@ -13,7 +11,7 @@ const cloneSchema = {
       title: 'New Scenario',
       description: 'Input scenario id or scenario title to search',
       format: 'scenario',
-      links: [{ rel: 'db', href: '/db/ai_scenario/{{$}}', model: 'AIScenario' }],
+      links: [{ rel: 'db', href: '/db/ai_scenario/{{$}}/version', model: 'AIScenario' }],
     },
   },
 }
@@ -62,11 +60,11 @@ module.exports = (AIChatMessageCloneView = (function () {
     }
 
     onClickSaveButton () {
-      const scenarioId = this.treema.data.newScenario
+      const scenarioOriginal = this.treema.data.newScenario
       fetchJson(`/db/ai_chat_message/${this.messageId}/clone`, {
         method: 'POST',
         json: {
-          pid: scenarioId,
+          pid: scenarioOriginal,
         },
       }).then((newMessage) => {
         this.hide()
@@ -83,75 +81,3 @@ module.exports = (AIChatMessageCloneView = (function () {
   AIChatMessageCloneView.initClass()
   return AIChatMessageCloneView
 })())
-
-class ScenarioNode extends treemaExt.IDReferenceNode {
-  valueClass = 'treema-scenario'
-  lastTerm = null
-  scenarios = {}
-  keyed = false
-  ordered = false
-  collection = false
-  directlyEditable = true
-
-  constructor (...args) {
-    super(...args)
-    // seems term search for announcement doesn't work well. so
-    // here i search for all and filter it locally first.
-    // TODO: fix the term search
-    this.getSearchResultsEl().empty().append('Searching')
-    this.collections = new CocoCollection([], { model: AIScenario })
-    this.collections.url = '/db/ai_scenario?project=_id,slug,original,name&limit=1000&sort=-_id'
-    this.collections.fetch()
-    this.collections.once('sync', this.loadAIScenarios, this)
-  }
-
-  loadAIScenarios () {
-    this.scenarios = this.collections
-    this.searchCallback()
-  }
-
-  buildValueForEditing (valEl, data) {
-    valEl.html(this.searchValueTemplate)
-    const input = valEl.find('input')
-    input.focus().keyup(this.search)
-    if (data) {
-      input.attr('placeholder', this.formatDocument(data))
-    }
-  }
-
-  searchCallback () {
-    const container = this.getSearchResultsEl().detach().empty()
-    let first = true
-    this.collections.models.forEach(model => {
-      const row = $('<div></div>').addClass('treema-search-result-row')
-      const text = this.formatDocument(model)
-      if (!text) {
-        return
-      }
-      if (first) {
-        row.addClass('treema-search-selected')
-      }
-      first = false
-      row.text(text)
-      row.data('value', model)
-      container.append(row)
-    })
-    if (!this.collections.models.length) {
-      container.append($('<div>No results</div>'))
-    }
-    this.getValEl().append(container)
-  }
-
-  search () {
-    const term = this.getValEl().find('input').val()
-    if (term === this.lastTerm) {
-      return
-    }
-    this.lastTerm = term
-    this.getSearchResultsEl().empty().append('Searching')
-    this.collections = new CocoCollection(this.scenarios.filter((scenario) => {
-      return scenario.get('original')?.toString() === term || scenario.get('name')?.toLowerCase()?.includes(term.toLowerCase())
-    }), { model: AIScenario })
-    this.searchCallback()
-  }
-}

--- a/app/views/editor/ai-project/AIProjectEditView.js
+++ b/app/views/editor/ai-project/AIProjectEditView.js
@@ -16,6 +16,7 @@ const AIProject = require('models/AIProject')
 const ConfirmModal = require('views/core/ConfirmModal')
 const PatchesView = require('views/editor/PatchesView')
 const errors = require('core/errors')
+const ScenarioNode = require('views/editor/ai-scenario/AIScenarioNode')
 
 const nodes = require('views/editor/level/treema_nodes')
 
@@ -62,7 +63,8 @@ module.exports = (AIProjectEditView = (function () {
         readOnly: me.get('anonymous'),
         supermodel: this.supermodel,
         nodeClasses: {
-          'chat-message-link': nodes.ChatMessageLinkNode
+          'chat-message-link': nodes.ChatMessageLinkNode,
+          scenario: ScenarioNode,
         }
       }
       this.treema = this.$el.find('#ai-project-treema').treema(options)

--- a/app/views/editor/ai-scenario/AIScenarioNode.js
+++ b/app/views/editor/ai-scenario/AIScenarioNode.js
@@ -1,0 +1,85 @@
+const CocoCollection = require('collections/CocoCollection')
+const AIScenario = require('models/AIScenario')
+require('lib/setupTreema')
+const treemaExt = require('core/treema-ext')
+
+module.exports = class ScenarioNode extends treemaExt.IDReferenceNode {
+  valueClass = 'treema-scenario'
+  lastTerm = null
+  scenarios = {}
+  keyed = false
+  ordered = false
+  collection = false
+  directlyEditable = true
+
+  constructor (...args) {
+    super(...args)
+    // seems term search for announcement doesn't work well. so
+    // here i search for all and filter it locally first.
+    // TODO: fix the term search
+    this.getSearchResultsEl().empty().append('Searching')
+    this.collections = new CocoCollection([], { model: AIScenario })
+    this.collections.url = '/db/ai_scenario?project=_id,slug,original,name&limit=1000&sort=-_id'
+    this.collections.fetch()
+    this.collections.once('sync', this.loadAIScenarios, this)
+  }
+
+  loadAIScenarios () {
+    this.scenarios = this.collections
+    this.searchCallback()
+  }
+
+  buildValueForEditing (valEl, data) {
+    valEl.html(this.searchValueTemplate)
+    const input = valEl.find('input')
+    input.focus().keyup(this.search)
+    if (data) {
+      input.attr('placeholder', this.formatDocument(data))
+    }
+  }
+
+  searchCallback () {
+    const container = this.getSearchResultsEl().detach().empty()
+    let first = true
+    this.collections.models.forEach(model => {
+      const row = $('<div></div>').addClass('treema-search-result-row')
+      const text = this.formatDocument(model)
+      if (!text) {
+        return
+      }
+      if (first) {
+        row.addClass('treema-search-selected')
+      }
+      first = false
+      row.text(text)
+      row.data('value', model)
+      container.append(row)
+    })
+    if (!this.collections.models.length) {
+      container.append($('<div>No results</div>'))
+    }
+    this.getValEl().append(container)
+  }
+
+  search () {
+    const term = this.getValEl().find('input').val()
+    if (term === this.lastTerm) {
+      return
+    }
+    this.lastTerm = term
+    this.getSearchResultsEl().empty().append('Searching')
+    this.collections = new CocoCollection(this.scenarios.filter((scenario) => {
+      return scenario.get('original')?.toString() === term || scenario.get('name')?.toLowerCase()?.includes(term.toLowerCase())
+    }), { model: AIScenario })
+    this.searchCallback()
+  }
+
+  saveChanges () {
+    const selected = this.getSelectedResultEl()
+    if (!selected.length) { return }
+    const fullValue = selected.data('value')
+    this.data = fullValue.attributes.original
+    this.instance = fullValue
+    return this.instance
+  }
+}

--- a/app/views/editor/ai-scenario/AIScenarioNode.js
+++ b/app/views/editor/ai-scenario/AIScenarioNode.js
@@ -32,7 +32,7 @@ module.exports = class ScenarioNode extends treemaExt.IDReferenceNode {
   buildValueForEditing (valEl, data) {
     valEl.html(this.searchValueTemplate)
     const input = valEl.find('input')
-    input.focus().keyup(this.search)
+    input.focus().keyup(this.search.bind(this))
     if (data) {
       input.attr('placeholder', this.formatDocument(data))
     }

--- a/app/views/editor/campaign/CampaignEditorView.js
+++ b/app/views/editor/campaign/CampaignEditorView.js
@@ -32,6 +32,7 @@ const PatchesView = require('views/editor/PatchesView')
 const RevertModal = require('views/modal/RevertModal')
 const modelDeltas = require('lib/modelDeltas')
 const globalVar = require('core/globalVar')
+const ScenarioNode = require('views/editor/ai-scenario/AIScenarioNode')
 require('vendor/scripts/jquery-ui-1.11.1.custom')
 require('vendor/styles/jquery-ui-1.11.1.custom.css')
 
@@ -378,7 +379,8 @@ module.exports = (CampaignEditorView = (function () {
           campaigns: CampaignsNode,
           campaign: CampaignNode,
           achievement: AchievementNode,
-          rewards: RewardsNode
+          rewards: RewardsNode,
+          scenario: ScenarioNode,
         },
         supermodel: this.supermodel
       }


### PR DESCRIPTION
scenario original input in treema should use scenarioNode class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a searchable scenario picker in editors for faster, easier scenario selection.
  * Clone modal now targets specific scenario versions for more accurate cloning.

* **Refactor**
  * Consolidated scenario selection into a single reusable component for consistent editing experience.
  * Schema metadata updated to include a standardized scenario format and version-aware links for reliable version resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->