### PR TITLE
[GD-824] Junior get-out level experiment

### DIFF
--- a/app/models/User.js
+++ b/app/models/User.js
@@ -685,13 +685,14 @@ module.exports = (User = (function () {
         return 'control'
       }
       let value
-      if (Math.random() < probability) {
+      const rnd = Math.random()
+      if (rnd < probability) {
         value = 'beta'
       } else {
         value = 'control'
         probability = 1 - probability
       }
-      console.log(`starting ${name} experiment with value ${value} and probability ${probability}`)
+      console.log(`starting ${name} experiment with value ${value} and probability ${probability} and rnd ${rnd}`)
       me.startExperiment(name, value, probability)
       return value
     }

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -27,6 +27,7 @@ const _ = require('lodash')
 const moment = require('moment')
 const NAPERVILLE_UNIQUE_KEY = 'naperville'
 const CHOCOLI_EXPERIMENT_NAME = 'chocoli'
+const GET_OUT_EXPERIMENT_NAME = 'get-out'
 const REQUIRE_SIGN_UP_EXPERIMENT = {
   dungeon: 'requires-sign-up-dungeon',
   junior: 'requires-sign-up-junior',
@@ -1494,6 +1495,31 @@ module.exports = (User = (function () {
         return value
       }
       return this.tryStartExperiment(REQUIRE_SIGN_UP_EXPERIMENT[CAMPAIGN])
+    }
+
+    getGetOutExperimentValue () {
+      if (me.isStudent() || me.isTeacher()) {
+        return 'control'
+      }
+      if (features?.chinaInfra) {
+        return 'control'
+      }
+      if (me.isPremium()) {
+        return 'control'
+      }
+      const value = utils.getFirstNonNull(
+        utils.getExperimentValueFromQuery(GET_OUT_EXPERIMENT_NAME),
+        me.getExperimentValue(GET_OUT_EXPERIMENT_NAME, null),
+      )
+      return value ?? null
+    }
+
+    getOrStartGetOutExperimentValue () {
+      const value = this.getGetOutExperimentValue()
+      if (value != null) {
+        return value
+      }
+      return this.tryStartExperiment(GET_OUT_EXPERIMENT_NAME)
     }
 
     getOrStartChocoliExperimentValue () {

--- a/app/views/play/level/modal/HeroVictoryModal.js
+++ b/app/views/play/level/modal/HeroVictoryModal.js
@@ -580,36 +580,9 @@ module.exports = (HeroVictoryModal = (function () {
       return campaign
     }
 
-    getNextLevelLink (returnToCourse) {
-      let link
-      if (returnToCourse == null) { returnToCourse = false }
-      if (this.level.get('product', true) === 'codecombat-junior' && this.nextLevel?.get('slug')) {
-        link = `/play/level/${this.nextLevel.get('slug')}`
-        if (this.courseID) {
-          link += `/${this.courseID}`
-          if (this.courseInstanceID) { link += `/${this.courseInstanceID}` }
-        }
-        if (this.parentCampaign) {
-          link += `?fromCampaign=${this.parentCampaign}`
-        }
-      } else if (this.level.isType('course')) {
-        link = '/students'
-        if (this.courseID) {
-          link += `/${this.courseID}`
-          if (this.courseInstanceID) { link += `/${this.courseInstanceID}` }
-        }
-      } else {
-        link = '/play'
-        const nextCampaign = this.getNextLevelCampaign()
-        link += '/' + nextCampaign
-      }
-      return link
-    }
-
     onClickContinue (e, extraOptions = null) {
       let needle1, viewArgs, viewClass
       this.playSound('menu-button-click')
-      let nextLevelLink = this.getNextLevelLink(extraOptions != null ? extraOptions.returnToCourse : undefined)
       // Preserve the supermodel as we navigate back to the world map.
       const options = {
         justBeatLevel: this.level,
@@ -618,32 +591,19 @@ module.exports = (HeroVictoryModal = (function () {
       if (extraOptions) { _.merge(options, extraOptions) }
       const returnAfterCompleteMap = this.level.get('returnAfterCompleteMap')
       const product = this.level.get('product', true)
-
-      // currently only junior set the nextLevel and practiceLevel, so we can start junior experiment without checking product
-      let levelRequiresSignUp = false
-      if (options.sendToPracticeLevel && this.practiceLevel?.get('slug')) {
-        levelRequiresSignUp = this.practiceLevel.get('requiresSignUp')
-      } else if (this.nextLevel?.get('slug')) {
-        levelRequiresSignUp = this.nextLevel.get('requiresSignUp')
-      }
-      if (levelRequiresSignUp && me.isAnonymous()) {
-        const userRequiresSignUp = me.getOrStartRequireSignupExperimentValue?.('junior')
-        if (userRequiresSignUp === 'beta') {
-          return this.openModalView(new CreateAccountModal({ accountRequiredMessage: $.i18n.t('account.unlock_next_level_with_sign_up') }))
-        }
-      }
+      let continueLink
 
       if (this.showHoc2016ExploreButton) {
         // Send players to /play after completing final game-dev activity project level
-        nextLevelLink = '/play'
+        continueLink = '/play'
         viewClass = 'views/play/CampaignView'
         viewArgs = [options]
       } else if (returnAfterCompleteMap && returnAfterCompleteMap[this.parentCampaign]) {
-        nextLevelLink = `/play/${returnAfterCompleteMap[this.parentCampaign]}`
+        continueLink = `/play/${returnAfterCompleteMap[this.parentCampaign]}`
         viewClass = 'views/play/CampaignView'
         viewArgs = [options, returnAfterCompleteMap[this.parentCampaign]]
       } else if (options.sendToPracticeLevel && product === 'codecombat-junior' && this.practiceLevel?.get('slug')) {
-        nextLevelLink = `/play/level/${this.practiceLevel.get('slug')}`
+        continueLink = `/play/level/${this.practiceLevel.get('slug')}`
         viewClass = 'views/play/level/PlayLevelView'
         options.parentCampaign = this.parentCampaign
         options.courseID = this.courseID
@@ -659,16 +619,29 @@ module.exports = (HeroVictoryModal = (function () {
           queryParams.push(`courseInstanceID=${this.courseInstanceID}`)
         }
         if (queryParams.length) {
-          nextLevelLink += `?${queryParams.join('&')}`
+          continueLink += `?${queryParams.join('&')}`
         }
         viewArgs = [options, this.practiceLevel.get('slug')]
       } else if ((this.level.isType('course') || product === 'codecombat-junior') && this.nextLevel?.get('slug') && !options.returnToCourse) {
+        continueLink = `/play/level/${this.nextLevel.get('slug')}`
+        if (this.courseID) {
+          continueLink += `/${this.courseID}`
+          if (this.courseInstanceID) { continueLink += `/${this.courseInstanceID}` }
+        }
+        if (this.parentCampaign) {
+          continueLink += `?fromCampaign=${this.parentCampaign}`
+        }
         viewClass = 'views/play/level/PlayLevelView'
         options.courseID = this.courseID
         options.courseInstanceID = this.courseInstanceID
         options.parentCampaign = this.parentCampaign
         viewArgs = [options, this.nextLevel.get('slug')]
       } else if (this.level.isType('course')) {
+        continueLink = '/students'
+        if (this.courseID) {
+          continueLink += `/${this.courseID}`
+          if (this.courseInstanceID) { continueLink += `/${this.courseInstanceID}` }
+        }
         // TODO: shouldn't set viewClass and route in different places
         viewClass = 'views/courses/CoursesView'
         viewArgs = [options]
@@ -679,8 +652,8 @@ module.exports = (HeroVictoryModal = (function () {
         }
       } else if (this.level.isType('course-ladder')) {
         const leagueID = this.courseInstanceID || utils.getQueryVariable('league')
-        nextLevelLink = `/play/ladder/${this.level.get('slug')}`
-        if (leagueID) { nextLevelLink += `/course/${leagueID}` }
+        continueLink = `/play/ladder/${this.level.get('slug')}`
+        if (leagueID) { continueLink += `/course/${leagueID}` }
         viewClass = 'views/ladder/LadderView'
         viewArgs = [options, this.level.get('slug')]
         if (leagueID) { viewArgs = viewArgs.concat(['course', leagueID]) }
@@ -689,10 +662,29 @@ module.exports = (HeroVictoryModal = (function () {
         if ((needle = this.level.get('slug'), Array.from(campaignEndLevels).includes(needle))) {
           options.worldComplete = this.level.get('campaign') || true
         }
+        continueLink = '/play'
+        const nextCampaign = this.getNextLevelCampaign()
+        continueLink += '/' + nextCampaign
         viewClass = 'views/play/CampaignView'
-        viewArgs = [options, this.getNextLevelCampaign()]
+        viewArgs = [options, nextCampaign]
       }
-      const navigationEvent = { route: nextLevelLink, viewClass, viewArgs }
+      // currently only junior set the nextLevel and practiceLevel, so we can start junior experiment without checking product
+      // If the link contains /play/level/, we need to check if the level requires sign up
+      if (continueLink.includes('/play/level/')) {
+        let levelRequiresSignUp = false
+        if (options.sendToPracticeLevel && this.practiceLevel?.get('slug')) {
+          levelRequiresSignUp = this.practiceLevel.get('requiresSignUp')
+        } else if (this.nextLevel?.get('slug')) {
+          levelRequiresSignUp = this.nextLevel.get('requiresSignUp')
+        }
+        if (levelRequiresSignUp && me.isAnonymous()) {
+          const userRequiresSignUp = me.getOrStartRequireSignupExperimentValue?.('junior')
+          if (userRequiresSignUp === 'beta') {
+            return this.openModalView(new CreateAccountModal({ accountRequiredMessage: $.i18n.t('account.unlock_next_level_with_sign_up') }))
+          }
+        }
+      }
+      const navigationEvent = { route: continueLink, viewClass, viewArgs }
       if ((this.level.get('slug') === 'lost-viking') && !((needle1 = me.get('age'), ['0-13', '14-17'].includes(needle1)))) {
         return this.showOffer(navigationEvent)
       } else {

--- a/app/views/play/level/modal/HeroVictoryModal.js
+++ b/app/views/play/level/modal/HeroVictoryModal.js
@@ -591,6 +591,7 @@ module.exports = (HeroVictoryModal = (function () {
       if (extraOptions) { _.merge(options, extraOptions) }
       const returnAfterCompleteMap = this.level.get('returnAfterCompleteMap')
       const product = this.level.get('product', true)
+      const isJunior = product === 'codecombat-junior'
       let continueLink
 
       if (this.showHoc2016ExploreButton) {
@@ -602,7 +603,7 @@ module.exports = (HeroVictoryModal = (function () {
         continueLink = `/play/${returnAfterCompleteMap[this.parentCampaign]}`
         viewClass = 'views/play/CampaignView'
         viewArgs = [options, returnAfterCompleteMap[this.parentCampaign]]
-      } else if (options.sendToPracticeLevel && product === 'codecombat-junior' && this.practiceLevel?.get('slug')) {
+      } else if (options.sendToPracticeLevel && isJunior && this.practiceLevel?.get('slug')) {
         continueLink = `/play/level/${this.practiceLevel.get('slug')}`
         viewClass = 'views/play/level/PlayLevelView'
         options.parentCampaign = this.parentCampaign
@@ -622,7 +623,7 @@ module.exports = (HeroVictoryModal = (function () {
           continueLink += `?${queryParams.join('&')}`
         }
         viewArgs = [options, this.practiceLevel.get('slug')]
-      } else if ((this.level.isType('course') || product === 'codecombat-junior') && this.nextLevel?.get('slug') && !options.returnToCourse) {
+      } else if ((this.level.isType('course') || isJunior) && this.nextLevel?.get('slug') && !options.returnToCourse) {
         continueLink = `/play/level/${this.nextLevel.get('slug')}`
         if (this.courseID) {
           continueLink += `/${this.courseID}`
@@ -668,20 +669,12 @@ module.exports = (HeroVictoryModal = (function () {
         viewClass = 'views/play/CampaignView'
         viewArgs = [options, nextCampaign]
       }
-      // currently only junior set the nextLevel and practiceLevel, so we can start junior experiment without checking product
       // If the link contains /play/level/, we need to check if the level requires sign up
-      if (continueLink.includes('/play/level/')) {
-        let levelRequiresSignUp = false
-        if (options.sendToPracticeLevel && this.practiceLevel?.get('slug')) {
-          levelRequiresSignUp = this.practiceLevel.get('requiresSignUp')
-        } else if (this.nextLevel?.get('slug')) {
-          levelRequiresSignUp = this.nextLevel.get('requiresSignUp')
-        }
-        if (levelRequiresSignUp && me.isAnonymous()) {
-          const userRequiresSignUp = me.getOrStartRequireSignupExperimentValue?.('junior')
-          if (userRequiresSignUp === 'beta') {
-            return this.openModalView(new CreateAccountModal({ accountRequiredMessage: $.i18n.t('account.unlock_next_level_with_sign_up') }))
-          }
+      // for home users we are going to try get-out experiment
+      if (isJunior && continueLink.includes('/play/level/') && (me.isHomeUser() || me.isAnonymous())) {
+        const getOutValue = me.getOrStartGetOutExperimentValue?.()
+        if (getOutValue === 'beta' && this.parentCampaign) {
+          continueLink = `/play/${this.parentCampaign}`
         }
       }
       const navigationEvent = { route: continueLink, viewClass, viewArgs }

--- a/app/views/play/level/modal/HeroVictoryModal.js
+++ b/app/views/play/level/modal/HeroVictoryModal.js
@@ -675,6 +675,8 @@ module.exports = (HeroVictoryModal = (function () {
         const getOutValue = me.getOrStartGetOutExperimentValue?.()
         if (getOutValue === 'beta' && this.parentCampaign) {
           continueLink = `/play/${this.parentCampaign}`
+          viewClass = 'views/play/CampaignView'
+          viewArgs = [options, this.parentCampaign]
         }
       }
       const navigationEvent = { route: continueLink, viewClass, viewArgs }


### PR DESCRIPTION
- experiment if after completed level sending player to the map or next level
- removed sign up experiment from victory modal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experiment control for level completion navigation flow.

* **Refactor**
  * Updated victory modal navigation logic to use experiment-based routing instead of previous sign-up gating.
  * Modified how user progression routes are determined after level completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->