### PR TITLE
Remove 'get-out' experiment logic

### DIFF
--- a/app/models/User.js
+++ b/app/models/User.js
@@ -27,7 +27,6 @@ const _ = require('lodash')
 const moment = window.moment
 const NAPERVILLE_UNIQUE_KEY = 'naperville'
 const CHOCOLI_EXPERIMENT_NAME = 'chocoli'
-const GET_OUT_EXPERIMENT_NAME = 'get-out'
 const REQUIRE_SIGN_UP_EXPERIMENT = {
   dungeon: 'requires-sign-up-dungeon',
   junior: 'requires-sign-up-junior',
@@ -1496,31 +1495,6 @@ module.exports = (User = (function () {
         return value
       }
       return this.tryStartExperiment(REQUIRE_SIGN_UP_EXPERIMENT[CAMPAIGN])
-    }
-
-    getGetOutExperimentValue () {
-      if (me.isStudent() || me.isTeacher()) {
-        return 'control'
-      }
-      if (features?.chinaInfra) {
-        return 'control'
-      }
-      if (me.isPremium()) {
-        return 'control'
-      }
-      const value = utils.getFirstNonNull(
-        utils.getExperimentValueFromQuery(GET_OUT_EXPERIMENT_NAME),
-        me.getExperimentValue(GET_OUT_EXPERIMENT_NAME, null),
-      )
-      return value ?? null
-    }
-
-    getOrStartGetOutExperimentValue () {
-      const value = this.getGetOutExperimentValue()
-      if (value != null) {
-        return value
-      }
-      return this.tryStartExperiment(GET_OUT_EXPERIMENT_NAME)
     }
 
     getOrStartChocoliExperimentValue () {

--- a/app/views/play/level/modal/HeroVictoryModal.js
+++ b/app/views/play/level/modal/HeroVictoryModal.js
@@ -623,6 +623,10 @@ module.exports = (HeroVictoryModal = (function () {
           continueLink += `?${queryParams.join('&')}`
         }
         viewArgs = [options, this.practiceLevel.get('slug')]
+      } else if (isJunior && (me.isHomeUser() || me.isAnonymous()) && this.parentCampaign) {
+        continueLink = `/play/${this.parentCampaign}`
+        viewClass = 'views/play/CampaignView'
+        viewArgs = [options, this.parentCampaign]
       } else if ((this.level.isType('course') || isJunior) && this.nextLevel?.get('slug') && !options.returnToCourse) {
         continueLink = `/play/level/${this.nextLevel.get('slug')}`
         if (this.courseID) {
@@ -668,16 +672,6 @@ module.exports = (HeroVictoryModal = (function () {
         continueLink += '/' + nextCampaign
         viewClass = 'views/play/CampaignView'
         viewArgs = [options, nextCampaign]
-      }
-      // If the link contains /play/level/, we need to check if the level requires sign up
-      // for home users we are going to try get-out experiment
-      if (isJunior && continueLink.includes('/play/level/') && (me.isHomeUser() || me.isAnonymous())) {
-        const getOutValue = me.getOrStartGetOutExperimentValue?.()
-        if (getOutValue === 'beta' && this.parentCampaign) {
-          continueLink = `/play/${this.parentCampaign}`
-          viewClass = 'views/play/CampaignView'
-          viewArgs = [options, this.parentCampaign]
-        }
       }
       const navigationEvent = { route: continueLink, viewClass, viewArgs }
       if ((this.level.get('slug') === 'lost-viking') && !((needle1 = me.get('age'), ['0-13', '14-17'].includes(needle1)))) {


### PR DESCRIPTION
- all home users get back to the map on the odyssey maps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated routing logic for junior users completing levels to improve campaign navigation
  * Streamlined experiment tracking system to support new requirements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/codecombat/codecombat/pull/8304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->