### PR TITLE
sort tournaments most-recent first

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -1127,7 +1127,7 @@ const tournamentSortFn = function (ta, tb) {
     initializing: 2,
     disabled: 4,
   }
-  return (stateOrder[ta.state] - stateOrder[tb.state]) || (new Date(ta.endDate) - new Date(tb.endDate))
+  return (stateOrder[ta.state] - stateOrder[tb.state]) || (new Date(tb.created) - new Date(ta.created))
 }
 
 const usStateCodes =


### PR DESCRIPTION
Closes ENG-2593

Sorts tournaments newest first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tournament ordering so items with the same state are sorted by creation date, with newer tournaments appearing first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->