### PR TITLE
skip save livecompletion when classroom disable it

### DIFF
--- a/app/views/play/menu/OptionsView.js
+++ b/app/views/play/menu/OptionsView.js
@@ -80,7 +80,7 @@ module.exports = (OptionsView = (function () {
     onHidden () {
       this.aceConfig.keyBindings = 'default' // We used to give them the option, but we took it away.
       this.aceConfig.behaviors = this.$el.find('#option-behaviors').prop('checked')
-      if (this.options.classroomAceConfig.liveCompletion === false) {
+      if (this.options?.classroomAceConfig?.liveCompletion === false) {
         // do not update liveCompletion when classroom disable the liveCompletion
         this.aceConfig.liveCompletion = this.$el.find('#option-live-completion').prop('checked')
       }


### PR DESCRIPTION
when classroom disable the live completion. the UI input is unchecked and would save to user's aceConfig if user open the menu option. we should skip saving it when classroom disable it.
fix ENG-2208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the live-completion setting could be overridden by the local checkbox even when disabled by classroom configuration; the UI now preserves classroom-controlled state and only applies the checkbox when the classroom setting explicitly allows it.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->