### PR TITLE
Fix translation key for practice license message about Practice levels

### DIFF
--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -250,7 +250,7 @@ if !editorMode
                         button.btn.btn-md.btn-illustrated(data-level-original=practiceLevel.original data-level-slug=practiceLevel.slug data-level-path=level.levelPath || 'level' data-level-name=level.name class=(practiceLevelStatus === "complete" ? "btn-primary" : "btn-success"))
                           span.glyphicon.glyphicon-play
                   if disabled
-                    span.practice-license-message(data-i18n="play.practice-license-required")
+                    span.practice-license-message(data-i18n="play.practice_license_required")
                 if practiceLevelStatus !== 'complete'
                   - break
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the internationalization key for the practice license notification to ensure the message displays properly when a practice level is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->