### PR TITLE
(GD-878) feat: mini_game schema for DB-attached mini-games 

### DIFF
--- a/app/schemas/models/mini_game.schema.js
+++ b/app/schemas/models/mini_game.schema.js
@@ -29,7 +29,7 @@ _.extend(MiniGameSchema.properties, {
       data: { type: 'string', title: 'Atlas JSON', format: 'file' },
     })),
   sounds: c.array({ title: 'Sounds', description: 'Codec pairs: consumers hand the game both URLs and the engine picks per browser.' },
-    c.sound({ key: c.shortString({ title: 'Key' }) })),
+    _.assign(c.sound({ key: c.shortString({ title: 'Key' }) }), { required: ['key'] })),
 })
 
 MiniGameSchema.required = ['name']

--- a/app/schemas/models/mini_game.schema.js
+++ b/app/schemas/models/mini_game.schema.js
@@ -1,0 +1,40 @@
+const _ = require('lodash')
+
+const c = require('./../schemas')
+
+const MiniGameSchema = c.object({
+  title: 'Mini-Game',
+  description: 'A Star Lab mini-game: a published code bundle plus the assets it needs, loaded at runtime by slug.',
+})
+
+// name first
+c.extendNamedProperties(MiniGameSchema)
+
+_.extend(MiniGameSchema.properties, {
+  code: {
+    type: 'string',
+    title: 'Code Bundle',
+    description: 'Published single-file IIFE game bundle (Phaser external), built in the codecombat-mini-games repo. Self-registers on window.CocoMiniGames[slug].',
+    format: 'js-file',
+  },
+  images: c.array({ title: 'Images', description: 'Plain images. `key` is the logical name the game code looks up — filenames are not keys.' },
+    c.object({ title: 'Image', required: ['key', 'image'] }, {
+      key: c.shortString({ title: 'Key' }),
+      image: { type: 'string', title: 'Image', format: 'image-file' },
+    })),
+  atlases: c.array({ title: 'Atlases', description: 'Texture atlases: image plus its TexturePacker JSON.' },
+    c.object({ title: 'Atlas', required: ['key', 'image', 'data'] }, {
+      key: c.shortString({ title: 'Key' }),
+      image: { type: 'string', title: 'Texture Image', format: 'image-file' },
+      data: { type: 'string', title: 'Atlas JSON', format: 'file' },
+    })),
+  sounds: c.array({ title: 'Sounds', description: 'Codec pairs: consumers hand the game both URLs and the engine picks per browser.' },
+    c.sound({ key: c.shortString({ title: 'Key' }) })),
+})
+
+MiniGameSchema.required = ['name']
+
+c.extendBasicProperties(MiniGameSchema, 'mini_game')
+c.extendVersionedProperties(MiniGameSchema, 'mini_game')
+
+module.exports = MiniGameSchema


### PR DESCRIPTION
## mini_game schema (GD-878)

Adds `app/schemas/models/mini_game.schema.js` — the document shape for DB-attached Star Lab mini-games:

- `name` / `slug` (named), `original` + version metadata (versioned)
- `code` — published single-file IIFE game bundle (`js-file`, Phaser external), built in `codecombat-mini-games`
- `images[{key, image}]`, `atlases[{key, image, data}]`, `sounds[{key, mp3, ogg}]` — `key` is the logical name the game code looks up; filenames are deliberately not keys

Schema only — no model, routes, or consumers in this repo. Server counterpart: codecombat-server PR on the same-name branch.

Part of GD-876 (mini-game detachment), stage 2: GD-878.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for defining mini-games with a required name, JavaScript game bundle, and associated image, texture-atlas, and sound assets.
  * Added versioned schema validation for mini-game data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->