### PR TITLE
Optimize 'course' category + add resource hub to patches url

### DIFF
--- a/app/views/admin/PendingPatchesView.js
+++ b/app/views/admin/PendingPatchesView.js
@@ -64,14 +64,14 @@ module.exports = (PendingPatchesView = (function () {
             patch.slug = _.string.slugify(name)
             patch.url = '/editor/' + (() => {
               switch (patch.target.collection) {
-                case 'level': case 'achievement': case 'article': case 'campaign': case 'poll':
+                case 'level': case 'achievement': case 'article': case 'campaign': case 'poll': case 'course':
                   return `${patch.target.collection}/${patch.slug}`
                 case 'thang_type':
                   return `thang/${patch.slug}`
                 case 'level_system': case 'level_component':
                   return `level/items?${patch.target.collection}=${patch.slug}`
-                case 'course':
-                  return `course/${patch.slug}`
+                case 'resource_hub_resource':
+                  return `resource/${patch.slug}`
                 default:
                   console.log(`Where do we review a ${patch.target.collection} patch?`)
                   return ''


### PR DESCRIPTION
Small patch to put course under the generic /collection_name/slug format, and added resource hub to URL to allow easier access to patches from the patches list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new resource type in patch administration and URL routing.

* **Bug Fixes**
  * Improved URL generation logic to eliminate redundant handling while maintaining existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->