### PR TITLE
deprecate dall-e and use gpt-image models

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -1710,6 +1710,7 @@ const aiToolToImage = {
   gpt: '/images/ai/ChatGPT.svg',
   'stable-diffusion': '/images/ai/Stable_Diffusion.png',
   'dall-e-3': '/images/ai/DALL-E.webp',
+  'gpt-image': '/images/ai/DALL-E.webp',
   claude: '/images/ai/claude.webp',
   gemini: '/images/ai/gemini.svg',
   imagen: '/images/ai/gemini.svg',
@@ -1718,7 +1719,7 @@ const aiToolToImage = {
 module.exports.getImageFromAiTool = (tool) => {
   if (tool.includes('claude')) {
     return aiToolToImage.claude
-  } else if (tool.includes('dall-e')) {
+  } else if (tool.includes('dall-e') || tool.includes('gpt-image')) {
     return aiToolToImage['dall-e-3']
   } else if (tool.includes('stable-diffusion')) {
     return aiToolToImage['stable-diffusion']


### PR DESCRIPTION
fix ENG-2494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image tool recognition to support both naming conventions for DALL-E image generation, ensuring consistent icon display and functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/codecombat/codecombat/pull/8312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->