### PR TITLE
cpp/java need fix health before sending to kodekeeper

### DIFF
--- a/app/views/play/level/tome/Spell.coffee
+++ b/app/views/play/level/tome/Spell.coffee
@@ -175,11 +175,8 @@ module.exports = class Spell
       @source = source
     else
       source = @getSource()
-    if @level.get('product') is 'codecombat-junior'
-      # Rewrite blank `health` calls to `hero.health`, otherwise global value assignment isn't dynamically updated
-      source = source.replace /(^|[^a-zA-Z.])health(?!\w)/g, (match, prefix) ->
-        return match if prefix.endsWith('hero.')
-        return "#{prefix}hero.health"
+    # we have some spell.transpile usage without fetchToken (maybe buggy?), so keep this line for the case
+    source = @view?.handleJuniorLevelHack(source)
     unless @language is 'html'
       @thang?.aether.transpile source
       @session.lastAST = @thang?.aether.ast

--- a/app/views/play/level/tome/SpellView.coffee
+++ b/app/views/play/level/tome/SpellView.coffee
@@ -125,6 +125,15 @@ module.exports = class SpellView extends CocoView
     @createOnCodeChangeHandlers()
     @lockDefaultCode()
     _.defer @onAllLoaded  # Needs to happen after the code generating this view is complete
+
+  handleJuniorLevelHack: (source) ->
+    if @options.level.get('product') is 'codecombat-junior'
+      # cpp/java need rewrite blank `health` calls to `hero.health` before sending to codekeeper.
+      source = source.replace /(^|[^a-zA-Z.])health(?!\w)/g, (match, prefix) ->
+        return match if prefix.endsWith('hero.')
+        return "#{prefix}hero.health"
+    return source
+
   # This ACE is used for the code editor, and is only instantiated once per level.
   createACE: ->
     # Test themes and settings here: http://ace.ajax.org/build/kitchen-sink.html
@@ -1209,6 +1218,7 @@ module.exports = class SpellView extends CocoView
   fetchToken: (source, language) =>
     if source of @loadedToken
       return Promise.resolve(@loadedToken[source])
+    source = @handleJuniorLevelHack(source)
     return aetherUtils.fetchToken(source, language)
 
   fetchTokenForSource: () =>


### PR DESCRIPTION
we had this hack in spell.transpile, while cpp/java do not use transpile to getting AST. so need run regex fix before sending to kodekeeper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of health variable references in CodeCombat Junior levels so spells execute reliably; junior-level code now correctly interprets unqualified "health" references to prevent runtime issues and ensure consistent spell behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->