### PR TITLE
back to map too when junior next level locked

### DIFF
--- a/app/templates/play/level/modal/course-rewards-view.pug
+++ b/app/templates/play/level/modal/course-rewards-view.pug
@@ -49,4 +49,7 @@
 
     .row
       .col-sm-3.col-sm-offset-9
-        button#continue-btn.btn.btn-illustrated.btn-primary.btn-block.btn-lg.text-uppercase(data-i18n="common.continue")
+        if view.nextLevelLocked
+          button#map-btn.btn.btn-illustrated.btn-block.btn-lg.text-uppercase(data-i18n='play_level.back_to_map')
+        else
+          button#continue-btn.btn.btn-illustrated.btn-primary.btn-block.btn-lg.text-uppercase(data-i18n="common.continue")

--- a/app/views/play/level/modal/CourseRewardsView.js
+++ b/app/views/play/level/modal/CourseRewardsView.js
@@ -34,13 +34,17 @@ module.exports = (CourseRewardsView = (function () {
       this.prototype.template = require('app/templates/play/level/modal/course-rewards-view')
 
       this.prototype.events =
-        { 'click #continue-btn': 'onClickContinueButton' }
+        {
+          'click #continue-btn': 'onClickContinueButton',
+          'click #map-btn': 'onClickMapButton',
+        }
     }
 
     initialize (options) {
       super.initialize()
       this.level = options.level
       this.session = options.session
+      this.nextLevelLocked = options.nextLevelLocked
       this.thangTypes = {}
       this.achievements = options.achievements
     }
@@ -55,6 +59,10 @@ module.exports = (CourseRewardsView = (function () {
     afterRender () {
       super.afterRender()
       return this.initializeAnimations()
+    }
+
+    onClickMapButton () {
+      return this.trigger('to-map')
     }
 
     onClickContinueButton () {

--- a/app/views/play/level/modal/CourseVictoryModal.js
+++ b/app/views/play/level/modal/CourseVictoryModal.js
@@ -138,8 +138,13 @@ module.exports = (CourseVictoryModal = (function () {
           }
         }
         if (showAchievements) {
-          const rewardsView = new CourseRewardsView({ level: this.level, session: this.session, achievements: this.achievements, supermodel: this.supermodel })
+          let nextLevelLocked = false
+          if (this.level.get('product') === 'codecombat-junior' && this.nextLevel && _.isEmpty(this.nextLevel.attributes)) {
+            nextLevelLocked = true
+          }
+          const rewardsView = new CourseRewardsView({ level: this.level, session: this.session, achievements: this.achievements, supermodel: this.supermodel, nextLevelLocked })
           rewardsView.on('continue', this.onViewContinue, this)
+          rewardsView.on('to-map', this.onToMap, this)
           this.views.push(rewardsView)
         }
       }


### PR DESCRIPTION

<img width="870" height="434" alt="image" src="https://github.com/user-attachments/assets/2e4792ad-2504-4d84-931c-4fcaa526be6a" />
fix ENG-2096

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Rewards modal now adapts based on progression: shows “Back to Map” when the next level is locked, and “Continue” when it’s available.
  - Added direct navigation to the map from the rewards modal via a new “Back to Map” button.
  - Improved post-level flow by clearly signaling when progression is blocked and offering an immediate return to the map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->