### PR TITLE
[GD-823] All Home Users Go to Odyssey

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -1844,7 +1844,7 @@ module.exports.getJuniorUrl = function () {
   if (me && me.isTeacher() && !me.isAnonymous()) {
     juniorPath = '/teachers/guide/junior'
   }
-  if (me?.getOdysseyValue?.()) {
+  if (me?.isHomeUser?.()) {
     juniorPath = '/play/odyssey'
   }
   return `${cocoBaseURL()}${juniorPath}`

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -1844,7 +1844,7 @@ module.exports.getJuniorUrl = function () {
   if (me && me.isTeacher() && !me.isAnonymous()) {
     juniorPath = '/teachers/guide/junior'
   }
-  if (me?.getOdysseyExperimentValue?.() === 'beta') {
+  if (me?.getOdysseyValue?.()) {
     juniorPath = '/play/odyssey'
   }
   return `${cocoBaseURL()}${juniorPath}`

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -1458,28 +1458,11 @@ module.exports = (User = (function () {
 
     //   return this.tryStartExperiment('template')
     // }
-
-    getOdysseyExperimentValue () {
+    getOdysseyValue () {
       if (me.isStudent() || me.isTeacher()) {
-        return 'control'
+        return false
       }
-      if (features?.chinaInfra) {
-        return 'control'
-      }
-      const value = utils.getFirstNonNull(
-        utils.getExperimentValueFromQuery('odyssey'),
-        me.getExperimentValue('odyssey', null),
-      )
-      if (value != null) {
-        return value
-      }
-      if (me.isPremium()) {
-        return 'control'
-      }
-      if (new Date(me.get('dateCreated')) < new Date('2026-03-16T00:00:00Z')) {
-        return 'control'
-      }
-      return null
+      return true
     }
 
     getRequireSignupExperimentValue (CAMPAIGN) {
@@ -1526,14 +1509,6 @@ module.exports = (User = (function () {
         return value
       }
       return this.tryStartExperiment(CHOCOLI_EXPERIMENT_NAME)
-    }
-
-    getOrStartOdysseyExperimentValue () {
-      const value = this.getOdysseyExperimentValue()
-      if (value != null) {
-        return value
-      }
-      return this.tryStartExperiment('odyssey')
     }
   }
 

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -1458,13 +1458,6 @@ module.exports = (User = (function () {
 
     //   return this.tryStartExperiment('template')
     // }
-    getOdysseyValue () {
-      if (me.isStudent() || me.isTeacher()) {
-        return false
-      }
-      return true
-    }
-
     getRequireSignupExperimentValue (CAMPAIGN) {
       if (!me.isAnonymous()) {
         return 'control'

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -333,31 +333,6 @@ class CampaignView extends RootView {
   }
 
   redirectMiddleware () {
-    const juniorRedirect = () => {
-      // Only bucket/start the odyssey experiment when the user is explicitly trying to enter Junior.
-      // This avoids side-effects from random "read" code paths that just want to know a value.
-      if (this.terrain === 'junior' && !this.editorMode) {
-        const odysseyValue = me.getOrStartOdysseyExperimentValue?.()
-        if (odysseyValue === 'beta') {
-          // Use the URL API to preserve/merge query params + hash when available; fallback for older/weird URL environments.
-          try {
-            const destUrl = new URL('/play/odyssey', window.location.origin)
-            const currentUrl = new URL(window.location.href)
-            currentUrl.searchParams.forEach((value, key) => destUrl.searchParams.set(key, value))
-            if (currentUrl.hash) destUrl.hash = currentUrl.hash
-            window.tracker?.trackEvent('Redirected Junior to Odyssey', { category: 'World Map', label: 'junior' })
-            application.router.navigate(destUrl.pathname + destUrl.search + destUrl.hash, { trigger: true, replace: true })
-          } catch (e) {
-            const query = location.search || ''
-            const hash = location.hash || ''
-            window.tracker?.trackEvent('Redirected Junior to Odyssey', { category: 'World Map', label: 'junior' })
-            application.router.navigate(`/play/odyssey${query}${hash}`, { trigger: true, replace: true })
-          }
-          return true
-        }
-      }
-    }
-
     const studentRedirect = () => {
       const courseInstanceId = utils.getQueryVariable('course-instance')
       if (!courseInstanceId && me.isStudent() && this.terrain !== 'intro') {
@@ -428,7 +403,7 @@ class CampaignView extends RootView {
       }
     }
 
-    return juniorRedirect() || hocRedirect() || studentRedirect()
+    return hocRedirect() || studentRedirect()
   }
 
   destroy () {

--- a/test/app/core/utils.spec.coco.js
+++ b/test/app/core/utils.spec.coco.js
@@ -1325,7 +1325,7 @@ describe('Utility library', function () {
       me = {
         isTeacher: jasmine.createSpy(),
         isAnonymous: jasmine.createSpy(),
-        getOdysseyExperimentValue: jasmine.createSpy()
+        getOdysseyValue: jasmine.createSpy()
       };
       global.me = me;
     });
@@ -1337,7 +1337,7 @@ describe('Utility library', function () {
   
     it('should return junior path for non-teacher or anonymous users', () => {
       me.isTeacher.and.returnValue(false);
-      me.getOdysseyExperimentValue.and.returnValue('control');
+      me.getOdysseyValue.and.returnValue(false);
       expect(utils.getJuniorUrl()).toEqual(`${utils.cocoBaseURL()}/play/junior`);
     });
   
@@ -1349,7 +1349,7 @@ describe('Utility library', function () {
 
     it('should return odyssey path when user is in odyssey beta', () => {
       me.isTeacher.and.returnValue(false);
-      me.getOdysseyExperimentValue.and.returnValue('beta');
+      me.getOdysseyValue.and.returnValue(true);
       expect(utils.getJuniorUrl()).toEqual(`${utils.cocoBaseURL()}/play/odyssey`);
     });
   });

--- a/test/app/core/utils.spec.coco.js
+++ b/test/app/core/utils.spec.coco.js
@@ -1325,7 +1325,7 @@ describe('Utility library', function () {
       me = {
         isTeacher: jasmine.createSpy(),
         isAnonymous: jasmine.createSpy(),
-        getOdysseyValue: jasmine.createSpy()
+        isHomeUser: jasmine.createSpy()
       };
       global.me = me;
     });
@@ -1337,7 +1337,7 @@ describe('Utility library', function () {
   
     it('should return junior path for non-teacher or anonymous users', () => {
       me.isTeacher.and.returnValue(false);
-      me.getOdysseyValue.and.returnValue(false);
+      me.isHomeUser.and.returnValue(false);
       expect(utils.getJuniorUrl()).toEqual(`${utils.cocoBaseURL()}/play/junior`);
     });
   
@@ -1347,9 +1347,9 @@ describe('Utility library', function () {
       expect(utils.getJuniorUrl()).toEqual(`${utils.cocoBaseURL()}/teachers/guide/junior`);
     });
 
-    it('should return odyssey path when user is in odyssey beta', () => {
+    it('should return odyssey path for home users', () => {
       me.isTeacher.and.returnValue(false);
-      me.getOdysseyValue.and.returnValue(true);
+      me.isHomeUser.and.returnValue(true);
       expect(utils.getJuniorUrl()).toEqual(`${utils.cocoBaseURL()}/play/odyssey`);
     });
   });


### PR DESCRIPTION
Refactor Odyssey experiment handling by renaming methods and simplifying logic; remove unused junior redirect functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the logic that sends junior users to Odyssey content — routing now uses a straightforward home-user check instead of experiment assignments.
  * Removed experiment-based eligibility handling for Odyssey.

* **Tests**
  * Updated tests to match the new Odyssey eligibility and routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->