### PR TITLE
Yuqiang/hs level numbering

### DIFF
--- a/app/core/store/modules/gameContent.js
+++ b/app/core/store/modules/gameContent.js
@@ -79,8 +79,11 @@ export default {
     addLevelNumber: (state, { levelId, levelNumber }) => {
       Vue.set(state.levelNumberMap, levelId, levelNumber)
     },
-    setLevelNumberMap (state, newMap) {
-      state.levelNumberMap = newMap
+    updateLevelNumberMap (state, newMap) {
+      state.levelNumberMap = {
+        ...(state.levelNumberMap || {}),
+        ...newMap,
+      }
     },
   },
 
@@ -197,7 +200,7 @@ export default {
       }
 
       const levelNumberMap = generateLevelNumberMap(allLevels, courseId)
-      commit('setLevelNumberMap', levelNumberMap)
+      commit('updateLevelNumberMap', levelNumberMap)
     },
   },
 }

--- a/app/schemas/models/course.schema.js
+++ b/app/schemas/models/course.schema.js
@@ -128,7 +128,7 @@ _.extend(CourseSchema.properties, {
   },
   curriculum: c.url({ title: 'Curriculum URL', description: 'Link to curriculum folder. Relevant for teacher dashboard curriculum guides.' }),
   product: { type: 'string', enum: ['ozaria', 'codecombat', 'hackstack', 'junior'], description: 'Which product this course is for, if applicable. Affects where the course appears in the teacher dashboard.' },
-  numbering: { type: 'boolean', title: 'Level Number', description: 'Whether to display level number or not.', default: true },
+  showLevelNumbers: { type: 'boolean', title: 'Level Number', description: 'Whether to display level number or not.', default: true },
 })
 
 c.extendBasicProperties(CourseSchema, 'Course')

--- a/app/schemas/models/course.schema.js
+++ b/app/schemas/models/course.schema.js
@@ -128,6 +128,7 @@ _.extend(CourseSchema.properties, {
   },
   curriculum: c.url({ title: 'Curriculum URL', description: 'Link to curriculum folder. Relevant for teacher dashboard curriculum guides.' }),
   product: { type: 'string', enum: ['ozaria', 'codecombat', 'hackstack', 'junior'], description: 'Which product this course is for, if applicable. Affects where the course appears in the teacher dashboard.' },
+  numbering: { type: 'boolean', title: 'Level Number', description: 'Whether to display level number or not.', default: true },
 })
 
 c.extendBasicProperties(CourseSchema, 'Course')

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleContent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleContent.vue
@@ -70,7 +70,7 @@ export default {
     },
 
     courseShowNumbering () {
-      return this.getCurrentCourse?.numbering ?? true
+      return this.getCurrentCourse?.showLevelNumbers ?? true
     },
 
     isJunior () {

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleContent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleContent.vue
@@ -69,6 +69,10 @@ export default {
       return this.getCurrentCourse?.name || ''
     },
 
+    courseShowNumbering () {
+      return this.getCurrentCourse?.numbering ?? true
+    },
+
     isJunior () {
       return utils.JUNIOR_COURSE_IDS.includes(this.getCurrentCourse?._id)
     },
@@ -183,7 +187,7 @@ export default {
       return this.isContentAccessible(moduleInfo.access)
     },
     getCurrentLevelNumber (original, icon, _id) {
-      if (this.isHackstack) {
+      if (this.isHackstack && !this.courseShowNumbering) {
         return ''
       }
       if (this.isOzariaNoCodeLevel(icon)) {

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleContent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleContent.vue
@@ -70,7 +70,7 @@ export default {
     },
 
     courseShowNumbering () {
-      return this.getCurrentCourse?.showLevelNumbers ?? true
+      return this.getCurrentCourse?.showLevelNumbers
     },
 
     isJunior () {

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
@@ -740,6 +740,7 @@ export default {
 
     generateHackStackModules (modules) {
       const course = this.classroomCourses.find(({ _id }) => _id === this.selectedCourseId)
+      const courseShowNumbers = course?.showLevelNumbers ?? true
       return Object.entries(modules).map(([moduleNum, moduleContent]) => {
         const classSummaryProgress = []
         const module = course?.modules?.[moduleNum] || {}
@@ -750,7 +751,7 @@ export default {
           contentList: moduleContent.map((scenario, index) => {
             const type = utils.scenarioMode2Icon(scenario.mode)
             let tooltipName = scenario.name
-            if (course?.numbering ?? true) {
+            if (courseShowNumbers) {
               const levelNumber = this.getLevelNumber(scenario.original)
               tooltipName = `${levelNumber}: ${scenario.name}`
             }
@@ -772,7 +773,7 @@ export default {
           studentSessions: this.students.reduce((studentSessions, student) => {
             studentSessions[student._id] = moduleContent.map((aiScenario, index) => {
               let tooltipName = aiScenario.name
-              if (course?.numbering ?? true) {
+              if (courseShowNumbers) {
                 const levelNumber = this.getLevelNumber(aiScenario.original)
                 tooltipName = `${levelNumber}: ${aiScenario.name}`
               }

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
@@ -740,7 +740,7 @@ export default {
 
     generateHackStackModules (modules) {
       const course = this.classroomCourses.find(({ _id }) => _id === this.selectedCourseId)
-      const courseShowNumbers = course?.showLevelNumbers ?? true
+      const courseShowNumbers = course?.showLevelNumbers
       return Object.entries(modules).map(([moduleNum, moduleContent]) => {
         const classSummaryProgress = []
         const module = course?.modules?.[moduleNum] || {}

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
@@ -620,7 +620,7 @@ export default {
       return aiProjects.map(p => (p.changed || '')).reduce((a, b) => a > b ? a : b)
     },
 
-    createProgressDetailsByAiScenario ({ aiScenario, index, student, classSummaryProgress, moduleNum }) {
+    createProgressDetailsByAiScenario ({ aiScenario, index, tooltipName, student, classSummaryProgress, moduleNum }) {
       const details = {}
       classSummaryProgress[index] = classSummaryProgress[index] || { status: 'assigned', border: '' }
       const aiProjects = this.aiProjectsMapByUser[student._id]?.[aiScenario.original]
@@ -654,6 +654,7 @@ export default {
       return {
         status: 'assigned',
         normalizedType: 'challengelvl',
+        tooltipName,
         isLocked,
         isSkipped: false,
         lockDate: null,
@@ -748,12 +749,17 @@ export default {
           access: module?.access,
           contentList: moduleContent.map((scenario, index) => {
             const type = utils.scenarioMode2Icon(scenario.mode)
+            let tooltipName = scenario.name
+            if (course?.numbering ?? true) {
+              const levelNumber = this.getLevelNumber(scenario.original)
+              tooltipName = `${levelNumber}: ${scenario.name}`
+            }
             return {
               displayName: scenario.name,
               type,
               _id: scenario._id,
               original: scenario.original,
-              tooltipName: scenario.name,
+              tooltipName,
               description: '',
               contentKey: scenario._id,
               normalizedOriginal: scenario.original,
@@ -765,10 +771,16 @@ export default {
           }),
           studentSessions: this.students.reduce((studentSessions, student) => {
             studentSessions[student._id] = moduleContent.map((aiScenario, index) => {
+              let tooltipName = aiScenario.name
+              if (course?.numbering ?? true) {
+                const levelNumber = this.getLevelNumber(aiScenario.original)
+                tooltipName = `${levelNumber}: ${aiScenario.name}`
+              }
               return this.createProgressDetailsByAiScenario({
                 aiScenario,
                 index,
                 student,
+                tooltipName,
                 classSummaryProgress,
                 moduleNum,
               })


### PR DESCRIPTION
<img width="756" height="243" alt="image" src="https://github.com/user-attachments/assets/9c298354-b960-43b9-a319-7c6a0c938adb" />
<img width="465" height="233" alt="image" src="https://github.com/user-attachments/assets/c0e2fc3e-006b-42aa-b6ce-3a422d45134d" />
<img width="685" height="824" alt="image" src="https://github.com/user-attachments/assets/1e624e48-2c41-4ac5-b674-fce3833ff251" />
fix ENG-2586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a course setting to show or hide level numbers (enabled by default).
  * HackStack curriculum/progress tiles now use numbering-aware labels when level numbers are enabled.
* **Bug Fixes**
  * Prevented saved level-number mappings from being overwritten when new campaign data is generated.
  * Updated teacher dashboard HackStack level-number rendering so numbering is suppressed only when level numbers are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->