### PR TITLE
add simple redeem/revoke button in license stats

### DIFF
--- a/ozaria/site/components/teacher-dashboard/BaseTeacherLicenses/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseTeacherLicenses/index.vue
@@ -16,18 +16,18 @@ export default {
     ModalGetLicenses,
     ModalApplyLicenses,
     ModalShareLicenses,
-    ModalLicenseStats
+    ModalLicenseStats,
   },
 
   props: {
     teacherId: { // sent from DSA
       type: String,
-      default: ''
+      default: '',
     },
     displayOnly: { // sent from DSA
       type: Boolean,
-      default: false
-    }
+      default: false,
+    },
   },
 
   data: () => {
@@ -36,7 +36,7 @@ export default {
       showModalApplyLicenses: false,
       showModalShareLicenses: false,
       showModalLicenseStats: false,
-      sharePrepaid: '' // for share licenses modal and license stats modal
+      sharePrepaid: '', // for share licenses modal and license stats modal
     }
   },
 
@@ -45,14 +45,21 @@ export default {
       loading: 'teacherDashboard/getLoadingState',
       activeLicenses: 'teacherDashboard/getActiveLicenses',
       expiredLicenses: 'teacherDashboard/getExpiredLicenses',
-      getTeacherId: 'teacherDashboard/teacherId'
+      getTeacherId: 'teacherDashboard/teacherId',
     }),
 
     showLicensesPage () {
       return this.displayOnly || this.activeLicenses.length > 0 || this.expiredLicenses.length > 0
-    }
+    },
   },
 
+  watch: {
+    activeLicenses () {
+      if (this.sharePrepaid) {
+        this.sharePrepaid = this.activeLicenses.find(license => license._id === this.sharePrepaid._id)
+      }
+    },
+  },
   mounted () {
     this.setTeacherId(this.teacherId || me.get('_id'))
     this.setPageTitle(PAGE_TITLES[this.$options.name])
@@ -66,12 +73,12 @@ export default {
   methods: {
     ...mapActions({
       fetchData: 'teacherDashboard/fetchData',
-      getTestLicense: 'prepaids/getTestLicense'
+      getTestLicense: 'prepaids/getTestLicense',
     }),
     ...mapMutations({
       resetLoadingState: 'teacherDashboard/resetLoadingState',
       setTeacherId: 'teacherDashboard/setTeacherId',
-      setPageTitle: 'teacherDashboard/setPageTitle'
+      setPageTitle: 'teacherDashboard/setPageTitle',
     }),
     getLicenses () {
       this.showModalGetLicenses = true
@@ -89,8 +96,8 @@ export default {
       window.tracker?.trackEvent('My Licenses: View License Stats Clicked', { category: 'Teachers' })
       this.showModalLicenseStats = true
       this.sharePrepaid = prepaid
-    }
-  }
+    },
+  },
 }
 </script>
 

--- a/ozaria/site/components/teacher-dashboard/common/_moon-button.scss
+++ b/ozaria/site/components/teacher-dashboard/common/_moon-button.scss
@@ -1,0 +1,26 @@
+.moon-btn {
+  background-color: $moon;
+  border-radius: 4px;
+  border-width: 0;
+  text-shadow: unset;
+  @include font-p-3-small-button-text-black;
+  background-image: unset;
+
+  &:hover {
+    background-color: $goldenlight;
+    transition: background-color .35s;
+    color: #ffffff;
+  }
+
+  &:disabled {
+    background: #ADADAD;
+    color: #000000;
+    cursor: default;
+  }
+
+  display: flex;
+  height: 33px;
+  padding: 0 17px;
+  justify-content: center;
+  align-items: center;
+}

--- a/ozaria/site/components/teacher-dashboard/common/_moon-button.scss
+++ b/ozaria/site/components/teacher-dashboard/common/_moon-button.scss
@@ -4,6 +4,7 @@
   border-width: 0;
   text-shadow: unset;
   @include font-p-3-small-button-text-black;
+
   background-image: unset;
 
   &:hover {

--- a/ozaria/site/components/teacher-dashboard/modals/ModalLicenseStats.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalLicenseStats.vue
@@ -99,7 +99,7 @@ export default Vue.extend({
                 span(v-else) {{ cls.name }}
               template(v-if="getClassName(user.userID)?.length > 2") {{ $t('teachers.and_more') }}
             .revoke
-              button.btn.btn-danger(@click="revokeUser(user.userID)") {{ 'revoke' }}
+              button.btn.purple-btn(@click="revokeUser(user.userID)") {{ $t('teacher.revoke_license') }}
 
         .content(v-else)
           .header {{ $t('common.empty_results') }}
@@ -115,14 +115,19 @@ export default Vue.extend({
             .startDate {{ moment(user.startDate).format('ll') }}
             .endDate {{ moment(user.endDate).format('ll') }}
             .redeem
-              button.btn.btn-warning(@click="redeemUser(user.userID)") {{ 'redeem' }}
+              button.btn.btn-gold(@click="redeemUser(user.userID)") {{ $t('teacher.apply_license') }}
         .content(v-else)
           .header {{ $t('common.empty_results') }}
 </template>
 
 <style lang="scss" scoped>
+@import "app/styles/bootstrap/variables";
+@import "ozaria/site/styles/common/variables.scss";
+@import "app/styles/ozaria/_ozaria-style-params.scss";
+@import "ozaria/site/components/teacher-dashboard/common/_purple-button";
+
 .license-stats {
-  min-width: 700px;
+  min-width: 800px;
   min-height: 400px;
   margin-bottom: 20px;
 
@@ -131,6 +136,10 @@ export default Vue.extend({
   }
   .user, .header {
     display: flex;
+
+    .classrooms {
+      flex-basis: 20em;
+    }
 
     .name, .startDate, .endDate, .revoke, .redeem {
       flex-basis: 10em;

--- a/ozaria/site/components/teacher-dashboard/modals/ModalLicenseStats.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalLicenseStats.vue
@@ -115,7 +115,7 @@ export default Vue.extend({
             .startDate {{ moment(user.startDate).format('ll') }}
             .endDate {{ moment(user.endDate).format('ll') }}
             .redeem
-              button.btn.btn-gold(@click="redeemUser(user.userID)") {{ $t('teacher.apply_license') }}
+              button.btn.moon-btn(@click="redeemUser(user.userID)") {{ $t('teacher.apply_license') }}
         .content(v-else)
           .header {{ $t('common.empty_results') }}
 </template>
@@ -125,6 +125,7 @@ export default Vue.extend({
 @import "ozaria/site/styles/common/variables.scss";
 @import "app/styles/ozaria/_ozaria-style-params.scss";
 @import "ozaria/site/components/teacher-dashboard/common/_purple-button";
+@import "ozaria/site/components/teacher-dashboard/common/_moon-button";
 
 .license-stats {
   min-width: 800px;

--- a/ozaria/site/components/teacher-dashboard/modals/ModalLicenseStats.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalLicenseStats.vue
@@ -3,6 +3,7 @@ import Modal from '../../common/Modal'
 import SecondaryButton from '../common/buttons/SecondaryButton'
 
 import { mapGetters, mapActions } from 'vuex'
+const Prepaid = require('app/models/Prepaid')
 const moment = window.moment
 export default Vue.extend({
   components: {
@@ -41,6 +42,7 @@ export default Vue.extend({
     ...mapActions({
       fetchName: 'users/fetchUserNamesById',
       fetchClassrooms: 'users/fetchClassroomNamesByUserId',
+      fetchPrepaidsForTeacher: 'prepaids/fetchPrepaidsForTeacher',
     }),
     trackEvent (eventName) {
       if (eventName) {
@@ -59,6 +61,14 @@ export default Vue.extend({
         return 0
       })
       return classrooms.slice(0, 2)
+    },
+    async revokeUser (id) {
+      await (new Prepaid(this.prepaid)).revoke(id)
+      this.fetchPrepaidsForTeacher({ teacherId: me.id })
+    },
+    async redeemUser (id) {
+      await (new Prepaid(this.prepaid)).redeem(id)
+      this.fetchPrepaidsForTeacher({ teacherId: me.id })
     },
   },
   mounted () {
@@ -88,6 +98,8 @@ export default Vue.extend({
                 a(v-if="cls.ownerID === me.id" :href="'/teachers/classes/' + cls._id") {{ cls.name }}
                 span(v-else) {{ cls.name }}
               template(v-if="getClassName(user.userID)?.length > 2") {{ $t('teachers.and_more') }}
+            .revoke
+              button.btn.btn-danger(@click="revokeUser(user.userID)") {{ 'revoke' }}
 
         .content(v-else)
           .header {{ $t('common.empty_results') }}
@@ -102,13 +114,15 @@ export default Vue.extend({
             .name {{ user.name }}
             .startDate {{ moment(user.startDate).format('ll') }}
             .endDate {{ moment(user.endDate).format('ll') }}
+            .redeem
+              button.btn.btn-warning(@click="redeemUser(user.userID)") {{ 'redeem' }}
         .content(v-else)
           .header {{ $t('common.empty_results') }}
 </template>
 
 <style lang="scss" scoped>
 .license-stats {
-  min-width: 600px;
+  min-width: 700px;
   min-height: 400px;
   margin-bottom: 20px;
 
@@ -118,8 +132,12 @@ export default Vue.extend({
   .user, .header {
     display: flex;
 
-    .name, .startDate, .endDate {
+    .name, .startDate, .endDate, .revoke, .redeem {
       flex-basis: 10em;
+    }
+
+    .revoke, .redeem {
+      text-align: center;
     }
   }
 


### PR DESCRIPTION
fix ENG-2651

i don't find a simple confirm dialogue so i add the redeem button to avoid teacher mis-click revoke.

<img width="480" height="356" alt="output" src="https://github.com/user-attachments/assets/dff1ee63-9455-4227-9c26-c170c21ba993" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added teacher controls to revoke prepaid-license access for active redeemers.
  * Added teacher controls to redeem previously removed redeemers.
  * License statistics now refresh immediately after revocation or redemption.
* **Improvements**
  * Ensured license sharing and statistics stay synchronized with the latest prepaid-license data.
* **Style / Chores**
  * Added styling for a new moon-themed button and adjusted modal layout for action buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->