### PR TITLE
add assign to class button in curriculum

### DIFF
--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -4947,6 +4947,7 @@ module.exports = {
       curriculum_glossary_desc_codecombat: 'CS: Computer Science, GD: Game Development, WD: Web Development',
       curriculum_glossary_desc_junior: 'JR: Junior',
       curriculum_glossary_close: 'Got it, hide this',
+      assign_to_class: 'Assign to Class →',
     },
 
     outcomes: {

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -4947,7 +4947,7 @@ module.exports = {
       curriculum_glossary_desc_codecombat: 'CS: Computer Science, GD: Game Development, WD: Web Development',
       curriculum_glossary_desc_junior: 'JR: Junior',
       curriculum_glossary_close: 'Got it, hide this',
-      assign_to_class: 'Assign to Class →',
+      assign_to_class: 'Assign to Class',
     },
 
     outcomes: {

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ButtonAssignCourse.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ButtonAssignCourse.vue
@@ -15,7 +15,7 @@ export default {
     :disabled="locked"
     @click="$emit('click')"
   >
-    <span>{{ $t('teacher_dashboard.assign_to_class') }}</span>
+    <span>{{ $t('teacher_dashboard.assign_to_class') }} →</span>
   </button>
 </template>
 

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ButtonAssignCourse.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ButtonAssignCourse.vue
@@ -1,0 +1,56 @@
+<script>
+export default {
+  props: {
+    locked: {
+      type: Boolean,
+      default: false,
+    },
+  },
+}
+</script>
+
+<template>
+  <button
+    :class="locked ? 'locked' : null"
+    :disabled="locked"
+    @click="$emit('click')"
+  >
+    <span>{{ $t('teacher_dashboard.assign_to_class') }}</span>
+  </button>
+</template>
+
+<style lang="scss" scoped>
+@import "app/styles/bootstrap/variables";
+@import "ozaria/site/styles/common/variables.scss";
+@import "app/styles/ozaria/_ozaria-style-params.scss";
+
+button {
+  background-color: $purple;
+  border-radius: 4px;
+  border-width: 0;
+  text-shadow: unset;
+  font-weight: bold;
+  @include font-p-3-small-button-text-black;
+  color: $white;
+  font-size: 14px;
+  line-height: 16px;
+  background-image: unset;
+
+  &:hover {
+    background-color: $purple-dark;
+    transition: background-color .35s;
+  }
+
+  display: flex;
+  height: 33px;
+  padding: 0 15px;
+  justify-content: center;
+  align-items: center;
+
+  &.locked {
+    background: #adadad;
+    cursor: default;
+    color: $pitch;
+  }
+}
+</style>

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleHeader.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleHeader.vue
@@ -95,7 +95,7 @@ export default {
     },
 
     assignCourse () {
-      this.trackEvent(`Click Assign to Class in Curriculum with course: ${this.getCurrentCourse?.slug}`)
+      this.trackEvent('Click Assign to Class in Curriculum')
       application.router.navigate(`/teachers/classes?assignContent=${this.getCurrentCourse?._id}`, { trigger: true })
     },
 

--- a/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleHeader.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseCurriculumGuide/components/ModuleHeader.vue
@@ -2,6 +2,7 @@
 import ButtonSlides from './ButtonSlides'
 import ButtonProjectReq from './ButtonProjectReq'
 import ButtonExemplar from './ButtonExemplar'
+import ButtonAssignCourse from './ButtonAssignCourse'
 
 import IconHelp from '../../common/icons/IconHelp'
 import { mapGetters } from 'vuex'
@@ -15,6 +16,7 @@ export default {
     ButtonSlides,
     ButtonProjectReq,
     ButtonExemplar,
+    ButtonAssignCourse,
     IconHelp,
     CodeRenderer,
     AccessLevelIndicator,
@@ -92,6 +94,11 @@ export default {
       return this.$t('teacher_dashboard.exemplar_projects_tooltip')
     },
 
+    assignCourse () {
+      this.trackEvent(`Click Assign to Class in Curriculum with course: ${this.getCurrentCourse?.slug}`)
+      application.router.navigate(`/teachers/classes?assignContent=${this.getCurrentCourse?._id}`, { trigger: true })
+    },
+
     trackEvent (eventName) {
       if (!this.isOnLockedCampaign && eventName) {
         window.tracker?.trackEvent(eventName, { category: this.getTrackCategory, label: this.courseName })
@@ -161,6 +168,12 @@ export default {
           @click.native="trackEvent('Curriculum Guide: Lesson Slides Clicked')"
         />
       </template>
+
+      <button-assign-course
+        class="margin-right"
+        :locked="isOnLockedCampaign"
+        @click="assignCourse"
+      />
 
       <button-project-req
         v-if="isCapstone"

--- a/ozaria/site/components/teacher-dashboard/BaseMyClasses/components/ClassSummaryRow.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseMyClasses/components/ClassSummaryRow.vue
@@ -94,7 +94,7 @@ export default {
           v-if="!archived && !displayOnly"
           id="class-header-shepherd"
           tag="a"
-          :to="`/teachers/classes/${classId}`"
+          :to="{ path: `/teachers/classes/${classId}`, query: $route.query }"
           class="flex-row clickable"
           @click.native="trackEvent('All Classes: Class Card Clicked')"
         >

--- a/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
+++ b/ozaria/site/components/teacher-dashboard/BaseSingleClass/index.vue
@@ -452,6 +452,9 @@ export default {
     if (this.defaultCourseId) {
       this.setSelectedCourseId({ courseId: this.defaultCourseId })
     }
+    if (this.$route?.query?.assignContent) {
+      this.setSelectedCourseId({ courseId: this.$route.query.assignContent })
+    }
     this.setTeacherId(this.teacherId || me.get('_id'))
     this.fetchClassroomData(this.classroomId).then(() => {
       this.$emit('auto-play-td-tour')

--- a/ozaria/site/components/teacher-dashboard/modals/ModalAssignContent/ModalAssignForm.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalAssignContent/ModalAssignForm.vue
@@ -38,6 +38,14 @@ export default {
     this.groupedCourses = utils.groupedCoursesList(this.courses)
   },
 
+  mounted () {
+    const paramCourse = this.$route?.query?.assignContent
+    console.log('waht ? ', paramCourse)
+    if (paramCourse) {
+      this.selected = paramCourse
+    }
+  },
+
   methods: {
     ...mapActions({
       assignCourse: 'courseInstances/assignCourse',
@@ -48,7 +56,7 @@ export default {
       if (!this.selected) {
         return
       }
-      const course = this.courses.find((v) => v.name === this.selected)
+      const course = this.courses.find((v) => v._id === this.selected)
 
       const sharedClassroomId = hasSharedWriteAccessPermission(this.classroom) ? this.classroom._id : null
       await this.assignCourse({
@@ -62,6 +70,12 @@ export default {
       } else {
         this.fetchData({ forceGameContentFetch: true }) // new course that didnt exist when classroom was created
       }
+      if (this.$route?.query?.assignContent) {
+        const query = this.$route.query
+        delete query.assignContent
+        const newUrl = this.$router.resolve({ query })
+        application.router.navigate(newUrl.href)
+      }
       this.$emit('close')
     },
 
@@ -69,7 +83,7 @@ export default {
       if (!this.selected) {
         return
       }
-      const course = this.courses.find((v) => v.name === this.selected)
+      const course = this.courses.find((v) => v._id === this.selected)
 
       await this.removeCourse({ course, members: this.selectedStudentIds, classroom: this.classroom })
       this.fetchData()
@@ -110,7 +124,7 @@ export default {
             <option
               v-for="course in groupedCourses"
               :key="course._id"
-              :value="course.name"
+              :value="course._id"
               :disabled="course.disabled"
             >
               {{ i18nName(course) }}

--- a/ozaria/site/components/teacher-dashboard/modals/ModalAssignContent/ModalAssignForm.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/ModalAssignContent/ModalAssignForm.vue
@@ -26,6 +26,7 @@ export default {
       classroomCourses: 'teacherDashboard/getCoursesCurrentClassroom',
       classroomMembers: 'teacherDashboard/getMembersCurrentClassroom',
       selectedStudentIds: 'baseSingleClass/selectedStudentIds',
+      selectedCourseId: 'teacherDashboard/getSelectedCourseIdCurrentClassroom',
       courses: 'courses/sorted',
     }),
   },
@@ -39,11 +40,7 @@ export default {
   },
 
   mounted () {
-    const paramCourse = this.$route?.query?.assignContent
-    console.log('waht ? ', paramCourse)
-    if (paramCourse) {
-      this.selected = paramCourse
-    }
+    this.selected = this.selectedCourseId
   },
 
   methods: {


### PR DESCRIPTION
fix ENG-2530
<img width="1233" height="806" alt="image" src="https://github.com/user-attachments/assets/9f9110d7-fd3b-4a1b-aed9-86575ac12ec8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Assign to Class” buttons to course/module headers.
  * Starting assignment from a URL now preselects the chosen course automatically.
  * Locked courses show a disabled assignment button.
* **Bug Fixes**
  * Course assignment now correctly targets items even when names match (uses unique identifiers).
  * Class navigation preserves existing URL query parameters.
  * Assignment URLs are cleaned by removing the temporary assignment parameter after use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->