### PR TITLE
hide modal when ask-ai clicked

### DIFF
--- a/app/views/play/level/AskAIHelpView.js
+++ b/app/views/play/level/AskAIHelpView.js
@@ -5,7 +5,11 @@ class AskAIHelpView extends ModalComponent {
   constructor (options = {}) {
     super(options)
     this.propsData = options.propsData
-    this.on('ask-ai-clicked', () => {
+  }
+
+  afterRender () {
+    super.afterRender()
+    this.vueComponent.$on('ask-ai-clicked', () => {
       this.hide()
     })
   }


### PR DESCRIPTION
<img width="526" height="341" alt="image" src="https://github.com/user-attachments/assets/2efb62e6-6dce-4346-9114-a86ff7b9be68" />
fix CHINA-83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where a modal in the level view failed to close when the AI help action was triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->