### PR TITLE
[GD-875] Junior pet-access experiment: free / signup / premium / module tiers (home users only)

### DIFF
--- a/app/lib/LevelLoader.coffee
+++ b/app/lib/LevelLoader.coffee
@@ -361,6 +361,8 @@ module.exports = class LevelLoader extends CocoClass
     if utils.isJuniorLevel(@level) and not utils.showOzaria()
       juniorThangType = session.get('heroConfig')?.juniorThangType
       juniorThangType ?= me.get('heroConfig')?.juniorThangType if session is @session and not @headless
+      # junior-pet-access: unowned pet falls back to the swap map below
+      juniorThangType = null if juniorThangType and not me.mayUseJuniorPet(juniorThangType)
     if juniorThangType
       # Junior levels honor the explicitly chosen pet; the swap map below is the fallback for configs without one
       heroThangType = juniorThangType

--- a/app/lib/ThangTypeConstants.coffee
+++ b/app/lib/ThangTypeConstants.coffee
@@ -84,6 +84,40 @@ ThangTypeConstants =
     { slug: 'dragonling-hero', access: 'premium' }
     { slug: 'kindling-elemental-hero', access: 'premium' }
   ]
+  # junior-pet-access experiment (GD-875), beta arm only. Control keeps using
+  # juniorHeroesConfig above. Same shape as that roster, plus per-pet:
+  #   access: free (anyone) | signup (selectable, Save routes to signup while
+  #           anonymous) | premium (subscribers) | module (unlocks when
+  #           unlockLevel is completed)
+  #   unlockLevel: level.original whose completion unlocks the pet (module
+  #                tier only). These are the odyssey modules' levelToUnlock
+  #                gates - each lives in the PREVIOUS module and unlocks the
+  #                next one. Completion read from level sessions.
+  #   hint: player-facing locked-pet copy shown in the modal
+  #   position: modal grid placement, row/column
+  # Assignment is provisional - PM adjusts by editing this array.
+  # Layout: row 0 = free pets then the 11 module-unlockable pets;
+  #         row 1 = signup pets then premium pets.
+  juniorPetAccessConfig: [
+    { slug: 'wolf-pup-hero', access: 'free', position: { row: 0, column: 0 } }
+    { slug: 'cougar-hero', access: 'free', position: { row: 0, column: 1 } }
+    { slug: 'turtle-hero', access: 'module', unlockLevel: '66072b276bfa8984388f2e65', hint: 'Complete Sun Shores to unlock', position: { row: 0, column: 2 } } # gate level in Sun Shores; completing it unlocks Amber Keys
+    { slug: 'brown-rat-hero', access: 'module', unlockLevel: '65ce52333ca6ed67e1be5447', hint: 'Complete Amber Keys to unlock', position: { row: 0, column: 3 } } # gate level in Amber Keys; completing it unlocks Crimson Sands
+    { slug: 'raven-hero', access: 'module', unlockLevel: '65ce63c53ca6ed67e1be6f75', hint: 'Complete Crimson Sands to unlock', position: { row: 0, column: 4 } } # gate level in Crimson Sands; completing it unlocks Blaze Coast
+    { slug: 'dragonling-hero', access: 'module', unlockLevel: '66072bfc6bfa8984388f3377', hint: 'Complete Blaze Coast to unlock', position: { row: 0, column: 5 } } # gate level in Blaze Coast; completing it unlocks Wild Growth
+    { slug: 'panther-cub-hero', access: 'module', unlockLevel: '66072c2b6bfa8984388f35ec', hint: 'Complete Wild Growth to unlock', position: { row: 0, column: 6 } } # gate level in Wild Growth; completing it unlocks Redrock Reach
+    { slug: 'kindling-elemental-hero', access: 'module', unlockLevel: '660f19ffddeab4a188453963', hint: 'Complete Redrock Reach to unlock', position: { row: 0, column: 7 } } # gate level in Redrock Reach; completing it unlocks Coldrock Pass
+    { slug: 'yetibab-hero', access: 'module', unlockLevel: '67180617c15a4d2ab0a38aef', hint: 'Complete Coldrock Pass to unlock', position: { row: 0, column: 8 } } # gate level in Coldrock Pass; completing it unlocks Cool Waters
+    { slug: 'mimic-hero', access: 'module', unlockLevel: '671a6929e431af0c7e6f1c9d', hint: 'Complete Cool Waters to unlock', position: { row: 0, column: 9 } } # gate level in Cool Waters; completing it unlocks Snow Isles
+    { slug: 'polar-bear-cub-hero', access: 'module', unlockLevel: '671a698ee431af0c7e6f210f', hint: 'Complete Snow Isles to unlock', position: { row: 0, column: 10 } } # gate level in Snow Isles; completing it unlocks Tundra Break
+    { slug: 'blue-fox-hero', access: 'module', unlockLevel: '67215459e389d6253f508cdc', hint: 'Complete Tundra Break to unlock', position: { row: 0, column: 11 } } # gate level in Tundra Break; completing it unlocks Greenrise Atoll
+    { slug: 'tiger-cub-hero', access: 'module', unlockLevel: '6723fed6e389d6253f518552', hint: 'Complete Greenrise Atoll to unlock', position: { row: 0, column: 12 } } # gate level in Greenrise Atoll; completing it unlocks Emerald Crown
+    { slug: 'duck-hero', access: 'signup', position: { row: 1, column: 0 } }
+    { slug: 'frog-hero', access: 'signup', position: { row: 1, column: 1 } }
+    { slug: 'pugicorn-hero', access: 'premium', position: { row: 1, column: 2 } }
+    { slug: 'phoenix-hero', access: 'premium', position: { row: 1, column: 3 } }
+    { slug: 'baby-griffin-hero', access: 'premium', position: { row: 1, column: 4 } }
+  ]
   juniorHeroReplacements:
     captain: 'wolf-pup-hero'
     knight: 'cougar-hero'

--- a/app/lib/ThangTypeConstants.coffee
+++ b/app/lib/ThangTypeConstants.coffee
@@ -96,27 +96,27 @@ ThangTypeConstants =
   #   hint: player-facing locked-pet copy shown in the modal
   #   position: modal grid placement, row/column
   # Assignment is provisional - PM adjusts by editing this array.
-  # Layout: row 0 = free pets then the 11 module-unlockable pets;
-  #         row 1 = signup pets then premium pets.
+  # Layout: row 0 = free pets, then signup pets, then premium pets;
+  #         row 1 = the 11 module-unlockable pets in island order.
   juniorPetAccessConfig: [
     { slug: 'wolf-pup-hero', access: 'free', position: { row: 0, column: 0 } }
     { slug: 'cougar-hero', access: 'free', position: { row: 0, column: 1 } }
-    { slug: 'turtle-hero', access: 'module', unlockLevel: '66072b276bfa8984388f2e65', hint: 'Complete Sun Shores to unlock', position: { row: 0, column: 2 } } # gate level in Sun Shores; completing it unlocks Amber Keys
-    { slug: 'brown-rat-hero', access: 'module', unlockLevel: '65ce52333ca6ed67e1be5447', hint: 'Complete Amber Keys to unlock', position: { row: 0, column: 3 } } # gate level in Amber Keys; completing it unlocks Crimson Sands
-    { slug: 'raven-hero', access: 'module', unlockLevel: '65ce63c53ca6ed67e1be6f75', hint: 'Complete Crimson Sands to unlock', position: { row: 0, column: 4 } } # gate level in Crimson Sands; completing it unlocks Blaze Coast
-    { slug: 'dragonling-hero', access: 'module', unlockLevel: '66072bfc6bfa8984388f3377', hint: 'Complete Blaze Coast to unlock', position: { row: 0, column: 5 } } # gate level in Blaze Coast; completing it unlocks Wild Growth
-    { slug: 'panther-cub-hero', access: 'module', unlockLevel: '66072c2b6bfa8984388f35ec', hint: 'Complete Wild Growth to unlock', position: { row: 0, column: 6 } } # gate level in Wild Growth; completing it unlocks Redrock Reach
-    { slug: 'kindling-elemental-hero', access: 'module', unlockLevel: '660f19ffddeab4a188453963', hint: 'Complete Redrock Reach to unlock', position: { row: 0, column: 7 } } # gate level in Redrock Reach; completing it unlocks Coldrock Pass
-    { slug: 'yetibab-hero', access: 'module', unlockLevel: '67180617c15a4d2ab0a38aef', hint: 'Complete Coldrock Pass to unlock', position: { row: 0, column: 8 } } # gate level in Coldrock Pass; completing it unlocks Cool Waters
-    { slug: 'mimic-hero', access: 'module', unlockLevel: '671a6929e431af0c7e6f1c9d', hint: 'Complete Cool Waters to unlock', position: { row: 0, column: 9 } } # gate level in Cool Waters; completing it unlocks Snow Isles
-    { slug: 'polar-bear-cub-hero', access: 'module', unlockLevel: '671a698ee431af0c7e6f210f', hint: 'Complete Snow Isles to unlock', position: { row: 0, column: 10 } } # gate level in Snow Isles; completing it unlocks Tundra Break
-    { slug: 'blue-fox-hero', access: 'module', unlockLevel: '67215459e389d6253f508cdc', hint: 'Complete Tundra Break to unlock', position: { row: 0, column: 11 } } # gate level in Tundra Break; completing it unlocks Greenrise Atoll
-    { slug: 'tiger-cub-hero', access: 'module', unlockLevel: '6723fed6e389d6253f518552', hint: 'Complete Greenrise Atoll to unlock', position: { row: 0, column: 12 } } # gate level in Greenrise Atoll; completing it unlocks Emerald Crown
-    { slug: 'duck-hero', access: 'signup', position: { row: 1, column: 0 } }
-    { slug: 'frog-hero', access: 'signup', position: { row: 1, column: 1 } }
-    { slug: 'pugicorn-hero', access: 'premium', position: { row: 1, column: 2 } }
-    { slug: 'phoenix-hero', access: 'premium', position: { row: 1, column: 3 } }
-    { slug: 'baby-griffin-hero', access: 'premium', position: { row: 1, column: 4 } }
+    { slug: 'duck-hero', access: 'signup', position: { row: 0, column: 2 } }
+    { slug: 'frog-hero', access: 'signup', position: { row: 0, column: 3 } }
+    { slug: 'pugicorn-hero', access: 'premium', position: { row: 0, column: 4 } }
+    { slug: 'phoenix-hero', access: 'premium', position: { row: 0, column: 5 } }
+    { slug: 'baby-griffin-hero', access: 'premium', position: { row: 0, column: 6 } }
+    { slug: 'turtle-hero', access: 'module', unlockLevel: '66072b276bfa8984388f2e65', hint: 'Complete Sun Shores to unlock', position: { row: 1, column: 0 } } # gate level in Sun Shores; completing it unlocks Amber Keys
+    { slug: 'brown-rat-hero', access: 'module', unlockLevel: '65ce52333ca6ed67e1be5447', hint: 'Complete Amber Keys to unlock', position: { row: 1, column: 1 } } # gate level in Amber Keys; completing it unlocks Crimson Sands
+    { slug: 'raven-hero', access: 'module', unlockLevel: '65ce63c53ca6ed67e1be6f75', hint: 'Complete Crimson Sands to unlock', position: { row: 1, column: 2 } } # gate level in Crimson Sands; completing it unlocks Blaze Coast
+    { slug: 'dragonling-hero', access: 'module', unlockLevel: '66072bfc6bfa8984388f3377', hint: 'Complete Blaze Coast to unlock', position: { row: 1, column: 3 } } # gate level in Blaze Coast; completing it unlocks Wild Growth
+    { slug: 'panther-cub-hero', access: 'module', unlockLevel: '66072c2b6bfa8984388f35ec', hint: 'Complete Wild Growth to unlock', position: { row: 1, column: 4 } } # gate level in Wild Growth; completing it unlocks Redrock Reach
+    { slug: 'kindling-elemental-hero', access: 'module', unlockLevel: '660f19ffddeab4a188453963', hint: 'Complete Redrock Reach to unlock', position: { row: 1, column: 5 } } # gate level in Redrock Reach; completing it unlocks Coldrock Pass
+    { slug: 'yetibab-hero', access: 'module', unlockLevel: '67180617c15a4d2ab0a38aef', hint: 'Complete Coldrock Pass to unlock', position: { row: 1, column: 6 } } # gate level in Coldrock Pass; completing it unlocks Cool Waters
+    { slug: 'mimic-hero', access: 'module', unlockLevel: '671a6929e431af0c7e6f1c9d', hint: 'Complete Cool Waters to unlock', position: { row: 1, column: 7 } } # gate level in Cool Waters; completing it unlocks Snow Isles
+    { slug: 'polar-bear-cub-hero', access: 'module', unlockLevel: '671a698ee431af0c7e6f210f', hint: 'Complete Snow Isles to unlock', position: { row: 1, column: 8 } } # gate level in Snow Isles; completing it unlocks Tundra Break
+    { slug: 'blue-fox-hero', access: 'module', unlockLevel: '67215459e389d6253f508cdc', hint: 'Complete Tundra Break to unlock', position: { row: 1, column: 9 } } # gate level in Tundra Break; completing it unlocks Greenrise Atoll
+    { slug: 'tiger-cub-hero', access: 'module', unlockLevel: '6723fed6e389d6253f518552', hint: 'Complete Greenrise Atoll to unlock', position: { row: 1, column: 10 } } # gate level in Greenrise Atoll; completing it unlocks Emerald Crown
   ]
   juniorHeroReplacements:
     captain: 'wolf-pup-hero'

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -1558,6 +1558,8 @@ module.exports = {
     choose_hero: {
       choose_hero: 'Choose Your Hero',
       choose_junior_hero: 'Choose Your Young Hero',
+      sign_up_to_unlock: 'Sign Up to Unlock!',
+      sign_up_pet_blurb: 'Create a free account to play as this pet!',
       programming_language: 'Programming Language',
       programming_language_description: 'Which programming language do you want to use?',
       default: 'Default',

--- a/app/models/Level.js
+++ b/app/models/Level.js
@@ -152,7 +152,8 @@ module.exports = (Level = (function () {
             }
             levelThang.components = [] // We have stored the placeholder values, so we can inherit everything else.
             const sessionHeroConfig = __guard__(session != null ? session.get('heroConfig') : undefined, x => x) || {}
-            const juniorThangType = utils.isJuniorLevel(this) ? sessionHeroConfig.juniorThangType : undefined
+            let juniorThangType = utils.isJuniorLevel(this) ? sessionHeroConfig.juniorThangType : undefined
+            if (juniorThangType && !me.mayUseJuniorPet(juniorThangType)) { juniorThangType = undefined } // junior-pet-access: unowned pet falls back to the swap map
             heroThangType = sessionHeroConfig.thangType
             if (juniorThangType) {
               // Junior levels honor the explicitly chosen pet; the swap map below is the fallback for configs without one
@@ -317,7 +318,8 @@ module.exports = (Level = (function () {
           if (!heroThangType) {
             heroThangType = ThangTypeConstants.heroes.knight
           }
-          const juniorThangType = utils.isJuniorLevel(this) ? (session.get('heroConfig')?.juniorThangType || me.get('heroConfig')?.juniorThangType) : undefined
+          let juniorThangType = utils.isJuniorLevel(this) ? (session.get('heroConfig')?.juniorThangType || me.get('heroConfig')?.juniorThangType) : undefined
+          if (juniorThangType && !me.mayUseJuniorPet(juniorThangType)) { juniorThangType = undefined } // junior-pet-access: unowned pet falls back to the swap map
           if (juniorThangType) {
             // Junior levels honor the explicitly chosen pet; the swap map below is the fallback for configs without one
             levelThang.thangType = juniorThangType

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -468,7 +468,12 @@ module.exports = (User = (function () {
       // Union rather than fallback-only-if-absent: a user with legacy junior purchases
       // in purchased.heroes must not lose them once the first juniorHeroes write lands.
       const juniorHeroIds = ThangTypeConstants.juniorHeroesConfig.map(h => ThangTypeConstants.heroes[h.slug])
-      const freeJuniorHeroes = ThangTypeConstants.juniorHeroesConfig
+      // junior-pet-access beta shrinks the free set to the experiment's free tier;
+      // earned/purchased/legacy ownership below is arm-independent
+      const freeConfig = this.getJuniorPetAccessExperimentValue() === 'beta'
+        ? ThangTypeConstants.juniorPetAccessConfig
+        : ThangTypeConstants.juniorHeroesConfig
+      const freeJuniorHeroes = freeConfig
         .filter(h => h.access === 'free')
         .map(h => ThangTypeConstants.heroes[h.slug])
       const legacyPurchased = (this.get('purchased')?.heroes || []).filter(id => juniorHeroIds.includes(id))

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -29,7 +29,7 @@ const NAPERVILLE_UNIQUE_KEY = 'naperville'
 const GALAXY_TUTORIAL_EXPERIMENT = 'galaxy-tutorial'
 const JUNIOR_PET_ACCESS_EXPERIMENT = 'junior-pet-access'
 // Users created before this date are grandfathered out of junior-pet-access; set to the rollout date before enabling
-const JUNIOR_PET_ACCESS_CUTOFF_DATE = '2026-08-01'
+const JUNIOR_PET_ACCESS_CUTOFF_DATE = '2026-07-29'
 
 // Pure functions for use in Vue
 // First argument is always a raw User.attributes

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -489,6 +489,22 @@ module.exports = (User = (function () {
       return this.isInGodMode() || this.juniorHeroes().includes(heroOriginal)
     }
 
+    mayUseJuniorPet (heroOriginal) {
+      // Render-time gate for heroConfig.juniorThangType. The field is client-writable,
+      // so the junior level-load read path checks it against the experiment tier rules;
+      // a pet that fails here renders the swap-map fallback instead, as if unset.
+      if (this.getJuniorPetAccessExperimentValue() !== 'beta') { return true } // control renders anything saved, as today
+      if (this.ownsJuniorHero(heroOriginal)) { return true }
+      const slug = _.invert(ThangTypeConstants.heroes)[heroOriginal]
+      const petAccess = _.find(ThangTypeConstants.juniorPetAccessConfig, { slug })
+      if (!petAccess) { return true } // not an experiment-managed pet; existing paths handle it
+      switch (petAccess.access) {
+        case 'signup': return !this.isAnonymous()
+        case 'premium': return this.isPremium()
+        default: return false // module pets render only once persisted into purchased.juniorHeroes
+      }
+    }
+
     items () {
       let left, left1
       return ((left = this.get('earned')?.items) != null ? left : []).concat((left1 = this.get('purchased')?.items) != null ? left1 : []).concat([ThangTypeConstants.items['simple-boots']])

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -495,8 +495,7 @@ module.exports = (User = (function () {
       // a pet that fails here renders the swap-map fallback instead, as if unset.
       if (this.getJuniorPetAccessExperimentValue() !== 'beta') { return true } // control renders anything saved, as today
       if (this.ownsJuniorHero(heroOriginal)) { return true }
-      const slug = _.invert(ThangTypeConstants.heroes)[heroOriginal]
-      const petAccess = _.find(ThangTypeConstants.juniorPetAccessConfig, { slug })
+      const petAccess = _.find(ThangTypeConstants.juniorPetAccessConfig, pet => ThangTypeConstants.heroes[pet.slug] === heroOriginal)
       if (!petAccess) { return true } // not an experiment-managed pet; existing paths handle it
       switch (petAccess.access) {
         case 'signup': return !this.isAnonymous()

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -26,11 +26,10 @@ const userUtils = require('lib/user-utils')
 const _ = require('lodash')
 const moment = window.moment
 const NAPERVILLE_UNIQUE_KEY = 'naperville'
-const REQUIRE_SIGN_UP_EXPERIMENT = {
-  dungeon: 'requires-sign-up-dungeon',
-  junior: 'requires-sign-up-junior',
-}
 const GALAXY_TUTORIAL_EXPERIMENT = 'galaxy-tutorial'
+const JUNIOR_PET_ACCESS_EXPERIMENT = 'junior-pet-access'
+// Users created before this date are grandfathered out of junior-pet-access; set to the rollout date before enabling
+const JUNIOR_PET_ACCESS_CUTOFF_DATE = '2026-08-01'
 
 // Pure functions for use in Vue
 // First argument is always a raw User.attributes
@@ -1554,27 +1553,44 @@ module.exports = (User = (function () {
 
     //   return this.tryStartExperiment('template')
     // }
-    getRequireSignupExperimentValue (CAMPAIGN) {
-      if (!me.isAnonymous()) {
+    getJuniorPetAccessExperimentValue () {
+      // Pre-conditions, re-evaluated on every read, before the query override or
+      // user.experiments: classrooms and China infra never get experiment behavior,
+      // even with a stored assignment. Registered home users keep their assigned
+      // value - signing up is part of the experiment, not an exit from it.
+      if (this.isStudent() || this.isTeacher()) {
         return 'control'
       }
-      const value = utils.getFirstNonNull(
-        utils.getExperimentValueFromQuery(REQUIRE_SIGN_UP_EXPERIMENT[CAMPAIGN]),
-        me.getExperimentValue(REQUIRE_SIGN_UP_EXPERIMENT[CAMPAIGN], null),
-      )
-
-      return value ?? null
+      if (features?.chinaInfra) {
+        return 'control'
+      }
+      return utils.getFirstNonNull(
+        utils.getExperimentValueFromQuery(JUNIOR_PET_ACCESS_EXPERIMENT),
+        this.getExperimentValue(JUNIOR_PET_ACCESS_EXPERIMENT, null),
+      ) ?? null
     }
 
-    getOrStartRequireSignupExperimentValue (CAMPAIGN) {
-      if (!(Object.keys(REQUIRE_SIGN_UP_EXPERIMENT).includes(CAMPAIGN))) {
-        return 'control'
-      }
-      const value = this.getRequireSignupExperimentValue(CAMPAIGN)
+    getOrStartJuniorPetAccessExperimentValue () {
+      const value = this.getJuniorPetAccessExperimentValue()
       if (value != null) {
         return value
       }
-      return this.tryStartExperiment(REQUIRE_SIGN_UP_EXPERIMENT[CAMPAIGN])
+      // Assignment Post-conditions: no pre-condition blocked and no value stored
+      // yet - decide whether to really start. Only anonymous home users in
+      // contexts that can actually see the locked-pet upsell enter; everyone
+      // else stays control. Already-assigned users returned above, so a user
+      // assigned while anonymous keeps their cohort after signing up.
+      if (!this.isAnonymous()) {
+        return 'control'
+      }
+      if (this.freeOnly() || this.isInHourOfCode()) {
+        // Locked pets are hidden entirely for these users, so they could never see the upsell
+        return 'control'
+      }
+      if (new Date(this.get('dateCreated')) < new Date(JUNIOR_PET_ACCESS_CUTOFF_DATE)) {
+        return 'control'
+      }
+      return this.tryStartExperiment(JUNIOR_PET_ACCESS_EXPERIMENT)
     }
 
     getGalaxyTutorialExperimentValue () {

--- a/app/styles/play/modal/junior-heroes-modal.sass
+++ b/app/styles/play/modal/junior-heroes-modal.sass
@@ -151,6 +151,10 @@ $heroCanvasHeight: 275px
             body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
               float: left
 
+          // junior-pet-access beta grid: config rows wrap at each row's first column
+          &.pet-row-1.pet-column-0, &.pet-row-2.pet-column-0
+            clear: left
+
           &.active
             background-image: url(/images/pages/play/modal/hero-portrait-selected.png)
             z-index: 6

--- a/app/styles/play/modal/junior-heroes-modal.sass
+++ b/app/styles/play/modal/junior-heroes-modal.sass
@@ -151,6 +151,11 @@ $heroCanvasHeight: 275px
             body[lang="he"] &, body[lang="ar"] &, body[lang="fa"] &, body[lang="ur"] &
               float: left
 
+            // junior-pet-access beta uses config-positioned rows; the legacy
+            // 15th/16th-item float would tear pets out of their row
+            .pet-access-beta &
+              float: left
+
           // junior-pet-access beta grid: config rows wrap at each row's first column
           &.pet-row-1.pet-column-0, &.pet-row-2.pet-column-0
             clear: left

--- a/app/styles/play/modal/junior-heroes-modal.sass
+++ b/app/styles/play/modal/junior-heroes-modal.sass
@@ -152,8 +152,10 @@ $heroCanvasHeight: 275px
               float: left
 
             // junior-pet-access beta uses config-positioned rows; the legacy
-            // 15th/16th-item float would tear pets out of their row
-            .pet-access-beta &
+            // 15th/16th-item float would tear pets out of their row. Beta
+            // indicators always carry pet-row-* classes (ancestor-prefixed
+            // .pet-access-beta & would compile with the wrong element order).
+            &[class*="pet-row-"]
               float: left
 
           // junior-pet-access beta grid: config rows wrap at each row's first column

--- a/app/templates/play/modal/junior-heroes-modal.pug
+++ b/app/templates/play/modal/junior-heroes-modal.pug
@@ -18,7 +18,7 @@
       .carousel-indicator-container
         ol.carousel-indicators
           for hero, index in heroes
-            li(data-hero-id=hero.get('original'), title=hero.name, data-slide-to=index, data-target="#hero-carousel", class="hero-indicator hero-index-" + index + (hero.locked ? " locked" : "") + (hero.purchasable ? " purchasable" : "") + (hero.restricted ? " restricted" : "") + (hero.unlockBySubscribing ? " subscribe-unlock " : "") + (hero.premium ? " premium " : ""))
+            li(data-hero-id=hero.get('original'), title=hero.name, data-slide-to=index, data-target="#hero-carousel", class="hero-indicator hero-index-" + index + (hero.locked ? " locked" : "") + (hero.purchasable ? " purchasable" : "") + (hero.restricted ? " restricted" : "") + (hero.unlockBySubscribing ? " subscribe-unlock " : "") + (hero.premium ? " premium " : "") + (hero.petRow != null ? " pet-row-" + hero.petRow + " pet-column-" + hero.petColumn : ""))
               .hero-avatar
       .carousel-inner
         for hero in heroes
@@ -70,11 +70,15 @@
           #hero-footer-text-background
             .image-block
               img(src= "/images/pages/play/modal/language-selector-background.png")
-          #locked-hero-explanation
-            h2(data-i18n=visibleHero.unlockBySubscribing ? 'play.subscribe_unlock' : 'play.subscribers_only')
-            span.spr.subscribers(data-i18n=visibleHero.unlockBySubscribing ? 'play.subscriber_heroes' : 'play.subscriber_gems')
-          button.btn.subscribe-button#subscribe-hero-button(data-hero-slug=visibleHero.get('slug'))
-            span.spr(data-i18n="subscribe.subscribe_title") Subscribe
+          if visibleHero.moduleHint
+            #locked-hero-explanation.module-locked
+              h2= visibleHero.moduleHint
+          else
+            #locked-hero-explanation
+              h2(data-i18n=visibleHero.unlockBySubscribing ? 'play.subscribe_unlock' : 'play.subscribers_only')
+              span.spr.subscribers(data-i18n=visibleHero.unlockBySubscribing ? 'play.subscriber_heroes' : 'play.subscriber_gems')
+            button.btn.subscribe-button#subscribe-hero-button(data-hero-slug=visibleHero.get('slug'))
+              span.spr(data-i18n="subscribe.subscribe_title") Subscribe
 
         else if visibleHero.loaded
           #hero-footer-text-background

--- a/app/templates/play/modal/junior-heroes-modal.pug
+++ b/app/templates/play/modal/junior-heroes-modal.pug
@@ -1,4 +1,4 @@
-.modal-dialog.codecombat-junior
+.modal-dialog(class="codecombat-junior" + (inPetAccessBeta ? " pet-access-beta" : ""))
   .modal-content
 
     img(src="/images/pages/play/modal/choosehero-background.png", draggable="false")#play-heroes-background

--- a/app/templates/play/modal/junior-heroes-modal.pug
+++ b/app/templates/play/modal/junior-heroes-modal.pug
@@ -18,7 +18,7 @@
       .carousel-indicator-container
         ol.carousel-indicators
           for hero, index in heroes
-            li(data-hero-id=hero.get('original'), title=hero.name, data-slide-to=index, data-target="#hero-carousel", class="hero-indicator hero-index-" + index + (hero.locked ? " locked" : "") + (hero.purchasable ? " purchasable" : "") + (hero.restricted ? " restricted" : "") + (hero.unlockBySubscribing ? " subscribe-unlock " : "") + (hero.premium ? " premium " : "") + (hero.petRow != null ? " pet-row-" + hero.petRow + " pet-column-" + hero.petColumn : ""))
+            li(data-hero-id=hero.get('original'), title=hero.name, data-slide-to=index, data-target="#hero-carousel", class="hero-indicator hero-index-" + index + (hero.locked ? " locked" : "") + (hero.purchasable ? " purchasable" : "") + (hero.restricted ? " restricted" : "") + (hero.silverFrame ? " subscribe-unlock " : "") + (hero.premium ? " premium " : "") + (hero.petRow != null ? " pet-row-" + hero.petRow + " pet-column-" + hero.petColumn : ""))
               .hero-avatar
       .carousel-inner
         for hero in heroes
@@ -79,6 +79,15 @@
               span.spr.subscribers(data-i18n=visibleHero.unlockBySubscribing ? 'play.subscriber_heroes' : 'play.subscriber_gems')
             button.btn.subscribe-button#subscribe-hero-button(data-hero-slug=visibleHero.get('slug'))
               span.spr(data-i18n="subscribe.subscribe_title") Subscribe
+
+        else if visibleHero.requiresSignup
+          #hero-footer-text-background
+            .image-block
+              img(src= "/images/pages/play/modal/language-selector-background.png")
+          #locked-hero-explanation.signup-required
+            h2(data-i18n="choose_hero.sign_up_to_unlock")
+            span.spr(data-i18n="choose_hero.sign_up_pet_blurb")
+          a#confirm-button(data-i18n="signup.sign_up", role="button", tabindex="0")
 
         else if visibleHero.loaded
           #hero-footer-text-background

--- a/app/views/play/modal/JuniorHeroesModal.js
+++ b/app/views/play/modal/JuniorHeroesModal.js
@@ -33,6 +33,7 @@ const ChangeLanguageTab = require('views/play/common/ChangeLanguageTab')
 const rosterBySlug = _.indexBy(ThangTypeConstants.juniorHeroesConfig, 'slug')
 const rosterOrder = {}
 ThangTypeConstants.juniorHeroesConfig.forEach((hero, index) => { rosterOrder[hero.slug] = index })
+const petAccessBySlug = _.indexBy(ThangTypeConstants.juniorPetAccessConfig, 'slug')
 
 module.exports = (JuniorHeroesModal = (function () {
   JuniorHeroesModal = class JuniorHeroesModal extends ModalView {
@@ -68,10 +69,21 @@ module.exports = (JuniorHeroesModal = (function () {
       this.options = options
       this.animateHeroes = this.animateHeroes.bind(this)
       this.confirmButtonI18N = options.confirmButtonI18N != null ? options.confirmButtonI18N : 'common.save'
+      // Opening this modal is the single assignment trigger for the junior-pet-access experiment
+      this.inPetAccessBeta = me.getOrStartJuniorPetAccessExperimentValue() === 'beta'
+      // Completed unlock levels for module-tier pets; loaded from level sessions when in beta
+      this.completedUnlockLevels = new Set()
       this.heroes = new CocoCollection([], { model: ThangType })
       this.heroes.url = '/db/thang.type?view=heroes-junior'
       this.heroes.setProjection(['original', 'name', 'slug', 'soundTriggers', 'featureImages', 'gems', 'heroClass', 'description', 'components', 'extendedName', 'shortName', 'i18n', 'poseImage', 'tier', 'releasePhase', 'kind'])
-      this.heroes.comparator = hero => rosterOrder[hero.get('slug')] != null ? rosterOrder[hero.get('slug')] : 999
+      this.heroes.comparator = hero => {
+        const slug = hero.get('slug')
+        if (this.inPetAccessBeta) {
+          const position = petAccessBySlug[slug]?.position
+          if (position) { return (position.row * 100) + position.column }
+        }
+        return rosterOrder[slug] != null ? rosterOrder[slug] : 999
+      }
       this.listenToOnce(this.heroes, 'sync', this.onHeroesLoaded)
       this.supermodel.loadCollection(this.heroes, 'heroes')
       this.stages = {}
@@ -114,14 +126,32 @@ module.exports = (JuniorHeroesModal = (function () {
       if (hero.name == null) { hero.name = utils.i18n(hero.attributes, 'name') }
       hero.description = utils.i18n(hero.attributes, 'description')
       const original = hero.get('original')
-      const access = (rosterBySlug[hero.attributes.slug] || {}).access
-      hero.free = access === 'free'
-      hero.unlockBySubscribing = access === 'subscriber'
-      hero.premium = access === 'premium'
-      hero.locked = !me.ownsJuniorHero(original) && !(hero.unlockBySubscribing && me.isPremium())
-      // Classroom: all pets stay unlocked for students and teachers (GD-872 preserves this; experiment scope TBD)
+      if (this.inPetAccessBeta) {
+        // junior-pet-access beta arm: tiers come from juniorPetAccessConfig
+        const petAccess = petAccessBySlug[hero.attributes.slug] || {}
+        hero.petTier = petAccess.access
+        hero.free = petAccess.access === 'free'
+        hero.unlockBySubscribing = petAccess.access === 'premium'
+        hero.premium = petAccess.access === 'premium'
+        // Signup-tier pets are selectable; saveAndHide routes anonymous users to signup instead of saving
+        hero.requiresSignup = petAccess.access === 'signup' && me.isAnonymous()
+        hero.locked = !me.ownsJuniorHero(original) && !(hero.unlockBySubscribing && me.isPremium())
+        if (petAccess.access === 'signup') { hero.locked = false }
+        if (petAccess.access === 'module' && this.completedUnlockLevels.has(petAccess.unlockLevel)) { hero.locked = false }
+        if (hero.locked && petAccess.access === 'module') { hero.moduleHint = petAccess.hint }
+        hero.petRow = petAccess.position?.row
+        hero.petColumn = petAccess.position?.column
+        hero.purchasable = false // no gem purchases in the experiment tiers; premium tier upsells the subscription
+      } else {
+        const access = (rosterBySlug[hero.attributes.slug] || {}).access
+        hero.free = access === 'free'
+        hero.unlockBySubscribing = access === 'subscriber'
+        hero.premium = access === 'premium'
+        hero.locked = !me.ownsJuniorHero(original) && !(hero.unlockBySubscribing && me.isPremium())
+        hero.purchasable = hero.locked && me.isPremium()
+      }
+      // Classroom: all pets stay unlocked for students and teachers (also a pre-condition of the experiment)
       if (me.isStudent() || me.isTeacher()) { hero.locked = false }
-      hero.purchasable = hero.locked && me.isPremium()
       if (this.options.level && (allowedHeroes = this.options.level.get('allowedHeroes'))) {
         let needle
         hero.restricted = !((needle = hero.get('original'), allowedHeroes.includes(needle)))

--- a/app/views/play/modal/JuniorHeroesModal.js
+++ b/app/views/play/modal/JuniorHeroesModal.js
@@ -226,6 +226,7 @@ module.exports = (JuniorHeroesModal = (function () {
       context.level = this.options.level
       context.confirmButtonI18N = this.confirmButtonI18N
       context.visibleHero = this.visibleHero
+      context.inPetAccessBeta = this.inPetAccessBeta
       context.gems = me.gems()
       return context
     }

--- a/app/views/play/modal/JuniorHeroesModal.js
+++ b/app/views/play/modal/JuniorHeroesModal.js
@@ -462,6 +462,20 @@ module.exports = (JuniorHeroesModal = (function () {
         return
       }
 
+      const selectedPet = this.selectedHero || this.visibleHero
+      if (this.inPetAccessBeta && selectedPet?.requiresSignup && me.isAnonymous()) {
+        // Signup-tier pet picked by an anonymous user: Save routes to signup instead
+        // of closing. Persist the choice on the anonymous doc first - the doc (and
+        // heroConfig) survives signup, and the junior read path won't render a
+        // signup-tier pet while anonymous, so the fallback pet shows until the
+        // account exists. After signup the page reloads and returns here via nextURL.
+        this.updateHeroConfig(me, hero)
+        me.patch()
+        window.nextURL = window.location.href
+        this.openModalView(new CreateAccountModal({ supermodel: this.supermodel }))
+        return
+      }
+
       if (this.session) {
         changed = this.updateHeroConfig(this.session, hero)
         if (this.session.get('codeLanguage') !== this.codeLanguage) {

--- a/app/views/play/modal/JuniorHeroesModal.js
+++ b/app/views/play/modal/JuniorHeroesModal.js
@@ -186,6 +186,9 @@ module.exports = (JuniorHeroesModal = (function () {
         hero.petRow = petAccess.position?.row
         hero.petColumn = petAccess.position?.column
         hero.purchasable = false // no gem purchases in the experiment tiers; premium tier upsells the subscription
+        // Frames: gem for the premium tier always (hero.premium), silver for any other gated pet -
+        // module pets while locked, and signup pets while the user is still anonymous
+        hero.silverFrame = (hero.locked || hero.requiresSignup) && petAccess.access !== 'premium'
       } else {
         const access = (rosterBySlug[hero.attributes.slug] || {}).access
         hero.free = access === 'free'
@@ -193,6 +196,7 @@ module.exports = (JuniorHeroesModal = (function () {
         hero.premium = access === 'premium'
         hero.locked = !me.ownsJuniorHero(original) && !(hero.unlockBySubscribing && me.isPremium())
         hero.purchasable = hero.locked && me.isPremium()
+        hero.silverFrame = hero.unlockBySubscribing // control keeps today's frames
       }
       // Classroom: all pets stay unlocked for students and teachers (also a pre-condition of the experiment)
       if (me.isStudent() || me.isTeacher()) { hero.locked = false }

--- a/app/views/play/modal/JuniorHeroesModal.js
+++ b/app/views/play/modal/JuniorHeroesModal.js
@@ -110,7 +110,9 @@ module.exports = (JuniorHeroesModal = (function () {
         .map(pet => pet.unlockLevel))
       if (!neededLevels.size) { return }
       const jqxhr = $.get(`/db/user/${me.id}/level.sessions`, { project: 'state.complete,level.original' })
-      this.supermodel.trackRequest(jqxhr)
+      // This handler must run before the supermodel's, so completions are applied
+      // before the single loaded-all render: jQuery fires callbacks in registration
+      // order, and a second render() here would replay the menu-open jingle.
       jqxhr.then(sessions => {
         if (this.destroyed) { return }
         for (const session of sessions || []) {
@@ -121,12 +123,10 @@ module.exports = (JuniorHeroesModal = (function () {
         }
         if (!this.completedUnlockLevels.size) { return }
         this.persistModuleUnlocks()
-        // Re-derive lock state now that completions are known
-        if (this.heroes.models.length) {
-          for (const hero of this.heroes.models) { this.formatHero(hero) }
-          this.render()
-        }
+        // Re-derive lock state; the render on supermodel loaded-all picks it up
+        for (const hero of this.heroes.models) { this.formatHero(hero) }
       })
+      this.supermodel.trackRequest(jqxhr)
     }
 
     persistModuleUnlocks () {

--- a/app/views/play/modal/JuniorHeroesModal.js
+++ b/app/views/play/modal/JuniorHeroesModal.js
@@ -105,17 +105,17 @@ module.exports = (JuniorHeroesModal = (function () {
     loadModuleUnlockCompletions () {
       // Module-tier pets unlock on completing their unlockLevel. Completion lives in
       // level sessions, not on the user doc, so fetch the user's sessions once.
-      const neededLevels = ThangTypeConstants.juniorPetAccessConfig
+      const neededLevels = new Set(ThangTypeConstants.juniorPetAccessConfig
         .filter(pet => pet.access === 'module' && !me.ownsJuniorHero(ThangTypeConstants.heroes[pet.slug]))
-        .map(pet => pet.unlockLevel)
-      if (!neededLevels.length) { return }
+        .map(pet => pet.unlockLevel))
+      if (!neededLevels.size) { return }
       const jqxhr = $.get(`/db/user/${me.id}/level.sessions`, { project: 'state.complete,level.original' })
       this.supermodel.trackRequest(jqxhr)
       jqxhr.then(sessions => {
         if (this.destroyed) { return }
         for (const session of sessions || []) {
           const original = session.level != null ? session.level.original : undefined
-          if (session.state?.complete && neededLevels.includes(original)) {
+          if (session.state?.complete && neededLevels.has(original)) {
             this.completedUnlockLevels.add(original)
           }
         }

--- a/app/views/play/modal/JuniorHeroesModal.js
+++ b/app/views/play/modal/JuniorHeroesModal.js
@@ -86,6 +86,7 @@ module.exports = (JuniorHeroesModal = (function () {
       }
       this.listenToOnce(this.heroes, 'sync', this.onHeroesLoaded)
       this.supermodel.loadCollection(this.heroes, 'heroes')
+      if (this.inPetAccessBeta) { this.loadModuleUnlockCompletions() }
       this.stages = {}
       this.layers = []
       this.session = options.session
@@ -99,6 +100,49 @@ module.exports = (JuniorHeroesModal = (function () {
           this.rerenderFooter()
         })
       }
+    }
+
+    loadModuleUnlockCompletions () {
+      // Module-tier pets unlock on completing their unlockLevel. Completion lives in
+      // level sessions, not on the user doc, so fetch the user's sessions once.
+      const neededLevels = ThangTypeConstants.juniorPetAccessConfig
+        .filter(pet => pet.access === 'module' && !me.ownsJuniorHero(ThangTypeConstants.heroes[pet.slug]))
+        .map(pet => pet.unlockLevel)
+      if (!neededLevels.length) { return }
+      const jqxhr = $.get(`/db/user/${me.id}/level.sessions`, { project: 'state.complete,level.original' })
+      this.supermodel.trackRequest(jqxhr)
+      jqxhr.then(sessions => {
+        if (this.destroyed) { return }
+        for (const session of sessions || []) {
+          const original = session.level != null ? session.level.original : undefined
+          if (session.state?.complete && neededLevels.includes(original)) {
+            this.completedUnlockLevels.add(original)
+          }
+        }
+        if (!this.completedUnlockLevels.size) { return }
+        this.persistModuleUnlocks()
+        // Re-derive lock state now that completions are known
+        if (this.heroes.models.length) {
+          for (const hero of this.heroes.models) { this.formatHero(hero) }
+          this.render()
+        }
+      })
+    }
+
+    persistModuleUnlocks () {
+      // Interim ownership persistence (GD-875: no achievement wiring yet): completed
+      // module pets are written into purchased.juniorHeroes so ownership flows
+      // through ownsJuniorHero everywhere - this modal, the level-load read path,
+      // and future sessions - without refetching level sessions each time.
+      const newlyUnlocked = ThangTypeConstants.juniorPetAccessConfig
+        .filter(pet => pet.access === 'module' && this.completedUnlockLevels.has(pet.unlockLevel))
+        .map(pet => ThangTypeConstants.heroes[pet.slug])
+        .filter(heroId => !me.ownsJuniorHero(heroId))
+      if (!newlyUnlocked.length) { return }
+      const purchased = _.clone(me.get('purchased')) || {}
+      purchased.juniorHeroes = (purchased.juniorHeroes || []).concat(newlyUnlocked)
+      me.set('purchased', purchased)
+      me.patch()
     }
 
     onHeroesLoaded () {


### PR DESCRIPTION
Closes GD-875

## What

Adds the `junior-pet-access` experiment. The beta arm splits the 18 junior pets into four tiers — free (selectable by anyone), signup (Save routes anonymous users to signup), premium (subscriber gate), and module (unlocked by completing a mapped junior level). The control arm is production behavior, unchanged.

Rollout is ops-controlled: no assignment happens until `serverConfig.experimentProbabilities['junior-pet-access'].beta` is set, so merging this is safe with zero user-facing change.

## Experiment mechanics

- **Assignment** happens only on first open of `JuniorHeroesModal` (`getOrStartJuniorPetAccessExperimentValue`), only for anonymous home users. Excluded: students/teachers, China infra, freeOnly/HoC contexts (locked pets are hidden there, so there's no upsell to measure), and accounts created before `JUNIOR_PET_ACCESS_CUTOFF_DATE` (grandfathering; date aligned to rollout schedule).
- **Read path** (`getJuniorPetAccessExperimentValue`) re-checks post-conditions on every read: students/teachers and China infra always fall through to control, even with a stored assignment. Registered home users keep their cohort through signup — the signup tier is the point.
- QA can force an arm via the standard query-string override.
- Also removes the retired `requires-sign-up-dungeon/junior` experiment getters (no remaining call sites), resolving the ticket's concern about the two experiments confounding each other.

## Tier behavior (beta arm)

- Tiers, ordering, unlock levels, and hints come from `juniorPetAccessConfig` in `ThangTypeConstants.coffee`; modal layout follows config row/column positions.
- **Signup tier:** the pet is selectable in-modal; `saveAndHide` intercepts anonymous saves and opens `CreateAccountModal` instead of closing. The choice is written to the anonymous doc first (it survives signup, and the read path refuses to render it while anonymous), and `window.nextURL` returns the player to the junior map after the post-signup reload. Registered users save normally. GD-873's in-signup picker will see the saved `juniorThangType` as its preselection.
- **Module tier:** modal open fetches level sessions once (only for unlock levels gating pets not yet owned; skipped when nothing is missing). Newly completed pets persist into `purchased.juniorHeroes` — same client-writable trust tier as the gem economy; the `earned.juniorHeroes` achievement path is out of scope per ticket.
- **Premium tier** mirrors the existing subscriber unlock pattern. No gem purchases in beta tiers.

## Read-path enforcement

`heroConfig.juniorThangType` is client-writable, so gating can't live only in the modal. `User.mayUseJuniorPet()` guards all three junior read sites (`Level.js` hero placeholders, `LevelLoader`): an unowned pet is treated as unset and the classic-hero swap map fallback renders instead. Control arm renders anything saved, as today.

Known cosmetic caveat: spectating a session whose owner has a pet the viewer lacks shows the viewer's fallback pet — consistent with never rendering an unowned pet.

## Out of scope (per ticket)

Achievement-based `earned.juniorHeroes` grants, victory-modal pet art, localization of experiment copy, any classroom pet access changes.

## Screenshots
<img width="874" height="671" alt="image" src="https://github.com/user-attachments/assets/c5cfe857-cca4-4a48-bf1b-857ccb673e1b" />
<img width="840" height="661" alt="image" src="https://github.com/user-attachments/assets/f63da702-2dd0-4f56-83b6-f67474dc9f61" />
<img width="830" height="666" alt="image" src="https://github.com/user-attachments/assets/6fc8feb3-4237-41e7-8937-af08a1ddc3eb" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a junior pet access beta experience with free, sign-up, premium, and module unlock tiers.
  - Updated the junior heroes modal with access-based ordering, improved locked-state messaging, module unlock hints, and sign-up prompts.
  - Added automatic module-tier unlock handling and anonymous sign-up support.

- **Bug Fixes**
  - Prevented inaccessible junior pets and heroes from being rendered or selected; invalid selections now use eligible alternatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->