### PR TITLE
use gray for licensed like before

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/CellStudent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/table/CellStudent.vue
@@ -72,9 +72,9 @@ export default {
     },
     licenseImg () {
       if (this.student.prepaidIncludesCourse(this.selectedCourseId)) {
-        return '/images/ozaria/teachers/dashboard/svg_icons/IconLicense_Purple.svg'
+        return '/images/ozaria/teachers/dashboard/svg_icons/IconLicense_Gray.svg'
       }
-      return '/images/ozaria/teachers/dashboard/svg_icons/IconLicense_Gray.svg'
+      return '/images/ozaria/teachers/dashboard/svg_icons/IconLicense_Moon.svg'
     },
     licensedStatus () {
       let title


### PR DESCRIPTION
<img width="710" height="144" alt="image" src="https://github.com/user-attachments/assets/1928e16a-7035-497d-b1ce-d48c6c856f5b" />
<img width="497" height="150" alt="image" src="https://github.com/user-attachments/assets/9c814c7b-532d-4f1c-8375-153e31889512" />
fix ENG-2496

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated license icons in the teacher dashboard student table to better reflect course access status. Icons now display in different colors depending on whether students have prepaid courses included, providing clearer visual distinction and improved visibility of student enrollment status for more effective classroom management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/codecombat/codecombat/pull/8314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->