### PR TITLE
add product in course schema

### DIFF
--- a/app/schemas/models/course.schema.js
+++ b/app/schemas/models/course.schema.js
@@ -127,6 +127,7 @@ _.extend(CourseSchema.properties, {
     },
   },
   curriculum: c.url({ title: 'Curriculum URL', description: 'Link to curriculum folder. Relevant for teacher dashboard curriculum guides.' }),
+  product: { type: 'string', enum: ['ozaria', 'codecombat', 'hackstack', 'junior'], description: 'Which product this course is for, if applicable. Affects where the course appears in the teacher dashboard.' },
 })
 
 c.extendBasicProperties(CourseSchema, 'Course')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Courses can now be assigned to specific products (Ozaria, CodeCombat, HackStack, or Junior), enabling improved content organization and product-specific dashboard placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->