### PR TITLE
show banner in defense of phishing attempt

### DIFF
--- a/app/components/common/DomainBanner.vue
+++ b/app/components/common/DomainBanner.vue
@@ -1,0 +1,123 @@
+<template>
+  <div
+    v-if="bannerType"
+    :class="['domain-banner', 'domain-banner--info']"
+    role="alert"
+  >
+    <span v-if="bannerType === 'info'">
+      <strong>{{ $t('general.domain_banner_warning') }}</strong>
+      {{ $t('general.domain_banner_message') }}
+      <a
+        href="https://codecombat.com"
+        rel="noopener noreferrer"
+      >{{ $t('general.domain_banner_link') }}</a>
+    </span>
+    <button
+      class="domain-banner__dismiss"
+      :aria-label="$t('teacher_dashboard.click_dismiss')"
+      @click="dismiss"
+    >
+      ×
+    </button>
+  </div>
+</template>
+
+<script>
+const LEGITIMATE_HOSTNAMES = [
+  'codecombat.com',
+  'ozaria.com',
+  'localhost',
+  '127.0.0.1',
+]
+
+// Matches EZProxy patterns like codecombat-com.ezproxy.orl.bc.ca regardless of TLD
+const EZPROXY_RE = /^codecombat[.-](?:com|org).*(?:ezproxy|proxy)\./i
+
+const DISMISS_KEY = 'domain-banner-dismissed'
+
+function dismissKey () {
+  return `${DISMISS_KEY}-${me.get('_id') || 'anonymous'}`
+}
+
+function isDismissed () {
+  return localStorage.getItem(dismissKey()) === '1'
+}
+
+function setDismissed () {
+  localStorage.setItem(dismissKey(), '1')
+}
+
+function detectDomainStatus (hostname) {
+  // TODO: Implement china specific checks
+  // TODO: verify all EZProxy URLs
+  const isLegitimate = LEGITIMATE_HOSTNAMES.some(d => hostname === d || hostname.endsWith(`.${d}`))
+  if (isLegitimate) return 'legitimate'
+  if (EZPROXY_RE.test(hostname)) return 'ezproxy'
+  return 'phishing'
+}
+
+export default Vue.extend({
+  name: 'DomainBanner',
+
+  data () {
+    if (isDismissed()) return { bannerType: null }
+    const status = detectDomainStatus(window.location.hostname)
+    if (status === 'legitimate' || status === 'ezproxy') return { bannerType: null }
+    return { bannerType: 'info' }
+  },
+
+  methods: {
+    dismiss () {
+      setDismissed()
+      this.bannerType = null
+    },
+  },
+})
+</script>
+
+<style scoped lang="scss">
+.domain-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  font-size: 14px;
+  width: 100%;
+  position: sticky;
+  top: 0;
+  z-index: 9999;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+
+  a {
+    font-weight: bold;
+    text-decoration: underline;
+  }
+
+  &__dismiss {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 18px;
+    line-height: 1;
+    padding: 0 4px;
+    margin-left: 8px;
+    opacity: 0.7;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  &--info {
+    background-color: #e8f4fd;
+    color: #1a6499;
+    border-bottom: 1px solid #bee3f8;
+
+    a,
+    .domain-banner__dismiss {
+      color: #1a6499;
+    }
+  }
+}
+</style>

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -965,6 +965,9 @@ module.exports = {
       here: 'here',
       from: 'From',
       classrooms: 'Classrooms',
+      domain_banner_warning: 'Warning: You may be on a fraudulent site.',
+      domain_banner_message: 'This does not appear to be the official CodeCombat website.',
+      domain_banner_link: 'Go to the real codecombat.com →',
     },
 
     units: {

--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -7,7 +7,9 @@ if showGameDevAlert
 // TODO: .gameplay-container causes world map buttons to briefly appear in top left of screen
 if !editorMode
   #main-nav
+
 .gameplay-container(class=campaign != null ? "in-campaign" : "in-portals")
+  #domain-banner-container
   div.under-logo.button-container
     if view.shouldShow('santa-clara-logo')
       #santa-clara-logo-container
@@ -411,7 +413,7 @@ if !editorMode
                               span= i18n(rightCampaign.attributes, 'description')
                   else
                     .side-campaign-container.empty
-  
+
     .game-controls.header-font(class=campaign != null ? "in-campaign" : "")
       if !(features && features.brainPop)
         if view.shouldShow('premium')

--- a/app/views/home/PageHome.vue
+++ b/app/views/home/PageHome.vue
@@ -1,5 +1,6 @@
 <template>
   <div id="page-home">
+    <domain-banner />
     <banner-component />
     <div class="container">
       <header-component class="container__header">
@@ -244,6 +245,7 @@ import ModalJunior from './ModalJunior'
 import ModalHackStack from './ModalHackStack'
 import HackstackAutoPromotion from '../ai/HackstackAutoPromotion'
 import BannerComponent from '../../components/common/elements/BannerComponent.vue'
+import DomainBanner from '../../components/common/DomainBanner.vue'
 import { getJuniorUrl } from 'core/utils'
 
 const utils = require('core/utils')
@@ -272,6 +274,7 @@ export default Vue.extend({
     ModalHackStack,
     HackstackAutoPromotion,
     BannerComponent,
+    DomainBanner,
   },
   data () {
     return {

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -51,6 +51,7 @@ const JuniorPromotionModal = require('views/core/JuniorPromotionModal')
 const CCHomePromotionModal = require('views/core/CCHomePromotionModal')
 const WorldsPromotionModal = require('views/core/WorldsPromotionModal') // Roblox modal
 const HackstackPromotionModal = require('views/core/HackstackPromotionModal')
+const DomainBanner = require('app/components/common/DomainBanner').default
 require('lib/game-libraries')
 
 const ROBLOX_MODAL_SHOWN = 'roblox-modal-shown'
@@ -406,6 +407,7 @@ class CampaignView extends RootView {
   }
 
   destroy () {
+    this.domainBannerVue?.$destroy()
     this.setupManager?.destroy()
     this.$el.find('.ui-draggable').off().draggable('destroy')
     window.removeEventListener('resize', this.onWindowResize)
@@ -942,8 +944,22 @@ class CampaignView extends RootView {
     }
   }
 
+  mountDomainBanner () {
+    const container = this.$el.find('#domain-banner-container')[0]
+    if (!container) return
+    if (this.domainBannerVue) {
+      $(container).replaceWith(this.domainBannerVue.$el)
+      return
+    }
+    this.domainBannerVue = new Vue({
+      el: container,
+      render: h => h(DomainBanner),
+    })
+  }
+
   afterRender () {
     super.afterRender()
+    this.mountDomainBanner()
     if ($.isTouchCapable() && (screen.availHeight < screen.availWidth)) {
       // scroll to vertical center on landscape touchscreens
       $('.portal').animate({


### PR DESCRIPTION
fixes eng-2512

<img width="1002" height="144" alt="Screenshot 2026-06-30 at 4 55 46 PM" src="https://github.com/user-attachments/assets/a1f7bbbb-a94e-4622-bed9-3d8fe5234be5" />
<img width="1143" height="148" alt="Screenshot 2026-06-30 at 5 09 18 PM" src="https://github.com/user-attachments/assets/a5a36add-de52-4fdb-890e-1317657687d0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a site banner that can appear at the top of key pages to warn users when they may be on an unofficial domain.
  * Added a dismiss option so the banner can be hidden after it’s closed.
  * Added new localized text and links to help users get back to the official site.

* **Bug Fixes**
  * Ensured the banner is properly loaded and cleaned up on affected pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->