### PR TITLE
add missing id for hs course

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/TableModuleHeader.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/TableModuleHeader.vue
@@ -285,7 +285,7 @@ export default {
       </v-popover>
     </div>
     <div
-      v-for="({ type, slug, introContent, ozariaType, introLevelSlug, isPractice, practiceLevels, tooltipName, description, normalizedOriginal, normalizedType, contentLevelSlug }, idx) of listOfContent"
+      v-for="({ type, slug, introContent, ozariaType, introLevelSlug, isPractice, practiceLevels, tooltipName, description, normalizedOriginal, normalizedType, contentLevelSlug, _id }, idx) of listOfContent"
       :key="`${idx}-${type}`"
       class="content-icons"
     >
@@ -320,7 +320,7 @@ export default {
             >
               <dynamic-link
                 target="_blank"
-                :href="isContentAccessible(access) ? getLevelUrl({ ozariaType, introLevelSlug, courseId: selectedCourseId, codeLanguage: classroom.aceConfig.language, slug, introContent }) : null"
+                :href="isContentAccessible(access) ? getLevelUrl({ ozariaType, introLevelSlug, courseId: selectedCourseId, codeLanguage: classroom.aceConfig.language, slug, introContent, _id }) : null"
               >
                 {{ tooltipName }}
               </dynamic-link>


### PR DESCRIPTION
fix ENG-2368
<img width="765" height="414" alt="image" src="https://github.com/user-attachments/assets/c7222521-b3f3-4728-aec4-e37f7184ee2c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation links in the teacher dashboard's course module interface. Lesson links now properly include required identifiers in their URLs, ensuring users are consistently directed to the correct course content when accessing lessons through module headers. This improvement enhances the overall reliability and user experience of lesson navigation throughout the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->