### PR TITLE
fix oz level url in coco dashboard

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/curriculum-guide-helper.js
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/curriculum-guide-helper.js
@@ -3,8 +3,11 @@ import utils from '../../../../../app/core/utils'
 export function getLevelUrl ({ ozariaType, introLevelSlug, courseId, codeLanguage, slug, introContent, moduleNum, _id }) {
   if (utils.HACKSTACK_COURSE_IDS.includes(courseId)) {
     return `/ai/play/scenario/${slug}`
-  } else if (utils.showOzaria() && !ozariaType && introLevelSlug) {
-    return `/play/intro/${introLevelSlug}?course=${courseId}&codeLanguage=${codeLanguage}&intro-content=${introContent || 0}`
+  } else if ((utils.isCodeCombat && utils.OZ_COURSE_IDS.includes(courseId)) || utils.showOzaria()) {
+    if (!ozariaType && introLevelSlug) {
+      return `/play/intro/${introLevelSlug}?course=${courseId}&codeLanguage=${codeLanguage}&intro-content=${introContent || 0}`
+    }
+    return `/play/ozaria/level/${slug}?course=${courseId}&codeLanguage=${codeLanguage}`
   } else if (slug) {
     let url = `/play/level/${slug}?course=${courseId}&codeLanguage=${codeLanguage}`
     if (courseId === utils.courseIDs.JUNIOR) {


### PR DESCRIPTION
<img width="1046" height="628" alt="image" src="https://github.com/user-attachments/assets/e96d90f2-c17e-4500-8ce2-b783a74f4af5" />
fix ENG-2558 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved URL routing logic for Ozaria curriculum content to ensure consistent handling of introductory and standard level materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->