### PR TITLE
[GD-871] Remove legacy misc-0/misc-1 inventory slots, add canonical slot whitelist

### DIFF
--- a/app/schemas/schemas.js
+++ b/app/schemas/schemas.js
@@ -402,11 +402,16 @@ me.activity = me.object({ description: 'Stats on an activity' }, {
 
 me.terrainString = me.shortString({ enum: ['Grass', 'Dungeon', 'Indoor', 'Desert', 'Mountain', 'Glacier', 'Volcano', 'Junior'], title: 'Terrain', description: 'Which terrain type this is.', inEditor: 'codecombat' })
 
+// All equippable inventory slots. The server strips any heroConfig.inventory key not in this list
+// on save (see codecombat-server User/LevelSession pre-save hooks), so keep it in sync when adding slots.
+me.heroInventorySlots = Object.freeze(['head', 'eyes', 'neck', 'torso', 'wrists', 'gloves', 'left-ring', 'right-ring', 'right-hand', 'left-hand', 'waist', 'feet', 'programming-book', 'pet', 'minion', 'flag'])
+
 me.HeroConfigSchema = me.object({ description: 'Which hero the player is using, equipped with what inventory.' }, {
   inventory: {
     type: 'object',
     description: 'The inventory of the hero: slots to item ThangTypes.',
-    additionalProperties: me.objectId({ description: 'An item ThangType.' }),
+    properties: _.zipObject(me.heroInventorySlots.map((slot) => [slot, me.objectId({ description: 'An item ThangType.' })])),
+    additionalProperties: me.objectId({ description: 'An item ThangType.' }), // deliberately not false: legacy docs may hold unknown slots; the server strips them on save instead of failing validation
   },
   thangType: me.objectId({ links: [{ rel: 'db', href: '/db/thang.type/{($)}/version' }], title: 'Thang Type', description: 'The ThangType of the hero.', format: 'thang-type' }),
 },

--- a/app/styles/play/menu/inventory-modal.sass
+++ b/app/styles/play/menu/inventory-modal.sass
@@ -152,20 +152,6 @@ $itemSlotGridHeight: 51px
         top: 10px
         left: 10px
 
-      &[data-slot="misc-1"]
-        display: none // hiding for now
-        left: 10px + ($itemSlotGridWidth * 0)
-        top: 15px + ($itemSlotGridHeight * 3)
-        .placeholder
-          background-position: (-0 * $itemSlotInnerWidth) 0px
-  
-      &[data-slot="misc-0"]
-        display: none // hiding for now
-        left: 10px + ($itemSlotGridWidth * 0)
-        top: 15px + ($itemSlotGridHeight * 2)
-        .placeholder
-          background-position: (-4 * $itemSlotInnerWidth) 0px
-
       &[data-slot="minion"]
         left: 10px + ($itemSlotGridWidth * 5)
         top: 15px + ($itemSlotGridHeight * 1)

--- a/app/templates/play/menu/inventory-modal.pug
+++ b/app/templates/play/menu/inventory-modal.pug
@@ -18,7 +18,7 @@
         img(src="/file/"+featureImages.hair, draggable="false")#hero-image-hair
         img(src="/file/"+featureImages.thumb, draggable="false")#hero-image-thumb
 
-      for slot in ['head', 'eyes', 'neck', 'torso', 'gloves', 'wrists', 'left-hand', 'right-hand', 'waist', 'feet', 'left-ring', 'right-ring', 'minion', 'flag', 'pet', 'programming-book', 'misc-0', 'misc-1']
+      for slot in ['head', 'eyes', 'neck', 'torso', 'gloves', 'wrists', 'left-hand', 'right-hand', 'waist', 'feet', 'left-ring', 'right-ring', 'minion', 'flag', 'pet', 'programming-book']
         .item-slot(data-slot=slot)
           .placeholder
           if equipment[slot]

--- a/app/templates/play/menu/inventory-modal.pug
+++ b/app/templates/play/menu/inventory-modal.pug
@@ -18,7 +18,7 @@
         img(src="/file/"+featureImages.hair, draggable="false")#hero-image-hair
         img(src="/file/"+featureImages.thumb, draggable="false")#hero-image-thumb
 
-      for slot in ['head', 'eyes', 'neck', 'torso', 'gloves', 'wrists', 'left-hand', 'right-hand', 'waist', 'feet', 'left-ring', 'right-ring', 'minion', 'flag', 'pet', 'programming-book']
+      for slot in slots
         .item-slot(data-slot=slot)
           .placeholder
           if equipment[slot]

--- a/app/views/play/menu/InventoryModal.js
+++ b/app/views/play/menu/InventoryModal.js
@@ -30,6 +30,7 @@ const SubscribeModal = require('views/core/SubscribeModal')
 require('vendor/scripts/jquery-ui-1.11.1.custom')
 require('vendor/styles/jquery-ui-1.11.1.custom.css')
 const utils = require('core/utils')
+const schemas = require('app/schemas/schemas')
 
 let hasGoneFullScreenOnce = false
 const debugInventory = false
@@ -40,7 +41,7 @@ module.exports = (InventoryModal = (function () {
       this.prototype.id = 'inventory-modal'
       this.prototype.className = 'modal fade play-modal'
       this.prototype.template = template
-      this.prototype.slots = ['head', 'eyes', 'neck', 'torso', 'wrists', 'gloves', 'left-ring', 'right-ring', 'right-hand', 'left-hand', 'waist', 'feet', 'programming-book', 'pet', 'minion', 'flag'] //, 'misc-0', 'misc-1']  # TODO: bring in misc slot(s) again when we have space
+      this.prototype.slots = schemas.heroInventorySlots
       this.prototype.ringSlots = ['left-ring', 'right-ring']
       this.prototype.closesOnClickOutside = false // because draggable somehow triggers hide when you don't drag onto a draggable
       this.prototype.trapsFocus = false

--- a/app/views/play/modal/PlayItemsModal.js
+++ b/app/views/play/modal/PlayItemsModal.js
@@ -52,8 +52,6 @@ const slotToCategory = {
   pet: 'misc',
   minion: 'misc',
   flag: 'misc',
-  'misc-0': 'misc',
-  'misc-1': 'misc',
 
   'programming-book': 'books'
 }


### PR DESCRIPTION
Part 1 of 2 — pairs with codecombat-server PR "GD-871: Strip unknown heroConfig.inventory slot keys on save". Merge this one first (the server build pins the client branch and imports the new constant).

## Why

The `misc-0`/`misc-1` slots have been hidden for ~10 years, but the template still rendered their divs, the hidden divs were read back on save, and the schema accepted any slot name. A player could `PUT heroConfig.inventory["misc-0"] = <itemId>` (or any invented key) via API/console and gain a full extra equipment slot in game.

## What

- New `heroInventorySlots` constant in `app/schemas/schemas.js` — the canonical frozen list of the 16 valid slots. The server imports it to strip unknown keys on save, and `InventoryModal` now uses it for its slot list, so the client UI and server whitelist can't drift apart.
- `HeroConfigSchema.inventory` documents the slots as explicit `properties`. `additionalProperties` deliberately stays permissive: the server validates whole documents on every save, so rejecting unknown keys would 422 legacy users containing `misc-*` on *any* profile save. Cleanup happens server-side on save instead (see server PR).
- Removed the `misc-0`/`misc-1` divs from `inventory-modal.pug`, the hidden-slot blocks from `inventory-modal.sass`, the slot→category mappings from `PlayItemsModal.js`, and the dead TODO in `InventoryModal.js`.

## Player impact

None breaking. Inventory is a slot→itemId map — a missing key is an empty slot. Item ownership lives in `earned`/`purchased`, so nothing is lost; an item stuck in a misc slot returns to the unequipped pool. The Equips game code in the DB already ignores misc slots, so exploiters lose the advantage silently.

## Testing

- `heroInventorySlots` loads frozen with 16 slots; schema module loads clean
- tv4 whole-doc validation: legacy docs containing `misc-0` still validate (no 422 regression), clean docs validate, sessions likewise
- `inventory-modal.pug` compiles; `inventory-modal.sass` compiles — 37 `data-slot` selectors, 0 `misc`
- eslint clean on changed lines
- No `misc-0`/`misc-1` references remain in app code (the unrelated `misc-level-completion` achievement option and the pet/minion/flag "misc" store category are intentionally untouched)

Closes [GD-871](https://linear.app/codecombat/issue/GD-871/remove-unused-misc-inventory-slots-and-whitelist-heroconfiginventory)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated hero inventory slot handling to use a shared, fixed list of supported equipment slots across configuration, validation, and UI rendering.
  * Removed the two `misc` slots (`misc-0` and `misc-1`) from the inventory modal display and item-to-category mapping.
  * Inventory data with legacy or unexpected slots remains compatible with validation to avoid breaking existing saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->