### PR TITLE
fix edit class modal courses-vs-languages-vs-codeformats

### DIFF
--- a/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalEditClass.vue
@@ -223,13 +223,6 @@ export default Vue.extend({
   },
 
   watch: {
-    availableCodeFormats () {
-      const ava = this.availableCodeFormats.filter(cf => !cf.disabled).map(cf => cf.id)
-      this.newCodeFormats = this.newCodeFormats.filter(cf => ava.includes(cf))
-      if (!this.newCodeFormats.includes(this.newCodeFormatDefault)) {
-        this.newCodeFormatDefault = this.newCodeFormats[0]
-      }
-    },
     otherProductClassroom (newOtherProductClassroom) {
       // update settings that are available on both coco and ozar
       const { language, levelChat, liveCompletion, disablePaste } = newOtherProductClassroom.aceConfig

--- a/ozaria/site/components/teacher-dashboard/modals/modal-edit-class-components/CourseCodeLanguageFormatComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/modal-edit-class-components/CourseCodeLanguageFormatComponent.vue
@@ -275,7 +275,7 @@ export default {
         return this.newInitialFreeCourses.includes(utils.courseIDs.INTRO_TO_AI) && this.newInitialFreeCourses?.length === 1
       } else {
         const courseInstances = this.getCourseInstances(this.classroomId)
-        return !(courseInstances?.some(ci => utils.HACKSTACK_COURSE_IDS.includes(ci.courseID)))
+        return courseInstances?.every(ci => utils.HACKSTACK_COURSE_IDS.includes(ci.courseID))
       }
     },
     availableCodeFormats () {
@@ -346,7 +346,8 @@ export default {
   watch: {
     availableCodeFormats () {
       const ava = this.availableCodeFormats.filter(cf => !cf.disabled).map(cf => cf.id)
-      this.newCodeFormats = this.newCodeFormats.filter(cf => ava.includes(cf))
+      const filtered = this.newCodeFormats.filter(cf => ava.includes(cf))
+      this.newCodeFormats = filtered.length > 0 ? filtered : (ava.length ? [ava[0]] : [])
       if (!this.newCodeFormats.includes(this.newCodeFormatDefault)) {
         this.newCodeFormatDefault = this.newCodeFormats[0]
       }

--- a/ozaria/site/components/teacher-dashboard/modals/modal-edit-class-components/CourseCodeLanguageFormatComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/modal-edit-class-components/CourseCodeLanguageFormatComponent.vue
@@ -272,10 +272,10 @@ export default {
     },
     hasOnlyHackstack () {
       if (this.isNewClassroom) {
-        return this.newInitialFreeCourses.includes(utils.courseIDs.HACKSTACK) && this.newInitialFreeCourses?.length === 1
+        return this.newInitialFreeCourses.includes(utils.courseIDs.INTRO_TO_AI) && this.newInitialFreeCourses?.length === 1
       } else {
         const courseInstances = this.getCourseInstances(this.classroomId)
-        return courseInstances?.some(ci => ci.courseID === utils.courseIDs.HACKSTACK) && courseInstances?.length === 1
+        return !(courseInstances?.some(ci => utils.HACKSTACK_COURSE_IDS.includes(ci.courseID)))
       }
     },
     availableCodeFormats () {
@@ -284,6 +284,7 @@ export default {
         codeFormats['blocks-icons'].disabled = true
       }
       if (!this.enableBlocks) {
+        codeFormats['blocks-icons'].disabled = true
         codeFormats['blocks-and-code'].disabled = true
         codeFormats['blocks-text'].disabled = true
       }
@@ -343,18 +344,34 @@ export default {
     },
   },
   watch: {
+    availableCodeFormats () {
+      const ava = this.availableCodeFormats.filter(cf => !cf.disabled).map(cf => cf.id)
+      this.newCodeFormats = this.newCodeFormats.filter(cf => ava.includes(cf))
+      if (!this.newCodeFormats.includes(this.newCodeFormatDefault)) {
+        this.newCodeFormatDefault = this.newCodeFormats[0]
+      }
+    },
     newProgrammingLanguage (newVal) {
       this.$emit('programmingLanguageUpdated', newVal)
     },
     newInitialFreeCourses (newVal) {
       this.$emit('initialFreeCoursesUpdated', newVal)
-      if (this.hasJunior && !this.newCodeFormats.includes('blocks-icons')) {
+      if (this.hasJunior && !this.newCodeFormats.includes('blocks-icons') && this.enableBlocks) {
         this.newCodeFormats.push('blocks-icons')
         this.$emit('codeFormatsUpdated', this.newCodeFormats)
       }
     },
-    newCodeFormats (newVal) {
-      this.$emit('codeFormatsUpdated', newVal)
+    newCodeFormats (newVal, oldVal) {
+      if (newVal.length === 0) { // prevent final code format unchecked
+        this.$nextTick(() => {
+          this.newCodeFormats = oldVal
+        })
+      } else {
+        this.$emit('codeFormatsUpdated', newVal)
+        if (!newVal.includes(this.newCodeFormatDefault)) {
+          this.newCodeFormatDefault = newVal[0]
+        }
+      }
     },
     newCodeFormatDefault (newVal) {
       this.$emit('codeFormatDefaultUpdated', newVal)


### PR DESCRIPTION
fix ENG-2372
<img width="670" height="535" alt="image" src="https://github.com/user-attachments/assets/83b34acf-4a53-45f0-875c-525cb0c4a0d5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code-format validation and selection to prevent invalid or empty selections and keep the default format valid.
  * Prevented the last remaining format from being unintentionally removed.
  * Made the block-style icon option auto-added only when block coding is enabled.
  * Adjusted course-type detection so available format options better reflect classroom setup.
  * Changed when format filtering/normalization runs to reduce unexpected automatic changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->