### PR TITLE
[Odyssey] Junior campaign type

### DIFF
--- a/app/schemas/models/campaign.schema.js
+++ b/app/schemas/models/campaign.schema.js
@@ -12,7 +12,7 @@ _.extend(CampaignSchema.properties, {
   i18n: { type: 'object', title: 'i18n', format: 'i18n', props: ['name', 'fullName', 'description'] },
   fullName: { type: 'string', title: 'Full Name', description: 'Ex.: "Kithgard Dungeon"' },
   description: { type: 'string', format: 'string', description: 'How long it takes and what players learn.' },
-  type: c.shortString({ title: 'Type', description: 'What kind of campaign this is.', enum: ['hero', 'course', 'hidden', 'hoc', 'hackstack'] }),
+  type: c.shortString({ title: 'Type', description: 'What kind of campaign this is.', enum: ['hero', 'course', 'hidden', 'hoc', 'hackstack', 'junior'] }),
 
   ambientSound: c.object({}, {
     mp3: { type: 'string', format: 'sound-file' },

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -1028,8 +1028,8 @@ class CampaignView extends RootView {
   }
 
   collapsePracticeLevels (levels) {
-    if (!['junior', '65c56663d2ca2055e65676af'].includes(this.terrain)) {
-      // Only do this for Junior levels for now
+    if (!['junior', '65c56663d2ca2055e65676af'].includes(this.terrain) && this.campaign?.get('type') !== 'junior') {
+      // Only do this for Junior campaigns for now
       return levels
     }
     // Collapse practice levels into their parent levels.


### PR DESCRIPTION
Update campaign schema to include 'junior' type and adjust collapsePracticeLevels logic for campaign type handling.

Right now we rely for practice collapsing and some junior only changes by hardcoded campaign id. Instead, better to use and extend campaign.type.

PR affects only new campaigns which are used for future CCJ2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced 'junior' as a new supported campaign type, expanding available campaign options.

* **Changes**
  * Updated practice level display logic to correctly handle 'junior' campaign types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->