### PR TITLE
Add modules support to campaigns for HS and Junior

### DIFF
--- a/app/schemas/models/campaign.schema.js
+++ b/app/schemas/models/campaign.schema.js
@@ -171,6 +171,31 @@ _.extend(CampaignSchema.properties, {
     },
   },
   isPremiumOnly: { type: 'boolean', description: 'Does this campaign require a subscription to access?', default: false },
+  modules: {
+    type: 'array',
+    title: 'Modules',
+    description: 'If the campaign is used as a parent campaign, it can have modules that are used as child campaigns.',
+    items: {
+      type: 'object',
+      properties: {
+        campaign: c.stringID({ title: 'Campaign', format: 'campaignID', model: 'Campaign', links: [{ rel: 'db', href: '/db/campaign/{{$}}', model: 'Campaign' }] }),
+        moduleNumber: { type: 'number', title: 'Module number', description: 'The number of the module if its defined in the related course.' },
+        portalImage: { format: 'image-file', title: 'Portal Image', description: 'The image to use for the portal of the module on interface.' },
+        position: {
+          type: 'object',
+          title: 'Position',
+          properties: {
+            // can be row/col or x/y, if both are provided, row/col takes precedence
+            row: { type: 'number', title: 'Row', description: 'The row of the module on the interface.' },
+            column: { type: 'number', title: 'Column', description: 'The column of the module on the interface.' },
+            x: { type: 'number', title: 'X', description: 'The x position of the module on the interface.' },
+            y: { type: 'number', title: 'Y', description: 'The y position of the module on the interface.' },
+          },
+        },
+        access: { type: 'string', enum: ['free', 'sales-call', 'paid'], title: 'Access', description: 'Whether this module is free, free with a sales call, or paid.' },
+      },
+    },
+  },
 })
 
 CampaignSchema.denormalizedLevelProperties = [

--- a/app/views/editor/campaign/CampaignEditorView.js
+++ b/app/views/editor/campaign/CampaignEditorView.js
@@ -33,6 +33,7 @@ const RevertModal = require('views/modal/RevertModal')
 const modelDeltas = require('lib/modelDeltas')
 const globalVar = require('core/globalVar')
 const { HackstackScenarioIDNode } = require('views/editor/ai-scenario/AIScenarioNode')
+const { CampaignIDNode } = require('./CampaignIDNode')
 require('vendor/scripts/jquery-ui-1.11.1.custom')
 require('vendor/styles/jquery-ui-1.11.1.custom.css')
 
@@ -386,6 +387,7 @@ module.exports = (CampaignEditorView = (function () {
           nextLevel: NextLevelNode,
           campaigns: CampaignsNode,
           campaign: CampaignNode,
+          campaignID: CampaignIDNode,
           achievement: AchievementNode,
           rewards: RewardsNode,
           scenario: HackstackScenarioIDNode,

--- a/app/views/editor/campaign/CampaignIDNode.js
+++ b/app/views/editor/campaign/CampaignIDNode.js
@@ -1,0 +1,129 @@
+require('lib/setupTreema')
+const treemaExt = require('core/treema-ext')
+const Campaign = require('models/Campaign')
+const Backbone = require('backbone')
+
+class CampaignIDNode extends treemaExt.IDReferenceNode {
+  static initClass () {
+    this.prototype.valueClass = 'treema-campaign-id'
+    this.campaigns = {}
+    this.mapped = []
+  }
+
+  constructor (...args) {
+    super(...args)
+    this.url = '/db/campaign'
+    this.model = Campaign
+    this.search = this.search.bind(this)
+
+    // Fetch all campaigns upfront (like CampaignsNode does)
+    if (!CampaignIDNode.mapped || CampaignIDNode.mapped.length === 0) {
+      const s = new Backbone.Collection([], { model: Campaign })
+      s.url = '/db/campaign'
+      s.fetch({ data: { project: Campaign.denormalizedCampaignProperties } })
+      s.once('sync', (collection) => {
+        for (const campaign of Array.from(collection.models)) {
+          CampaignIDNode.campaigns[campaign.id] = campaign
+        }
+        CampaignIDNode.mapped = (Array.from(collection.models).map((r) => ({ label: r.get('name'), value: r.id })))
+        // Refresh display if we have data, so campaign names show up
+        if (this.getData() && !this.isEditing()) {
+          this.refreshDisplay()
+        }
+      })
+    } else {
+      // Campaigns already loaded, refresh display if we have data
+      if (this.getData() && !this.isEditing()) {
+        this.refreshDisplay()
+      }
+    }
+  }
+
+  search () {
+    const term = this.getValEl().find('input').val()
+    if (term === this.lastTerm) { return }
+
+    if (this.lastTerm && !term) { this.getSearchResultsEl().empty() }
+    if (!term) { return }
+    this.lastTerm = term
+
+    this.getSearchResultsEl().empty().append('Searching')
+
+    // Use pre-loaded campaigns data (like CampaignsNode.childSource)
+    const lowerTerm = term.toLowerCase()
+    const sorted = _.filter(CampaignIDNode.mapped, item => _.string.contains(item.label.toLowerCase(), lowerTerm))
+    const startsWithTerm = _.filter(sorted, item => _.string.startsWith(item.label.toLowerCase(), lowerTerm))
+    _.pull(sorted, ...Array.from(startsWithTerm))
+    const filtered = _.flatten([startsWithTerm, sorted])
+
+    // Display results
+    const container = this.getSearchResultsEl().detach().empty()
+    let first = true
+    for (const item of Array.from(filtered)) {
+      const campaign = CampaignIDNode.campaigns[item.value]
+      if (!campaign) { continue }
+      const row = $('<div></div>').addClass('treema-search-result-row')
+      const text = this.modelToString(campaign)
+      if (text == null) { continue }
+      if (first) { row.addClass('treema-search-selected') }
+      first = false
+      row.text(text)
+      row.data('value', campaign)
+      container.append(row)
+    }
+    if (!filtered.length) {
+      container.append($('<div>No results</div>'))
+    }
+    return this.getValEl().append(container)
+  }
+
+  buildValueForDisplay (valEl, data) {
+    super.buildValueForDisplay(valEl, data)
+    let campaignId
+    if (typeof data === 'string') {
+      campaignId = data
+    } else if (data && data._id) {
+      campaignId = data._id
+    }
+
+    if (campaignId) {
+      this.$el.find('.campaign-link').remove()
+      this.$el.find('.treema-row').prepend($(`<span class='campaign-link'><a href='/editor/campaign/${campaignId}' title='Edit Campaign' target='_blank' rel='noopener noreferrer'>(e)</a>&nbsp;</span>`))
+    }
+
+    return valEl
+  }
+
+  modelToString (model) {
+    const name = model.get('name') || model.id
+    return name
+  }
+
+  formatDocument (docOrModel) {
+    if (docOrModel && docOrModel.get && docOrModel.attributes) {
+      return this.modelToString(docOrModel)
+    }
+    const data = this.getData()
+    if (!data) { return 'None' }
+
+    // Use pre-loaded campaigns data (like CampaignsNode does)
+    if (CampaignIDNode.campaigns && CampaignIDNode.campaigns[data]) {
+      return this.modelToString(CampaignIDNode.campaigns[data])
+    }
+
+    // Fall back to supermodel
+    if (!this.settings.supermodel) { return '' + data }
+    let m = this.settings.supermodel.getModel(this.model, data)
+    if (!m && this.instance) {
+      m = this.instance
+      this.settings.supermodel.registerModel(m)
+    }
+    return m ? this.modelToString(m) : '' + data
+  }
+}
+CampaignIDNode.initClass()
+
+// Exports
+module.exports = {
+  CampaignIDNode,
+}


### PR DESCRIPTION
Add modules support to Campaign schema and implement CampaignIDNode for campaign selection in editor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Campaigns now support a modular structure: add child campaigns with positioning metadata and access control options (free, sales-call, paid)
  * Campaign editor features enhanced campaign selection with integrated search functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->