### PR TITLE
Revert "show details in licensed title"

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -1918,27 +1918,6 @@ module.exports.groupedCoursesList = (courses) => {
   }
 }
 
-module.exports.courseDescription = (includedCourseIDs, credit = undefined) => {
-  const { LICENSE_PRESETS } = require('./constants')
-  const numericalCourses = courses => courses.reduce((s, k) => s + courseNumericalStatus[k], 0)
-  const courseSame = (a, b) => a.length === b.length && numericalCourses(a) === numericalCourses(b)
-  if (includedCourseIDs) {
-    const hsCourses = [...HACKSTACK_COURSE_IDS.filter(x => x !== allCourseIDs.HACKSTACK)]
-    if (credit && courseSame(includedCourseIDs, hsCourses)) {
-      return $.i18n.t('teacher.hackstack_license') + $.i18n.t('teacher.hackstack_credits', credit)
-    }
-    if (courseSame(includedCourseIDs, LICENSE_PRESETS['COCO-OLD(No HS, OZ)'])) {
-      return $.i18n.t('teacher.coco_full_license')
-    }
-    if (courseSame(includedCourseIDs, LICENSE_PRESETS['CH1+CH2+CH3+CH4(OZ only)'])) {
-      return $.i18n.t('teacher.ozar_full_license')
-    }
-    return $.i18n.t('teacher.customized_license') + ': ' + (includedCourseIDs.map(id => courseAcronyms[id])).join('+')
-  } else {
-    return $.i18n.t('teacher.full_license')
-  }
-}
-
 module.exports = {
   ...module.exports,
   activeAndPastArenas,

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -2969,8 +2969,6 @@ module.exports = {
       CS_short: 'CS',
       SANDBOX_short: 'Sandbox',
       EXPLORATIONS_short: 'Explorations',
-      course_not_covered: 'Course __course__ not covered',
-      license_is: 'The student license is: ',
     },
 
     teacher_licenses: {

--- a/app/models/Prepaid.js
+++ b/app/models/Prepaid.js
@@ -14,6 +14,7 @@
 let Prepaid
 const CocoModel = require('./CocoModel')
 const utils = require('../core/utils')
+const constants = require('../core/constants')
 
 module.exports = (Prepaid = (function () {
   Prepaid = class Prepaid extends CocoModel {
@@ -75,16 +76,40 @@ module.exports = (Prepaid = (function () {
       if (type === 'starter_license') {
         return i18n.t('teacher.starter_license')
       }
+      const arraySame = (a, b) => a.length === b.length && a.every((v, i) => v === b[i])
       const includedCourseIDs = this.get('includedCourseIDs')
-      const credit = this.get('properties')?.creditDetails
-      return utils.courseDescription(includedCourseIDs, credit)
+      if (includedCourseIDs) {
+        const credit = this.get('properties')?.creditDetails
+        const hsCourses = [...utils.HACKSTACK_COURSE_IDS.filter(x => x !== utils.allCourseIDs.HACKSTACK)]
+        if (credit && arraySame(includedCourseIDs, hsCourses)) {
+          return i18n.t('teacher.hackstack_license') + i18n.t('teacher.hackstack_credits', credit)
+        }
+        if (arraySame(includedCourseIDs, constants.LICENSE_PRESETS['COCO-OLD(No HS, OZ)'])) {
+          return i18n.t('teacher.coco_full_license')
+        }
+        if (arraySame(includedCourseIDs, constants.LICENSE_PRESETS['CH1+CH2+CH3+CH4(OZ only)'])) {
+          return i18n.t('teacher.ozar_full_license')
+        }
+        return i18n.t('teacher.customized_license') + ': ' + (includedCourseIDs.map(id => utils.courseAcronyms[id])).join('+')
+      } else {
+        return i18n.t('teacher.full_license')
+      }
     }
 
     typeDescriptionWithTime () {
+      const type = this.get('type')
       const endDate = moment(this.get('endDate')).utc().format('ll')
       let endAt = `<br>${i18n.t('teacher.status_enrolled')}`
       endAt = endAt.replace('{{date}}', endDate)
-      return this.typeDescription() + endAt
+      if (type === 'starter_license') {
+        return i18n.t('teacher.starter_license') + endAt
+      }
+      const includedCourseIDs = this.get('includedCourseIDs')
+      if (includedCourseIDs) {
+        return i18n.t('teacher.customized_license') + ': ' + (includedCourseIDs.map(id => utils.courseAcronyms[id])).join('+') + endAt
+      } else {
+        return i18n.t('teacher.full_license') + endAt
+      }
     }
 
     redeem (user, options) {

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -864,16 +864,6 @@ module.exports = (User = (function () {
       return 'course'
     }
 
-    prepaidTypeDescription () {
-      const courseProducts = this.activeProducts('course')
-      if (!courseProducts.length) { return '' }
-      // NOTE: Full licenses implicitly include all courses
-      if (_.any(courseProducts, p => (p.productOptions?.includedCourseIDs == null))) { return utils.courseDescription() }
-      const union = (res, prepaid) => _.union(res, prepaid.productOptions?.includedCourseIDs != null ? prepaid.productOptions?.includedCourseIDs : [])
-      const includedCourseIDs = _.reduce(courseProducts, union, [])
-      return utils.courseDescription(includedCourseIDs)
-    }
-
     prepaidIncludesCourse (course) {
       const courseProducts = this.activeProducts('course')
       if (!courseProducts.length) { return false }

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
@@ -380,7 +380,6 @@ export default {
         return {
           displayName,
           _id: userObj._id,
-          userObj,
           isEnrolled,
           firstName: userObj.firstName || displayName,
           lastName: userObj.lastName || displayName,

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/CellStudent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/CellStudent.vue
@@ -1,38 +1,34 @@
 <script>
-import { isOzaria, courseIDs, OZ_COURSE_IDS, courseAcronyms } from 'core/utils'
+import { isOzaria, courseIDs, OZ_COURSE_IDS } from 'core/utils'
 import { mapMutations, mapGetters } from 'vuex'
 export default {
   props: {
     studentName: {
       type: String,
-      required: true,
+      required: true
     },
     studentId: {
       type: String,
-      required: true,
-    },
-    studentObj: {
-      type: Object,
-      default: null,
+      required: true
     },
     checked: {
       type: Boolean,
-      required: true,
+      required: true
     },
     isEnrolled: {
       type: Boolean,
-      default: false,
+      default: false
     },
     studentSessions: {
-      type: Array,
-    },
+      type: Array
+    }
   },
 
   computed: {
     ...mapGetters({
       classroom: 'teacherDashboard/getCurrentClassroom',
       selectedCourseId: 'teacherDashboard/getSelectedCourseIdCurrentClassroom',
-      getCourseInstancesOfClass: 'courseInstances/getCourseInstancesOfClass',
+      getCourseInstancesOfClass: 'courseInstances/getCourseInstancesOfClass'
     }),
 
     selectedCourseInstanceId () {
@@ -66,30 +62,10 @@ export default {
     isOzCourse () {
       return OZ_COURSE_IDS.includes(this.selectedCourseId)
     },
-    student () {
-      const User = require('models/User')
-      return new User(this.studentObj)
-    },
-    licenseImg () {
-      if (this.student.prepaidIncludesCourse(this.selectedCourseId)) {
-        return '/images/ozaria/teachers/dashboard/svg_icons/IconLicense_Purple.svg'
-      }
-      return '/images/ozaria/teachers/dashboard/svg_icons/IconLicense_Gray.svg'
-    },
-    licensedStatus () {
-      let title
-      const covers = $.i18n.t('teacher.license_is')
-      if (this.student.prepaidIncludesCourse(this.selectedCourseId)) {
-        title = $.i18n.t('teacher.owned_license')
-      } else {
-        title = $.i18n.t('teacher.course_not_covered', { course: courseAcronyms[this.selectedCourseId] })
-      }
-      return title + ` \n${covers}${this.student.prepaidTypeDescription()}`
-    },
   },
   methods: {
     ...mapMutations({
-      openModalEditStudent: 'baseSingleClass/openModalEditStudent',
+      openModalEditStudent: 'baseSingleClass/openModalEditStudent'
     }),
     certUrl (studentId) {
       let urlStarts = '/certificates'
@@ -98,7 +74,7 @@ export default {
       }
       return `${urlStarts}/${studentId}?class=${this.classroom._id}&course=${this.selectedCourseId}&course-instance=${this.selectedCourseInstanceId}`
     },
-  },
+  }
 }
 </script>
 <template>
@@ -131,8 +107,8 @@ export default {
       </a>
       <img
         v-if="isEnrolled"
-        :src="licenseImg"
-        :title="licensedStatus"
+        src="/images/ozaria/teachers/dashboard/svg_icons/IconLicense_Gray.svg"
+        title="Licensed"
       >
     </div>
   </div>

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/TableStudentList.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/TableStudentList.vue
@@ -50,9 +50,9 @@ export default {
 <template>
   <div id="studentList">
     <CellStudent
-      v-for="{ displayName, _id, userObj, isEnrolled, studentCombinedSessions } of studentsWithSessions"
+      v-for="{ displayName, _id, isEnrolled, studentCombinedSessions } of studentsWithSessions"
       :key="_id"
-      :student-obj="userObj"
+
       :student-id="_id"
       :student-name="displayName"
       :is-enrolled="isEnrolled"

--- a/ozaria/site/components/teacher-dashboard/BaseTeacherLicenses/common/LicenseCard.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseTeacherLicenses/common/LicenseCard.vue
@@ -47,7 +47,7 @@ export default {
     },
     includedCourseIds: {
       type: Array,
-      default: () => undefined,
+      default: () => [],
     },
     disableApplyLicenses: {
       type: Boolean,
@@ -105,8 +105,14 @@ export default {
       return credit && includedCourseIds?.length === 1 && includedCourseIds[0] === utils.courseIDs.HACKSTACK
     },
     licenseName () {
-      const typeDescription = utils.courseDescription(this.includedCourseIds, this.properties?.creditDetails)
-      return typeDescription.split(':')[0]
+      if (this.customizedLicense) {
+        if (this.hackstackLicense) {
+          return $.i18n.t('teacher.hackstack_license')
+        }
+        return $.i18n.t('teacher.customized_license')
+      } else {
+        return $.i18n.t('teacher.full_license')
+      }
     },
     licenseDescription () {
       if (this.customizedLicense) {


### PR DESCRIPTION
Reverts codecombat/codecombat#8306

we decide to only apply new logic for customized license. so revert first , and rollback the full license logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified license display and description logic throughout the application
  * Updated license icon rendering in the teacher dashboard to a consistent design
  * Streamlined student information structure in class rosters
  * Improved license card identification for customized and specialized license types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/codecombat/codecombat/pull/8309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->