### PR TITLE
new teacher should not see end-of-trial

### DIFF
--- a/app/models/User.js
+++ b/app/models/User.js
@@ -713,8 +713,8 @@ module.exports = (User = (function () {
         return false
       }
       const seenPromotion = this.getSeenPromotion(key)
-      if (seenPromotion && new Date(seenPromotion) > new Date()) {
-        // seenPromotion in the future means we should show the manual promotion
+      if (seenPromotion === false) {
+        // don't seePromotion so should show it
         return true
       }
       return false


### PR DESCRIPTION
testing path:
new reigster teacher -- no modal
admin setting `seenPromotions -- end-of-trial-promotion-modal` to false -- show the modal
admin setting `seenPromotions -- end-of-trial-promotion-modal` to false again and assign a license to the teacher -- no modal

fix ENG-2196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual control for promotional modals (e.g., end-of-trial): promotions can now be explicitly shown or suppressed via manual flags.
  * Promotion logic updated to honor manual promotion keys while preserving existing time-based scheduling and seen-state behavior for other promotions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->