### PR TITLE
use node22 esper.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "nanoscroller": "~0.8.0",
     "treema": "https://github.com/codecombat/treema.git#master",
     "validated-backbone-mediator": "~0.1.3",
-    "esper.js": "https://files.codecombat.com/esper-2024-06-15-1.tar.gz",
+    "esper.js": "https://files.codecombat.com/esper-2026-06-30.tar.gz",
     "algolia-autocomplete.js": "^0.17.0",
     "algolia-autocomplete-no-conflict": "1.0.0",
     "font-awesome": "fontawesome#^4.7.0",

--- a/vendor/esper-plugin-lang-cpp-modern.js
+++ b/vendor/esper-plugin-lang-cpp-modern.js
@@ -1,10 +1,10 @@
 /*!
  * jaba
  * 
- * Compiled: Mon May 15 2023 19:36:01 GMT+0800 (GMT+08:00)
+ * Compiled: Tue Jun 30 2026 18:11:16 GMT+0800 (China Standard Time)
  * Target  : web (umd)
  * Profile : modern
- * Version : 7f6792a
+ * Version : 504110d-dirty
  * 
  * 
  * 

--- a/vendor/esper-plugin-lang-java-modern.js
+++ b/vendor/esper-plugin-lang-java-modern.js
@@ -1,10 +1,10 @@
 /*!
  * jaba
  * 
- * Compiled: Mon May 15 2023 19:36:01 GMT+0800 (GMT+08:00)
+ * Compiled: Tue Jun 30 2026 18:11:16 GMT+0800 (China Standard Time)
  * Target  : web (umd)
  * Profile : modern
- * Version : 7f6792a
+ * Version : 504110d-dirty
  * 
  * 
  * 
@@ -146,7 +146,7 @@ let plugin = module.exports = {
 	name: 'lang-java',
 	parser: parser,
 	init: function(esper) {
-		//esper.plugin('babylon');
+		esper.plugin('babylon');
 		esper.languages.java = plugin;
 	},
 	setupEngine: function(esper, engine) {


### PR DESCRIPTION
i don't know why i need enable babylon plugin for cpp/java to make it work. but, enable it won't be a bad thing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled Esper-related assets to newer build versions.
  * Refreshed package reference to the latest Esper tarball.

* **Bug Fixes**
  * Improved Java modern plugin initialization so its Babylon-related support is now enabled during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->