### PR TITLE
add ai capstone mode to teacher dashboard

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -1872,6 +1872,7 @@ const AI_MODE_ICON_MAP = {
   use: 'ai-use',
   practice: 'ai-practice',
   'learn to use': 'ai-learn',
+  capstone: 'ai-capstone'
 }
 
 module.exports.aiProjectModes = Object.keys(AI_MODE_ICON_MAP)

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -4760,6 +4760,7 @@ module.exports = {
       learn_to_use_tooltip: '<h3>Learn</h3><p>Students follow guided steps to learn how to craft effective AI prompts, building skills through structured practice.</p>',
       practice_tooltip: '<h3>Practice</h3><p>Students apply their prompting skills with light teacher guidance, bridging structured learning and open-ended creation.</p>',
       use_tooltip: '<h3>Create</h3><p>Students freely apply their prompting skills with open-ended access to the AI model.</p>',
+      ai_capstone_tooltip: '<h3>AI Capstone</h3><p>A summative assessment at the end of each module where students build a project from scratch using all the prompting skills from the module.</p>',
       concept_checks: 'Concept Checks',
       practice_level: 'Practice Level',
       practice_levels: 'Practice Levels',

--- a/ozaria/site/common/ozariaUtils.js
+++ b/ozaria/site/common/ozariaUtils.js
@@ -329,6 +329,8 @@ export function internationalizeContentType (type) {
       return $.i18n.t('play_level.learn_to_use')
     case 'ai-practice':
       return $.i18n.t('play_level.level_type_practice')
+    case 'ai-capstone':
+      return $.i18n.t('play_level.level_type_capstone')
     default:
       return $.i18n.t(isCodeCombat ? 'play_level.level_type_level' : 'play_level.level_type_challenge') // show everything else as "challenge" for now
   }

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/Guidelines.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/Guidelines.vue
@@ -137,6 +137,13 @@ const hackstackContentGuideItems = [
     iconStyle: 'width: 22px;',
     text: $.i18n.t('teacher_dashboard.use_levels'),
   },
+  {
+    tooltip: $.i18n.t('teacher_dashboard.ai_capstone_tooltip'),
+    classes: 'capstone-icon',
+    icon: 'ai-capstone',
+    iconStyle: 'width: 22px;',
+    text: $.i18n.t('play_level.level_type_capstone'),
+  },
 ]
 
 const gameDevContentGuideItems = [
@@ -461,8 +468,8 @@ export default {
 
     &.hackstack-container {
       grid-template-areas:
-        "type-title type-title type-title"
-        "learn-icon practice-icon use-icon";
+        "type-title type-title type-title type-title"
+        "learn-icon practice-icon use-icon capstone-icon";
     }
 
   ::v-deep {

--- a/ozaria/site/components/teacher-dashboard/common/icons/ContentIcon.vue
+++ b/ozaria/site/components/teacher-dashboard/common/icons/ContentIcon.vue
@@ -46,7 +46,7 @@ export default {
   >
     <IconCutscene v-if="icon=='cutscene'" />
     <IconCinematic v-else-if="icon=='cinematic'" />
-    <IconCapstone v-else-if="['capstone'].includes(icon)" />
+    <IconCapstone v-else-if="['capstone', 'ai-capstone'].includes(icon)" />
     <IconInteractive v-else-if="icon=='interactive'" />
     <IconPracticeLevel v-else-if="icon=='practicelvl'" />
     <IconChallengeLevel v-else-if="['challengelvl', 'hero'].includes(icon)" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an **AI Capstone** content type and icon throughout the teacher dashboard.
  * Teachers now see a new AI Capstone tooltip and label in the Hackstack guidelines area.
  * The new content type is now properly recognized and displayed with the correct localized name and icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->