### PR TITLE
[GD] Support multi-file upload for Animate .js in thang editor

### DIFF
--- a/app/templates/editor/thang/thang-type-edit-view.pug
+++ b/app/templates/editor/thang/thang-type-edit-view.pug
@@ -116,7 +116,7 @@ block outer_content
                   button.reoptimize-btn.btn.btn-sm(type="button" disabled=authorized === true ? undefined : "true" data-containers="true") +containers
                   button.reoptimize-btn.btn.btn-sm(type="button" disabled=authorized === true ? undefined : "true" data-containers="true" data-shapes="true") all
                 input#real-upload-button(type="file")
-                input#real-animate-upload-button(type="file")
+                input#real-animate-upload-button(type="file", multiple=true)
               #thang-type-file-size= fileSizeString
           div#thang-type-treema
           .clearfix

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -445,6 +445,10 @@ module.exports = (ThangTypeEditView = (function () {
         }
         try {
           const source = await this.readFileAsText(file)
+          if (!source || !source.trim()) {
+            failed.push({ name: file.name, reason: 'file is empty' })
+            continue
+          }
           const output = await this.parseAnimateSource(source)
           this.thangType.attributes.raw = this.thangType.attributes.raw || {}
           _.merge(this.thangType.attributes.raw, JSON.parse(output))

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -479,17 +479,24 @@ module.exports = (ThangTypeEditView = (function () {
     parseAnimateSource (source) {
       return new Promise((resolve, reject) => {
         const worker = new AnimateImporterWorker()
-        worker.addEventListener('message', ({ data }) => {
+        const timer = setTimeout(() => {
           worker.terminate()
+          reject(new Error('Animate parser timed out after 60s'))
+        }, 60000)
+        const finish = (fn, value) => {
+          clearTimeout(timer)
+          worker.terminate()
+          fn(value)
+        }
+        worker.addEventListener('message', ({ data }) => {
           if (data.output) {
-            resolve(data.output)
+            finish(resolve, data.output)
           } else {
-            reject(new Error(data.error || 'unknown Animate parser error'))
+            finish(reject, new Error(data.error || 'unknown Animate parser error'))
           }
         })
         worker.addEventListener('error', event => {
-          worker.terminate()
-          reject(new Error(event.message || 'Animate parser worker crashed'))
+          finish(reject, new Error(event.message || 'Animate parser worker crashed'))
         })
         worker.postMessage({ input: source })
       })

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -218,7 +218,6 @@ module.exports = (ThangTypeEditView = (function () {
       super(options)
       this.initComponents = this.initComponents.bind(this)
       this.onComponentsChanged = this.onComponentsChanged.bind(this)
-      this.onAnimateFileLoad = this.onAnimateFileLoad.bind(this)
       this.onFileLoad = this.onFileLoad.bind(this)
       this.fileLoaded = this.fileLoaded.bind(this)
       this.refreshAnimation = this.refreshAnimation.bind(this)
@@ -427,45 +426,69 @@ module.exports = (ThangTypeEditView = (function () {
     }
 
     animateAnimationFileChosen (e) {
-      const file = e.target.files[0]
-      if (!file) { return }
-      if (!_.string.endsWith(file.type, 'javascript')) {
-        noty({ text: "Only accepts files ending with '.js'", type: 'error', timeout: 5000 })
-        return
-      }
-      this.reader = new FileReader()
-      this.reader.onload = this.onAnimateFileLoad
-      return this.reader.readAsText(file)
+      const files = Array.from(e.target.files)
+      e.target.value = '' // allow re-selecting the same files later
+      if (!files.length) { return }
+      return this.processAnimateFiles(files)
     }
 
-    onAnimateFileLoad (e) {
-      const {
-        result
-      } = this.reader
-
-      const worker = new AnimateImporterWorker()
-      worker.addEventListener('message', event => {
-        worker.terminate()
-        this.hideLoading()
-
-        const {
-          data
-        } = event
-
-        if (data.output) {
-          this.thangType.attributes.raw = this.thangType.attributes.raw || {}
-          _.merge(this.thangType.attributes.raw, JSON.parse(data.output))
-
-          return this.fileLoaded()
-        } else if (data.error) {
-          noty({ text: 'Error occurred. Check console. Please inform eng team and provide Adobe Animate File.', type: 'error', timeout: 10000000 })
-          throw data.error
-        }
-      })
-
+    async processAnimateFiles (files) {
+      const uploaded = []
+      const failed = []
       this.showLoading()
-      this.updateProgress(0.50)
-      return worker.postMessage({ input: result })
+      for (let i = 0; i < files.length; i++) {
+        const file = files[i]
+        this.updateProgress((i + 0.5) / files.length)
+        if (!_.string.endsWith(file.type, 'javascript') && !_.string.endsWith(file.name, '.js')) {
+          failed.push({ name: file.name, reason: "only accepts files ending with '.js'" })
+          continue
+        }
+        try {
+          const source = await this.readFileAsText(file)
+          const output = await this.parseAnimateSource(source)
+          this.thangType.attributes.raw = this.thangType.attributes.raw || {}
+          _.merge(this.thangType.attributes.raw, JSON.parse(output))
+          uploaded.push(file.name)
+        } catch (error) {
+          console.error(`Animate import failed for ${file.name}:`, error)
+          failed.push({ name: file.name, reason: (error != null ? error.message : undefined) || `${error}` })
+        }
+      }
+      this.hideLoading()
+      if (uploaded.length) { this.fileLoaded() }
+      const lines = [`Uploaded ${uploaded.length}/${files.length} file(s).`]
+      if (uploaded.length) { lines.push(`Succeeded: ${uploaded.map(_.escape).join(', ')}`) }
+      if (failed.length) { lines.push(`Skipped: ${failed.map(f => `${_.escape(f.name)} (${_.escape(f.reason)})`).join('; ')}`) }
+      const type = failed.length ? (uploaded.length ? 'warning' : 'error') : 'success'
+      return noty({ text: lines.join('<br>'), type, timeout: failed.length ? 30000 : 5000 })
+    }
+
+    readFileAsText (file) {
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader()
+        reader.onload = () => resolve(reader.result)
+        reader.onerror = () => reject(reader.error || new Error('could not read file'))
+        reader.readAsText(file)
+      })
+    }
+
+    parseAnimateSource (source) {
+      return new Promise((resolve, reject) => {
+        const worker = new AnimateImporterWorker()
+        worker.addEventListener('message', ({ data }) => {
+          worker.terminate()
+          if (data.output) {
+            resolve(data.output)
+          } else {
+            reject(new Error(data.error || 'unknown Animate parser error'))
+          }
+        })
+        worker.addEventListener('error', event => {
+          worker.terminate()
+          reject(new Error(event.message || 'Animate parser worker crashed'))
+        })
+        worker.postMessage({ input: source })
+      })
     }
 
     onFileLoad (e) {

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -439,7 +439,7 @@ module.exports = (ThangTypeEditView = (function () {
       for (let i = 0; i < files.length; i++) {
         const file = files[i]
         this.updateProgress((i + 0.5) / files.length)
-        if (!_.string.endsWith(file.type, 'javascript') && !_.string.endsWith(file.name, '.js')) {
+        if (!_.string.endsWith(file.type, 'javascript') && !_.string.endsWith(file.name.toLowerCase(), '.js')) {
           failed.push({ name: file.name, reason: "only accepts files ending with '.js'" })
           continue
         }

--- a/test/app/views/editor/thang/ThangTypeEditView.spec.js
+++ b/test/app/views/editor/thang/ThangTypeEditView.spec.js
@@ -37,42 +37,50 @@ describe('ThangTypeEditView Animate upload', function () {
     view = makeView()
   })
 
-  it('merges every valid file into thangType.raw and calls fileLoaded once', async function () {
-    await run(view, [file('a.js'), file('b.js')])
-    expect(view.thangType.attributes.raw['source:a.js']).toEqual({ ok: true })
-    expect(view.thangType.attributes.raw['source:b.js']).toEqual({ ok: true })
-    expect(view.fileLoaded.calls.count()).toBe(1)
-    expect(view.hideLoading).toHaveBeenCalled()
-    expect(notySpy.calls.mostRecent().args[0].type).toBe('success')
+  it('merges every valid file into thangType.raw and calls fileLoaded once', function (done) {
+    run(view, [file('a.js'), file('b.js')]).then(function () {
+      expect(view.thangType.attributes.raw['source:a.js']).toEqual({ ok: true })
+      expect(view.thangType.attributes.raw['source:b.js']).toEqual({ ok: true })
+      expect(view.fileLoaded.calls.count()).toBe(1)
+      expect(view.hideLoading).toHaveBeenCalled()
+      expect(notySpy.calls.mostRecent().args[0].type).toBe('success')
+      done()
+    }).catch(done.fail)
   })
 
-  it('accepts uppercase .js extensions even when the MIME type is empty', async function () {
-    await run(view, [file('CAP.JS', '')])
-    expect(view.thangType.attributes.raw['source:CAP.JS']).toEqual({ ok: true })
-    expect(notySpy.calls.mostRecent().args[0].type).toBe('success')
+  it('accepts uppercase .js extensions even when the MIME type is empty', function (done) {
+    run(view, [file('CAP.JS', '')]).then(function () {
+      expect(view.thangType.attributes.raw['source:CAP.JS']).toEqual({ ok: true })
+      expect(notySpy.calls.mostRecent().args[0].type).toBe('success')
+      done()
+    }).catch(done.fail)
   })
 
-  it('skips files that are not .js and continues with the rest', async function () {
-    await run(view, [file('bad.txt', 'text/plain'), file('good.js')])
-    expect(view.thangType.attributes.raw['source:good.js']).toEqual({ ok: true })
-    expect(view.thangType.attributes.raw['source:bad.txt']).toBeUndefined()
-    const arg = notySpy.calls.mostRecent().args[0]
-    expect(arg.type).toBe('warning')
-    expect(arg.text).toContain('bad.txt')
-    expect(arg.text).toContain('only accepts files ending with')
+  it('skips files that are not .js and continues with the rest', function (done) {
+    run(view, [file('bad.txt', 'text/plain'), file('good.js')]).then(function () {
+      expect(view.thangType.attributes.raw['source:good.js']).toEqual({ ok: true })
+      expect(view.thangType.attributes.raw['source:bad.txt']).toBeUndefined()
+      const arg = notySpy.calls.mostRecent().args[0]
+      expect(arg.type).toBe('warning')
+      expect(arg.text).toContain('bad.txt')
+      expect(arg.text).toContain('only accepts files ending with')
+      done()
+    }).catch(done.fail)
   })
 
-  it('skips empty files with a reason', async function () {
+  it('skips empty files with a reason', function (done) {
     view = makeView({ readFileAsText (f) { return Promise.resolve(f.name === 'empty.js' ? '   ' : `source:${f.name}`) } })
-    await run(view, [file('empty.js'), file('good.js')])
-    expect(view.thangType.attributes.raw['source:good.js']).toEqual({ ok: true })
-    expect(Object.keys(view.thangType.attributes.raw)).not.toContain('source:empty.js')
-    const arg = notySpy.calls.mostRecent().args[0]
-    expect(arg.type).toBe('warning')
-    expect(arg.text).toContain('file is empty')
+    run(view, [file('empty.js'), file('good.js')]).then(function () {
+      expect(view.thangType.attributes.raw['source:good.js']).toEqual({ ok: true })
+      expect(Object.keys(view.thangType.attributes.raw)).not.toContain('source:empty.js')
+      const arg = notySpy.calls.mostRecent().args[0]
+      expect(arg.type).toBe('warning')
+      expect(arg.text).toContain('file is empty')
+      done()
+    }).catch(done.fail)
   })
 
-  it('skips files whose parse rejects and keeps going', async function () {
+  it('skips files whose parse rejects and keeps going', function (done) {
     view = makeView({
       parseAnimateSource (source) {
         return source === 'source:broken.js'
@@ -80,19 +88,23 @@ describe('ThangTypeEditView Animate upload', function () {
           : Promise.resolve(JSON.stringify({ [source]: { ok: true } }))
       },
     })
-    await run(view, [file('broken.js'), file('good.js')])
-    expect(view.thangType.attributes.raw['source:good.js']).toEqual({ ok: true })
-    const arg = notySpy.calls.mostRecent().args[0]
-    expect(arg.type).toBe('warning')
-    expect(arg.text).toContain('broken.js')
-    expect(arg.text).toContain('boom')
+    run(view, [file('broken.js'), file('good.js')]).then(function () {
+      expect(view.thangType.attributes.raw['source:good.js']).toEqual({ ok: true })
+      const arg = notySpy.calls.mostRecent().args[0]
+      expect(arg.type).toBe('warning')
+      expect(arg.text).toContain('broken.js')
+      expect(arg.text).toContain('boom')
+      done()
+    }).catch(done.fail)
   })
 
-  it('reports an error and never calls fileLoaded when all files fail', async function () {
-    await run(view, [file('bad.txt', 'text/plain')])
-    expect(view.fileLoaded).not.toHaveBeenCalled()
-    expect(view.thangType.attributes.raw).toBeUndefined()
-    expect(notySpy.calls.mostRecent().args[0].type).toBe('error')
-    expect(view.hideLoading).toHaveBeenCalled()
+  it('reports an error and never calls fileLoaded when all files fail', function (done) {
+    run(view, [file('bad.txt', 'text/plain')]).then(function () {
+      expect(view.fileLoaded).not.toHaveBeenCalled()
+      expect(view.thangType.attributes.raw).toBeUndefined()
+      expect(notySpy.calls.mostRecent().args[0].type).toBe('error')
+      expect(view.hideLoading).toHaveBeenCalled()
+      done()
+    }).catch(done.fail)
   })
 })

--- a/test/app/views/editor/thang/ThangTypeEditView.spec.js
+++ b/test/app/views/editor/thang/ThangTypeEditView.spec.js
@@ -1,0 +1,98 @@
+const ThangTypeEditView = require('views/editor/thang/ThangTypeEditView')
+
+// These specs exercise the multi-file Animate upload orchestration
+// (processAnimateFiles) in isolation, stubbing the per-file read/parse so we
+// don't need a real Worker, FileReader, or a fully rendered editor view.
+describe('ThangTypeEditView Animate upload', function () {
+  const proto = ThangTypeEditView.prototype
+  let view, notySpy
+
+  // Build a fake `this` with just the collaborators processAnimateFiles touches.
+  // By default every file reads to non-empty text and parses to a raw fragment
+  // keyed by the file name, so merges are observable.
+  function makeView (overrides = {}) {
+    const v = {
+      thangType: { attributes: {} },
+      showLoading: jasmine.createSpy('showLoading'),
+      hideLoading: jasmine.createSpy('hideLoading'),
+      updateProgress: jasmine.createSpy('updateProgress'),
+      fileLoaded: jasmine.createSpy('fileLoaded'),
+      readFileAsText (file) { return Promise.resolve(`source:${file.name}`) },
+      parseAnimateSource (source) { return Promise.resolve(JSON.stringify({ [source]: { ok: true } })) },
+    }
+    return Object.assign(v, overrides)
+  }
+
+  function file (name, type = 'application/javascript') {
+    return { name, type }
+  }
+
+  function run (v, files) {
+    return proto.processAnimateFiles.call(v, files)
+  }
+
+  beforeEach(function () {
+    notySpy = jasmine.createSpy('noty')
+    window.noty = notySpy
+    view = makeView()
+  })
+
+  it('merges every valid file into thangType.raw and calls fileLoaded once', async function () {
+    await run(view, [file('a.js'), file('b.js')])
+    expect(view.thangType.attributes.raw['source:a.js']).toEqual({ ok: true })
+    expect(view.thangType.attributes.raw['source:b.js']).toEqual({ ok: true })
+    expect(view.fileLoaded.calls.count()).toBe(1)
+    expect(view.hideLoading).toHaveBeenCalled()
+    expect(notySpy.calls.mostRecent().args[0].type).toBe('success')
+  })
+
+  it('accepts uppercase .js extensions even when the MIME type is empty', async function () {
+    await run(view, [file('CAP.JS', '')])
+    expect(view.thangType.attributes.raw['source:CAP.JS']).toEqual({ ok: true })
+    expect(notySpy.calls.mostRecent().args[0].type).toBe('success')
+  })
+
+  it('skips files that are not .js and continues with the rest', async function () {
+    await run(view, [file('bad.txt', 'text/plain'), file('good.js')])
+    expect(view.thangType.attributes.raw['source:good.js']).toEqual({ ok: true })
+    expect(view.thangType.attributes.raw['source:bad.txt']).toBeUndefined()
+    const arg = notySpy.calls.mostRecent().args[0]
+    expect(arg.type).toBe('warning')
+    expect(arg.text).toContain('bad.txt')
+    expect(arg.text).toContain('only accepts files ending with')
+  })
+
+  it('skips empty files with a reason', async function () {
+    view = makeView({ readFileAsText (f) { return Promise.resolve(f.name === 'empty.js' ? '   ' : `source:${f.name}`) } })
+    await run(view, [file('empty.js'), file('good.js')])
+    expect(view.thangType.attributes.raw['source:good.js']).toEqual({ ok: true })
+    expect(Object.keys(view.thangType.attributes.raw)).not.toContain('source:empty.js')
+    const arg = notySpy.calls.mostRecent().args[0]
+    expect(arg.type).toBe('warning')
+    expect(arg.text).toContain('file is empty')
+  })
+
+  it('skips files whose parse rejects and keeps going', async function () {
+    view = makeView({
+      parseAnimateSource (source) {
+        return source === 'source:broken.js'
+          ? Promise.reject(new Error('boom'))
+          : Promise.resolve(JSON.stringify({ [source]: { ok: true } }))
+      },
+    })
+    await run(view, [file('broken.js'), file('good.js')])
+    expect(view.thangType.attributes.raw['source:good.js']).toEqual({ ok: true })
+    const arg = notySpy.calls.mostRecent().args[0]
+    expect(arg.type).toBe('warning')
+    expect(arg.text).toContain('broken.js')
+    expect(arg.text).toContain('boom')
+  })
+
+  it('reports an error and never calls fileLoaded when all files fail', async function () {
+    await run(view, [file('bad.txt', 'text/plain')])
+    expect(view.fileLoaded).not.toHaveBeenCalled()
+    expect(view.thangType.attributes.raw).toBeUndefined()
+    expect(notySpy.calls.mostRecent().args[0].type).toBe('error')
+    expect(view.hideLoading).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Selecting several .js files now processes them sequentially, skipping files that fail validation or parsing, then shows a summary noty of what was uploaded and what was skipped (with reasons).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animation upload now supports selecting multiple files in one action.
  * Loading/progress and a per-file results summary (success/warnings/errors) are shown after processing.
* **Bug Fixes**
  * Re-selecting the same files works reliably.
  * Valid files can still be imported even if other selected files are invalid or fail parsing.
* **Tests**
  * Added unit tests covering multi-file animation upload behavior, including success, skipping non-`.js` inputs, empty content handling, and all-fail scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->