### PR TITLE
hide related account settings for home user and remove teacher dashbo…

### DIFF
--- a/app/templates/account/account-settings-view.pug
+++ b/app/templates/account/account-settings-view.pug
@@ -90,19 +90,13 @@ else
                 label.control-label(for="password2", data-i18n="account_settings.new_password_verify") Verify
                 input#password2.form-control(name="password2", type="password")
 
-      .panel.panel-default.related-account
-        .panel-heading
-          .panel-title(data-i18n="related_accounts.title")
-        .panel-body
-          .related-account-sub(data-i18n="related_accounts.subtitle")
-          a.btn.btn-primary.related-account-manage(href="/users/switch-account" target="_blank" data-i18n="common.manage")
-
-      if me.isTeacher()
-        .panel.panel-default
+      if !me.isHomeUser()
+        .panel.panel-default.related-account
           .panel-heading
-            .panel-title#connect-roblox-title(data-i18n="account_settings.switch_new_teacher_dashboard")
+            .panel-title(data-i18n="related_accounts.title")
           .panel-body
-            #dashboard-toggle
+            .related-account-sub(data-i18n="related_accounts.subtitle")
+            a.btn.btn-primary.related-account-manage(href="/users/switch-account" target="_blank" data-i18n="common.manage")
 
       if me.canDeleteAccount()
         .panel.panel-default


### PR DESCRIPTION
…ard toggle setting from account settings
fixes eng-2684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The related-account panel is now hidden for home users in account settings.
  * The panel remains available for other account types, including its existing account management link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->