### PR TITLE
cleanup trial-class exp code that was already won by trial-class option

### DIFF
--- a/app/models/User.js
+++ b/app/models/User.js
@@ -1166,10 +1166,6 @@ module.exports = (User = (function () {
       return true
     }
 
-    getEducatorSignupExperimentValue () {
-      return 'beta'
-    }
-
     shouldShowLevelAIChat () {
       if (utils.isOzaria) {
         return false

--- a/app/views/home/ButtonSection.vue
+++ b/app/views/home/ButtonSection.vue
@@ -5,7 +5,7 @@
       class="button-section"
     >
       <CTAButton
-        :href="`/schools${ educatorSignupExperiment ? '#create-account-teacher' : '' }`"
+        href="/schools#create-account-teacher"
         @click="homePageEvent(isCodeCombat ? 'Homepage Click Teacher Button #1 CTA' : 'Started Signup')"
       >
         {{ $t('new_home.im_an_educator') }}
@@ -83,10 +83,6 @@ export default {
     },
     me () {
       return me
-    },
-    educatorSignupExperiment () {
-      const value = me.getEducatorSignupExperimentValue()
-      return value === 'beta'
     },
   },
   beforeDestroy () {

--- a/app/views/home/PageHome.vue
+++ b/app/views/home/PageHome.vue
@@ -9,7 +9,7 @@
               <mixed-color-label :text="$t('home_v3.learn_to_code')" />
             </h1>
             <p class="text-24">
-              {{ $t(educatorSignupExperiment ? 'home_v3.sign_up_today' :'home_v3.innovative_play_experiences') }}
+              {{ $t('home_v3.sign_up_today') }}
             </p>
             <div class="buttons">
               <ButtonSection />
@@ -449,11 +449,6 @@ export default Vue.extend({
 
     me () {
       return me
-    },
-
-    educatorSignupExperiment () {
-      const value = me.getEducatorSignupExperimentValue()
-      return value === 'beta'
     },
   },
   mounted () {

--- a/app/views/landing-pages/parents/PageParents.vue
+++ b/app/views/landing-pages/parents/PageParents.vue
@@ -281,16 +281,10 @@
                 {{ $t('parents_landing_1.course_offering') }}
               </h1>
               <p
-                v-if="trialClassExperiment == 'trial-class'"
                 style="margin: 0 auto;"
               >
                 {{ $t('parents_landing_1.flexible_scheduling') }}
               </p>
-              <p
-                v-else
-                style="margin: 0 auto;"
-                v-html="$t('parents_landing_1.private_instructions')"
-              />
             </div>
           </div>
         </div>
@@ -1160,13 +1154,9 @@ export default {
     },
 
     videoId () {
-      if (this.trialClassExperiment === 'trial-class') {
-        return 'bb2e8bf84df5c2cfa0fcdab9517f1d9e'
-      } else {
-        return '3cba970325cb3c6df117c018f7862317'
-      }
-    }
-  }
+      return 'bb2e8bf84df5c2cfa0fcdab9517f1d9e'
+    },
+  },
 }
 </script>
 


### PR DESCRIPTION
fixes eng-2218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Parents landing page now consistently presents the "trial-class" experience (fixed messaging, scheduling paragraph shown, and a single trial-class video).
  * Homepage headline and CTA text now consistently show the same teacher sign-up messaging.
  * Sign-up button/link always directs to the teacher create-account flow instead of varying by experiment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->