### PR TITLE
fix assessment permission

### DIFF
--- a/app/views/courses/StudentLevelProgressDot.vue
+++ b/app/views/courses/StudentLevelProgressDot.vue
@@ -43,7 +43,7 @@
       'courseInstance',
       'course',
       'classroom',
-      'readOnly'
+      'schoolAdminOnly'
     ],
     components: {
       PieChart
@@ -71,7 +71,7 @@
         utils.i18n(@level, 'displayName') || utils.i18n(@level, 'name')
       link: ->
         if @progress.started
-          if @readOnly
+          if @schoolAdminOnly
             link = '/school-administrator/teacher/' + @classroom.ownerID + '/classroom/' + @classroom._id
           else
             link = '/teachers/classes/' + @classroom._id

--- a/ozaria/site/components/teacher-dashboard/BaseStudentAssessments/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseStudentAssessments/index.vue
@@ -180,8 +180,6 @@ export default {
           progress: progressData?.get({ classroom: classroomInstance, course: new Course(course) }),
           courseInstance,
           classroom: classroomInstance.toJSON(),
-          // bad naming, readOnly means school-admin to verify teacher's classroom. so should have no read permission (not classroom owner or shared owner)
-          readOnly: !classroomInstance.hasReadPermission(),
         }
         console.log('propsData', this.propsData)
       }


### PR DESCRIPTION
fix ENG-2106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Teacher dashboard no longer forces assessments into read-only; editability now reflects actual classroom permissions.
* **Chores**
  * Student progress links updated to use a role-specific flag (school admin vs teacher), changing which dashboard URL is generated for different users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->