### PR TITLE
[GD-321] Recolor CodeCombat Junior trail to purple start-to-end gradient

### DIFF
--- a/app/core/colors.js
+++ b/app/core/colors.js
@@ -2,6 +2,16 @@
  * Color values named by appearance (not by UI function).
  * Use functional names only at the call site, e.g. lockedColor = colors.grey
  */
+/** '#7B1FA2' (or '7B1FA2', '#abc') → [123, 31, 162] */
+const hexToRgb = hex => {
+  hex = hex.replace(/^#/, '')
+  if (hex.length === 3) hex = hex.split('').map(c => c + c).join('')
+  return [0, 2, 4].map(i => parseInt(hex.slice(i, i + 2), 16))
+}
+
+/** [123, 31, 162] → '#7b1fa2' */
+const rgbToHex = rgb => '#' + rgb.map(c => Math.round(c).toString(16).padStart(2, '0')).join('')
+
 module.exports = {
   black: '#000000',
   grey: '#d9d9d9',
@@ -19,4 +29,14 @@ module.exports = {
   lightGreen: '#90EE90',
   darkGreen: '#006400',
   mysticViolet: '#AD62F8',
+
+  green: '#00ff00',
+  blue: '#0000ff',
+  leafGreen: '#4FCA52',
+  skyBlue: '#45AAFF',
+  lavender: '#D8B4FE',
+  deepPurple: '#7B1FA2',
+
+  hexToRgb,
+  rgbToHex,
 }

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -1938,9 +1938,12 @@ module.exports.groupedCoursesList = (courses) => {
     return cs
   }
 }
+const isJuniorLevel = level => level?.get('product') === 'codecombat-junior'
+module.exports.isJuniorLevel = isJuniorLevel
+
 module.exports.guardJuniorLevelHealthCode = (level, source) => {
   if (typeof source !== 'string') return source // should not happen
-  if (level?.get('product') === 'codecombat-junior') {
+  if (isJuniorLevel(level)) {
     source = source.replace(/(^|[^a-zA-Z.])health(?!\w)/g, (match, prefix) => `${prefix}hero.health`)
   }
   return source

--- a/app/lib/surface/TrailMaster.coffee
+++ b/app/lib/surface/TrailMaster.coffee
@@ -6,8 +6,9 @@ TARGET_ALPHA = 1
 TARGET_WIDTH = 10
 FUTURE_PATH_INTERVAL_DIVISOR = 4
 PAST_PATH_INTERVAL_DIVISOR = 2
-START_DOT_COLOR = [206, 147, 216]  # light purple, same family as PET_PATH_COLOR
-PET_PATH_COLOR = [178, 75, 224]  # CodeCombat Junior pet trail; exact purple TBD with art
+PET_PATH_COLOR_LIGHT = [216, 180, 254]  # CodeCombat Junior trail gradient: path start
+PET_PATH_COLOR_DARK = [123, 31, 162]  # CodeCombat Junior trail gradient: path end
+PET_PATH_COLOR_STEPS = 8  # max distinct dot colors along the gradient (spritesheet cache bound)
 TEAM_COLORS =
   codecombat:
     neutral: [0, 255, 0]
@@ -49,7 +50,6 @@ module.exports = class TrailMaster extends CocoClass
     @tweens = []
 
   createGraphics: ->
-    @startDotKey = @cachePathDot(TARGET_WIDTH, [START_DOT_COLOR..., 1], [0, 0, 0, 1])  # Just for CCJ so far
     @targetDotKey = @cachePathDot(TARGET_WIDTH, @colorForThang(@thang.team, TARGET_ALPHA), [0, 0, 0, 1])
     @pastDotKey = @cachePathDot(PAST_PATH_WIDTH, @colorForThang(@thang.team, PAST_PATH_ALPHA), [0, 0, 0, 1])
     @futureDotKey = @cachePathDot(FUTURE_PATH_WIDTH, [255, 255, 255, FUTURE_PATH_ALPHA], @colorForThang(@thang.team, 1))
@@ -68,8 +68,17 @@ module.exports = class TrailMaster extends CocoClass
   colorForThang: (team, alpha=1.0) ->
     palette = if utils.isCodeCombat then TEAM_COLORS.codecombat else TEAM_COLORS.ozaria
     rgb = palette[team] ? palette.neutral
-    rgb = PET_PATH_COLOR if team is 'humans' and utils.isJuniorLevel @level
+    rgb = PET_PATH_COLOR_DARK if team is 'humans' and utils.isJuniorLevel @level
     return [rgb..., alpha]
+
+  useJuniorGradient: ->
+    @thang.team is 'humans' and utils.isJuniorLevel @level
+
+  # Quantized lerp light->dark: at most PET_PATH_COLOR_STEPS distinct colors get cached as dot graphics
+  petColorAt: (t) ->
+    t = Math.round(t * (PET_PATH_COLOR_STEPS - 1)) / (PET_PATH_COLOR_STEPS - 1)
+    for c, j in PET_PATH_COLOR_LIGHT
+      Math.round(c + (PET_PATH_COLOR_DARK[j] - c) * t)
 
   createPastPath: ->
     return unless points = @world.pointsForThang @thang.id, @camera
@@ -81,18 +90,24 @@ module.exports = class TrailMaster extends CocoClass
     return unless points = @world.pointsForThang @thang.id, @camera
     interval = Math.max(1, parseInt(@world.frameRate / FUTURE_PATH_INTERVAL_DIVISOR))
     params = { interval: interval, animate: true, frameKey: @futureDotKey }
+    params.gradientStroke = @useJuniorGradient()
     return @createPath(points, params)
 
   createTargets: ->
     return unless @thang.allTargets
     container = new createjs.Container(@layerAdapter.spriteSheet)
+    numTargets = @thang.allTargets.length / 2
     for x, i in @thang.allTargets by 2
       y = @thang.allTargets[i + 1]
       sup = @camera.worldToSurface x: x, y: y
       sprite = new createjs.Sprite(@layerAdapter.spriteSheet)
       sprite.scaleX = sprite.scaleY = 1 / @layerAdapter.resolutionFactor
       sprite.scaleY *= @camera.y2x
-      graphicsKey = if i is 0 and utils.isJuniorLevel @level then @startDotKey else @targetDotKey
+      if @useJuniorGradient()
+        t = if numTargets > 1 then (i / 2) / (numTargets - 1) else 0
+        graphicsKey = @cachePathDot(TARGET_WIDTH, [@petColorAt(t)..., TARGET_ALPHA], [0, 0, 0, 1])
+      else
+        graphicsKey = @targetDotKey
       sprite.gotoAndStop(graphicsKey)
       sprite.x = sup.x
       sprite.y = sup.y
@@ -105,8 +120,14 @@ module.exports = class TrailMaster extends CocoClass
     key = options.frameKey or @pastDotKey
     container = new createjs.Container(@layerAdapter.spriteSheet)
 
+    numDots = Math.ceil(points.length / (interval * 2))
+    dotIndex = 0
     for x, i in points by interval * 2
       y = points[i + 1]
+      if options.gradientStroke
+        t = if numDots > 1 then dotIndex / (numDots - 1) else 0
+        key = @cachePathDot(FUTURE_PATH_WIDTH, [255, 255, 255, FUTURE_PATH_ALPHA], [@petColorAt(t)..., 1])
+      dotIndex++
       sprite = new createjs.Sprite(@layerAdapter.spriteSheet)
       sprite.scaleX = sprite.scaleY = 1 / @layerAdapter.resolutionFactor
       sprite.scaleY *= @camera.y2x

--- a/app/lib/surface/TrailMaster.coffee
+++ b/app/lib/surface/TrailMaster.coffee
@@ -6,23 +6,24 @@ TARGET_ALPHA = 1
 TARGET_WIDTH = 10
 FUTURE_PATH_INTERVAL_DIVISOR = 4
 PAST_PATH_INTERVAL_DIVISOR = 2
-PET_PATH_COLOR_LIGHT = [216, 180, 254]  # CodeCombat Junior trail gradient: path start
-PET_PATH_COLOR_DARK = [123, 31, 162]  # CodeCombat Junior trail gradient: path end
+Camera = require './Camera'
+CocoClass = require 'core/CocoClass'
+colors = require 'core/colors'
+createjs = require 'lib/createjs-parts'
+utils = require 'core/utils'
+
+PET_PATH_COLOR_LIGHT = colors.hexToRgb(colors.lavender)  # CodeCombat Junior trail gradient: path start
+PET_PATH_COLOR_DARK = colors.hexToRgb(colors.deepPurple)  # CodeCombat Junior trail gradient: path end
 PET_PATH_COLOR_STEPS = 8  # max distinct dot colors along the gradient (spritesheet cache bound)
 TEAM_COLORS =
   codecombat:
-    neutral: [0, 255, 0]
-    humans: [255, 0, 0]
-    ogres: [0, 0, 255]
+    neutral: colors.hexToRgb(colors.green)
+    humans: colors.hexToRgb(colors.red)
+    ogres: colors.hexToRgb(colors.blue)
   ozaria:
-    neutral: [79, 202, 82]
-    humans: [69, 170, 255]
-    ogres: [255, 0, 0]
-
-Camera = require './Camera'
-CocoClass = require 'core/CocoClass'
-createjs = require 'lib/createjs-parts'
-utils = require 'core/utils'
+    neutral: colors.hexToRgb(colors.leafGreen)
+    humans: colors.hexToRgb(colors.skyBlue)
+    ogres: colors.hexToRgb(colors.red)
 
 module.exports = class TrailMaster extends CocoClass
   world: null

--- a/app/lib/surface/TrailMaster.coffee
+++ b/app/lib/surface/TrailMaster.coffee
@@ -55,11 +55,15 @@ module.exports = class TrailMaster extends CocoClass
       # Register every gradient bucket before any dot sprite exists: a first-seen graphic
       # rebuilds the layer spritesheet, destroying the sheet already-created sprites reference.
       # The flat team-color keys are skipped here; gradient mode never draws them.
-      # Last iteration leaves the darkest-bucket keys as valid defaults for @targetDotKey/@futureDotKey
-      for step in [0...PET_PATH_COLOR_STEPS]
-        color = @petColorAt(step / (PET_PATH_COLOR_STEPS - 1))
-        @targetDotKey = @cachePathDot(TARGET_WIDTH, [color..., TARGET_ALPHA], [0, 0, 0, 1])
-        @futureDotKey = @cachePathDot(FUTURE_PATH_WIDTH, [255, 255, 255, FUTURE_PATH_ALPHA], [color..., 1])
+      @gradientTargetKeys = []
+      @gradientStrokeKeys = []
+      for bucket in [0...PET_PATH_COLOR_STEPS]
+        color = @petColorForBucket(bucket)
+        @gradientTargetKeys.push @cachePathDot(TARGET_WIDTH, [color..., TARGET_ALPHA], [0, 0, 0, 1])
+        @gradientStrokeKeys.push @cachePathDot(FUTURE_PATH_WIDTH, [255, 255, 255, FUTURE_PATH_ALPHA], [color..., 1])
+      # Darkest-bucket keys double as valid defaults for any non-gradient fallback path
+      @targetDotKey = @gradientTargetKeys[PET_PATH_COLOR_STEPS - 1]
+      @futureDotKey = @gradientStrokeKeys[PET_PATH_COLOR_STEPS - 1]
     else
       @targetDotKey = @cachePathDot(TARGET_WIDTH, @colorForThang(@thang.team, TARGET_ALPHA), [0, 0, 0, 1])
       @pastDotKey = @cachePathDot(PAST_PATH_WIDTH, @colorForThang(@thang.team, PAST_PATH_ALPHA), [0, 0, 0, 1])
@@ -84,11 +88,14 @@ module.exports = class TrailMaster extends CocoClass
   useJuniorGradient: ->
     @thang.team is 'humans' and utils.isJuniorLevel @level
 
-  # Quantized lerp light->dark: at most PET_PATH_COLOR_STEPS distinct colors get cached as dot graphics
-  petColorAt: (t) ->
-    t = Math.round(t * (PET_PATH_COLOR_STEPS - 1)) / (PET_PATH_COLOR_STEPS - 1)
+  # Gradient quantized to PET_PATH_COLOR_STEPS buckets so only that many dot graphics get cached
+  petBucketFor: (t) ->
+    Math.round(t * (PET_PATH_COLOR_STEPS - 1))
+
+  petColorForBucket: (bucket) ->
+    f = bucket / (PET_PATH_COLOR_STEPS - 1)
     for c, j in PET_PATH_COLOR_LIGHT
-      Math.round(c + (PET_PATH_COLOR_DARK[j] - c) * t)
+      Math.round(c + (PET_PATH_COLOR_DARK[j] - c) * f)
 
   createPastPath: ->
     return unless points = @world.pointsForThang @thang.id, @camera
@@ -107,15 +114,16 @@ module.exports = class TrailMaster extends CocoClass
     return unless @thang.allTargets
     container = new createjs.Container(@layerAdapter.spriteSheet)
     numTargets = @thang.allTargets.length / 2
+    useGradient = @useJuniorGradient()
     for x, i in @thang.allTargets by 2
       y = @thang.allTargets[i + 1]
       sup = @camera.worldToSurface x: x, y: y
       sprite = new createjs.Sprite(@layerAdapter.spriteSheet)
       sprite.scaleX = sprite.scaleY = 1 / @layerAdapter.resolutionFactor
       sprite.scaleY *= @camera.y2x
-      if @useJuniorGradient()
+      if useGradient
         t = if numTargets > 1 then (i / 2) / (numTargets - 1) else 0
-        graphicsKey = @cachePathDot(TARGET_WIDTH, [@petColorAt(t)..., TARGET_ALPHA], [0, 0, 0, 1])
+        graphicsKey = @gradientTargetKeys[@petBucketFor(t)]
       else
         graphicsKey = @targetDotKey
       sprite.gotoAndStop(graphicsKey)
@@ -136,7 +144,7 @@ module.exports = class TrailMaster extends CocoClass
       y = points[i + 1]
       if options.gradientStroke
         t = if numDots > 1 then dotIndex / (numDots - 1) else 0
-        key = @cachePathDot(FUTURE_PATH_WIDTH, [255, 255, 255, FUTURE_PATH_ALPHA], [@petColorAt(t)..., 1])
+        key = @gradientStrokeKeys[@petBucketFor(t)]
       dotIndex++
       sprite = new createjs.Sprite(@layerAdapter.spriteSheet)
       sprite.scaleX = sprite.scaleY = 1 / @layerAdapter.resolutionFactor

--- a/app/lib/surface/TrailMaster.coffee
+++ b/app/lib/surface/TrailMaster.coffee
@@ -53,6 +53,13 @@ module.exports = class TrailMaster extends CocoClass
     @targetDotKey = @cachePathDot(TARGET_WIDTH, @colorForThang(@thang.team, TARGET_ALPHA), [0, 0, 0, 1])
     @pastDotKey = @cachePathDot(PAST_PATH_WIDTH, @colorForThang(@thang.team, PAST_PATH_ALPHA), [0, 0, 0, 1])
     @futureDotKey = @cachePathDot(FUTURE_PATH_WIDTH, [255, 255, 255, FUTURE_PATH_ALPHA], @colorForThang(@thang.team, 1))
+    if @useJuniorGradient()
+      # Register every gradient bucket before any dot sprite exists: a first-seen graphic
+      # rebuilds the layer spritesheet, destroying the sheet already-created sprites reference
+      for step in [0...PET_PATH_COLOR_STEPS]
+        color = @petColorAt(step / (PET_PATH_COLOR_STEPS - 1))
+        @cachePathDot(TARGET_WIDTH, [color..., TARGET_ALPHA], [0, 0, 0, 1])
+        @cachePathDot(FUTURE_PATH_WIDTH, [255, 255, 255, FUTURE_PATH_ALPHA], [color..., 1])
 
   cachePathDot: (width, fillColor, strokeColor) ->
     key = "path-dot-#{width}-#{fillColor}-#{strokeColor}"

--- a/app/lib/surface/TrailMaster.coffee
+++ b/app/lib/surface/TrailMaster.coffee
@@ -55,10 +55,11 @@ module.exports = class TrailMaster extends CocoClass
       # Register every gradient bucket before any dot sprite exists: a first-seen graphic
       # rebuilds the layer spritesheet, destroying the sheet already-created sprites reference.
       # The flat team-color keys are skipped here; gradient mode never draws them.
+      # Last iteration leaves the darkest-bucket keys as valid defaults for @targetDotKey/@futureDotKey
       for step in [0...PET_PATH_COLOR_STEPS]
         color = @petColorAt(step / (PET_PATH_COLOR_STEPS - 1))
-        @cachePathDot(TARGET_WIDTH, [color..., TARGET_ALPHA], [0, 0, 0, 1])
-        @cachePathDot(FUTURE_PATH_WIDTH, [255, 255, 255, FUTURE_PATH_ALPHA], [color..., 1])
+        @targetDotKey = @cachePathDot(TARGET_WIDTH, [color..., TARGET_ALPHA], [0, 0, 0, 1])
+        @futureDotKey = @cachePathDot(FUTURE_PATH_WIDTH, [255, 255, 255, FUTURE_PATH_ALPHA], [color..., 1])
     else
       @targetDotKey = @cachePathDot(TARGET_WIDTH, @colorForThang(@thang.team, TARGET_ALPHA), [0, 0, 0, 1])
       @pastDotKey = @cachePathDot(PAST_PATH_WIDTH, @colorForThang(@thang.team, PAST_PATH_ALPHA), [0, 0, 0, 1])

--- a/app/lib/surface/TrailMaster.coffee
+++ b/app/lib/surface/TrailMaster.coffee
@@ -50,16 +50,18 @@ module.exports = class TrailMaster extends CocoClass
     @tweens = []
 
   createGraphics: ->
-    @targetDotKey = @cachePathDot(TARGET_WIDTH, @colorForThang(@thang.team, TARGET_ALPHA), [0, 0, 0, 1])
-    @pastDotKey = @cachePathDot(PAST_PATH_WIDTH, @colorForThang(@thang.team, PAST_PATH_ALPHA), [0, 0, 0, 1])
-    @futureDotKey = @cachePathDot(FUTURE_PATH_WIDTH, [255, 255, 255, FUTURE_PATH_ALPHA], @colorForThang(@thang.team, 1))
     if @useJuniorGradient()
       # Register every gradient bucket before any dot sprite exists: a first-seen graphic
-      # rebuilds the layer spritesheet, destroying the sheet already-created sprites reference
+      # rebuilds the layer spritesheet, destroying the sheet already-created sprites reference.
+      # The flat team-color keys are skipped here; gradient mode never draws them.
       for step in [0...PET_PATH_COLOR_STEPS]
         color = @petColorAt(step / (PET_PATH_COLOR_STEPS - 1))
         @cachePathDot(TARGET_WIDTH, [color..., TARGET_ALPHA], [0, 0, 0, 1])
         @cachePathDot(FUTURE_PATH_WIDTH, [255, 255, 255, FUTURE_PATH_ALPHA], [color..., 1])
+    else
+      @targetDotKey = @cachePathDot(TARGET_WIDTH, @colorForThang(@thang.team, TARGET_ALPHA), [0, 0, 0, 1])
+      @pastDotKey = @cachePathDot(PAST_PATH_WIDTH, @colorForThang(@thang.team, PAST_PATH_ALPHA), [0, 0, 0, 1])
+      @futureDotKey = @cachePathDot(FUTURE_PATH_WIDTH, [255, 255, 255, FUTURE_PATH_ALPHA], @colorForThang(@thang.team, 1))
 
   cachePathDot: (width, fillColor, strokeColor) ->
     key = "path-dot-#{width}-#{fillColor}-#{strokeColor}"
@@ -75,7 +77,6 @@ module.exports = class TrailMaster extends CocoClass
   colorForThang: (team, alpha=1.0) ->
     palette = if utils.isCodeCombat then TEAM_COLORS.codecombat else TEAM_COLORS.ozaria
     rgb = palette[team] ? palette.neutral
-    rgb = PET_PATH_COLOR_DARK if team is 'humans' and utils.isJuniorLevel @level
     return [rgb..., alpha]
 
   useJuniorGradient: ->

--- a/app/lib/surface/TrailMaster.coffee
+++ b/app/lib/surface/TrailMaster.coffee
@@ -6,6 +6,17 @@ TARGET_ALPHA = 1
 TARGET_WIDTH = 10
 FUTURE_PATH_INTERVAL_DIVISOR = 4
 PAST_PATH_INTERVAL_DIVISOR = 2
+START_DOT_COLOR = [206, 147, 216]  # light purple, same family as PET_PATH_COLOR
+PET_PATH_COLOR = [178, 75, 224]  # CodeCombat Junior pet trail; exact purple TBD with art
+TEAM_COLORS =
+  codecombat:
+    neutral: [0, 255, 0]
+    humans: [255, 0, 0]
+    ogres: [0, 0, 255]
+  ozaria:
+    neutral: [79, 202, 82]
+    humans: [69, 170, 255]
+    ogres: [255, 0, 0]
 
 Camera = require './Camera'
 CocoClass = require 'core/CocoClass'
@@ -38,7 +49,7 @@ module.exports = class TrailMaster extends CocoClass
     @tweens = []
 
   createGraphics: ->
-    @startDotKey = @cachePathDot(TARGET_WIDTH, [94, 152, 81, 1], [0, 0, 0, 1])  # Just for CCJ so far; match start block color
+    @startDotKey = @cachePathDot(TARGET_WIDTH, [START_DOT_COLOR..., 1], [0, 0, 0, 1])  # Just for CCJ so far
     @targetDotKey = @cachePathDot(TARGET_WIDTH, @colorForThang(@thang.team, TARGET_ALPHA), [0, 0, 0, 1])
     @pastDotKey = @cachePathDot(PAST_PATH_WIDTH, @colorForThang(@thang.team, PAST_PATH_ALPHA), [0, 0, 0, 1])
     @futureDotKey = @cachePathDot(FUTURE_PATH_WIDTH, [255, 255, 255, FUTURE_PATH_ALPHA], @colorForThang(@thang.team, 1))
@@ -55,16 +66,10 @@ module.exports = class TrailMaster extends CocoClass
     return key
 
   colorForThang: (team, alpha=1.0) ->
-    if utils.isCodeCombat
-      rgb = [0, 255, 0]
-      rgb = [255, 0, 0] if team is 'humans'
-      rgb = [0, 0, 255] if team is 'ogres'
-    else
-      rgb = [79, 202, 82]
-      rgb = [69, 170, 255] if team is 'humans'
-      rgb = [255, 0, 0] if team is 'ogres'
-    rgb.push(alpha)
-    return rgb
+    palette = if utils.isCodeCombat then TEAM_COLORS.codecombat else TEAM_COLORS.ozaria
+    rgb = palette[team] ? palette.neutral
+    rgb = PET_PATH_COLOR if team is 'humans' and utils.isJuniorLevel @level
+    return [rgb..., alpha]
 
   createPastPath: ->
     return unless points = @world.pointsForThang @thang.id, @camera
@@ -87,7 +92,7 @@ module.exports = class TrailMaster extends CocoClass
       sprite = new createjs.Sprite(@layerAdapter.spriteSheet)
       sprite.scaleX = sprite.scaleY = 1 / @layerAdapter.resolutionFactor
       sprite.scaleY *= @camera.y2x
-      graphicsKey = if i is 0 and @level?.get('product') is 'codecombat-junior' then @startDotKey else @targetDotKey
+      graphicsKey = if i is 0 and utils.isJuniorLevel @level then @startDotKey else @targetDotKey
       sprite.gotoAndStop(graphicsKey)
       sprite.x = sup.x
       sprite.y = sup.y


### PR DESCRIPTION
Junior movement trails were red — same as the hero/human color, hard to tell paths apart (especially on sand). This recolors Junior trails to purple and adds a light→dark gradient along the path, so the direction of travel is readable from color alone.

Closes [GD-321](https://linear.app/codecombat/issue/GD-321/recolor-trail-for-pets-in-ccj)

## Changes

- Trail dots (targets + upcoming steps) lerp from lavender to deep purple along the path, quantized to max 8 colors so the spritesheet stays small; neighbouring dots share a bucket
- First dot is the lightest bucket, replacing the old green start-dot special case
- Gradient applies to Junior levels only (`product === 'codecombat-junior'`, humans team); classic red/blue/green trails and Ozaria unchanged
- Gradient dot graphics are pre-registered before any sprite is created — registering them mid-loop rebuilt the layer spritesheet and blanked/froze the trail on the first cast
- New `utils.isJuniorLevel(level)` helper, adopted in `guardJuniorLevelHealthCode` and TrailMaster
- Trail colors moved to `core/colors.js` (with `hexToRgb`/`rgbToHex` helpers); `colorForThang` refactored to a palette lookup, no inline RGB literals left

## Testing

- Junior level, first cast after page load: full gradient trail, animated, hero + pet paths both visible
- Classic level: trails unchanged (red humans / blue ogres)

## Screenshots

### Before

<img width="1690" height="920" alt="Screenshot 2026-07-28 at 12 51 01" src="https://github.com/user-attachments/assets/c105593f-75f4-45ce-94b0-f7ddf9c5660b" />


### After

<img width="1710" height="978" alt="Screenshot 2026-07-28 at 13 23 05" src="https://github.com/user-attachments/assets/2b9f5e06-5566-4d49-bd27-cbe047e4d6d2" />
<img width="1908" height="1222" alt="Screenshot 2026-07-28 at 13 47 57" src="https://github.com/user-attachments/assets/f228a03b-13a5-4eb7-bdd0-c6d90661381f" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Junior gradient visualization for path dots, with smoother progression coloring across targets.
  * Added color conversion utilities to translate between hex and RGB values.

* **Improvements**
  * Enhanced Junior-level health-code handling using a dedicated Junior-level detector, keeping behavior consistent for other levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->