### PR TITLE
cyber security modal

### DIFF
--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -5771,6 +5771,8 @@ module.exports = {
       ai_made_ss: 'AI Made Simple & Safe -- Start Today!',
       aiss_body: 'Built as the simplest path to AI literacy, this tool empowers learners to harness top LLMs with hands-on AI training, making creation easy—whether it’s games, art, writing, code, or more. Together, we help learners safely bring their ideas to life across any subject.',
       learn_more: 'Learn More!',
+      cyber_security_modal_header: 'Cybersecurity Curriculum for AP and CompTIA Security+',
+      cyber_security_modal_body: 'Our Cybersecurity curriculum has now officially launched. Give students a classroom-ready way to prepare for AP Cybersecurity and CompTIA Security+ through digital simulations, technical writing, and real-world security scenarios, with no specialized hardware required.',
     },
     user_credits: {
       level_chat_left_in_duration: '__credits__ AI Bot queries left for the __duration_key__',

--- a/app/views/ai/CyberSecurityComponent.vue
+++ b/app/views/ai/CyberSecurityComponent.vue
@@ -12,7 +12,10 @@
           srcset="/images/pages/hackstack/cyber/hero-simulation.webp"
           type="image/webp"
         >
-        <img src="/images/pages/hackstack/cyber/hero-simulation.webp">
+        <img
+          src="/images/pages/hackstack/cyber/hero-simulation.webp"
+          alt="IT Help Desk Simulation"
+        >
       </picture>
     </div>
     <p class="text-p">
@@ -76,11 +79,13 @@ export default {
 
   .img {
     margin-bottom: 10px;
-    width: 600px;
+    width: 100%;
+    max-width: 600px;
     position: relative;
 
     img {
-      width: 600px;
+      width: 100%;
+      height: auto;
     }
   }
 

--- a/app/views/ai/CyberSecurityComponent.vue
+++ b/app/views/ai/CyberSecurityComponent.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="hs-modal-content-container">
+    <h2
+      id="hs-modal-title"
+      class="text-h2"
+    >
+      {{ $t('ai.cyber_security_modal_header') }}
+    </h2>
+    <div class="img">
+      <picture>
+        <source
+          srcset="/images/pages/hackstack/cyber/hero-simulation.webp"
+          type="image/webp"
+        >
+        <img src="/images/pages/hackstack/cyber/hero-simulation.webp">
+      </picture>
+    </div>
+    <p class="text-p">
+      {{ $t('ai.cyber_security_modal_body') }}
+    </p>
+
+    <CTAButton
+      href="/hackstack-cyber"
+      @clickedCTA="onLearnMore"
+    >
+      {{ $t('ai.learn_more') }}
+    </CTAButton>
+  </div>
+</template>
+
+<script>
+import CTAButton from 'app/components/common/buttons/CTAButton.vue'
+import trackable from 'app/components/mixins/trackable.js'
+export default {
+  name: 'HackstackModalComponent',
+  components: {
+    CTAButton,
+  },
+  mixins: [trackable],
+  data () {
+    return {
+    }
+  },
+  methods: {
+    onLearnMore () {
+      this.$emit('close')
+      this.trackEvent('Cyber Security Promo Modal: Learn more clicked', { category: 'Hackstack' })
+    },
+  },
+}
+</script>
+
+<style scoped lang="scss">
+@import 'app/styles/core/variables.scss';
+@import 'app/styles/common/_button.scss';
+@import 'app/styles/component_variables.scss';
+
+.hs-modal-content-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 10px 30px;
+  text-align: center;
+  position: relative;
+
+  .text-h2#hs-modal-title {
+    font-family: $main-font-family;
+    font-weight: bold;
+    margin: 10px auto;
+  }
+
+  >* {
+    max-width: 800px;
+  }
+
+  .img {
+    margin-bottom: 10px;
+    width: 600px;
+    position: relative;
+
+    img {
+      width: 600px;
+    }
+  }
+
+  .text-p {
+    font-size: 0.9em;
+  }
+}
+</style>

--- a/app/views/ai/CybersecurityAutoPromotion.vue
+++ b/app/views/ai/CybersecurityAutoPromotion.vue
@@ -1,0 +1,43 @@
+<script>
+import ModalDynamicPromotion from 'ozaria/site/components/teacher-dashboard/modals/ModalDynamicContent'
+import CyberSecurityComponent from './CyberSecurityComponent'
+export default {
+  components: {
+    ModalDynamicPromotion,
+    CyberSecurityComponent,
+  },
+  computed: {
+    showPromotion () {
+      return true
+    },
+  },
+  methods: {
+    onClose () {
+      this.$refs.modal.onClose()
+    },
+  },
+}
+</script>
+
+<template>
+  <div class="promotion-modal">
+    <ModalDynamicPromotion
+      v-if="showPromotion"
+      ref="modal"
+      modal-type="newModal"
+      seen-promotions-property="cyber-security-promotion-modal"
+    >
+      <template #content>
+        <CyberSecurityComponent
+          @close="onClose"
+        />
+      </template>
+    </ModalDynamicPromotion>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import 'app/styles/core/variables.scss';
+@import 'app/styles/common/_button.scss';
+@import 'app/styles/component_variables.scss';
+</style>

--- a/app/views/ai/CybersecurityAutoPromotion.vue
+++ b/app/views/ai/CybersecurityAutoPromotion.vue
@@ -1,6 +1,9 @@
 <script>
 import ModalDynamicPromotion from 'ozaria/site/components/teacher-dashboard/modals/ModalDynamicContent'
 import CyberSecurityComponent from './CyberSecurityComponent'
+import utils from 'app/core/utils'
+
+const dayjs = window.dayjs
 export default {
   components: {
     ModalDynamicPromotion,
@@ -8,7 +11,8 @@ export default {
   },
   computed: {
     showPromotion () {
-      return true
+      const aweekago = dayjs().subtract(1, 'week')
+      return utils.isCodeCombat && aweekago.isAfter(me.get('dateCreated'))
     },
   },
   methods: {

--- a/app/views/home/PageHome.vue
+++ b/app/views/home/PageHome.vue
@@ -217,10 +217,10 @@
         </div>
       </div>
     </div>
+    <CybersecurityAutoPromotion v-if="!isMobile" />
     <ModalJunior />
     <ModalHackStack />
     <HackstackAutoPromotion v-if="!isMobile" />
-    <CybersecurityAutoPromotion v-if="!isMobile" />
   </div>
 </template>
 

--- a/app/views/home/PageHome.vue
+++ b/app/views/home/PageHome.vue
@@ -220,6 +220,7 @@
     <ModalJunior />
     <ModalHackStack />
     <HackstackAutoPromotion v-if="!isMobile" />
+    <CybersecurityAutoPromotion v-if="!isMobile" />
   </div>
 </template>
 
@@ -243,6 +244,7 @@ import HeaderComponent from '../../components/common/elements/HeaderComponent.vu
 import ModalJunior from './ModalJunior'
 import ModalHackStack from './ModalHackStack'
 import HackstackAutoPromotion from '../ai/HackstackAutoPromotion'
+import CybersecurityAutoPromotion from '../ai/CybersecurityAutoPromotion'
 import BannerComponent from '../../components/common/elements/BannerComponent.vue'
 import { getJuniorUrl } from 'core/utils'
 
@@ -271,6 +273,7 @@ export default Vue.extend({
     ModalJunior,
     ModalHackStack,
     HackstackAutoPromotion,
+    CybersecurityAutoPromotion,
     BannerComponent,
   },
   data () {


### PR DESCRIPTION
fix ENG-2658

<img width="1307" height="957" alt="image" src="https://github.com/user-attachments/assets/bc3c16d8-ceb1-49d3-b06b-8a6a94a75752" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Cybersecurity curriculum promotion modal to the home page on desktop devices.
  * Included localized modal content describing an AP Cybersecurity and CompTIA Security+ classroom-ready curriculum.
  * Added a “Learn More” call to action that closes the modal and records interaction tracking.
* **Bug Fixes**
  * Promotion now appears only under the intended conditions (including a time-based eligibility window).
* **UI Improvements**
  * Improved modal hero image presentation for better responsive sizing and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->