### PR TITLE
Fix nav dropdown description contrast in dark mode

### DIFF
--- a/app/components/common/Navigation.vue
+++ b/app/components/common/Navigation.vue
@@ -645,6 +645,12 @@ export default Vue.extend({
               background: lighten($dark-grey-2, 10%);
             }
           }
+
+          // Raise the dropdown description subtitle's contrast in dark mode;
+          // the shared light-page rule keeps $dark-grey-2 for marketing/home.
+          .text-p>.text-description {
+            color: $light-grey-2;
+          }
         }
       }
     }

--- a/app/components/common/Navigation.vue
+++ b/app/components/common/Navigation.vue
@@ -646,8 +646,7 @@ export default Vue.extend({
             }
           }
 
-          // Raise the dropdown description subtitle's contrast in dark mode;
-          // the shared light-page rule keeps $dark-grey-2 for marketing/home.
+          // Extra specific to handle use in both dark and light backgrounds
           .text-p>.text-description {
             color: $light-grey-2;
           }


### PR DESCRIPTION
Closes ENG-2545

Fixes nearly invisible text for subtitles when background was dark. 

## Root cause

`$dark-grey-2` does double duty: it is both the dark menu/item background color and the subtitle text color. In dark mode the blanket "white text" override was lower CSS specificity than the legacy `.text-description` color rule, so the subtitle kept the dark value and disappeared against the dark background.

## Fix

More specific rule for the dark background, rather than changing anything about the way we use the color. Wouldn't necessarily help anywhere else, but keeps the change small and easily re-used for other colors we use for multiple things across light and dark.

## Validation

- `/play` (dark mode): subtitle computed color is now `#c7c7c7`, readable on both the default item background and the hover background.
- `/home` (light mode): subtitle unchanged at `#111928`, still readable dark-on-light - no regression.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark-mode readability in the navigation dropdown by adjusting the subtitle text color for better contrast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->