### PR TITLE
[GD] Locked Planets experiment

### DIFF
--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -6512,6 +6512,7 @@ module.exports = {
       description: 'Explore new worlds and use AI to help you in your journey. ',
       premium_only: 'Premium only',
       not_enrolled: 'Not Enrolled',
+      need_sign_up: 'Sign up to access',
       locked_by_teacher: 'Locked by teacher',
     },
     new_premium: {

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -26,6 +26,11 @@ const userUtils = require('lib/user-utils')
 const _ = require('lodash')
 const moment = window.moment
 const NAPERVILLE_UNIQUE_KEY = 'naperville'
+const REQUIRE_SIGN_UP_EXPERIMENT = {
+  dungeon: 'requires-sign-up-dungeon',
+  junior: 'requires-sign-up-junior',
+}
+const LOCKED_PLANETS_EXPERIMENT_NAME = 'locked-planets'
 
 // Pure functions for use in Vue
 // First argument is always a raw User.attributes
@@ -1464,6 +1469,56 @@ module.exports = (User = (function () {
 
     //   return this.tryStartExperiment('template')
     // }
+    getRequireSignupExperimentValue (CAMPAIGN) {
+      if (!me.isAnonymous()) {
+        return 'control'
+      }
+      const value = utils.getFirstNonNull(
+        utils.getExperimentValueFromQuery(REQUIRE_SIGN_UP_EXPERIMENT[CAMPAIGN]),
+        me.getExperimentValue(REQUIRE_SIGN_UP_EXPERIMENT[CAMPAIGN], null),
+      )
+
+      return value ?? null
+    }
+
+    getOrStartRequireSignupExperimentValue (CAMPAIGN) {
+      if (!(Object.keys(REQUIRE_SIGN_UP_EXPERIMENT).includes(CAMPAIGN))) {
+        return 'control'
+      }
+      const value = this.getRequireSignupExperimentValue(CAMPAIGN)
+      if (value != null) {
+        return value
+      }
+      return this.tryStartExperiment(REQUIRE_SIGN_UP_EXPERIMENT[CAMPAIGN])
+    }
+
+    getLockedPlanetsExperimentValue () {
+      if (me.isStudent() || me.isTeacher()) {
+        return 'control'
+      }
+      if (features?.chinaInfra) {
+        return 'control'
+      }
+      if (me.isPremium()) {
+        return 'control'
+      }
+      // We don't take non anonymus premium users into account for this experiment
+      // However if they are already in the experiment, we should return the value
+      const value = utils.getFirstNonNull(
+        utils.getExperimentValueFromQuery(LOCKED_PLANETS_EXPERIMENT_NAME),
+        me.getExperimentValue(LOCKED_PLANETS_EXPERIMENT_NAME, null),
+        (!me.isAnonymous() ? 'control' : null),
+      )
+      return value ?? null
+    }
+
+    getOrStartLockedPlanetsExperimentValue () {
+      const value = this.getLockedPlanetsExperimentValue()
+      if (value != null) {
+        return value
+      }
+      return this.tryStartExperiment(LOCKED_PLANETS_EXPERIMENT_NAME)
+    }
   }
 
   User.initClass()


### PR DESCRIPTION
Add 'need_sign_up' message to localization and implement locked plants experiment logic in User model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sign-up messaging in the HackStack Galaxy section with new English translation prompting users to "Sign up to access".
  * Introduced a experiments framework to manage "locked planets" access and a "requires sign-up" flow, allowing dynamic control of access based on user type, premium status, query signals, and infra settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->