### PR TITLE
add schema support for ozlevels

### DIFF
--- a/app/schemas/models/classroom.stats.schema.js
+++ b/app/schemas/models/classroom.stats.schema.js
@@ -10,34 +10,38 @@ _.extend(ClassroomStatsSchema.properties, {
   course: c.array({
     title: 'Course',
     description: 'The course set of the classroom.',
-    items: c.objectId()
+    items: c.objectId(),
   }),
   date: c.stringDate({ description: 'the daily date of the stats' }),
   membersWithCode: c.array({
     title: 'Members with code',
     description: 'The members set who have submitted code.',
-    items: c.objectId()
+    items: c.objectId(),
   }),
   programs: {
     type: 'number',
-    description: 'the number of programs(level.sessions) submitted on this day for a course'
+    description: 'the number of programs(level.sessions) submitted on this day for a course',
+  },
+  ozLevels: {
+    type: 'number',
+    description: 'the number of ozaria levels(esp. intro session contains multiple levels)',
   },
   playtime: {
     type: 'number',
-    description: 'The total play time on this day for a course'
+    description: 'The total play time on this day for a course',
   },
   projects: {
     type: 'number',
-    description: 'The project number on this day for a course'
+    description: 'The project number on this day for a course',
   },
   linesOfCode: {
     type: 'number',
-    description: 'The lines of code on this day for a course'
+    description: 'The lines of code on this day for a course',
   },
   language: {
     type: 'string',
-    enum: ['cpp', 'python', 'javascript', 'java']
-  }
+    enum: ['cpp', 'python', 'javascript', 'java'],
+  },
 })
 
 c.extendBasicProperties(ClassroomStatsSchema, 'classroom.stats')


### PR DESCRIPTION
for classroom: 694e59ce31fdf9e858f73d7f the report is correct now.
<img width="1062" height="434" alt="image" src="https://github.com/user-attachments/assets/60f30047-4726-4c2c-96fa-15e28b3372c7" />


fix ENG-2624

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Classroom statistics now include the number of Ozaria levels completed.

* **Updates**
  * Improved consistency in the classroom statistics data presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->