### PR TITLE
use webpack caching only on development

### DIFF
--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -347,11 +347,5 @@ module.exports = (env) => {
     ].concat(extraIgnorePluginEntries),
     optimization: {},
     stats: 'minimal',
-    cache: {
-      type: 'filesystem',
-      buildDependencies: {
-        config: [__filename]
-      }
-    },
   }
 }

--- a/webpack.development.config.js
+++ b/webpack.development.config.js
@@ -71,7 +71,13 @@ module.exports = (env) => {
       watchOptions: {
         ignored: /node_modules(?!\/ai\/dist)|bower_components|\.#|~$/,
       },
-      mode: 'development'
+      mode: 'development',
+      cache: {
+        type: 'filesystem',
+        buildDependencies: {
+          config: [__filename]
+        }
+      },
     })
   )
 }


### PR DESCRIPTION
trying to fix incvrease in build size around the time this commit was introduced

fixes eng-2195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build caching configuration for improved development workflow efficiency. Enabled persistent filesystem-based caching specifically for development builds, reducing incremental rebuild times and enhancing build consistency during development iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->