### PR TITLE
use sessionsDate to check stale matches

### DIFF
--- a/app/lib/simulator/Simulator.coffee
+++ b/app/lib/simulator/Simulator.coffee
@@ -387,6 +387,7 @@ module.exports = class Simulator extends CocoClass
       sessions: []
       simulator: @simulator
       randomSeed: @task.world.randomSeed
+      sessionsDate: @task.getSessionsDate()
 
     for session in @task.getSessions()
       sessionResult =
@@ -489,5 +490,7 @@ class SimulationTask
   getReceiptHandle: -> @rawData.receiptHandle
 
   getSessions: -> @rawData.sessions
+
+  getSessionsDate: -> @rawData.sessionsDate
 
   setWorld: (@world) ->

--- a/app/templates/play/ladder/my_matches_tab.pug
+++ b/app/templates/play/ladder/my_matches_tab.pug
@@ -64,8 +64,9 @@ row
                 - var yourTeam = 'humans'
                 - var sessionOne = team.session.id
                 - var sessionTwo = match.sessionID
-              a(href='/play/spectate/' + levelID + '?session-one=' + sessionOne + '&session-two=' + sessionTwo, target='_blank')
-                span(data-i18n="play_level.watch_game")
+              if !match.stale
+                a(href='/play/spectate/' + levelID + '?session-one=' + sessionOne + '&session-two=' + sessionTwo, target='_blank')
+                  span(data-i18n="play_level.watch_game")
             td.battle-cell
               if view.level.isType('ladder')
                 - var yourTeam = 'humans'


### PR DESCRIPTION
fix ENG-2598

also hide the spectate button for stale matches --  since code already changed, spectate mean nothing.
 
<img width="726" height="364" alt="image" src="https://github.com/user-attachments/assets/e72246f9-7272-45d8-becd-442fca34e251" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added session date information to match result submissions, improving the accuracy of saved game data.
  * Hid the “watch game” link for stale matches so outdated games no longer appear as available to view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->