### PR TITLE
remove vimeo players which do not work and add some fallback

### DIFF
--- a/app/schemas/models/level.js
+++ b/app/schemas/models/level.js
@@ -435,6 +435,7 @@ _.extend(LevelSchema.properties, {
   classroomSub: { $ref: '#/definitions/classroomSub', inEditor: true },
   requiresSignUp: { title: 'Require SignUp', description: 'Whether this level is available to anonymous user', type: 'boolean', inEditor: 'codecombat' },
   tasks: c.array({ title: 'Tasks', description: 'Tasks to be completed for this level.' }, c.task),
+  // seems having videos but no usage
   helpVideos: c.array({ title: 'Help Videos', inEditor: 'codecombat' }, c.object({ default: { style: 'eccentric', url: '', free: false } }, {
     style: c.shortString({ title: 'Style', description: 'Like: original, eccentric, scripted, edited, etc.' }),
     free: { type: 'boolean', title: 'Free', description: 'Whether this video is freely available to all players without a subscription.' },

--- a/app/views/courses/TeacherCoursesView.js
+++ b/app/views/courses/TeacherCoursesView.js
@@ -163,32 +163,22 @@ module.exports = (TeacherCoursesView = (function () {
     }
 
     onClickVideoThumbnail (e) {
-      let video_url
+      let videoUrl
       this.$('#video-modal').modal('show')
       const image_src = e.target.src.slice(e.target.src.search('/images'))
       const video = (Object.values(this.videoLevels || {}).find(l => l.thumbnail_unlocked === image_src) || {})
       if (me.showChinaVideo()) {
-        video_url = video.cn_url
+        videoUrl = video.cn_url + '?autoplay=1'
       } else {
-        video_url = video.url
+        videoUrl = video.url
         const preferred = me.get('preferredLanguage') || 'en'
         const video_language_code = (video.captions_available || [])
           .find(language_code => (language_code === preferred) || (language_code === preferred.split('-')[0]))
-        video_url = video_url.replace(/defaultTextTrack=[\w\d-]+/, 'defaultTextTrack=' + (video_language_code || 'en'))
+        videoUrl = videoUrl.replace(/defaultTextTrack=[\w\d-]+/, 'defaultTextTrack=' + (video_language_code || 'en'))
+        videoUrl += '&autoplay=1'
       }
-      this.$('.video-player')[0].src = video_url
+      this.$('.video-player')[0].src = videoUrl
 
-      if (!me.showChinaVideo()) {
-        require.ensure(['@vimeo/player'], require => {
-          const VideoPlayer = require('@vimeo/player').default
-          this.videoPlayer = new VideoPlayer(this.$('.video-player')[0])
-          return this.videoPlayer.play().catch(err => console.error('Error while playing the video:', err))
-        }
-        , e => {
-          return console.error(e)
-        }
-        , 'vimeo')
-      }
       return this.$('#video-modal').on(('hide.bs.modal'), e => {
         if (me.showChinaVideo()) {
           return this.$('.video-player').attr('src', '')

--- a/app/views/play/level/PlayLevelVideoComponent.vue
+++ b/app/views/play/level/PlayLevelVideoComponent.vue
@@ -26,7 +26,6 @@ flat-layout
 <script>
 import utils from 'core/utils'
 import FlatLayout from 'core/components/FlatLayout'
-import VideoPlayer from '@vimeo/player'
 
 export default Vue.extend({
   props: {
@@ -70,12 +69,6 @@ export default Vue.extend({
 
   mounted() {
     this.$nextTick(function () {
-      if(!me.showChinaVideo()){
-        const player = new VideoPlayer($('.video')[0]);
-        player.on('ended', function() {
-          $('#next-level-btn')[0].style.display = "block"
-        })
-      }
       // hack to remove base template's header and footer
       // store existing display settings to revert to these before leaving
       this.originalDisplaySettings = {

--- a/app/views/play/level/modal/CourseVideosModalComponent.vue
+++ b/app/views/play/level/modal/CourseVideosModalComponent.vue
@@ -43,7 +43,6 @@
 <script>
 import api from 'core/api';
 import utils from 'core/utils'
-import VideoPlayer from '@vimeo/player'
 import co from 'co'
 
 export default Vue.extend({
@@ -96,14 +95,10 @@ export default Vue.extend({
       src = src.slice(src.search('/images'))
       let video = (this.videoLevels.find(l => l.thumbnail_unlocked == src) || {})
       let frame = $('.video-frame')[0]
-      frame.src = me.showChinaVideo() ? video.cn_url : video.url
+      frame.src = (me.showChinaVideo() ? (video.cn_url + '?') : (video.url + '&')) + 'autoplay=1'
       frame.style['z-index'] = 3
       $('#videos-content')[0].style.display = "none"
       $('#video-close-btn')[0].style.display = "block"
-      if(!me.showChinaVideo()){
-        const p = new VideoPlayer(frame);
-        p.play().catch((err) => console.log("Error while playing the video:", err))
-      }
     }
   },
 });

--- a/ozaria/site/components/cutscene/PageCutscene/index.vue
+++ b/ozaria/site/components/cutscene/PageCutscene/index.vue
@@ -34,7 +34,6 @@ module.exports = Vue.extend({
   },
 
   data: () => ({
-    vimeoId: null,
     videoSrc: null,
     captions: () => ([]),
     cutscene: {},
@@ -68,8 +67,6 @@ module.exports = Vue.extend({
         this.videoSrc = cutscene.chinaVideoSrc
       } else if (cutscene.cloudflareID) {
         this.cloudflareID = cutscene.cloudflareID
-      } else {
-        this.vimeoId = cutscene.vimeoId
       }
 
       /**
@@ -127,17 +124,6 @@ module.exports = Vue.extend({
 
       :cutscene="cutscene"
       :cloudflare-i-d="cloudflareID"
-      :sound-on="soundOn"
-
-      @completed="onCompleted"
-    />
-    <!-- VIMEO PLAYER -->
-    <base-video
-      v-if="vimeoId"
-      id="cutscene-player"
-
-      ref="vimeo-player"
-      :vimeo-id="vimeoId"
       :sound-on="soundOn"
 
       @completed="onCompleted"

--- a/ozaria/site/components/cutscene/common/BaseVideo.vue
+++ b/ozaria/site/components/cutscene/common/BaseVideo.vue
@@ -1,9 +1,7 @@
 <script>
 import 'vendor/styles/plyr.css'
 import BaseModal from 'ozaria/site/components/common/BaseModal'
-import { cutsceneEvent } from './cutsceneUtil'
 const Plyr = require('vendor/scripts/plyr')
-const VimeoPlayer = require('@vimeo/player').default
 
 export default {
 
@@ -11,11 +9,6 @@ export default {
     BaseModal
   },
   props: {
-    vimeoId: {
-      type: String,
-      required: false
-    },
-
     videoSrc: {
       type: String,
       required: false
@@ -39,54 +32,15 @@ export default {
     skipping: false
   }),
 
-  watch: {
-    soundOn () {
-      if (!this.vimeoPlayer) {
-        return
-      }
-      this.updateVideoSound()
-    }
-  },
-
   async mounted () {
-    if (!(this.vimeoId || this.videoSrc)) {
-      throw new Error('You must pass in a "vimeoId" or a "videoSrc"')
+    if (!this.videoSrc) {
+      throw new Error('You must pass in a "videoSrc"')
     }
-
-    if (this.vimeoId) {
-      const player = this.vimeoPlayer = new VimeoPlayer(this.$refs['vimeo-player'])
-
-      // TODO: Instead of emitting completed, requires end screen UI.
-      //        Currently a stop gap to provide Intro support.
-      player.on('ended', () => this.$emit('completed'))
-
-      // Unfortunately, we have to use a promise here because the Vimeo error handling
-      // does not throw an error like expected. Only the .catch at the end of this chain
-      // is really able to handle the 403.
-      player.ready().then(async () => {
-        try {
-          cutsceneEvent('Video Loaded')
-          await player.setVolume(this.soundOn ? 1 : 0)
-          await player.play()
-        } catch (e) {
-          console.warn('Wasn\'t able to auto play video.')
-        }
-      }).catch((e) => {
-        console.error(e)
-        this.videoUnavailable = true
-      })
-    } else if (this.videoSrc) {
-      const vid = new Plyr(this.$refs.player, { captions: { active: true } })
-      vid.on('ended', () => this.$emit('completed'))
-    }
+    const vid = new Plyr(this.$refs.player, { captions: { active: true } })
+    vid.on('ended', () => this.$emit('completed'))
   },
 
   methods: {
-    updateVideoSound () {
-      // TODO: This can sometimes pause the video when turning on the volume.
-      this.vimeoPlayer.setVolume(this.soundOn ? 1 : 0)
-        .catch((e) => console.warn('Couldn\'t set volume of cutscene'))
-    },
     skip () {
       this.skipping = true
       this.$emit('completed')

--- a/ozaria/site/components/cutscene/common/BaseVideo.vue
+++ b/ozaria/site/components/cutscene/common/BaseVideo.vue
@@ -27,7 +27,7 @@ export default {
   },
 
   data: () => ({
-    vimeoPlayer: null,
+    player: null,
     videoUnavailable: false,
     skipping: false
   }),
@@ -36,8 +36,12 @@ export default {
     if (!this.videoSrc) {
       throw new Error('You must pass in a "videoSrc"')
     }
-    const vid = new Plyr(this.$refs.player, { captions: { active: true } })
-    vid.on('ended', () => this.$emit('completed'))
+    this.player = new Plyr(this.$refs.player, { captions: { active: true } })
+    this.player.on('ended', () => this.$emit('completed'))
+  },
+
+  beforeDestroy () {
+    this.player?.destroy?.()
   },
 
   methods: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@datadog/browser-rum": "^5.4.0",
         "@stripe/stripe-js": "^1.32.0",
         "@usesuperflow/client": "^1.0.2",
-        "@vimeo/player": "^2.17.1",
         "ace-builds": "^1.36.0",
         "ace-diff": "github:smallst/ace-diff#v1.06",
         "acorn-loose": "^8.0.1",
@@ -12475,15 +12474,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@usesuperflow/client/-/client-1.0.2.tgz",
       "integrity": "sha512-mjaFtdzckVydU5RGRtnGuLWH9TFCwkKZZfBmAJYEpqpmXo5wkrsZhabI+ivUSd7Po1679EkQxt/N6oXaoF25Sw=="
-    },
-    "node_modules/@vimeo/player": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/@vimeo/player/-/player-2.17.1.tgz",
-      "integrity": "sha512-M8uMYiOwFkqD070/pO/CuRmwKvnHBmEZKckt5C2tAaMhlldzui+lUC5zMFzO0RDPmIXwg1WdDxaJnzuic6ll/A==",
-      "dependencies": {
-        "native-promise-only": "0.8.1",
-        "weakmap-polyfill": "2.0.4"
-      }
     },
     "node_modules/@vitest/expect": {
       "version": "0.34.7",
@@ -27316,11 +27306,6 @@
       "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
       "optional": true
     },
-    "node_modules/native-promise-only": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg=="
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -36368,14 +36353,6 @@
       "dev": true,
       "dependencies": {
         "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/weakmap-polyfill": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/weakmap-polyfill/-/weakmap-polyfill-2.0.4.tgz",
-      "integrity": "sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw==",
-      "engines": {
-        "node": ">=8.10.0"
       }
     },
     "node_modules/webidl-conversions": {
@@ -45539,15 +45516,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@usesuperflow/client/-/client-1.0.2.tgz",
       "integrity": "sha512-mjaFtdzckVydU5RGRtnGuLWH9TFCwkKZZfBmAJYEpqpmXo5wkrsZhabI+ivUSd7Po1679EkQxt/N6oXaoF25Sw=="
-    },
-    "@vimeo/player": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/@vimeo/player/-/player-2.17.1.tgz",
-      "integrity": "sha512-M8uMYiOwFkqD070/pO/CuRmwKvnHBmEZKckt5C2tAaMhlldzui+lUC5zMFzO0RDPmIXwg1WdDxaJnzuic6ll/A==",
-      "requires": {
-        "native-promise-only": "0.8.1",
-        "weakmap-polyfill": "2.0.4"
-      }
     },
     "@vitest/expect": {
       "version": "0.34.7",
@@ -56918,11 +56886,6 @@
       "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
       "optional": true
     },
-    "native-promise-only": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg=="
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -63861,11 +63824,6 @@
       "requires": {
         "defaults": "^1.0.3"
       }
-    },
-    "weakmap-polyfill": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/weakmap-polyfill/-/weakmap-polyfill-2.0.4.tgz",
-      "integrity": "sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw=="
     },
     "webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "@datadog/browser-rum": "^5.4.0",
     "@stripe/stripe-js": "^1.32.0",
     "@usesuperflow/client": "^1.0.2",
-    "@vimeo/player": "^2.17.1",
     "ace-builds": "^1.36.0",
     "ace-diff": "github:smallst/ace-diff#v1.06",
     "acorn-loose": "^8.0.1",


### PR DESCRIPTION
fix ENG-2610

case:
1. baseVideo have the vimeo usage but never called. all 18 cutscene turn to the cloudflare videos
2. other @vimeo/player usage are all accept cloudflare url and not work at all. i add some `autplay` to make it effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video thumbnails and course videos now launch with autoplay using direct URLs (including autoplay/query handling and preferred captions when available).
  * Cutscenes now play video via Cloudflare and China-hosted sources without relying on Vimeo playback.

* **Bug Fixes**
  * Video playback behavior has been streamlined to a single runtime path for better consistency.
  * Updated next-level progression behavior by removing Vimeo-player end-event handling.

* **Chores**
  * Removed Vimeo integration from the app’s video playback dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->