### PR TITLE
FIX: intermittent "ReferenceError: features is not defined" on app boot

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,4 +1,7 @@
 global.$ = window.$ = global.jQuery = window.jQuery = require('jquery');
+// features is normally injected by the server into the page HTML; default it so
+// bare `features?.x` references don't throw when the shell arrives without it.
+window.features = window.features || {};
 import 'bootstrap';
 import './app.sass';
 import 'core-js/stable';

--- a/app/core/initialize.js
+++ b/app/core/initialize.js
@@ -108,10 +108,6 @@ const definitionSchemas = {
 
 var init = function () {
   if (app) { return }
-  // features is normally injected by the server into the page HTML; when the shell
-  // arrives without it (cached page, bfcache), bare `features?.x` references throw
-  // ReferenceError, so declare it with all flags off.
-  window.features = window.features || {}
   if (!(window.userObject != null ? window.userObject._id : undefined)) {
     const options = { cache: false }
     options.data = _.pick(utils.getQueryVariables(), 'preferredLanguage')

--- a/app/core/initialize.js
+++ b/app/core/initialize.js
@@ -108,6 +108,10 @@ const definitionSchemas = {
 
 var init = function () {
   if (app) { return }
+  // features is normally injected by the server into the page HTML; when the shell
+  // arrives without it (cached page, bfcache), bare `features?.x` references throw
+  // ReferenceError, so declare it with all flags off.
+  window.features = window.features || {}
   if (!(window.userObject != null ? window.userObject._id : undefined)) {
     const options = { cache: false }
     options.data = _.pick(utils.getQueryVariables(), 'preferredLanguage')


### PR DESCRIPTION
## Problem

Opening any page (commonly the level editor) sometimes crashes app boot with:
```

Uncaught ReferenceError: features is not defined
at User.js:1457 (useChinaHomeView)
at Router.js:460
```


`window.features` is normally injected by the server into the page HTML alongside `window.userObject`. When the HTML shell arrives without those globals (cached shell, bfcache), `init()` in `app/core/initialize.js` recovers the missing `userObject` via `/auth/whoami` — but nothing recovers `features`, so it stays undeclared.

The Router then builds its routes object eagerly at module load (`CocoRouter.initClass()`), and the `preview`/`seen` route entries call `me.useChinaHomeView()` immediately, which evaluates the bare `features?.china`. Optional chaining does not guard an *undeclared* identifier — it still throws ReferenceError, killing boot.

This is intermittent because it only happens on page loads served without the injected server globals.

## Fix

Default the global before anything reads it:

```js
window.features = window.features || {}
```

- app/core/initialize.js — at the top of init(), before the whoami branch
- app/app.js — at the bundle entry point, for anything that runs before init()
|| preserves the server-provided value on normal loads; on a "naked" load all feature flags simply default to off. This also protects the other bare features?. references (User.js, Router.js:665/669, application.js:80) without touching them. Same defensive pattern already used in app/core/Tracker2/index.js ((window.features || {}).china).

## Verification
Reproduced the throwing expression from User.js:1457 in isolation: without a declared features global it throws ReferenceError: features is not defined; with the default in place it returns false. To reproduce in the browser: strip the injected <script> globals (or delete window.features before boot) and reload — boot now survives, whoami recovers the user, flags default off.



Small note: chief's draft title say "windows.features" — extra **s**, wrong word. Use `window.features`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup resilience when feature data is missing on page load.
  * Prevented runtime errors by safely initializing feature settings so optional feature checks continue to work, including on cached or restored pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->