### PR TITLE
use courseid is enough for ozaria checking

### DIFF
--- a/app/core/urls.js
+++ b/app/core/urls.js
@@ -37,6 +37,9 @@ module.exports = {
     let url = `/play/level/${level.get('slug')}?course=${courseInstance.get(
       'courseID'
     )}&course-instance=${courseInstance.id}`
+    if (utils.OZ_COURSE_IDS.includes(courseInstance.get('courseID'))) {
+      url = url.replace('/play/level', '/play/ozaria/level')
+    }
     if (level.get('primerLanguage')) {
       url += `&codeLanguage=${level.get('primerLanguage')}`
     }
@@ -90,7 +93,7 @@ module.exports = {
     if (queryString) {
       url += `?${queryString}`
     }
-    if (utils.showOzaria()) {
+    if (utils.OZ_COURSE_IDS.includes(courseId) && !url.startsWith('/play/ozaria')) {
       url = url.replace(/^\/play/, '/play/ozaria')
     }
     return url

--- a/app/templates/courses/courses-view.pug
+++ b/app/templates/courses/courses-view.pug
@@ -63,8 +63,6 @@ mixin course-instance-entry(courseInstance, classroom, juniorCourseInstances, co
     .course-instance-entry.rtl-allowed
       if course
         - var courseUrl = view.urls.courseWorldMap({ course, courseInstance, campaignId: course.campaignID })
-        if isOzariaCourse
-          - courseUrl = courseUrl.replace(/^\/play\//, '/play/ozaria/')
         h6
           span.spr= i18n(course, 'name')
           small
@@ -136,8 +134,6 @@ mixin course-instance-body(courseInstance, classroom, stats, nextLevel, propMapU
           button.btn.btn-default.btn-lg.m-b-1(disabled=true, data-i18n="courses.unit_complete")
     else if nextLevel
       - var url = view.urls.courseWorldMap({course: course, courseInstance: courseInstance, classroom: classroom, campaignId: course.campaignID});
-      if isOzariaCourse
-        - url = url.replace(/^\/play\//, '/play/ozaria/')
       if view.utils.isOzaria && isLocked
         button.play-btn.btn.btn-forest.btn-lg.m-b-1(disabled=isLocked)
           span(data-i18n="common.locked")

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleContent.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleContent.vue
@@ -195,12 +195,6 @@ export default {
       }
       return this.getLevelNumber(original)
     },
-    mapUrl (url) {
-      if (utils.isCodeCombat && this.isOzariaCourse) {
-        return url?.replace(/^\/play\/(level|intro)/, '/play/ozaria/$1')
-      }
-      return url
-    },
   },
 }
 </script>
@@ -217,7 +211,7 @@ export default {
         :is="isAccessible(moduleNum)? 'a' : 'span'"
         v-for="{ icon, name, _id, url, description, isPartOfIntro, isIntroHeadingRow, original, assessment, slug, fromIntroLevelOriginal, tool }, key in getContentTypes"
         :key="`${_id}-${isIntroHeadingRow}`"
-        :href="isAccessible(moduleNum) ? mapUrl(url) : null"
+        :href="isAccessible(moduleNum) ? url : null"
         target="_blank"
         rel="noreferrer"
       >

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/curriculum-guide-helper.js
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/curriculum-guide-helper.js
@@ -3,7 +3,7 @@ import utils from '../../../../../app/core/utils'
 export function getLevelUrl ({ ozariaType, introLevelSlug, courseId, codeLanguage, slug, introContent, moduleNum, _id }) {
   if (utils.HACKSTACK_COURSE_IDS.includes(courseId)) {
     return `/ai/play/scenario/${slug}`
-  } else if ((utils.isCodeCombat && utils.OZ_COURSE_IDS.includes(courseId)) || utils.showOzaria()) {
+  } else if (utils.isOzaria || utils.OZ_COURSE_IDS.includes(courseId)) {
     if (!ozariaType && introLevelSlug) {
       return `/play/intro/${introLevelSlug}?course=${courseId}&codeLanguage=${codeLanguage}&intro-content=${introContent || 0}`
     }


### PR DESCRIPTION
utils.showOzaria rely on the window.location.pathname while, some vue computes variable before url change can lead into bug.

fix ENG-2633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed curriculum guide navigation so module links open the correct destination without altering the URL.
  - Updated course and level navigation to route to the correct Ozaria paths based on the specific course, avoiding incorrect global rewrites.
  - Improved level/map linking consistency when moving between curriculum modules and related gameplay.

- **Refactor**
  - Simplified course instance UI rendering by introducing a shared session-aware template for start/continue/locked states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->