### PR TITLE
use same name logic for tournament tile always

### DIFF
--- a/app/templates/courses/tournament-tile-mixin.pug
+++ b/app/templates/courses/tournament-tile-mixin.pug
@@ -22,10 +22,7 @@ mixin tournamentTileMixin(tournament)
     .tile-text-backdrop
     .stats-text-container
       .overlay-text.stats-text
-        if showLadderImage
-          span= tournament.displayName || tournament.name
-        else
-          span= tournament.name
+        span= tournament.displayName || tournament.name
     .play-text-container
       .overlay-text.play-text
         if tournament.state == 'initializing'


### PR DESCRIPTION
fix ENG-2594

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tournament tiles now consistently show the tournament’s display name when available, improving title accuracy in the overlay.
  * When no display name is set, the tournament name is still shown as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->