### PR TITLE
AI Junior: finish the paper loop (client)

### DIFF
--- a/app/components/common/elements/AIJuniorProjectOutput.vue
+++ b/app/components/common/elements/AIJuniorProjectOutput.vue
@@ -1,130 +1,786 @@
 <template>
   <div class="ai-junior-project-output">
-    <h3
-      v-if="project.name"
-    >
-      {{ project.name }}
-    </h3>
     <div
-      v-if="project.processingStatus === 'processing' || project.processingStatus === 'pending' || !project.processingStatus"
-      class="processing"
-    >
-      <div class="spinner" />
-      <p>Processing your project...</p>
-    </div>
-    <div
-      v-else-if="project.processingStatus === 'failed'"
+      v-if="isFailed"
       class="failed"
     >
+      <h3>😿 Something went wrong</h3>
       <p>Processing failed. Please try again.</p>
+      <p
+        v-if="project.processingError"
+        class="processing-error"
+      >
+        {{ project.processingError }}
+      </p>
       <button
         v-if="!hideReprocessButton"
+        class="btn btn-primary"
         @click="$emit('reprocess-project')"
       >
-        Reprocess
+        Try Again
       </button>
     </div>
-    <div
-      v-else-if="project.processingStatus === 'completed'"
-      class="completed"
-    >
+
+    <template v-else>
       <div
-        v-if="scenario.output.html"
-        class="project-preview"
+        v-if="isProcessing"
+        class="processing"
       >
-        <h4>Project Preview</h4>
-        <iframe
-          :key="compiledOutput"
-          :srcdoc="compiledOutput"
-          class="preview-frame"
-        />
-      </div>
-      <div
-        v-for="response in project.promptResponses"
-        :key="response.promptId"
-        class="prompt-response"
-      >
+        <p class="processing-message">
+          {{ processingMessage }}
+        </p>
         <div
-          v-if="response.promptId === 'characterImage'"
-          class="response-character-image"
+          class="progress-track"
+          role="progressbar"
+          :aria-valuenow="Math.round(progress * 100)"
+          aria-valuemin="0"
+          aria-valuemax="100"
         >
-          <h4>{{ response.promptId }}</h4>
-          <p v-if="response.text">
-            {{ response.text }}
-          </p>
-          <!-- <img
-            v-if="response.image"
-            :src="response.image"
-            alt="Generated image"
-          > -->
+          <div
+            class="progress-fill"
+            :class="{ stalled: isStalled }"
+            :style="{ width: `${(progress * 100).toFixed(1)}%` }"
+          />
+        </div>
+        <p class="processing-elapsed">
+          {{ elapsedLabel }}
+        </p>
+
+        <div
+          v-if="isStalled"
+          class="stalled-note"
+        >
+          <p>This is taking longer than it should. It may have got stuck.</p>
+          <button
+            v-if="!hideReprocessButton"
+            class="btn btn-primary"
+            @click="$emit('reprocess-project')"
+          >
+            Start it again
+          </button>
         </div>
       </div>
-      <button
-        v-if="!hideReprocessButton"
-        @click="$emit('reprocess-project')"
+
+      <!-- The creation itself. Exactly one canonical rendering: the scenario's
+           own output template when it has one, otherwise the generated images.
+           Anything the template does not reference is shown underneath, so a
+           multi-image scenario still surfaces every image without the single
+           `<img>` scenarios rendering their picture twice. -->
+      <div
+        class="creation-layout"
+        :class="{ 'with-original': isCompleted && originals.length }"
       >
-        Reprocess
-      </button>
-    </div>
+        <div class="creation">
+          <div
+            v-if="hasPreview"
+            class="project-preview"
+          >
+            <div
+              ref="previewWrap"
+              class="preview-wrap"
+              @mouseenter="focusPreview"
+              @pointerdown="focusPreview"
+            >
+              <iframe
+                ref="previewFrame"
+                :key="compiledOutput"
+                :srcdoc="compiledOutput"
+                class="preview-frame"
+                allow="fullscreen"
+                @load="onPreviewLoad"
+              />
+            </div>
+          </div>
+
+          <div
+            v-for="response in unreferencedImages"
+            :key="response.promptId"
+            class="response-image"
+          >
+            <a
+              :href="response.image"
+              target="_blank"
+              rel="noopener"
+              title="Open full size"
+            >
+              <img
+                :src="response.image"
+                :alt="response.promptId"
+              >
+            </a>
+          </div>
+
+          <div
+            v-if="showCreationActions"
+            class="creation-actions no-print"
+          >
+            <button
+              v-if="hasPreview"
+              class="btn btn-default"
+              @click="fullscreenPreview"
+            >
+              ⛶ Fullscreen
+            </button>
+            <a
+              v-for="response in imageResponses"
+              :key="`dl-${response.promptId}`"
+              class="btn btn-default"
+              :href="response.image"
+              :download="downloadName(response)"
+            >⬇ Download{{ imageResponses.length > 1 ? ` ${response.promptId}` : '' }}</a>
+            <button
+              v-if="canShare"
+              class="btn btn-primary"
+              @click="showShare = !showShare"
+            >
+              🔗 Share
+            </button>
+            <button
+              v-if="!hideReprocessButton"
+              class="btn btn-default"
+              @click="$emit('reprocess-project')"
+            >
+              🔁 Remake It
+            </button>
+          </div>
+        </div>
+
+        <!-- What the child actually made, beside what it became rather than far
+             below it, so a wide screen shows the before and after together. -->
+        <aside
+          v-if="isCompleted && originals.length"
+          class="originals"
+        >
+          <h4 class="originals-heading">
+            {{ originalsHeading }}
+          </h4>
+          <figure
+            v-for="original in originals"
+            :key="original.id"
+            class="original"
+          >
+            <a
+              :href="original.src"
+              target="_blank"
+              rel="noopener"
+              title="Open full size"
+            >
+              <img
+                :src="original.src"
+                :alt="original.label"
+              >
+            </a>
+            <figcaption>{{ original.label }}</figcaption>
+          </figure>
+        </aside>
+      </div>
+
+      <AIJuniorShareBox
+        v-if="showShare && canShare"
+        :project="project"
+        class="no-print"
+        @shared="onShared"
+      />
+
+      <div
+        v-if="isCompleted && !hideReprocessButton"
+        class="details-toggle no-print"
+      >
+        <button
+          class="btn btn-link btn-sm"
+          @click="showDetails = !showDetails"
+        >
+          {{ showDetails ? 'Hide' : 'Show' }} Details
+        </button>
+      </div>
+
+      <div
+        v-if="showDetails"
+        class="details"
+      >
+        <div
+          v-for="response in project.promptResponses"
+          :key="`detail-${response.promptId}`"
+          class="detail-response"
+        >
+          <h5>{{ response.promptId }} <span class="detail-time">({{ responseSeconds(response) }}s)</span></h5>
+          <pre>{{ response.text }}</pre>
+        </div>
+      </div>
+    </template>
   </div>
 </template>
 
 <script>
+import AIJuniorShareBox from './AIJuniorShareBox.vue'
+
+// Simple `<%= name %>` interpolations, which is all scenario outputs use.
+// Declared with the `g` flag but only ever used via matchAll, which does not
+// carry lastIndex between calls.
+const TEMPLATE_IDENTIFIER = /<%[=-]?\s*([A-Za-z_$][\w$]*)\s*%>/g
+
+// Past this, and past a multiple of the scenario's own estimate, a run is
+// treated as stuck rather than slow.
+const STALL_SECONDS = 240
+
+const PROCESSING_MESSAGES = [
+  'Reading your worksheet…',
+  'Imagining your creation…',
+  'Painting the pictures…',
+  'Adding the finishing touches…',
+  'Almost there…',
+]
+
 export default {
   name: 'AIJuniorProjectOutput',
+  components: {
+    AIJuniorShareBox,
+  },
   props: {
     project: {
       type: Object,
-      required: true
+      required: true,
     },
     scenario: {
       type: Object,
-      required: true
+      required: true,
     },
     hideReprocessButton: {
       type: Boolean,
       default: false,
     },
+    // Public share pages render the same creation but must not offer owner-only
+    // actions (re-share, remake, details).
+    readOnly: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data () {
+    return {
+      showDetails: false,
+      showShare: false,
+      elapsedSeconds: 0,
+      // Reactive clock, so the progress bar keeps easing forward between polls
+      // rather than only moving when a prompt finishes.
+      nowMs: Date.now(),
+      elapsedTimer: null,
+    }
   },
   computed: {
-    compiledOutput () {
-      let { html, css, js } = this.scenario.output
+    isProcessing () {
+      const status = this.project.processingStatus
+      return status === 'processing' || status === 'pending' || !status
+    },
+    isCompleted () {
+      return this.project.processingStatus === 'completed'
+    },
+    isFailed () {
+      return this.project.processingStatus === 'failed'
+    },
+    imageResponses () {
+      return (this.project.promptResponses || []).filter((r) => r.image)
+    },
+    // Everything the output templates interpolate, so the preview can tell
+    // whether it has enough to render.
+    templateNames () {
+      const output = this.scenario.output || {}
+      const names = new Set()
+      for (const template of [output.html, output.css, output.js]) {
+        for (const match of String(template || '').matchAll(TEMPLATE_IDENTIFIER)) names.add(match[1])
+      }
+      return [...names]
+    },
+    // Wait for every referenced value before showing the preview. Rendering it
+    // half-finished turns `<img src="<%= characterImage %>">` into an empty
+    // `<img src="">` — a broken-image dot in a big empty frame — while the
+    // image prompt is still running. Until then the generated images appear on
+    // their own as they arrive, which is the progressive behaviour we want.
+    previewReady () {
+      if (!this.scenario.output?.html) return false
+      // Once the run is finished, render whatever there is: a blank field the
+      // child chose not to fill in is a real answer, and waiting on it forever
+      // would mean never showing the creation at all.
+      if (!this.isProcessing) return true
+      return this.templateNames.every((name) => {
+        const value = this.templateContext[name]
+        return value != null && value !== ''
+      })
+    },
+    hasPreview () {
+      return this.previewReady
+    },
+    // Images the scenario's output template already puts on screen. Rendering
+    // these again above the preview is what made every result appear twice.
+    unreferencedImages () {
+      if (!this.hasPreview) return this.imageResponses
+      return this.imageResponses.filter((response) => !this.templateNames.includes(response.promptId))
+    },
+    showCreationActions () {
+      return this.isCompleted && (this.hasPreview || this.imageResponses.length)
+    },
+    // Auto-focusing is right for something interactive and wrong for a picture,
+    // where stealing focus would just scroll the page down to the iframe.
+    isGameLike () {
+      const output = this.scenario.output || {}
+      return /<canvas|addEventListener|requestAnimationFrame/i.test(`${output.html || ''}${output.js || ''}`)
+    },
+    canShare () {
+      return !this.readOnly && this.isCompleted && Boolean(this.project._id)
+    },
+    // The child's own work. A scanned project has both the whole page and the
+    // cropped drawing, and showing both means showing the same drawing twice —
+    // the page already contains it — so the page wins when it exists. Only an
+    // on-screen drawing, which has no page, falls back to the crops.
+    originals () {
+      if (this.project.uploadedWorksheet) {
+        return [{ id: 'worksheet', label: 'Your worksheet', src: `/file/${this.project.uploadedWorksheet}` }]
+      }
+      const items = []
+      const inputValues = this.project.inputValues || {}
+      for (const input of this.scenario.inputs || []) {
+        if (input.type !== 'image-field') continue
+        const value = inputValues[input.id]
+        if (typeof value !== 'string' || !value) continue
+        const src = value.startsWith('data:') || value.startsWith('/') ? value : `/file/${value}`
+        items.push({ id: input.id, label: input.label || input.text || 'What you drew', src })
+      }
+      return items
+    },
+    originalsHeading () {
+      return this.originals.length === 1 && this.originals[0].id === 'worksheet'
+        ? 'Made from your worksheet'
+        : 'Made from your drawing'
+    },
+    processingMessage () {
+      if (this.isStalled) return 'Still waiting…'
+      const doneCount = (this.project.promptResponses || []).length
+      const index = Math.min(doneCount + Math.floor(this.elapsedSeconds / 25), PROCESSING_MESSAGES.length - 1)
+      return PROCESSING_MESSAGES[index]
+    },
+    // Rough seconds per prompt, from measured runs: gemini image ~15-20s,
+    // opus writing a game ~35-45s, sonnet reading a sketch ~15s. Only the
+    // ratios really matter — they decide how much of the bar each step is
+    // worth — and the easing below absorbs a step that runs long.
+    promptWeights () {
+      const weights = (this.scenario.prompts || []).map((prompt) => {
+        const model = String(prompt.model || '')
+        if (/image/.test(model)) return /gemini/.test(model) ? 18 : 45
+        if (/opus/.test(model)) return 45
+        if (/haiku/.test(model)) return 10
+        if (/sonnet|^gpt-/.test(model)) return 15
+        return 25
+      })
+      // A scanned worksheet is read by a vision pass before any prompt runs,
+      // which is real time the bar should account for.
+      if (weights.length && this.project.uploadedWorksheet) weights[0] += 10
+      return weights
+    },
+    /**
+     * A bar that behaves like it knows something, because it does: finished
+     * prompts contribute their full share, and the one still running eases
+     * toward its share on 1 - e^-t/estimate. That approaches its ceiling
+     * without ever arriving, so the bar keeps creeping when a step runs long
+     * instead of either sticking or claiming to be finished.
+     */
+    progress () {
+      const weights = this.promptWeights
+      if (!weights.length) return Math.min(0.9, this.elapsedSeconds / 90)
+      const total = weights.reduce((sum, w) => sum + w, 0)
+      const responses = this.project.promptResponses || []
+      const doneCount = Math.min(responses.length, weights.length)
+
+      let doneWeight = 0
+      for (let i = 0; i < doneCount; i++) doneWeight += weights[i]
+
+      if (doneCount >= weights.length) return 0.97
+
+      // Time spent on the step currently running, measured from when the last
+      // one finished rather than from the start of the whole run.
+      const lastEnd = responses.length ? new Date(responses[responses.length - 1].endDate).getTime() : null
+      const start = this.project.processingStartTime ? new Date(this.project.processingStartTime).getTime() : Date.now()
+      const since = (this.nowMs - (lastEnd && !isNaN(lastEnd) ? lastEnd : start)) / 1000
+      const current = weights[doneCount]
+      const currentProgress = 1 - Math.exp(-Math.max(0, since) / current)
+
+      return Math.max(0.02, Math.min(0.97, (doneWeight + current * currentProgress) / total))
+    },
+    estimatedTotalSeconds () {
+      const weights = this.promptWeights
+      return weights.length ? weights.reduce((sum, w) => sum + w, 0) : 90
+    },
+    elapsedLabel () {
+      const remaining = Math.round(this.estimatedTotalSeconds - this.elapsedSeconds)
+      if (this.isStalled) return `${this.elapsedSeconds}s elapsed`
+      if (remaining > 5) return `${this.elapsedSeconds}s — about ${remaining}s to go`
+      return `${this.elapsedSeconds}s — almost there`
+    },
+    // Long past any plausible finish. The server also fails a run that overruns,
+    // but a server that was restarted mid-run leaves a project marked
+    // "processing" for ever, and only the page is around to notice.
+    isStalled () {
+      return this.isProcessing && this.elapsedSeconds > Math.max(STALL_SECONDS, this.estimatedTotalSeconds * 4)
+    },
+    templateContext () {
       const context = { ...this.project.inputValues }
       for (const promptResponse of this.project.promptResponses || []) {
         context[promptResponse.promptId] = promptResponse.image || promptResponse.text
+        // Text prompts respond with JSON objects; expose their keys to the
+        // output templates just like the server exposes them to later prompts.
+        if (!promptResponse.image && promptResponse.text) {
+          try {
+            const parsed = JSON.parse(promptResponse.text.replace(/^```(?:json)?\s*|```\s*$/g, ''))
+            if (parsed && typeof parsed === 'object') Object.assign(context, parsed)
+          } catch (err) {
+            // Not JSON — leave the raw text mapping
+          }
+        }
       }
-      try {
-        html = _.template(html, context)
-        css = _.template(css, context)
-        js = _.template(js, context)
-      } catch (err) {
-        console.log('Template context error:', err, html, css, js, context)
+      return context
+    },
+    compiledOutput () {
+      let { html, css, js } = this.scenario.output
+      const context = this.templateContext
+      // Compiled lodash templates run inside `with (data)`, so any name the
+      // context is missing — an unticked radio, a prompt that has not finished
+      // yet — throws and leaves the whole creation unrendered. Fill the gaps
+      // with blanks first so a partial project still shows what it has.
+      const render = (template) => {
+        if (!template) return template
+        const filled = { ...context }
+        for (const match of template.matchAll(TEMPLATE_IDENTIFIER)) {
+          if (filled[match[1]] == null) filled[match[1]] = ''
+        }
+        try {
+          return _.template(template, filled)
+        } catch (err) {
+          console.log('Template context error:', err, template, filled)
+          return ''
+        }
       }
+      html = render(html)
+      css = render(css)
+      js = render(js)
+      // `.aij-fullscreen` is added to the iframe body while the preview is
+      // fullscreen: inline the preview is measured and sized to its content,
+      // but fullscreen it has to fill and centre inside a fixed viewport.
+      const baseCss = `
+        body { margin: 8px; font-family: sans-serif; }
+        img { max-width: 100%; height: auto; }
+        body.aij-fullscreen {
+          margin: 0; width: 100vw; height: 100vh; background: #111;
+          display: flex; align-items: center; justify-content: center; overflow: hidden;
+        }
+        body.aij-fullscreen > * { margin: 0 !important; }
+        body.aij-fullscreen img, body.aij-fullscreen canvas, body.aij-fullscreen video {
+          max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain;
+        }
+      `
       // eslint-disable-next-line no-useless-escape
-      return `<html>\n  <head>\n    <style>${css}</style>\n  </head>\n  <body>\n    ${html}\n    <script>${js}<\/script>\n  </body>\n</html>`
-    }
-  }
+      return `<html>\n  <head>\n    <style>${baseCss}</style>\n    <style>${css}</style>\n  </head>\n  <body>\n    ${html}\n    <script>${js}<\/script>\n  </body>\n</html>`
+    },
+  },
+  watch: {
+    isProcessing: {
+      immediate: true,
+      handler (processing) {
+        if (processing && !this.elapsedTimer) {
+          const start = this.project.processingStartTime ? new Date(this.project.processingStartTime).getTime() : Date.now()
+          this.elapsedTimer = setInterval(() => {
+            this.nowMs = Date.now()
+            this.elapsedSeconds = Math.max(0, Math.round((this.nowMs - start) / 1000))
+          }, 500)
+        } else if (!processing && this.elapsedTimer) {
+          clearInterval(this.elapsedTimer)
+          this.elapsedTimer = null
+        }
+      },
+    },
+  },
+  mounted () {
+    document.addEventListener('fullscreenchange', this.onFullscreenChange)
+    document.addEventListener('webkitfullscreenchange', this.onFullscreenChange)
+  },
+  beforeDestroy () {
+    if (this.elapsedTimer) clearInterval(this.elapsedTimer)
+    document.removeEventListener('fullscreenchange', this.onFullscreenChange)
+    document.removeEventListener('webkitfullscreenchange', this.onFullscreenChange)
+  },
+  methods: {
+    onPreviewLoad () {
+      this.sizePreview()
+      // A game listens for arrow keys inside the iframe, but an iframe receives
+      // no key events until it has focus — so without this the keys go to the
+      // page behind it and just scroll it. Hovering or touching the game hands
+      // focus over, which is what a player does before pressing anything.
+      if (this.isGameLike) this.focusPreview()
+    },
+    focusPreview () {
+      const iframe = this.$refs.previewFrame
+      try {
+        iframe?.contentWindow?.focus()
+      } catch (err) {
+        // Nothing to do if focusing is refused; the game still plays by touch.
+      }
+    },
+    // Size the preview iframe to its content so any scenario output — square
+    // image, 800x500 game, multi-page story — displays without inner scrollbars.
+    sizePreview () {
+      const iframe = this.$refs.previewFrame
+      if (!iframe) return
+      try {
+        const contentHeight = iframe.contentDocument.body.scrollHeight
+        const maxHeight = Math.round(window.innerHeight * 0.85)
+        iframe.style.height = `${Math.min(Math.max(contentHeight + 24, 240), maxHeight)}px`
+      } catch (err) {
+        iframe.style.height = '600px'
+      }
+    },
+    // Fullscreen the wrapper rather than the iframe itself: an iframe made
+    // fullscreen keeps whatever width/height it was given, so the page ended up
+    // letterboxed in the corner instead of covering the screen.
+    fullscreenPreview () {
+      const wrap = this.$refs.previewWrap
+      if (!wrap) return
+      const request = wrap.requestFullscreen || wrap.webkitRequestFullscreen
+      if (request) request.call(wrap)
+    },
+    onFullscreenChange () {
+      const iframe = this.$refs.previewFrame
+      const wrap = this.$refs.previewWrap
+      if (!iframe || !wrap) return
+      const element = document.fullscreenElement || document.webkitFullscreenElement
+      const isFull = element === wrap
+      iframe.style.height = isFull ? '100%' : ''
+      try {
+        iframe.contentDocument.body.classList.toggle('aij-fullscreen', isFull)
+      } catch (err) {
+        // Cross-origin srcdoc should not happen, but never let it break exit.
+      }
+      if (isFull) this.focusPreview()
+      else this.sizePreview()
+    },
+    onShared (shared) {
+      this.$emit('shared', shared)
+    },
+    downloadName (response) {
+      const base = (this.project.name || 'ai-junior').replace(/[^\w-]+/g, '-').toLowerCase()
+      const extension = (response.image || '').split('.').pop().split('?')[0] || 'png'
+      return `${base}-${response.promptId}.${extension}`
+    },
+    responseSeconds (response) {
+      if (!response.startDate || !response.endDate) return '?'
+      return ((new Date(response.endDate) - new Date(response.startDate)) / 1000).toFixed(0)
+    },
+  },
 }
 </script>
 
 <style scoped>
-.spinner {
-  border: 4px solid #f3f3f3;
-  border-top: 4px solid #3498db;
-  border-radius: 50%;
-  width: 40px;
-  height: 40px;
-  animation: spin 1s linear infinite;
+.ai-junior-project-output {
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+/* Creation and original side by side where there is room for both, stacked
+   where there is not. The creation gets the space; the worksheet is a
+   companion, not an equal. */
+.creation-layout.with-original {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+@media (min-width: 1000px) {
+  .creation-layout.with-original {
+    grid-template-columns: minmax(0, 1fr) minmax(200px, 300px);
+  }
+}
+
+.creation {
+  min-width: 0;
+}
+
+.processing {
+  text-align: center;
+  padding: 3rem 0;
+}
+
+.processing-message {
+  font-size: 1.8rem;
+  margin-bottom: 1.2rem;
+}
+
+.progress-track {
+  max-width: 460px;
+  height: 14px;
+  margin: 0 auto;
+  background: #e9edf2;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #4a9cff, #3ddc84);
+  border-radius: 999px;
+  /* Matches the timer tick, so the bar creeps rather than stepping. */
+  transition: width 0.5s linear;
+}
+
+.progress-fill.stalled {
+  background: #d9a441;
+}
+
+.processing-elapsed {
+  color: #888;
+  font-size: 1.3rem;
+  margin-top: 0.8rem;
+}
+
+.stalled-note {
+  margin-top: 1.5rem;
+}
+
+.stalled-note p {
+  color: #8a6d3b;
+  font-size: 1.5rem;
+}
+
+.response-image {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.response-image img {
+  max-width: 100%;
+  max-height: 75vh;
+  border-radius: 12px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+}
+
+.project-preview {
+  margin: 0 0 1rem;
+}
+
+.preview-wrap {
+  background: #fff;
+  border-radius: 12px;
+}
+
+.preview-wrap:fullscreen {
+  background: #111;
+  border-radius: 0;
+  width: 100vw;
+  height: 100vh;
 }
 
 .preview-frame {
+  display: block;
   width: 100%;
-  height: 500px;
-  border: 1px solid #ccc;
+  border: 1px solid #ddd;
+  border-radius: 12px;
+  background: #fff;
+}
+
+.preview-wrap:fullscreen .preview-frame {
+  border: none;
+  border-radius: 0;
+  height: 100%;
+}
+
+.creation-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  justify-content: center;
+  margin: 1.2rem 0 0;
+}
+
+.originals {
+  min-width: 0;
+}
+
+.originals-heading {
+  color: #777;
+  font-size: 1.3rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0 0 0.7rem;
+  text-align: center;
+}
+
+.original {
+  margin: 0 0 1rem;
+  max-width: 100%;
+}
+
+.original img {
+  display: block;
+  width: 100%;
+  max-height: 45vh;
+  object-fit: contain;
+  border-radius: 8px;
+  border: 1px solid #e3e3e3;
+  background: #fff;
+}
+
+.original figcaption {
+  text-align: center;
+  font-size: 1.2rem;
+  color: #999;
+  margin-top: 0.3rem;
+}
+
+/* Stacked, the worksheet should not dominate the creation above it. */
+@media (max-width: 999px) {
+  .originals {
+    border-top: 1px solid #eee;
+    padding-top: 1.2rem;
+    max-width: 460px;
+    margin: 1.5rem auto 0;
+  }
+}
+
+.details-toggle {
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.failed {
+  text-align: center;
+  padding: 3rem 0;
+}
+
+.processing-error {
+  font-family: monospace;
+  font-size: 12px;
+  color: #a94442;
+  background: #f2dede;
+  padding: 8px;
+  border-radius: 4px;
+  max-width: 600px;
+  margin: 1rem auto;
+  text-align: left;
+}
+
+.details {
+  border-top: 1px solid #eee;
+  padding-top: 1rem;
+}
+
+.detail-response pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 11px;
+  max-height: 300px;
+  overflow: auto;
+}
+
+.detail-time {
+  color: #999;
+  font-weight: normal;
+  font-size: 1.2rem;
 }
 </style>

--- a/app/components/common/elements/AIJuniorProjectOutput.vue
+++ b/app/components/common/elements/AIJuniorProjectOutput.vue
@@ -212,6 +212,7 @@
 </template>
 
 <script>
+import compileTemplate from 'lodash-4/template'
 import AIJuniorShareBox from './AIJuniorShareBox.vue'
 
 // Simple `<%= name %>` interpolations, which is all scenario outputs use.
@@ -452,7 +453,7 @@ export default {
           if (filled[match[1]] == null) filled[match[1]] = ''
         }
         try {
-          return _.template(template, filled)
+          return compileTemplate(template)(filled)
         } catch (err) {
           console.log('Template context error:', err, template, filled)
           return ''

--- a/app/components/common/elements/AIJuniorShareBox.vue
+++ b/app/components/common/elements/AIJuniorShareBox.vue
@@ -1,0 +1,204 @@
+<template>
+  <div class="ai-junior-share-box">
+    <h4>Share this creation</h4>
+    <p class="share-hint">
+      Anyone with the link can see it — no account needed.
+    </p>
+
+    <div class="share-modes">
+      <label
+        v-for="mode in MODES"
+        :key="mode.value"
+        class="share-mode"
+        :class="{ active: shared === mode.value }"
+      >
+        <input
+          type="radio"
+          name="ai-junior-share-mode"
+          :value="mode.value"
+          :checked="shared === mode.value"
+          :disabled="saving"
+          @change="setMode(mode.value)"
+        >
+        <span class="share-mode-label">{{ mode.label }}</span>
+        <span class="share-mode-hint">{{ mode.hint }}</span>
+      </label>
+    </div>
+
+    <div
+      v-if="isShared"
+      class="share-link-row"
+    >
+      <input
+        ref="linkInput"
+        class="share-link"
+        type="text"
+        readonly
+        :value="shareUrl"
+        @focus="$event.target.select()"
+      >
+      <button
+        class="btn btn-primary"
+        @click="copyLink"
+      >
+        {{ copied ? '✓ Copied' : 'Copy' }}
+      </button>
+    </div>
+
+    <p
+      v-if="error"
+      class="share-error"
+    >
+      {{ error }}
+    </p>
+  </div>
+</template>
+
+<script>
+import { shareAIJuniorProject } from 'core/api/ai-junior-projects'
+
+const MODES = [
+  { value: 'none', label: 'Private', hint: 'Only you' },
+  { value: 'result', label: 'Just the creation', hint: 'The finished result' },
+  { value: 'full', label: 'Creation + worksheet', hint: 'Also shows what they drew and wrote' },
+]
+
+export default {
+  name: 'AIJuniorShareBox',
+  props: {
+    project: {
+      type: Object,
+      required: true,
+    },
+  },
+  data () {
+    return {
+      MODES,
+      shared: this.project.shared || 'none',
+      saving: false,
+      copied: false,
+      error: null,
+    }
+  },
+  computed: {
+    isShared () {
+      return this.shared === 'result' || this.shared === 'full'
+    },
+    shareUrl () {
+      return `${window.location.origin}/ai-junior/creation/${this.project._id}`
+    },
+  },
+  methods: {
+    async setMode (mode) {
+      const previous = this.shared
+      this.shared = mode
+      this.saving = true
+      this.error = null
+      this.copied = false
+      try {
+        await shareAIJuniorProject({ projectHandle: this.project._id, shared: mode })
+        this.$emit('shared', mode)
+      } catch (err) {
+        console.error('Error sharing project:', err)
+        this.shared = previous
+        this.error = 'Could not update sharing. Please try again.'
+      } finally {
+        this.saving = false
+      }
+    },
+    async copyLink () {
+      try {
+        await navigator.clipboard.writeText(this.shareUrl)
+      } catch (err) {
+        // Clipboard API needs a secure context; fall back to selecting the text.
+        this.$refs.linkInput?.select()
+        document.execCommand?.('copy')
+      }
+      this.copied = true
+      setTimeout(() => { this.copied = false }, 2000)
+    },
+  },
+}
+</script>
+
+<style scoped>
+.ai-junior-share-box {
+  max-width: 560px;
+  margin: 1.2rem auto 0;
+  padding: 1.2rem 1.4rem 1.4rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  background: #fafafa;
+}
+
+.ai-junior-share-box h4 {
+  margin: 0 0 0.2rem;
+}
+
+.share-hint {
+  color: #777;
+  font-size: 1.3rem;
+  margin-bottom: 1rem;
+}
+
+.share-modes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+
+.share-mode {
+  flex: 1 1 150px;
+  display: block;
+  margin: 0;
+  padding: 0.7rem 0.8rem;
+  border: 2px solid #ddd;
+  border-radius: 10px;
+  background: #fff;
+  cursor: pointer;
+  font-weight: normal;
+}
+
+.share-mode.active {
+  border-color: #337ab7;
+  background: #f0f7fd;
+}
+
+.share-mode input {
+  display: none;
+}
+
+.share-mode-label {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.share-mode-hint {
+  display: block;
+  font-size: 1.2rem;
+  color: #888;
+}
+
+.share-link-row {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.share-link {
+  flex: 1;
+  min-width: 0;
+  padding: 0.5rem 0.7rem;
+  font-size: 1.4rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.share-error {
+  color: #b3261e;
+  font-size: 1.3rem;
+  margin: 0.8rem 0 0;
+}
+</style>

--- a/app/components/common/elements/AIJuniorWorksheet.vue
+++ b/app/components/common/elements/AIJuniorWorksheet.vue
@@ -4,6 +4,75 @@ import { createNewAIJuniorProject, processAIJuniorProject } from 'core/api/ai-ju
 import QRCode from 'qrcode'
 import { markedInline } from 'core/utils'
 
+// Cap the canvas backing store resolution: sharp enough to print, small enough to submit.
+const MAX_PIXEL_RATIO = 2
+
+// Drop pointer samples closer together than this (in canvas pixels) so strokes stay small.
+const MIN_POINT_DISTANCE = 1.5
+
+// Never hand the AI a drawing narrower than this; a sketch box on a laptop can
+// lay out at a few hundred pixels, which is too little for a model to follow.
+const MIN_EXPORT_WIDTH = 1024
+
+// Crayon-box colours, in place of a raw colour picker no child can aim at.
+const PALETTE = [
+  '#000000', '#e53935', '#fb8c00', '#fdd835', '#43a047',
+  '#1e88e5', '#8e24aa', '#8d5524', '#f48fb1', '#ffffff',
+]
+
+const BRUSH_SIZES = [
+  { label: 'Thin', width: 4 },
+  { label: 'Medium', width: 9 },
+  { label: 'Thick', width: 18 },
+  { label: 'Fat', width: 32 },
+]
+
+// Injected into the page while a worksheet is mounted, so that printing yields exactly one sheet of
+// paper at full size. It cannot live in the scoped styles below: it has to reach the surrounding page
+// chrome, and it has to come back out again when the worksheet goes away.
+const PRINT_CSS = `
+@page {
+  size: 11in 8.5in;
+  margin: 0;
+}
+
+@media print {
+  html, body {
+    width: 11in;
+    height: 8.5in;
+    margin: 0 !important;
+    padding: 0 !important;
+    background: #fff !important;
+    overflow: hidden;
+  }
+
+  #site-content-area, .style-flat {
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+
+  body * {
+    visibility: hidden;
+  }
+
+  .worksheet-outer-container, .worksheet-outer-container * {
+    visibility: visible;
+  }
+
+  .worksheet-outer-container {
+    position: absolute !important;
+    top: 0 !important;
+    left: 0 !important;
+    /* scaleWorksheet() shrinks the sheet to fit the browser window; print it full size. */
+    transform: none !important;
+  }
+
+  .no-print, nav#main-nav, footer#site-footer {
+    display: none !important;
+  }
+}
+`
+
 export default Vue.extend({
   name: 'AIJuniorWorksheet',
 
@@ -18,20 +87,46 @@ export default Vue.extend({
       required: false,
       default: null,
     },
+    // When given, the worksheet renders that project's answers instead of collecting new ones.
+    project: {
+      type: Object,
+      required: false,
+      default: null,
+    },
+    // When given (class printing), the QR code targets this student instead of
+    // the viewing user, and their name pre-fills the name line.
+    printUser: {
+      type: Object,
+      required: false,
+      default: null,
+    },
   },
+
+  emits: ['process-project'],
 
   data: () => ({
     error: null,
     qrCodeUrl: '',
     styleElement: null,
+    printStyleElement: null,
+    PALETTE,
+    BRUSH_SIZES,
     isDrawing: false,
-    currentColor: '#33CC33',
-    lineWidth: 8,
+    isErasing: false,
+    currentColor: '#000000',
+    lineWidth: 9,
+    bigInputId: null,
+    // { [inputId]: [stroke] } — undone strokes, so Undo is not a one-way door.
+    redoStacks: {},
     canvasRefs: {},
     scale: 1,
-    lastX: 0,
-    lastY: 0,
-    canvasContents: {}, // Store canvas content for each input
+    // { [inputId]: [{ color, width, erase, points: [{ x, y }] }] }, with points normalized to 0-1 so
+    // that drawings survive canvas resizes and pixel ratio changes.
+    strokes: {},
+    activeStroke: null,
+    activeInputId: null,
+    pixelRatios: {},
+    projectImages: {},
     projectName: '',
   }),
 
@@ -39,23 +134,43 @@ export default Vue.extend({
     me () {
       return me
     },
+
+    // The editor passes `slug`, the scenario views only pass `scenario`, so fall back through both.
+    scenarioSlug () {
+      return this.slug || this.scenario?.slug || this.scenario?._id || null
+    },
+
+    readOnly () {
+      return Boolean(this.project)
+    },
+
+    projectInputValues () {
+      return this.project?.inputValues || {}
+    },
+
+    canProcessProject () {
+      return this.readOnly && this.project.processingStatus === 'pending'
+    },
   },
 
   watch: {
     scenario: {
-      handler (newScenario) {
-        console.log('Scenario updated:', newScenario)
+      handler () {
         this.generateQRCode()
         this.updateDynamicCss()
         this.scaleWorksheet()
+        this.initializeCanvases()
       },
-      deep: true
+      deep: true,
     },
     'scenario.inputCss': {
       handler (newCss) {
         this.updateDynamicCss(newCss)
       },
-      immediate: true
+      immediate: true,
+    },
+    project () {
+      this.initializeCanvases()
     },
     scale () {
       this.$nextTick(() => {
@@ -66,33 +181,34 @@ export default Vue.extend({
     },
   },
 
-  async mounted () {
-    if (!this.scenario) {
-      console.log('mounted', this.slug, { scenarioHandle: this.slug || '' })
-      try {
-        // this.scenario = await getAIJuniorScenario({ scenarioHandle: this.slug || '' })
-        // TODO: data vs. prop, passing in slug vs. passing in scenario?
-        this.generateQRCode()
-        this.updateDynamicCss()
-      } catch (err) {
-        console.error('Error fetching scenario:', err)
-        this.error = 'An error occurred while fetching the scenario.'
-      }
-    }
+  mounted () {
+    // TODO: data vs. prop, passing in slug vs. passing in scenario?
+    // this.scenario = await getAIJuniorScenario({ scenarioHandle: this.slug || '' })
 
+    // The scenario is normally handed to us fully loaded, in which case the watcher above never fires.
+    // Kept off `data` deliberately: it holds a DOM node, and making Vue observe
+    // one costs a deep walk of the whole element tree for no benefit.
+    this.bigOverlayHome = null
+
+    if (this.printUser) {
+      this.projectName = this.printUser.name || [this.printUser.firstName, this.printUser.lastName].filter(Boolean).join(' ')
+    }
+    this.generateQRCode()
+    this.updateDynamicCss()
+    this.installPrintCss()
+    this.scaleWorksheet()
     this.initializeCanvases()
+    this.onResize = _.debounce(this.onResize, 100)
     window.addEventListener('resize', this.onResize)
   },
 
-  updated () {
-    this.$nextTick(() => {
-      // this.initializeCanvases() // TODO: figure out which fields need to re-initialize canvases because name definitely does not need to
-    })
-  },
-
   beforeDestroy () {
+    this.returnBigOverlay()
     if (this.styleElement) {
       this.styleElement.remove()
+    }
+    if (this.printStyleElement) {
+      this.printStyleElement.remove()
     }
     window.removeEventListener('resize', this.onResize)
   },
@@ -101,13 +217,17 @@ export default Vue.extend({
     markedInline,
 
     async generateQRCode () {
-      if (this.scenario && this.scenario.slug) {
-        const url = `https://codecombat.com/ai-junior/project/${this.slug}/${this.me.id}`
-        try {
-          this.qrCodeUrl = await QRCode.toDataURL(url)
-        } catch (err) {
-          console.error('Error generating QR code:', err)
-        }
+      if (!this.scenarioSlug) { return }
+      const userId = this.printUser?._id || this.me.id
+      // Point at the scan flow, not the project page: the thing you want after
+      // filling in a paper worksheet is to photograph it. This also means the
+      // phone's own camera app resolves the sheet to the right scenario and
+      // student without the in-app QR reader having to do anything.
+      const url = `${window.location.origin}/ai-junior/scan/${this.scenarioSlug}/${userId}`
+      try {
+        this.qrCodeUrl = await QRCode.toDataURL(url)
+      } catch (err) {
+        console.error('Error generating QR code:', err)
       }
     },
 
@@ -123,140 +243,417 @@ export default Vue.extend({
       }
     },
 
+    installPrintCss () {
+      if (this.printStyleElement) { return }
+      this.printStyleElement = document.createElement('style')
+      this.printStyleElement.setAttribute('data-ai-junior-worksheet-print', '')
+      this.printStyleElement.textContent = PRINT_CSS
+      document.head.appendChild(this.printStyleElement)
+    },
+
+    printWorksheet () {
+      window.print()
+    },
+
     scaleWorksheet () {
       const worksheet = this.$el
+      if (!worksheet || !worksheet.style) { return }
       const container = $(worksheet).parent()
       const scaleX = container.width() / (11 * 96) // 11 inches * 96 pixels per inch
       const scaleY = container.height() / (8.5 * 96) // 8.5 inches * 96 pixels per inch
-      this.scale = Math.min(scaleX, scaleY)
-      if (this.scale > 0) {
-        worksheet.style.transform = `scale(${this.scale})`
-        worksheet.style.transformOrigin = 'top left'
-      }
+      const scale = Math.min(scaleX, scaleY)
+      if (!(scale > 0)) { return } // Hidden or not laid out yet; leave the sheet alone
+      this.scale = scale
+      worksheet.style.transform = `scale(${scale})`
+      worksheet.style.transformOrigin = 'top left'
     },
 
     initializeCanvases () {
       this.$nextTick(() => {
-        this.scenario?.inputs.forEach(input => {
+        for (const input of this.scenario?.inputs || []) {
           if (input.type === 'image-field') {
             this.initializeCanvas(input.id)
           }
-        })
+        }
+        this.loadProjectDrawings()
       })
     },
 
     initializeCanvas (inputId) {
       const canvasRef = this.$refs[`canvas-${inputId}`]
-      if (canvasRef && canvasRef[0]) {
-        const canvas = canvasRef[0]
-        const ctx = canvas.getContext('2d')
+      const canvas = canvasRef && canvasRef[0]
+      if (!canvas) { return }
 
-        // Set canvas size to match its display size
-        const rect = canvas.getBoundingClientRect()
-        canvas.width = rect.width
-        canvas.height = rect.height
+      // The sheet is a fixed 11x8.5in that is only visually shrunk with a CSS transform, so size the
+      // backing store from the untransformed layout box. Otherwise drawings made on a small screen
+      // come out blurry when the worksheet is printed or reopened larger.
+      const rect = canvas.getBoundingClientRect()
+      const cssWidth = canvas.clientWidth || rect.width
+      const cssHeight = canvas.clientHeight || rect.height
+      if (!cssWidth || !cssHeight) { return }
 
-        ctx.lineJoin = 'round'
-        ctx.lineCap = 'round'
-        this.canvasRefs[inputId] = canvas
+      const ratio = Math.min(window.devicePixelRatio || 1, MAX_PIXEL_RATIO)
+      canvas.width = Math.round(cssWidth * ratio)
+      canvas.height = Math.round(cssHeight * ratio)
 
-        // Restore previous content if available
-        if (this.canvasContents[inputId]) {
-          ctx.putImageData(this.canvasContents[inputId], 0, 0)
+      this.canvasRefs[inputId] = canvas
+      this.pixelRatios[inputId] = ratio
+      if (!this.strokes[inputId]) {
+        this.$set(this.strokes, inputId, [])
+      }
+
+      this.redrawCanvas(inputId)
+    },
+
+    // Load any drawings the student already submitted so we can paint them into the read-only sheet.
+    loadProjectDrawings () {
+      if (!this.readOnly) { return }
+      for (const input of this.scenario?.inputs || []) {
+        if (input.type !== 'image-field') { continue }
+        const dataUrl = this.projectInputValues[input.id]
+        if (!dataUrl || this.projectImages[input.id]) { continue }
+        const image = new Image()
+        image.onload = () => {
+          this.projectImages[input.id] = image
+          this.redrawCanvas(input.id)
         }
+        image.onerror = () => console.error('Error loading project drawing for', input.id)
+        image.src = dataUrl
       }
     },
 
-    startDrawing (event) {
-      this.isDrawing = true
-      const { x, y } = this.getCoordinates(event)
-      this.lastX = x
-      this.lastY = y
-    },
-
-    draw (event) {
-      if (!this.isDrawing) return
-      const canvas = event.target
+    // Single source of truth for what is on a canvas: the submitted drawing, then the stroke model.
+    redrawCanvas (inputId) {
+      const canvas = this.canvasRefs[inputId]
+      if (!canvas) { return }
       const ctx = canvas.getContext('2d')
-      const { x, y } = this.getCoordinates(event)
+      ctx.setTransform(1, 0, 0, 1, 0, 0)
+      ctx.globalCompositeOperation = 'source-over'
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
 
+      const image = this.projectImages[inputId]
+      if (image) {
+        ctx.drawImage(image, 0, 0, canvas.width, canvas.height)
+      }
+
+      const ratio = this.pixelRatios[inputId] || 1
+      for (const stroke of this.strokes[inputId] || []) {
+        this.drawStroke(ctx, canvas, stroke, ratio)
+      }
+    },
+
+    applyStrokeStyle (ctx, stroke, ratio) {
+      ctx.lineJoin = 'round'
+      ctx.lineCap = 'round'
+      ctx.lineWidth = stroke.width * ratio
+      ctx.strokeStyle = stroke.color
+      ctx.fillStyle = stroke.color
+      ctx.globalCompositeOperation = stroke.erase ? 'destination-out' : 'source-over'
+    },
+
+    drawStroke (ctx, canvas, stroke, ratio) {
+      const points = stroke.points
+      if (!points.length) { return }
+      const width = canvas.width
+      const height = canvas.height
+
+      ctx.save()
+      this.applyStrokeStyle(ctx, stroke, ratio)
       ctx.beginPath()
-      ctx.moveTo(this.lastX, this.lastY)
-      ctx.lineTo(x, y)
-      ctx.strokeStyle = this.currentColor
-      ctx.lineWidth = this.lineWidth
+      if (points.length === 1) {
+        // A single tap should still leave a dot
+        ctx.arc(points[0].x * width, points[0].y * height, (stroke.width * ratio) / 2, 0, Math.PI * 2)
+        ctx.fill()
+      } else {
+        // Smooth the sampled points by curving through the midpoints between them
+        ctx.moveTo(points[0].x * width, points[0].y * height)
+        for (let i = 1; i < points.length - 1; i++) {
+          const midX = ((points[i].x + points[i + 1].x) / 2) * width
+          const midY = ((points[i].y + points[i + 1].y) / 2) * height
+          ctx.quadraticCurveTo(points[i].x * width, points[i].y * height, midX, midY)
+        }
+        const last = points[points.length - 1]
+        ctx.lineTo(last.x * width, last.y * height)
+        ctx.stroke()
+      }
+      ctx.restore()
+    },
+
+    // Paint only the newest piece of the stroke in progress, so drawing stays smooth on tablets.
+    drawLatestSegment (inputId) {
+      const canvas = this.canvasRefs[inputId]
+      const stroke = this.activeStroke
+      if (!canvas || !stroke) { return }
+      const points = stroke.points
+      const count = points.length
+      if (count < 2) { return }
+
+      const width = canvas.width
+      const height = canvas.height
+      const ctx = canvas.getContext('2d')
+      ctx.save()
+      this.applyStrokeStyle(ctx, stroke, this.pixelRatios[inputId] || 1)
+      ctx.beginPath()
+      if (count === 2) {
+        ctx.moveTo(points[0].x * width, points[0].y * height)
+        ctx.lineTo(((points[0].x + points[1].x) / 2) * width, ((points[0].y + points[1].y) / 2) * height)
+      } else {
+        const [previous, control, current] = points.slice(count - 3)
+        ctx.moveTo(((previous.x + control.x) / 2) * width, ((previous.y + control.y) / 2) * height)
+        ctx.quadraticCurveTo(control.x * width, control.y * height, ((control.x + current.x) / 2) * width, ((control.y + current.y) / 2) * height)
+      }
       ctx.stroke()
-
-      this.lastX = x
-      this.lastY = y
-
-      // Store the updated canvas content
-      this.canvasContents[canvas.id] = ctx.getImageData(0, 0, canvas.width, canvas.height)
+      ctx.restore()
     },
 
-    stopDrawing () {
+    startDrawing (event, inputId) {
+      if (this.readOnly) { return }
+      const canvas = this.canvasRefs[inputId] || event.currentTarget
+      if (!canvas) { return }
+      event.preventDefault()
+
+      // Capture the pointer so a stroke keeps going even if a finger wanders off the box
+      if (event.pointerId != null && canvas.setPointerCapture) {
+        try {
+          canvas.setPointerCapture(event.pointerId)
+        } catch (err) {
+          // Some browsers throw if the pointer is already gone; drawing still works without capture
+        }
+      }
+
+      if (!this.strokes[inputId]) {
+        this.$set(this.strokes, inputId, [])
+      }
+      // A new mark is a new branch of history.
+      if (this.redoCount(inputId)) { this.$set(this.redoStacks, inputId, []) }
+      this.isDrawing = true
+      this.activeInputId = inputId
+      this.activeStroke = {
+        color: this.currentColor,
+        width: this.lineWidth * this.pressureScale(event),
+        erase: this.isErasing,
+        points: [this.getCoordinates(event, canvas)],
+      }
+      this.strokes[inputId].push(this.activeStroke)
+    },
+
+    draw (event, inputId) {
+      if (!this.isDrawing || this.activeInputId !== inputId || !this.activeStroke) { return }
+      const canvas = this.canvasRefs[inputId]
+      if (!canvas) { return }
+      event.preventDefault()
+
+      const point = this.getCoordinates(event, canvas)
+      const points = this.activeStroke.points
+      const previous = points[points.length - 1]
+      const dx = (point.x - previous.x) * canvas.width
+      const dy = (point.y - previous.y) * canvas.height
+      if (Math.sqrt((dx * dx) + (dy * dy)) < MIN_POINT_DISTANCE) { return }
+
+      points.push(point)
+      this.drawLatestSegment(inputId)
+    },
+
+    stopDrawing (event, inputId) {
+      if (!this.isDrawing) { return }
+      const drawnInputId = this.activeInputId
+      const canvas = this.canvasRefs[drawnInputId]
+      if (canvas && event?.pointerId != null && canvas.hasPointerCapture?.(event.pointerId)) {
+        canvas.releasePointerCapture(event.pointerId)
+      }
+
       this.isDrawing = false
+      this.activeStroke = null
+      this.activeInputId = null
+
+      // Repaint from the model so what we submit matches it exactly
+      this.redrawCanvas(drawnInputId)
     },
 
-    getCoordinates (event) {
-      const canvas = event.target
+    // Stylus pressure, when there is a stylus. Mice and fingers report a flat
+    // 0.5 (or 0), which must not silently halve every line, so only a real pen
+    // is allowed to change the width.
+    pressureScale (event) {
+      if (event.pointerType !== 'pen') { return 1 }
+      const pressure = typeof event.pressure === 'number' && event.pressure > 0 ? event.pressure : 0.5
+      return 0.45 + pressure
+    },
+
+    // Normalized 0-1 coordinates within the canvas content box, so they stay valid whatever size the
+    // canvas is drawn at. The bounding rect is the border box as it appears on screen, so back out both
+    // the CSS transform that fits the sheet to the window and the canvas border.
+    getCoordinates (event, canvas) {
       const rect = canvas.getBoundingClientRect()
-      const scaleX = canvas.width / rect.width
-      const scaleY = canvas.height / rect.height
-      const x = (event.clientX - rect.left) * scaleX
-      const y = (event.clientY - rect.top) * scaleY
-      return { x, y }
+      const shrinkX = canvas.offsetWidth ? rect.width / canvas.offsetWidth : 1
+      const shrinkY = canvas.offsetHeight ? rect.height / canvas.offsetHeight : 1
+      const width = canvas.clientWidth || rect.width
+      const height = canvas.clientHeight || rect.height
+      return Object.freeze({
+        x: (((event.clientX - rect.left) / shrinkX) - canvas.clientLeft) / width,
+        y: (((event.clientY - rect.top) / shrinkY) - canvas.clientTop) / height,
+      })
+    },
+
+    // What actually gets sent to the AI. Two things matter beyond copying
+    // pixels: the drawing canvas is transparent where nothing was drawn, and an
+    // image model handed a transparent PNG has no page to reason about — the
+    // same drawing on paper arrives as dark marks on white and is matched far
+    // more faithfully. So composite onto white, and never send a thumbnail:
+    // upscale small canvases so a rushed line still has strokes to follow.
+    exportInputImage (inputId) {
+      const canvas = this.canvasRefs[inputId]
+      if (!canvas || !canvas.width || !canvas.height) { return null }
+      const scale = Math.max(1, MIN_EXPORT_WIDTH / canvas.width)
+      const out = document.createElement('canvas')
+      out.width = Math.round(canvas.width * scale)
+      out.height = Math.round(canvas.height * scale)
+      const ctx = out.getContext('2d')
+      ctx.fillStyle = '#ffffff'
+      ctx.fillRect(0, 0, out.width, out.height)
+      ctx.imageSmoothingQuality = 'high'
+      ctx.drawImage(canvas, 0, 0, out.width, out.height)
+      return out.toDataURL('image/png')
+    },
+
+    strokeCount (inputId) {
+      return (this.strokes[inputId] || []).length
+    },
+
+    redoCount (inputId) {
+      return (this.redoStacks[inputId] || []).length
+    },
+
+    undoStroke (inputId) {
+      const strokes = this.strokes[inputId]
+      if (!strokes || !strokes.length) { return }
+      if (!this.redoStacks[inputId]) { this.$set(this.redoStacks, inputId, []) }
+      this.redoStacks[inputId].push(strokes.pop())
+      this.redrawCanvas(inputId)
+    },
+
+    redoStroke (inputId) {
+      const redo = this.redoStacks[inputId]
+      if (!redo || !redo.length) { return }
+      if (!this.strokes[inputId]) { this.$set(this.strokes, inputId, []) }
+      this.strokes[inputId].push(redo.pop())
+      this.redrawCanvas(inputId)
     },
 
     clearCanvas (inputId) {
-      const canvas = this.canvasRefs[inputId]
-      if (canvas) {
-        const ctx = canvas.getContext('2d')
-        ctx.clearRect(0, 0, canvas.width, canvas.height)
-        // Clear stored content
-        this.canvasContents[inputId] = null
+      const strokes = this.strokes[inputId] || []
+      if (strokes.length) { this.$set(this.redoStacks, inputId, strokes.slice().reverse()) }
+      this.$set(this.strokes, inputId, [])
+      this.redrawCanvas(inputId)
+    },
+
+    toggleEraser () {
+      this.isErasing = !this.isErasing
+    },
+
+    chooseColor (color) {
+      this.currentColor = color
+      this.isErasing = false
+    },
+
+    chooseWidth (width) {
+      this.lineWidth = width
+      this.isErasing = false
+    },
+
+    // --- draw big ---------------------------------------------------------
+    // Strokes are stored in normalized 0-1 coordinates, so the same drawing can
+    // be rendered into a canvas of any size. That makes a full-screen drawing
+    // surface almost free: point the existing handlers at a big canvas, and the
+    // small one on the sheet catches up when it closes.
+
+    openBig (inputId) {
+      if (this.readOnly) { return }
+      this.bigInputId = inputId
+      this.$nextTick(() => {
+        // The sheet is a fixed 11x8.5in box that is scaled to fit with a CSS
+        // transform and clips its overflow. `position: fixed` inside a
+        // transformed ancestor resolves against that ancestor rather than the
+        // viewport, so the overlay has to live on <body> while it is open.
+        const overlay = this.$refs.bigOverlay
+        if (overlay) {
+          this.bigOverlayHome = overlay.parentNode
+          document.body.appendChild(overlay)
+        }
+        this.initializeBigCanvas()
+      })
+    },
+
+    initializeBigCanvas () {
+      const canvas = this.$refs.bigCanvas
+      if (!canvas) { return }
+      const rect = canvas.getBoundingClientRect()
+      if (!rect.width || !rect.height) { return }
+      const ratio = Math.min(window.devicePixelRatio || 1, MAX_PIXEL_RATIO)
+      canvas.width = Math.round(rect.width * ratio)
+      canvas.height = Math.round(rect.height * ratio)
+      // Standing in for the sheet's canvas means every existing pointer handler,
+      // undo and colour change works in here with no duplicate code.
+      this.canvasRefs[this.bigInputId] = canvas
+      this.pixelRatios[this.bigInputId] = ratio
+      this.redrawCanvas(this.bigInputId)
+    },
+
+    closeBig () {
+      const inputId = this.bigInputId
+      this.returnBigOverlay()
+      this.bigInputId = null
+      if (!inputId) { return }
+      this.$nextTick(() => this.initializeCanvas(inputId))
+    },
+
+    // Hand the node back to the component before Vue tears it down; removing a
+    // v-if element Vue no longer owns the parent of throws.
+    returnBigOverlay () {
+      const overlay = this.$refs.bigOverlay
+      if (overlay && this.bigOverlayHome) {
+        this.bigOverlayHome.appendChild(overlay)
       }
+      this.bigOverlayHome = null
+    },
+
+    bigAspectRatio () {
+      const input = (this.scenario?.inputs || []).find(i => i.id === this.bigInputId)
+      if (!input) { return '4 / 3' }
+      // The sheet is 11x8.5in, so a region's on-paper aspect is its percentage
+      // box scaled by the page's own proportions.
+      const w = (input.width || 40) * 11
+      const h = (input.height || 40) * 8.5
+      return `${w} / ${h}`
     },
 
     onResize () {
       this.scaleWorksheet()
       this.$nextTick(() => {
         Object.keys(this.canvasRefs).forEach(inputId => {
-          this.resizeCanvas(inputId)
+          this.initializeCanvas(inputId)
         })
       })
     },
 
-    resizeCanvas (inputId) {
-      const canvas = this.canvasRefs[inputId]
-      if (canvas) {
-        const ctx = canvas.getContext('2d')
-        const oldWidth = canvas.width
-        const oldHeight = canvas.height
+    projectValue (inputId) {
+      return this.projectInputValues[inputId] || ''
+    },
 
-        // Store the current drawing
-        const imageData = ctx.getImageData(0, 0, oldWidth, oldHeight)
+    isChoiceSelected (input, choiceId) {
+      return this.readOnly && this.projectValue(input.id) === choiceId
+    },
 
-        // Resize canvas
-        const rect = canvas.getBoundingClientRect()
-        canvas.width = rect.width
-        canvas.height = rect.height
+    isFreeChoiceSelected (input) {
+      const value = this.projectValue(input.id)
+      return Boolean(this.readOnly && value && !(input.choices || []).some(choice => choice.id === value))
+    },
 
-        // Scale and restore the drawing
-        ctx.save()
-        ctx.scale(canvas.width / oldWidth, canvas.height / oldHeight)
-        ctx.putImageData(imageData, 0, 0)
-        ctx.restore()
-
-        // Update stored content
-        this.canvasContents[inputId] = ctx.getImageData(0, 0, canvas.width, canvas.height)
-
-        ctx.lineJoin = 'round'
-        ctx.lineCap = 'round'
-      }
+    freeChoiceText (input) {
+      return this.isFreeChoiceSelected(input) ? this.projectValue(input.id) : ''
     },
 
     async submitWorksheet () {
+      if (this.readOnly) { return }
       const inputValues = {}
       // Collect input fields' values
       for (const input of this.scenario.inputs) {
@@ -271,23 +668,11 @@ export default Vue.extend({
           }
           inputValues[input.id] = selectedValue || ''
         } else if (input.type === 'image-field') {
-          const canvas = this.canvasRefs[input.id]
-          if (canvas) {
-            try {
-              const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'))
-              // Convert blob to base64
-              const base64 = await new Promise((resolve) => {
-                const reader = new FileReader()
-                reader.onloadend = () => resolve(reader.result)
-                reader.readAsDataURL(blob)
-              })
-              inputValues[input.id] = base64
-              console.log('got base64 for', input.id)
-            } catch (error) {
-              console.error('Error getting base64 for', input.id, error)
-            }
+          const dataUrl = this.exportInputImage(input.id)
+          if (dataUrl) {
+            inputValues[input.id] = dataUrl
           } else {
-            console.log('no canvas for', input.id, this.canvasRefs)
+            console.error('No canvas for', input.id, this.canvasRefs)
           }
         } else if (input.type === 'text-field') {
           const inputElement = document.getElementById(`${input.id}-text-field`)
@@ -320,7 +705,7 @@ export default Vue.extend({
         const project = await createNewAIJuniorProject(projectData)
         processAIJuniorProject({ projectHandle: project._id, force: true })
         // TODO: I had the new page start processing, but it wasn't set up right, so starting processing here, waiting a bit, and then opening it.
-        _.delay(() => window.open(`/ai-junior/project/${this.slug || this.scenario?._id}/${this.me.id}/${project._id}`, '_blank'), 500)
+        _.delay(() => window.open(`/ai-junior/project/${this.scenarioSlug}/${this.me.id}/${project._id}`, '_blank'), 500)
       } catch (error) {
         console.error('Error submitting worksheet:', error)
         alert('An error occurred while submitting the worksheet. Please try again.')
@@ -348,9 +733,9 @@ export default Vue.extend({
       <div class="student-name-container">
         <h2 class="student-name-header">
           <span
-            v-if="false && (me.get('name') || me.get('firstName') || me.get('lastName'))"
+            v-if="readOnly"
             class="student-name"
-          >{{ me.broadName() }}</span>
+          >Name: {{ project.name || me.broadName() }}</span>
           <span
             v-else
             class="student-name-field"
@@ -370,12 +755,28 @@ export default Vue.extend({
       >
         Error: {{ error }}
       </p>
-      <button
-        class="submit-button no-print"
-        @click="submitWorksheet"
-      >
-        Submit
-      </button>
+      <div class="worksheet-buttons no-print">
+        <button
+          class="worksheet-button"
+          @click="printWorksheet"
+        >
+          Print
+        </button>
+        <button
+          v-if="canProcessProject"
+          class="worksheet-button"
+          @click="$emit('process-project')"
+        >
+          Process
+        </button>
+        <button
+          v-if="!readOnly"
+          class="worksheet-button"
+          @click="submitWorksheet"
+        >
+          Submit
+        </button>
+      </div>
       <img
         v-if="qrCodeUrl"
         :src="qrCodeUrl"
@@ -419,6 +820,8 @@ export default Vue.extend({
               :type="input.type"
               :name="input.id"
               :value="choice.id"
+              :checked="isChoiceSelected(input, choice.id)"
+              :disabled="readOnly"
             >
             <label :for="`${input.id}-choice-${choice.id}`">{{ choice.text }}</label>
           </div>
@@ -431,9 +834,20 @@ export default Vue.extend({
               :type="input.type"
               :name="input.id"
               value="other"
+              :checked="isFreeChoiceSelected(input)"
+              :disabled="readOnly"
             >
             <label :for="`${input.id}-free-choice`">Other:</label>
             <input
+              v-if="readOnly"
+              :id="`${input.id}-free-choice-text`"
+              type="text"
+              :name="`${input.id}-free-choice-text`"
+              :value="freeChoiceText(input)"
+              readonly
+            >
+            <input
+              v-else
               :id="`${input.id}-free-choice-text`"
               type="text"
               :name="`${input.id}-free-choice-text`"
@@ -445,6 +859,14 @@ export default Vue.extend({
           class="input-text-field"
         >
           <textarea
+            v-if="readOnly"
+            :id="`${input.id}-text-field`"
+            :name="input.id"
+            :value="projectValue(input.id)"
+            readonly
+          />
+          <textarea
+            v-else
             :id="`${input.id}-text-field`"
             :name="input.id"
           />
@@ -457,28 +879,45 @@ export default Vue.extend({
           <canvas
             :ref="`canvas-${input.id}`"
             class="drawing-canvas"
-            @mousedown="startDrawing"
-            @mousemove="draw"
-            @mouseup="stopDrawing"
-            @mouseleave="stopDrawing"
+            :class="{ 'read-only': readOnly }"
+            @pointerdown="startDrawing($event, input.id)"
+            @pointermove="draw($event, input.id)"
+            @pointerup="stopDrawing($event, input.id)"
+            @pointercancel="stopDrawing($event, input.id)"
+            @pointerleave="stopDrawing($event, input.id)"
           />
           <div
+            v-if="!readOnly"
             class="drawing-controls no-print"
             :style="{ transform: `scale(${1/scale})`, transformOrigin: 'bottom left' }"
           >
+            <button
+              class="draw-big-button"
+              @click="openBig(input.id)"
+            >
+              ✏️ Draw Big
+            </button>
+            <button
+              :disabled="!strokeCount(input.id)"
+              @click="undoStroke(input.id)"
+            >
+              Undo
+            </button>
+            <button
+              :disabled="!redoCount(input.id)"
+              @click="redoStroke(input.id)"
+            >
+              Redo
+            </button>
             <button @click="clearCanvas(input.id)">
               Clear
             </button>
-            <input
-              v-model="currentColor"
-              type="color"
+            <button
+              :class="{ 'control-active': isErasing }"
+              @click="toggleEraser"
             >
-            <input
-              v-model.number="lineWidth"
-              type="range"
-              min="1"
-              max="20"
-            >
+              Eraser
+            </button>
           </div>
         </div>
       </div>
@@ -488,6 +927,83 @@ export default Vue.extend({
       class="loading-container"
     >
       <h1>Loading...</h1>
+    </div>
+
+    <!-- Full-screen drawing surface. Strokes live in normalized coordinates, so
+         this edits the very same drawing the small box on the sheet shows. -->
+    <div
+      v-if="bigInputId"
+      ref="bigOverlay"
+      class="draw-big-overlay no-print"
+    >
+      <div class="draw-big-bar">
+        <div class="draw-big-palette">
+          <button
+            v-for="color in PALETTE"
+            :key="color"
+            class="swatch"
+            :class="{ 'swatch-active': !isErasing && currentColor === color, 'swatch-light': color === '#ffffff' }"
+            :style="{ backgroundColor: color }"
+            :aria-label="color"
+            @click="chooseColor(color)"
+          />
+        </div>
+        <div class="draw-big-brushes">
+          <button
+            v-for="brush in BRUSH_SIZES"
+            :key="brush.width"
+            class="brush"
+            :class="{ 'brush-active': !isErasing && lineWidth === brush.width }"
+            @click="chooseWidth(brush.width)"
+          >
+            <span
+              class="brush-dot"
+              :style="{ width: `${brush.width}px`, height: `${brush.width}px`, backgroundColor: isErasing ? '#bbb' : currentColor }"
+            />
+          </button>
+          <button
+            class="brush brush-eraser"
+            :class="{ 'brush-active': isErasing }"
+            @click="toggleEraser"
+          >
+            Eraser
+          </button>
+        </div>
+        <div class="draw-big-actions">
+          <button
+            :disabled="!strokeCount(bigInputId)"
+            @click="undoStroke(bigInputId)"
+          >
+            ↶ Undo
+          </button>
+          <button
+            :disabled="!redoCount(bigInputId)"
+            @click="redoStroke(bigInputId)"
+          >
+            ↷ Redo
+          </button>
+          <button @click="clearCanvas(bigInputId)">
+            Clear
+          </button>
+          <button
+            class="draw-big-done"
+            @click="closeBig"
+          >
+            ✓ Done
+          </button>
+        </div>
+      </div>
+      <div class="draw-big-stage">
+        <canvas
+          ref="bigCanvas"
+          class="draw-big-canvas"
+          :style="{ aspectRatio: bigAspectRatio() }"
+          @pointerdown="startDrawing($event, bigInputId)"
+          @pointermove="draw($event, bigInputId)"
+          @pointerup="stopDrawing($event, bigInputId)"
+          @pointercancel="stopDrawing($event, bigInputId)"
+        />
+      </div>
     </div>
   </div>
 </template>
@@ -634,12 +1150,110 @@ h2.student-name-header {
   position: absolute;
   /* border: 1px dotted #ccc; */
 
+  // A label above a drawing box used to sit on top of a `height: 100%` drawing
+  // container, so the box overflowed its own border by the height of the label
+  // and the toolbar landed outside the frame. Lay it out as a column instead
+  // and let the canvas take whatever room is left.
   &.scenario-input-image-field {
     border: 4px solid black;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
 
     .input-label {
+      flex: 0 0 auto;
       text-align: center;
       color: #888;
+      margin: 2px 0 0;
+    }
+
+    .input-text {
+      flex: 0 0 auto;
+      display: block;
+      text-align: center;
+      font-size: 15px;
+      color: #888;
+    }
+
+    .drawing-container {
+      flex: 1 1 auto;
+      height: auto;
+      min-height: 0;
+    }
+  }
+
+  &.scenario-input-label {
+    .input-label {
+      margin: 0 0 2px;
+      font-size: 21px;
+    }
+
+    .input-text {
+      display: block;
+      font-size: $input-text-font-size;
+      line-height: 1.3;
+    }
+  }
+
+  // Text fields had no styles at all: the textarea fell back to its browser
+  // default size and spilled out of the box it was given.
+  &.scenario-input-text-field {
+    display: flex;
+    flex-direction: column;
+
+    .input-label {
+      flex: 0 0 auto;
+      margin: 0 0 2px;
+      font-size: 21px;
+      font-weight: bold;
+    }
+
+    .input-text {
+      flex: 0 0 auto;
+      display: block;
+      font-size: $input-text-font-size;
+      line-height: 1.3;
+    }
+
+    // An outlined box, so the field reads as somewhere to write. Ruled lines
+    // alone are not enough: they are a background image, and browsers drop
+    // background images when printing unless told otherwise, which left a blank
+    // gap on paper that children skipped straight past. The border always
+    // prints; print-color-adjust keeps the rules as well where it is honoured.
+    .input-text-field {
+      flex: 1 1 auto;
+      min-height: 0;
+      margin-top: 6px;
+      border: 2px solid #000;
+      border-radius: 6px;
+      padding: 3px 6px;
+      overflow: hidden;
+    }
+
+    textarea {
+      display: block;
+      width: 100%;
+      height: 100%;
+      resize: none;
+      box-sizing: border-box;
+      border: none;
+      padding: 0 2px;
+      font-size: 22px;
+      background-color: transparent;
+      line-height: 34px;
+      background-image: repeating-linear-gradient(
+        to bottom,
+        transparent 0,
+        transparent 32px,
+        #bbb 32px,
+        #bbb 33px
+      );
+      print-color-adjust: exact;
+      -webkit-print-color-adjust: exact;
+
+      &:focus {
+        outline: none;
+      }
     }
   }
 
@@ -696,14 +1310,16 @@ h2.student-name-header {
       }
 
       input[type="text"] {
-        flex-grow: 1;
+        /* flex-basis 0 + min-width 0 so the underline shrinks to fit narrow
+           boxes instead of overflowing at the browser's ~20ch default size */
+        flex: 1 1 0;
+        min-width: 40px;
         border: none;
         border-bottom: 2px solid black;
         padding: 5px 5px 0 5px;
         margin-left: 8px;
         font-size: $input-text-font-size;
         line-height: 1.5em; /* Height of the underline */
-        width: auto; /* Adjust width to take remaining space */
       }
     }
   }
@@ -723,20 +1339,166 @@ h2.student-name-header {
   width: 100%;
   height: 100%;
   border: 1px solid #ccc;
+  cursor: crosshair;
+  touch-action: none; /* Draw with a finger without scrolling the page */
+
+  &.read-only {
+    pointer-events: none;
+    cursor: default;
+  }
+}
+
+.draw-big-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: #2b2f38;
+  display: flex;
+  flex-direction: column;
+}
+
+.draw-big-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 1.2rem;
+  padding: 0.8rem 1rem;
+  background: #1e222a;
+}
+
+.draw-big-palette {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.swatch {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 3px solid transparent;
+  padding: 0;
+  cursor: pointer;
+
+  &.swatch-light {
+    border-color: #8a90a0;
+  }
+
+  &.swatch-active {
+    border-color: #fff;
+    box-shadow: 0 0 0 3px #4a9cff;
+  }
+}
+
+.draw-big-brushes,
+.draw-big-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.brush {
+  min-width: 48px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  border: 2px solid #464c5a;
+  background: #2b303a;
+  color: #dfe3ea;
+  font-size: 1.3rem;
+  cursor: pointer;
+
+  &.brush-active {
+    border-color: #4a9cff;
+    background: #10305c;
+  }
+}
+
+.brush-dot {
+  display: block;
+  border-radius: 50%;
+  max-width: 32px;
+  max-height: 32px;
+}
+
+.draw-big-actions button {
+  height: 44px;
+  padding: 0 1rem;
+  border-radius: 10px;
+  border: 2px solid #464c5a;
+  background: #2b303a;
+  color: #dfe3ea;
+  font-size: 1.4rem;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+
+  &.draw-big-done {
+    border-color: #3ddc84;
+    background: #10402a;
+    color: #d6ffe8;
+    font-weight: bold;
+  }
+}
+
+.draw-big-stage {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.draw-big-canvas {
+  max-width: 100%;
+  max-height: 100%;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.45);
+  touch-action: none;
+  cursor: crosshair;
 }
 
 .drawing-controls {
   position: absolute;
   bottom: 10px;
   left: 10px;
+  right: 10px;
   display: flex;
-  gap: 10px;
+  flex-wrap: wrap; /* small sketch boxes get two rows of controls, not clipped ones */
+  gap: 6px 10px;
+  align-items: center;
 
   button, input {
     font-size: 14px;
     padding: 0px;
     border: 0;
     background-color: transparent;
+  }
+
+  button {
+    flex: 0 0 auto;
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: default;
+    }
+
+    &.control-active {
+      font-weight: bold;
+      text-decoration: underline;
+    }
+
+    &.draw-big-button {
+      font-weight: bold;
+      color: #1565c0;
+    }
   }
 
   input {
@@ -746,7 +1508,7 @@ h2.student-name-header {
   /* Styles for the range input */
   input[type="range"] {
     -webkit-appearance: none;
-    width: 100%;
+    width: 80px;
     height: 30px;
     background: transparent;
     padding: 0;
@@ -801,17 +1563,22 @@ h2.student-name-header {
   }
 }
 
-.submit-button {
+.worksheet-buttons {
   position: absolute;
   top: -40px;
   right: 0px; // Positioned above the QR code
+  display: flex;
+  gap: 8px;
+  z-index: 10;
+}
+
+.worksheet-button {
   padding: 5px 8px;
   background-color: #007bff;
   color: white;
   border: none;
   cursor: pointer;
   font-size: 16px;
-  z-index: 10;
 
   &:hover {
     background-color: #0056b3;
@@ -821,6 +1588,24 @@ h2.student-name-header {
 @media print {
   .no-print {
     display: none !important;
+  }
+
+  .worksheet-outer-container {
+    /* Keep checked boxes and drawings black rather than dropping the backgrounds */
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  /* An empty name box should print as a blank line to write on */
+  .student-name-field .student-name-input {
+    -webkit-appearance: none;
+    appearance: none;
+    background: transparent !important;
+    border: none !important;
+    border-bottom: 2px solid #000 !important;
+    border-radius: 0;
+    height: 1.5em;
+    line-height: 1.5em;
   }
 }
 </style>

--- a/app/components/common/elements/AIJuniorWorksheet.vue
+++ b/app/components/common/elements/AIJuniorWorksheet.vue
@@ -219,7 +219,11 @@ export default Vue.extend({
 
     async generateQRCode () {
       if (!this.scenarioSlug) { return }
-      const userId = this.printUser?._id || this.me.id
+      // Only a class print needs to name the child: the code says which sheet
+      // belongs to whom. On a sheet printed for yourself the scanner is already
+      // the owner, so leaving the id out shortens the payload enough to drop a
+      // whole QR version — 25 modules instead of 29, for nothing.
+      const userId = this.printUser?._id || null
       // A short uppercase code rather than the full path. It still resolves to
       // the scan flow — so a phone's own camera app lands in the right place —
       // but at a third of the characters and in QR's alphanumeric mode, which
@@ -1153,11 +1157,26 @@ h2.student-name-header {
 // downward: below the header is where scenarios put their fields, and a bigger
 // code there silently covered an answer box on five of nine worksheets. Ending
 // flush with the bottom of the header keeps it clear of every field.
+// Sized for the camera, not for the header.
+//
+// The printed code is what decides whether a phone can read the sheet, and
+// measured on real captures it was landing at about two pixels per module —
+// below what any decoder manages. It now starts just inside the top edge of the
+// paper and runs 1.8in square: up through the whole half-inch page margin, and
+// about half an inch down into the content area.
+//
+// That last part is a real claim on the sheet, so scenarios must keep their
+// fields clear of the top-right corner. WORKSHEET_QR_FOOTPRINT below says how
+// much, checkAIJuniorWorksheetLayout enforces it, and fitScenariosAroundQR
+// moved the existing scenarios out of the way.
+// Percentages are of the header band ($header-height: 0.85in):
+//   top    -(0.5in margin - 0.05in bleed) / 0.85in = -52.9%
+//   height  1.8in / 0.85in                         = 211.8%
 .qr-code {
   position: absolute;
-  top: -48%;
-  right: -0.75%;
-  height: 148%;
+  top: -52.9%;
+  right: 0;
+  height: 211.8%;
   width: auto;
 }
 

--- a/app/components/common/elements/AIJuniorWorksheet.vue
+++ b/app/components/common/elements/AIJuniorWorksheet.vue
@@ -225,7 +225,14 @@ export default Vue.extend({
       // student without the in-app QR reader having to do anything.
       const url = `${window.location.origin}/ai-junior/scan/${this.scenarioSlug}/${userId}`
       try {
-        this.qrCodeUrl = await QRCode.toDataURL(url)
+        // Printed at a fixed size, so the thing that decides whether a phone can
+        // read it is how few modules have to fit in that square. Measured on
+        // real captures the printed code was landing at about two pixels per
+        // module, under what any decoder manages: level L drops this payload
+        // from 37 modules to 33, and the default four-module quiet zone is
+        // wider than it needs to be. Together they make each module about a
+        // fifth larger for nothing.
+        this.qrCodeUrl = await QRCode.toDataURL(url, { errorCorrectionLevel: 'L', margin: 2 })
       } catch (err) {
         console.error('Error generating QR code:', err)
       }
@@ -1138,11 +1145,17 @@ h2.student-name-header {
   text-align: center;
 }
 
+// A code sized to the header came out around 0.85in, which at normal scanning
+// distance is roughly two pixels per module — right at the edge of unreadable.
+// It grows *upward* into the half-inch page margin above the header rather than
+// downward: below the header is where scenarios put their fields, and a bigger
+// code there silently covered an answer box on five of nine worksheets. Ending
+// flush with the bottom of the header keeps it clear of every field.
 .qr-code {
   position: absolute;
-  top: -0.875%;
+  top: -48%;
   right: -0.75%;
-  height: 100%;
+  height: 148%;
   width: auto;
 }
 

--- a/app/components/common/elements/AIJuniorWorksheet.vue
+++ b/app/components/common/elements/AIJuniorWorksheet.vue
@@ -11,6 +11,9 @@ const MAX_PIXEL_RATIO = 2
 // Drop pointer samples closer together than this (in canvas pixels) so strokes stay small.
 const MIN_POINT_DISTANCE = 1.5
 
+// How far the drawing toolbar may counter-scale against a shrunken sheet.
+const MAX_CONTROL_SCALE = 1.5
+
 // Never hand the AI a drawing narrower than this; a sketch box on a laptop can
 // lay out at a few hundred pixels, which is too little for a model to follow.
 const MIN_EXPORT_WIDTH = 1024
@@ -58,6 +61,12 @@ const PRINT_CSS = `
 
   .worksheet-outer-container, .worksheet-outer-container * {
     visibility: visible;
+    /* Browsers drop background colours and images when printing unless told
+       otherwise. Scenarios draw real content with them — Design a Character's
+       pointer is white text on a black background, which prints as white text
+       on white paper — so the sheet has to opt in. */
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
   }
 
   .worksheet-outer-container {
@@ -151,6 +160,24 @@ export default Vue.extend({
 
     canProcessProject () {
       return this.readOnly && this.project.processingStatus === 'pending'
+    },
+
+    /**
+     * The drawing toolbar counteracts the sheet's own scaling so its buttons
+     * stay a usable size on screen. Left uncapped that is why the worksheet
+     * looks like three different documents: in the editor's small preview the
+     * multiplier reaches about 3x and the toolbar sprawls across the fields
+     * beside it, in the full-size project view it is close to 1x, and in print
+     * the toolbar is hidden altogether. Capping it keeps the three within sight
+     * of each other while still keeping the buttons tappable when the sheet is
+     * shrunk right down.
+     */
+    controlsStyle () {
+      const counter = this.scale > 0 ? 1 / this.scale : 1
+      return {
+        transform: `scale(${Math.min(counter, MAX_CONTROL_SCALE)})`,
+        transformOrigin: 'bottom left',
+      }
     },
   },
 
@@ -902,7 +929,7 @@ export default Vue.extend({
           <div
             v-if="!readOnly"
             class="drawing-controls no-print"
-            :style="{ transform: `scale(${1/scale})`, transformOrigin: 'bottom left' }"
+            :style="controlsStyle"
           >
             <button
               class="draw-big-button"

--- a/app/components/common/elements/AIJuniorWorksheet.vue
+++ b/app/components/common/elements/AIJuniorWorksheet.vue
@@ -2,6 +2,7 @@
 // import { getAIJuniorScenario } from 'core/api/ai-junior-scenarios'
 import { createNewAIJuniorProject, processAIJuniorProject } from 'core/api/ai-junior-projects'
 import QRCode from 'qrcode'
+import { worksheetQRText } from 'lib/doc-capture/qr'
 import { markedInline } from 'core/utils'
 
 // Cap the canvas backing store resolution: sharp enough to print, small enough to submit.
@@ -219,20 +220,21 @@ export default Vue.extend({
     async generateQRCode () {
       if (!this.scenarioSlug) { return }
       const userId = this.printUser?._id || this.me.id
-      // Point at the scan flow, not the project page: the thing you want after
-      // filling in a paper worksheet is to photograph it. This also means the
-      // phone's own camera app resolves the sheet to the right scenario and
-      // student without the in-app QR reader having to do anything.
-      const url = `${window.location.origin}/ai-junior/scan/${this.scenarioSlug}/${userId}`
+      // A short uppercase code rather than the full path. It still resolves to
+      // the scan flow — so a phone's own camera app lands in the right place —
+      // but at a third of the characters and in QR's alphanumeric mode, which
+      // between them make each printed module half as small again. On real
+      // scans the previous code was landing at about two pixels per module and
+      // never decoded once.
+      const scenarioId = this.scenario?._id || this.scenarioSlug
+      const url = worksheetQRText(window.location.origin, scenarioId, userId)
       try {
-        // Printed at a fixed size, so the thing that decides whether a phone can
-        // read it is how few modules have to fit in that square. Measured on
-        // real captures the printed code was landing at about two pixels per
-        // module, under what any decoder manages: level L drops this payload
-        // from 37 modules to 33, and the default four-module quiet zone is
-        // wider than it needs to be. Together they make each module about a
-        // fifth larger for nothing.
-        this.qrCodeUrl = await QRCode.toDataURL(url, { errorCorrectionLevel: 'L', margin: 2 })
+        // Printed at a fixed size, so what decides whether a phone can read it
+        // is how few modules have to fit in that square. The default four-module
+        // quiet zone is wider than it needs to be, and with the short payload
+        // levels M and L land on the same 29-module symbol — so the stronger
+        // error correction costs nothing.
+        this.qrCodeUrl = await QRCode.toDataURL(url, { errorCorrectionLevel: 'M', margin: 2 })
       } catch (err) {
         console.error('Error generating QR code:', err)
       }

--- a/app/core/Router.js
+++ b/app/core/Router.js
@@ -93,6 +93,12 @@ module.exports = (CocoRouter = (function () {
         'ai-junior/project/:scenarioId/:userId/:projectId': go('core/SingletonAppVueComponentView'),
 
         'ai-junior/demo': go('core/SingletonAppVueComponentView'),
+        'ai-junior/print/:scenarioHandle': go('core/SingletonAppVueComponentView'),
+        'ai-junior/print/:scenarioHandle/:classroomId': go('core/SingletonAppVueComponentView'),
+        'ai-junior/scan': go('core/SingletonAppVueComponentView'),
+        'ai-junior/scan/:scenarioHandle': go('core/SingletonAppVueComponentView'),
+        'ai-junior/scan/:scenarioHandle/:forUserId': go('core/SingletonAppVueComponentView'),
+        'ai-junior/creation/:projectId': go('core/SingletonAppVueComponentView'),
 
         licensor: go('LicensorView'),
 

--- a/app/core/api/ai-junior-projects.js
+++ b/app/core/api/ai-junior-projects.js
@@ -17,3 +17,14 @@ export const getAIJuniorProjects = (options = {}) => fetchJson('/db/ai_junior_pr
 export const getAIJuniorProject = ({ projectHandle }, options = {}) => fetchJson(`/db/ai_junior_project/${projectHandle}`, options)
 
 export const getAIJuniorProjectsForScenarioAndUser = ({ scenarioHandle, userId }, options = {}) => fetchJson(`/db/ai_junior_project?scenarioHandle=${scenarioHandle}&userId=${userId}&sort=-1`, options)
+
+// shared: 'none' | 'result' | 'full'
+export const shareAIJuniorProject = ({ projectHandle, shared }, options = {}) =>
+  fetchJson(`/db/ai_junior_project/${projectHandle}/share`, _.assign({}, options, {
+    method: 'POST',
+    json: { shared },
+  }))
+
+// Public — works with no session, which is the whole point of a share link.
+export const getSharedAIJuniorProject = ({ projectHandle }, options = {}) =>
+  fetchJson(`/db/ai_junior_project/${projectHandle}/shared`, options)

--- a/app/core/treema-ext.js
+++ b/app/core/treema-ext.js
@@ -878,10 +878,23 @@ class TaskTreema extends TreemaNode.nodeMap.string {
   }
 }
 
+// A plain number that happens to be measured in percent, like the AI Junior worksheet geometry.
+class PercentTreema extends TreemaNode.nodeMap.number {
+  static initClass () {
+    this.prototype.valueClass = 'treema-percent'
+  }
+
+  buildValueForDisplay (valEl, data) {
+    return this.buildValueForDisplaySimply(valEl, _.isNumber(data) ? `${data}%` : JSON.stringify(data) || '')
+  }
+}
+PercentTreema.initClass()
+
 // class CheckboxTreema extends TreemaNode.nodeMap.boolean
 // TODO: try this out
 
 module.exports.setup = function () {
+  TreemaNode.setNodeSubclass('percent', PercentTreema)
   TreemaNode.setNodeSubclass('date-time', DateTimeTreema)
   TreemaNode.setNodeSubclass('version', VersionTreema)
   TreemaNode.setNodeSubclass('markdown', LiveEditingMarkup)

--- a/app/core/vueRouter.js
+++ b/app/core/vueRouter.js
@@ -12,6 +12,14 @@ export default function getVueRouter () {
 
       routes: [
         {
+          // Public share page. Deliberately a sibling of /ai-junior rather than
+          // a child: it must render without the AI Junior header or its
+          // "you do not have access" banner for logged-out visitors.
+          path: '/ai-junior/creation/:projectId',
+          component: () => import(/* webpackChunkName: "aiJunior" */ 'app/views/ai-junior/AIJuniorSharedView'),
+          props: true,
+        },
+        {
           path: '/ai-junior',
           component: () => import(/* webpackChunkName: "aiJunior" */ 'app/views/ai-junior/AIJuniorView'),
           children: [
@@ -37,6 +45,16 @@ export default function getVueRouter () {
             {
               path: 'demo',
               component: () => import(/* webpackChunkName: "aiJunior" */ 'app/views/ai-junior/AIJuniorDemoView'),
+              props: true,
+            },
+            {
+              path: 'print/:scenarioHandle/:classroomId?',
+              component: () => import(/* webpackChunkName: "aiJunior" */ 'app/views/ai-junior/AIJuniorClassPrintView'),
+              props: true,
+            },
+            {
+              path: 'scan/:scenarioHandle?/:forUserId?',
+              component: () => import(/* webpackChunkName: "aiJunior" */ 'app/views/ai-junior/AIJuniorCaptureView'),
               props: true,
             },
           ],

--- a/app/lib/doc-capture/capture.js
+++ b/app/lib/doc-capture/capture.js
@@ -20,6 +20,7 @@
 import { detectQuad, snapQuad, QuadTracker } from './detect.js'
 import {
   warpQuad, cropRegions, regionToPixels, suggestOutputSize, LETTER_LANDSCAPE,
+  FULL_PAGE_FRAME, WORKSHEET_CONTENT_FRAME, WORKSHEET_GEOMETRY,
 } from './warp.js'
 import { orderQuad, dist } from './geom.js'
 import { cleanPage } from './cleanup.js'
@@ -28,6 +29,7 @@ import { decodeQR, parseWorksheetQR } from './qr.js'
 export {
   detectQuad, snapQuad, QuadTracker,
   warpQuad, cropRegions, regionToPixels, suggestOutputSize, LETTER_LANDSCAPE,
+  FULL_PAGE_FRAME, WORKSHEET_CONTENT_FRAME, WORKSHEET_GEOMETRY,
   orderQuad, cleanPage, decodeQR, parseWorksheetQR,
 }
 
@@ -70,8 +72,8 @@ export function warpToCanvas (img, quad, outW = LETTER_LANDSCAPE.width, outH = L
  * Crop percentage-defined regions out of a rectified page.
  * @returns {Array<{id, canvas, dataUrl, rect}>}
  */
-export function cropRegionsToCanvases (pageImageData, regions, type = 'image/png') {
-  return cropRegions(pageImageData, regions).map(r => {
+export function cropRegionsToCanvases (pageImageData, regions, frame = FULL_PAGE_FRAME, type = 'image/png') {
+  return cropRegions(pageImageData, regions, frame).map(r => {
     const canvas = imageDataToCanvas(r.image)
     return { id: r.id, canvas, dataUrl: canvas.toDataURL(type), rect: r.rect }
   })
@@ -129,8 +131,12 @@ export function drawOverlay (ctx, quad, options = {}) {
       remaining -= seg
     }
     ctx.strokeStyle = o.lineColor
-    ctx.lineWidth = o.lineWidth + 2
+    ctx.lineWidth = o.lineWidth + 5
+    ctx.lineCap = 'round'
+    ctx.shadowColor = o.lineColor
+    ctx.shadowBlur = 12
     ctx.stroke()
+    ctx.shadowBlur = 0
   }
 
   if (o.handles) {
@@ -196,9 +202,24 @@ export class DocumentScanner {
     this.targetFps = options.targetFps ?? 12
     this.output = options.output ?? LETTER_LANDSCAPE
     this.regions = options.regions ?? []
+    // Worksheet field percentages are relative to the printable area inside the
+    // page margins and header, not to the sheet. See WORKSHEET_CONTENT_FRAME.
+    this.contentFrame = options.contentFrame ?? WORKSHEET_CONTENT_FRAME
     this.autoCapture = options.autoCapture ?? true
+    // Confidence here is the WEAKEST of the four edges, which separates the two
+    // populations cleanly. Measured across the synthetic suite plus hand-grip
+    // cases: every frame that rectifies correctly scores >= 0.59, every frame
+    // that produces a wrong quad scores <= 0.21. 0.45 sits in that gap with
+    // roughly 2x margin on both sides.
+    this.autoCaptureConfidence = options.autoCaptureConfidence ?? 0.45
+    this.autoCaptureMinArea = options.autoCaptureMinArea ?? 0.18
     this.detectOptions = options.detectOptions ?? {}
     this.clean = options.clean ?? true
+    // Keep the unstraightened frame alongside each capture, so detection can be
+    // measured against real photographs instead of synthetic ones.
+    this.keepRaw = options.keepRaw ?? true
+    this.rawSize = options.rawSize ?? 1400
+    this.rawQuality = options.rawQuality ?? 0.72
     // When set, every few frames are also searched for a worksheet QR code, so
     // a scan page opened with no scenario can work out which sheet this is.
     this.wantQR = options.wantQR ?? false
@@ -423,11 +444,24 @@ export class DocumentScanner {
     const warning = warningFor(result)
     this.lastWarning = warning
 
+    // "Held still" is not the same as "correct" -- a wrong outline sits just as
+    // still as a right one. Auto-capture additionally requires that the image
+    // actually backs those edges, and that the quad covers a plausible share of
+    // the frame, so a lock onto some printed box inside the page cannot fire.
+    const confidence = result?.confidence ?? 0
+    const areaFraction = result?.areaFraction ?? 0
+    const trustworthy = !warning &&
+      confidence >= this.autoCaptureConfidence &&
+      areaFraction >= this.autoCaptureMinArea
+
     this.onUpdate({
       quad,
       stable: tracked.stable,
-      progress: warning ? 0 : tracked.progress,
+      progress: trustworthy ? tracked.progress : 0,
       score: result?.score ?? 0,
+      confidence,
+      areaFraction,
+      trustworthy,
       touchesBorder: result?.touchesBorder ?? false,
       clipped: result?.clipped ?? false,
       fillsFrame: result?.fillsFrame ?? false,
@@ -438,7 +472,7 @@ export class DocumentScanner {
 
     if (this.wantQR && now - this._lastQRRun > this.qrIntervalMs) this._scanQR(now)
 
-    if (tracked.stable && this.autoCapture && !warning) {
+    if (tracked.stable && this.autoCapture && trustworthy) {
       this.tracker.reset()
       this.capture(quad, 'auto')
     }
@@ -526,12 +560,38 @@ export class DocumentScanner {
       quad: use.map(p => ({ ...p })),
       canvas,
       dataUrl: canvas.toDataURL('image/png'),
-      regions: this.regions.length ? cropRegionsToCanvases(page, this.regions) : [],
+      regions: this.regions.length ? cropRegionsToCanvases(page, this.regions, this.contentFrame) : [],
       handsRemoved: cleaned.handsRemoved,
+      cleanupSkipped: cleaned.skipped || null,
+      // The unstraightened frame this was made from, plus the corners we chose.
+      // Only the rectified page is otherwise kept, and a rectified page cannot
+      // tell you whether the corners were right — so without this there is no
+      // way to measure or improve detection against real captures.
+      rawDataUrl: this.keepRaw ? this._rawJpeg(frame) : null,
       source,
     }
     this.onCapture(result)
     return result
+  }
+
+  /**
+   * A modest JPEG of the frame detection ran against, for later analysis.
+   * Deliberately downscaled: this is diagnostic data attached to every scan, and
+   * corner accuracy is judged at a far lower resolution than the page itself.
+   */
+  _rawJpeg (frame) {
+    try {
+      const scale = Math.min(1, this.rawSize / Math.max(frame.width, frame.height))
+      const full = imageDataToCanvas(frame)
+      if (scale >= 1) return full.toDataURL('image/jpeg', this.rawQuality)
+      const small = createCanvas(Math.round(frame.width * scale), Math.round(frame.height * scale))
+      const ctx = small.getContext('2d')
+      ctx.imageSmoothingQuality = 'high'
+      ctx.drawImage(full, 0, 0, small.width, small.height)
+      return small.toDataURL('image/jpeg', this.rawQuality)
+    } catch (err) {
+      return null // diagnostics must never break a capture
+    }
   }
 
   /** Run the same pipeline over a still image (file upload, testing). */
@@ -558,7 +618,7 @@ export class DocumentScanner {
       quad: pixels.map(p => ({ x: p.x / width, y: p.y / height })),
       canvas,
       dataUrl: canvas.toDataURL('image/png'),
-      regions: this.regions.length ? cropRegionsToCanvases(page, this.regions) : [],
+      regions: this.regions.length ? cropRegionsToCanvases(page, this.regions, this.contentFrame) : [],
       handsRemoved: cleaned.handsRemoved,
       source: 'image',
     }

--- a/app/lib/doc-capture/capture.js
+++ b/app/lib/doc-capture/capture.js
@@ -1,0 +1,566 @@
+/**
+ * capture.js -- public API for real-time worksheet capture and straightening.
+ *
+ * Everything below the DOM helpers (detect.js, warp.js, geom.js, imageops.js)
+ * is pure math on ImageData-shaped buffers with no browser dependency, so the
+ * pipeline is testable in Node. This file is the only one that touches
+ * `document`, `navigator` or `canvas`.
+ *
+ * Typical use:
+ *
+ *   const scanner = new DocumentScanner({
+ *     video: videoEl,
+ *     regions: [{ id: 'drawing', left: 6, top: 26, width: 42, height: 56 }],
+ *     onUpdate: ({ quad, stable, progress }) => drawOverlay(quad, progress),
+ *     onCapture: ({ dataUrl, regions }) => show(dataUrl, regions)
+ *   })
+ *   await scanner.start()
+ */
+
+import { detectQuad, snapQuad, QuadTracker } from './detect.js'
+import {
+  warpQuad, cropRegions, regionToPixels, suggestOutputSize, LETTER_LANDSCAPE,
+} from './warp.js'
+import { orderQuad, dist } from './geom.js'
+import { cleanPage } from './cleanup.js'
+import { decodeQR, parseWorksheetQR } from './qr.js'
+
+export {
+  detectQuad, snapQuad, QuadTracker,
+  warpQuad, cropRegions, regionToPixels, suggestOutputSize, LETTER_LANDSCAPE,
+  orderQuad, cleanPage, decodeQR, parseWorksheetQR,
+}
+
+// --------------------------------------------------------------------------
+// Canvas helpers
+// --------------------------------------------------------------------------
+
+export function createCanvas (width, height) {
+  const c = document.createElement('canvas')
+  c.width = width
+  c.height = height
+  return c
+}
+
+export function imageDataToCanvas (img) {
+  const canvas = createCanvas(img.width, img.height)
+  const ctx = canvas.getContext('2d')
+  const id = ctx.createImageData(img.width, img.height)
+  id.data.set(img.data)
+  ctx.putImageData(id, 0, 0)
+  return canvas
+}
+
+/** Draw any drawable (video, image, canvas) into a fresh ImageData buffer. */
+export function readFrame (source, width, height) {
+  const canvas = createCanvas(width, height)
+  const ctx = canvas.getContext('2d', { willReadFrequently: true })
+  ctx.drawImage(source, 0, 0, width, height)
+  return ctx.getImageData(0, 0, width, height)
+}
+
+/** Rectify a quad out of an ImageData and return a canvas. */
+export function warpToCanvas (img, quad, outW = LETTER_LANDSCAPE.width, outH = LETTER_LANDSCAPE.height) {
+  const warped = warpQuad(img, quad, outW, outH)
+  if (!warped) return null
+  return imageDataToCanvas(warped)
+}
+
+/**
+ * Crop percentage-defined regions out of a rectified page.
+ * @returns {Array<{id, canvas, dataUrl, rect}>}
+ */
+export function cropRegionsToCanvases (pageImageData, regions, type = 'image/png') {
+  return cropRegions(pageImageData, regions).map(r => {
+    const canvas = imageDataToCanvas(r.image)
+    return { id: r.id, canvas, dataUrl: canvas.toDataURL(type), rect: r.rect }
+  })
+}
+
+// --------------------------------------------------------------------------
+// Overlay rendering
+// --------------------------------------------------------------------------
+
+const OVERLAY_DEFAULTS = {
+  lineColor: '#3ddc84',
+  searchColor: 'rgba(255,255,255,0.35)',
+  fillColor: 'rgba(61,220,132,0.12)',
+  handleColor: '#ffffff',
+  handleRadius: 11,
+  lineWidth: 3,
+}
+
+/**
+ * Paint the detected page outline onto an overlay canvas.
+ * `quad` is in normalized 0..1 coordinates so the caller never has to think
+ * about the mismatch between detection resolution and display size.
+ */
+export function drawOverlay (ctx, quad, options = {}) {
+  const o = { ...OVERLAY_DEFAULTS, ...options }
+  const { width, height } = ctx.canvas
+  ctx.clearRect(0, 0, width, height)
+  if (!quad) return
+  const pts = quad.map(p => ({ x: p.x * width, y: p.y * height }))
+
+  ctx.save()
+  ctx.beginPath()
+  ctx.moveTo(pts[0].x, pts[0].y)
+  for (let i = 1; i < 4; i++) ctx.lineTo(pts[i].x, pts[i].y)
+  ctx.closePath()
+  ctx.fillStyle = o.fillColor
+  ctx.fill()
+  ctx.lineJoin = 'round'
+  ctx.lineWidth = o.lineWidth
+  ctx.strokeStyle = o.stable ? o.lineColor : o.searchColor
+  ctx.stroke()
+
+  // Progress toward auto-capture: trace the outline clockwise as it fills.
+  if (o.progress > 0 && o.progress < 1) {
+    const total = pts.reduce((sum, p, i) => sum + dist(p, pts[(i + 1) % 4]), 0)
+    let remaining = total * o.progress
+    ctx.beginPath()
+    ctx.moveTo(pts[0].x, pts[0].y)
+    for (let i = 0; i < 4 && remaining > 0; i++) {
+      const a = pts[i]
+      const b = pts[(i + 1) % 4]
+      const seg = dist(a, b)
+      const t = Math.min(1, remaining / seg)
+      ctx.lineTo(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t)
+      remaining -= seg
+    }
+    ctx.strokeStyle = o.lineColor
+    ctx.lineWidth = o.lineWidth + 2
+    ctx.stroke()
+  }
+
+  if (o.handles) {
+    for (const p of pts) {
+      ctx.beginPath()
+      ctx.arc(p.x, p.y, o.handleRadius, 0, Math.PI * 2)
+      ctx.fillStyle = o.handleColor
+      ctx.fill()
+      ctx.lineWidth = 3
+      ctx.strokeStyle = o.lineColor
+      ctx.stroke()
+    }
+  }
+  ctx.restore()
+}
+
+/**
+ * Turn the detector's self-reported trouble flags into a message, or null when
+ * the frame looks trustworthy. Drives both the on-screen hint and the decision
+ * to hold off on auto-capture.
+ */
+export function warningFor (result) {
+  if (!result) return null
+  if (result.fillsFrame) {
+    return 'Can\u2019t see all four paper edges \u2014 move the camera back, or put the sheet on a darker surface.'
+  }
+  if (result.clipped || result.touchesBorder) {
+    return 'The page runs past the edge of the frame \u2014 move the camera back.'
+  }
+  return null
+}
+
+/** Index of the corner nearest to a normalized point, or -1 if none is close. */
+export function pickCorner (quad, point, tolerance = 0.06) {
+  let best = -1
+  let bestD = tolerance
+  for (let i = 0; i < 4; i++) {
+    const d = Math.hypot(quad[i].x - point.x, quad[i].y - point.y)
+    if (d < bestD) { bestD = d; best = i }
+  }
+  return best
+}
+
+// --------------------------------------------------------------------------
+// Scanner
+// --------------------------------------------------------------------------
+
+/**
+ * Camera session: opens the stream, runs detection on a throttled loop, tracks
+ * stability, and rectifies on capture.
+ *
+ * Detection runs on a downscaled copy of the frame (detectSize) while capture
+ * always rectifies from the full-resolution frame, so preview cost stays low
+ * without giving up output quality.
+ */
+export class DocumentScanner {
+  constructor (options = {}) {
+    this.video = options.video
+    // 640 rather than 480: corner accuracy is what decides whether the page
+    // comes out square, and the adaptive throttle below already backs off the
+    // frame rate on a device that cannot keep up.
+    this.detectSize = options.detectSize ?? 640
+    this.targetFps = options.targetFps ?? 12
+    this.output = options.output ?? LETTER_LANDSCAPE
+    this.regions = options.regions ?? []
+    this.autoCapture = options.autoCapture ?? true
+    this.detectOptions = options.detectOptions ?? {}
+    this.clean = options.clean ?? true
+    // When set, every few frames are also searched for a worksheet QR code, so
+    // a scan page opened with no scenario can work out which sheet this is.
+    this.wantQR = options.wantQR ?? false
+    this.qrIntervalMs = options.qrIntervalMs ?? 250
+    this.qrSize = options.qrSize ?? 1280
+    this.onUpdate = options.onUpdate ?? (() => {})
+    this.onCapture = options.onCapture ?? (() => {})
+    this.onQR = options.onQR ?? (() => {})
+    this.onError = options.onError ?? (err => console.error(err))
+
+    // Looser than a document scanner would normally allow, because the subject
+    // here is a sheet held by a child or propped in front of a laptop webcam:
+    // waiting a full second for sub-2% corner stillness meant auto-capture
+    // effectively never fired.
+    this.tracker = new QuadTracker({
+      stableMs: options.stableMs ?? 700,
+      tolFraction: options.tolFraction ?? 0.035,
+      minFrames: options.minFrames ?? 4,
+    })
+    this.lastQRText = null
+    this._lastQRRun = 0
+    this._qrBusy = false
+    this.stream = null
+    this.running = false
+    this.manual = false
+    this.manualQuad = null
+    this.lastQuad = null
+    this.lastDetectMs = 0
+    this.lastWarning = null
+    this.still = null
+    this._raf = null
+    this._lastRun = 0
+    this._scratch = null
+  }
+
+  /** The element frames are read from: a loaded still takes over from the video. */
+  get source () {
+    return this.still ?? this.video
+  }
+
+  async start (constraints) {
+    const wanted = constraints ?? {
+      video: {
+        facingMode: { ideal: 'environment' },
+        width: { ideal: 1920 },
+        height: { ideal: 1080 },
+      },
+      audio: false,
+    }
+    try {
+      this.stream = await navigator.mediaDevices.getUserMedia(wanted)
+    } catch (err) {
+      // Back-facing camera is only a preference; a laptop webcam is fine.
+      if (constraints) throw err
+      this.stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false })
+    }
+    this.video.srcObject = this.stream
+    this.video.setAttribute('playsinline', '')
+    this.video.muted = true
+    await this.video.play()
+    this.running = true
+    this.tracker.reset()
+    this._loop()
+    return this.stream
+  }
+
+  stop () {
+    this.running = false
+    if (this._raf) cancelAnimationFrame(this._raf)
+    this._raf = null
+    if (this.stream) {
+      for (const track of this.stream.getTracks()) track.stop()
+      this.stream = null
+    }
+  }
+
+  get frameSize () {
+    const s = this.source
+    if (!s) return { width: 0, height: 0 }
+    return {
+      width: s.naturalWidth ?? s.videoWidth ?? s.width ?? 0,
+      height: s.naturalHeight ?? s.videoHeight ?? s.height ?? 0,
+    }
+  }
+
+  /**
+   * Detect against a still image instead of the live camera. Lets the whole
+   * pipeline be exercised (and real photos checked) on a machine with no camera.
+   */
+  useStill (image) {
+    this.still = image
+    this.manual = false
+    this.manualQuad = null
+    this.tracker.reset()
+    if (this.video && !this.video.paused) this.video.pause()
+    return this.detectOnce()
+  }
+
+  clearStill () {
+    this.still = null
+    this.tracker.reset()
+    if (this.running && this.video) this.video.play()
+  }
+
+  /** Single detection pass over the current source, without the tracking loop. */
+  detectOnce () {
+    const { width, height } = this.frameSize
+    if (!width || !height) return null
+    const scale = Math.min(1, this.detectSize / Math.max(width, height))
+    const frame = readFrame(this.source, Math.round(width * scale), Math.round(height * scale))
+    const t0 = performance.now()
+    const result = detectQuad(frame, this.detectOptions)
+    this.lastDetectMs = performance.now() - t0
+    this.lastQuad = result ? result.quadNormalized.map(p => ({ ...p })) : null
+    this.lastWarning = warningFor(result)
+    this.onUpdate({
+      quad: this.lastQuad,
+      stable: !!result,
+      progress: 0,
+      score: result?.score ?? 0,
+      touchesBorder: result?.touchesBorder ?? false,
+      clipped: result?.clipped ?? false,
+      fillsFrame: result?.fillsFrame ?? false,
+      warning: this.lastWarning,
+      detectMs: this.lastDetectMs,
+      manual: false,
+    })
+    return result
+  }
+
+  /** Freeze the preview so corners can be dragged against a still frame. */
+  enterManualMode () {
+    const quad = this.lastQuad ?? [
+      { x: 0.12, y: 0.12 }, { x: 0.88, y: 0.12 }, { x: 0.88, y: 0.88 }, { x: 0.12, y: 0.88 },
+    ]
+    this.manualQuad = quad.map(p => ({ ...p }))
+    this.manual = true
+    if (this.video && !this.video.paused) this.video.pause()
+    this.onUpdate({ quad: this.manualQuad, stable: false, progress: 0, manual: true })
+    return this.manualQuad
+  }
+
+  exitManualMode () {
+    // Against a frozen still there is no live detection to fall back to, so the
+    // hand-placed corners become the current quad instead of being discarded.
+    // With the camera running, dropping them is right: tracking takes over.
+    if (this.still && this.manualQuad) {
+      this.lastQuad = this.manualQuad.map(p => ({ ...p }))
+    }
+    this.manual = false
+    this.manualQuad = null
+    this.tracker.reset()
+    if (this.running && !this.still && this.video) this.video.play()
+  }
+
+  setManualQuad (quad) {
+    this.manualQuad = quad.map(p => ({
+      x: Math.min(1, Math.max(0, p.x)),
+      y: Math.min(1, Math.max(0, p.y)),
+    }))
+    this.onUpdate({ quad: this.manualQuad, stable: false, progress: 0, manual: true })
+  }
+
+  /** Pull the manually placed corners onto the nearest real image edges. */
+  snapManualQuad () {
+    if (!this.manualQuad) return null
+    const { width, height } = this.frameSize
+    if (!width) return null
+    const frame = readFrame(this.source, width, height)
+    const pixels = this.manualQuad.map(p => ({ x: p.x * width, y: p.y * height }))
+    const snapped = snapQuad(frame, pixels)
+    if (!snapped) return this.manualQuad
+    this.setManualQuad(snapped.map(p => ({ x: p.x / width, y: p.y / height })))
+    return this.manualQuad
+  }
+
+  _loop () {
+    if (!this.running) return
+    this._raf = requestAnimationFrame(() => this._loop())
+    if (this.manual || this.still) return
+    const now = performance.now()
+    // Adaptive throttle: never spend more than roughly half the wall clock on
+    // detection, so a slow device degrades in frame rate rather than locking up.
+    const interval = Math.max(1000 / this.targetFps, this.lastDetectMs * 1.8)
+    if (now - this._lastRun < interval) return
+    this._lastRun = now
+
+    const { width, height } = this.frameSize
+    if (!width || !height) return
+    const scale = Math.min(1, this.detectSize / Math.max(width, height))
+    const dw = Math.max(2, Math.round(width * scale))
+    const dh = Math.max(2, Math.round(height * scale))
+
+    let frame
+    try {
+      frame = this._readScratch(dw, dh)
+    } catch (err) {
+      this.onError(err)
+      return
+    }
+
+    const t0 = performance.now()
+    let result = null
+    try {
+      result = detectQuad(frame, this.detectOptions)
+    } catch (err) {
+      this.onError(err)
+    }
+    this.lastDetectMs = performance.now() - t0
+
+    const diag = Math.hypot(dw, dh)
+    const pixelQuad = result ? result.quad : null
+    const tracked = this.tracker.update(pixelQuad, now, diag)
+    const quad = tracked.quad
+      ? tracked.quad.map(p => ({ x: p.x / dw, y: p.y / dh }))
+      : null
+    this.lastQuad = quad
+
+    // Never auto-fire on a frame the detector has told us it cannot trust:
+    // a page that overruns the viewport yields a quad around some printed box
+    // inside the sheet, and silently capturing that is worse than not capturing.
+    const warning = warningFor(result)
+    this.lastWarning = warning
+
+    this.onUpdate({
+      quad,
+      stable: tracked.stable,
+      progress: warning ? 0 : tracked.progress,
+      score: result?.score ?? 0,
+      touchesBorder: result?.touchesBorder ?? false,
+      clipped: result?.clipped ?? false,
+      fillsFrame: result?.fillsFrame ?? false,
+      warning,
+      detectMs: this.lastDetectMs,
+      manual: false,
+    })
+
+    if (this.wantQR && now - this._lastQRRun > this.qrIntervalMs) this._scanQR(now)
+
+    if (tracked.stable && this.autoCapture && !warning) {
+      this.tracker.reset()
+      this.capture(quad, 'auto')
+    }
+  }
+
+  /**
+   * Look for a worksheet QR code in the current frame. Runs off the detection
+   * frame that was already read, and never more than one at a time, so turning
+   * it on does not slow page tracking down.
+   */
+  _scanQR (now) {
+    if (this._qrBusy) return
+    const { width, height } = this.frameSize
+    if (!width || !height) return
+    this._qrBusy = true
+    this._lastQRRun = now
+    // Deliberately not the 640px detection frame: the printed code is under a
+    // tenth of the page wide, which at detection resolution leaves barely one
+    // pixel per QR module. This reads its own larger frame a few times a second.
+    const scale = Math.min(1, this.qrSize / Math.max(width, height))
+    const frame = readFrame(this.source, Math.round(width * scale), Math.round(height * scale))
+    Promise.resolve(decodeQR(this.source, frame))
+      .then(text => {
+        if (!text || text === this.lastQRText) return
+        const parsed = parseWorksheetQR(text)
+        if (!parsed) return
+        this.lastQRText = text
+        this.onQR({ text, ...parsed })
+      })
+      .catch(() => {})
+      .finally(() => { this._qrBusy = false })
+  }
+
+  /** One-shot QR read against the current source, at full resolution. */
+  async scanQROnce () {
+    const { width, height } = this.frameSize
+    if (!width || !height) return null
+    // Full resolution here: a printed QR is small on the page, and this runs
+    // once against a still rather than every frame of a preview.
+    const frame = readFrame(this.source, width, height)
+    const text = await decodeQR(this.source, frame)
+    if (!text) return null
+    const parsed = parseWorksheetQR(text)
+    if (parsed) {
+      this.lastQRText = text
+      this.onQR({ text, ...parsed })
+    }
+    return parsed
+  }
+
+  _readScratch (w, h) {
+    if (!this._scratch || this._scratch.canvas.width !== w || this._scratch.canvas.height !== h) {
+      const canvas = createCanvas(w, h)
+      this._scratch = { canvas, ctx: canvas.getContext('2d', { willReadFrequently: true }) }
+    }
+    const { canvas, ctx } = this._scratch
+    ctx.drawImage(this.source, 0, 0, w, h)
+    return ctx.getImageData(0, 0, canvas.width, canvas.height)
+  }
+
+  /**
+   * Rectify the current frame and crop the configured regions.
+   * @param {Array<{x,y}>} [quad] normalized corners; defaults to the tracked quad
+   * @returns {{quad, canvas, dataUrl, regions, source}|null}
+   */
+  capture (quad = null, source = 'manual') {
+    const use = quad ?? this.manualQuad ?? this.lastQuad
+    if (!use) return null
+    const { width, height } = this.frameSize
+    if (!width || !height) return null
+
+    const frame = readFrame(this.source, width, height)
+    const pixels = orderQuad(use.map(p => ({ x: p.x * width, y: p.y * height })))
+    const warped = warpQuad(frame, pixels, this.output.width, this.output.height)
+    if (!warped) return null
+
+    // Flatten the lighting and paint out any hand holding the sheet before
+    // anything downstream sees it: the region crops and the archived page
+    // should both be the cleaned version, not the raw photo.
+    const cleaned = this.clean ? cleanPage(warped) : { image: warped, handsRemoved: 0 }
+    const page = cleaned.image
+
+    const canvas = imageDataToCanvas(page)
+    const result = {
+      quad: use.map(p => ({ ...p })),
+      canvas,
+      dataUrl: canvas.toDataURL('image/png'),
+      regions: this.regions.length ? cropRegionsToCanvases(page, this.regions) : [],
+      handsRemoved: cleaned.handsRemoved,
+      source,
+    }
+    this.onCapture(result)
+    return result
+  }
+
+  /** Run the same pipeline over a still image (file upload, testing). */
+  captureFromImage (source, quad = null) {
+    const width = source.naturalWidth ?? source.width
+    const height = source.naturalHeight ?? source.height
+    const frame = readFrame(source, width, height)
+    let pixels
+    if (quad) {
+      pixels = orderQuad(quad.map(p => ({ x: p.x * width, y: p.y * height })))
+    } else {
+      const scale = Math.min(1, this.detectSize / Math.max(width, height))
+      const small = readFrame(source, Math.round(width * scale), Math.round(height * scale))
+      const found = detectQuad(small, this.detectOptions)
+      if (!found) return null
+      pixels = found.quadNormalized.map(p => ({ x: p.x * width, y: p.y * height }))
+    }
+    const warped = warpQuad(frame, pixels, this.output.width, this.output.height)
+    if (!warped) return null
+    const cleaned = this.clean ? cleanPage(warped) : { image: warped, handsRemoved: 0 }
+    const page = cleaned.image
+    const canvas = imageDataToCanvas(page)
+    return {
+      quad: pixels.map(p => ({ x: p.x / width, y: p.y / height })),
+      canvas,
+      dataUrl: canvas.toDataURL('image/png'),
+      regions: this.regions.length ? cropRegionsToCanvases(page, this.regions) : [],
+      handsRemoved: cleaned.handsRemoved,
+      source: 'image',
+    }
+  }
+}

--- a/app/lib/doc-capture/cleanup.js
+++ b/app/lib/doc-capture/cleanup.js
@@ -1,0 +1,304 @@
+/**
+ * cleanup.js -- making a rectified worksheet photo look like a scan.
+ *
+ * Two passes, both on the already-warped page so they can assume a flat sheet:
+ *
+ *   flattenPage()  divides out the lighting gradient, so the paper reads white
+ *                  and pencil reads dark wherever the photo was taken.
+ *   removeHands()  paints out fingers and thumbs holding the sheet down.
+ *
+ * Both are pure functions over ImageData-shaped `{width, height, data}` buffers
+ * with no browser dependency, matching the rest of doc-capture.
+ */
+import { boxBlur } from './imageops.js'
+
+const DEFAULTS = {
+  // Mask work happens on a downscaled copy: a finger is centimetres wide, so
+  // sub-millimetre mask precision buys nothing and costs a lot of time.
+  maskMaxDim: 640,
+  // A hand has to be a real chunk of the page, not a skin-coloured crayon mark.
+  minAreaFraction: 0.0016,
+  // Fingers enter from outside, so only blobs that reach the paper's edge are
+  // treated as hands. A face drawn in the middle of the sheet never qualifies.
+  borderMarginFraction: 0.035,
+  // Grow the mask to swallow the shadow and the slightly-out-of-gamut fringe
+  // around a finger, in units of the downscaled mask's smaller dimension.
+  dilateFraction: 0.012,
+  // The background estimate runs smaller still than the hand mask: it only has
+  // to describe a smooth lighting gradient, and a smaller field keeps the
+  // max-filter window wide relative to the drawing without costing anything.
+  backgroundMaxDim: 224,
+  // Wide enough that the window reaches past a solidly coloured drawing to the
+  // paper around it.
+  backgroundBlurFraction: 0.12,
+  // Below this the "paper" is really a dark photo and flattening would only
+  // amplify noise.
+  minBackground: 24,
+}
+
+function clamp255 (v) {
+  return v < 0 ? 0 : (v > 255 ? 255 : v)
+}
+
+/**
+ * Classic skin-tone test: the RGB rule from Kovac et al. for daylight, ORed
+ * with a YCbCr chroma box. Together they cover the range of skin tones and
+ * camera white balances a phone produces indoors.
+ */
+export function isSkin (r, g, b) {
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  const rgbRule = r > 95 && g > 40 && b > 20 && (max - min) > 15 &&
+    Math.abs(r - g) > 15 && r > g && r > b
+  const cb = 128 - 0.168736 * r - 0.331264 * g + 0.5 * b
+  const cr = 128 + 0.5 * r - 0.418688 * g - 0.081312 * b
+  const ycbcrRule = cb >= 77 && cb <= 130 && cr >= 133 && cr <= 178 && r > g && r > b
+  return rgbRule || ycbcrRule
+}
+
+/** Nearest-neighbour downscale of an RGBA buffer into a smaller RGBA buffer. */
+function downscaleRGBA (img, maxDim) {
+  const scale = Math.min(1, maxDim / Math.max(img.width, img.height))
+  const w = Math.max(1, Math.round(img.width * scale))
+  const h = Math.max(1, Math.round(img.height * scale))
+  const data = new Uint8ClampedArray(w * h * 4)
+  for (let y = 0; y < h; y++) {
+    const sy = Math.min(img.height - 1, Math.floor((y + 0.5) / scale))
+    for (let x = 0; x < w; x++) {
+      const sx = Math.min(img.width - 1, Math.floor((x + 0.5) / scale))
+      const si = (sy * img.width + sx) * 4
+      const di = (y * w + x) * 4
+      data[di] = img.data[si]
+      data[di + 1] = img.data[si + 1]
+      data[di + 2] = img.data[si + 2]
+      data[di + 3] = 255
+    }
+  }
+  return { width: w, height: h, data, scale }
+}
+
+/** Label 4-connected true runs, reporting size and whether each reaches a margin. */
+function components (mask, width, height, borderMargin) {
+  const labels = new Int32Array(width * height).fill(-1)
+  const stack = new Int32Array(width * height)
+  const found = []
+  for (let start = 0; start < mask.length; start++) {
+    if (!mask[start] || labels[start] !== -1) continue
+    const id = found.length
+    let top = 0
+    stack[top++] = start
+    labels[start] = id
+    let size = 0
+    let touchesBorder = false
+    const pixels = []
+    while (top > 0) {
+      const p = stack[--top]
+      const x = p % width
+      const y = (p / width) | 0
+      size++
+      pixels.push(p)
+      if (x <= borderMargin || y <= borderMargin ||
+          x >= width - 1 - borderMargin || y >= height - 1 - borderMargin) {
+        touchesBorder = true
+      }
+      if (x > 0 && mask[p - 1] && labels[p - 1] === -1) { labels[p - 1] = id; stack[top++] = p - 1 }
+      if (x < width - 1 && mask[p + 1] && labels[p + 1] === -1) { labels[p + 1] = id; stack[top++] = p + 1 }
+      if (y > 0 && mask[p - width] && labels[p - width] === -1) { labels[p - width] = id; stack[top++] = p - width }
+      if (y < height - 1 && mask[p + width] && labels[p + width] === -1) { labels[p + width] = id; stack[top++] = p + width }
+    }
+    found.push({ id, size, touchesBorder, pixels })
+  }
+  return found
+}
+
+/**
+ * Separable max filter over a float field: the brightest value within `radius`.
+ * Used to find the paper level underneath the drawing.
+ */
+function maxFilter (values, width, height, radius) {
+  const tmp = new Float32Array(values.length)
+  for (let y = 0; y < height; y++) {
+    const row = y * width
+    for (let x = 0; x < width; x++) {
+      let best = -Infinity
+      const from = Math.max(0, x - radius)
+      const to = Math.min(width - 1, x + radius)
+      for (let xx = from; xx <= to; xx++) if (values[row + xx] > best) best = values[row + xx]
+      tmp[row + x] = best
+    }
+  }
+  const out = new Float32Array(values.length)
+  for (let x = 0; x < width; x++) {
+    for (let y = 0; y < height; y++) {
+      let best = -Infinity
+      const from = Math.max(0, y - radius)
+      const to = Math.min(height - 1, y + radius)
+      for (let yy = from; yy <= to; yy++) if (tmp[yy * width + x] > best) best = tmp[yy * width + x]
+      out[y * width + x] = best
+    }
+  }
+  return out
+}
+
+/** Grow a boolean mask by `radius` using a separable two-pass max filter. */
+function dilate (mask, width, height, radius) {
+  if (radius < 1) return mask
+  const tmp = new Uint8Array(mask.length)
+  for (let y = 0; y < height; y++) {
+    const row = y * width
+    for (let x = 0; x < width; x++) {
+      let on = 0
+      for (let d = -radius; d <= radius && !on; d++) {
+        const xx = x + d
+        if (xx >= 0 && xx < width && mask[row + xx]) on = 1
+      }
+      tmp[row + x] = on
+    }
+  }
+  const out = new Uint8Array(mask.length)
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      let on = 0
+      for (let d = -radius; d <= radius && !on; d++) {
+        const yy = y + d
+        if (yy >= 0 && yy < height && tmp[yy * width + x]) on = 1
+      }
+      out[y * width + x] = on
+    }
+  }
+  return out
+}
+
+/**
+ * Even out the lighting across a photographed page.
+ *
+ * The page's own illumination is estimated with a wide box blur of the
+ * brightest channel, then divided out. Paper goes uniformly white, pencil and
+ * crayon keep their colour, and a shadow across one corner stops looking like
+ * grey paper to whatever reads the sheet next.
+ *
+ * @returns {{width, height, data}} a new buffer; the input is not modified
+ */
+export function flattenPage (img, options = {}) {
+  const opts = { ...DEFAULTS, ...options }
+  const { width, height, data } = img
+  const out = new Uint8ClampedArray(data.length)
+
+  // The illumination estimate is built on a small copy and sampled back up: a
+  // wide blur over the full 2200x1700 page would allocate tens of megabytes on
+  // a phone for an identical result.
+  const scale = Math.min(1, opts.backgroundMaxDim / Math.max(width, height))
+  const bw = Math.max(1, Math.round(width * scale))
+  const bh = Math.max(1, Math.round(height * scale))
+  const luma = new Float32Array(bw * bh)
+  for (let y = 0; y < bh; y++) {
+    const sy = Math.min(height - 1, Math.floor((y + 0.5) / scale))
+    for (let x = 0; x < bw; x++) {
+      const sx = Math.min(width - 1, Math.floor((x + 0.5) / scale))
+      const i = (sy * width + sx) * 4
+      luma[y * bw + x] = Math.max(data[i], data[i + 1], data[i + 2])
+    }
+  }
+
+  // Estimate the paper, not the average. A mean-based background is dragged
+  // down by whatever is drawn on top of it, so a large block of colour ends up
+  // dividing by its own darkness and is bleached away — which is exactly what
+  // happens to a drawing a child has coloured in solidly. Taking a local
+  // maximum first finds the paper showing between and around the marks, so the
+  // gradient still goes but the marks keep their contrast.
+  const radius = Math.max(2, Math.round(Math.min(bw, bh) * opts.backgroundBlurFraction))
+  const paperLevel = maxFilter(luma, bw, bh, radius)
+  const bg = boxBlur({ width: bw, height: bh, data: paperLevel }, radius).data
+
+  for (let i = 0, p = 0; i < data.length; i += 4, p++) {
+    const x = p % width
+    const y = (p / width) | 0
+    const bx = Math.min(bw - 1, (x * scale) | 0)
+    const by = Math.min(bh - 1, (y * scale) | 0)
+    const base = Math.max(opts.minBackground, bg[by * bw + bx])
+    const gain = 255 / base
+    out[i] = clamp255(data[i] * gain)
+    out[i + 1] = clamp255(data[i + 1] * gain)
+    out[i + 2] = clamp255(data[i + 2] * gain)
+    out[i + 3] = 255
+  }
+  return { width, height, data: out }
+}
+
+/**
+ * Paint out hands holding the page down.
+ *
+ * Only skin-coloured regions that are both large and connected to the edge of
+ * the sheet are removed, so a child's crayon drawing of a person survives even
+ * when it is exactly the same colour as the thumb in the corner. Removed areas
+ * are filled with the paper colour sampled just outside the mask, which reads
+ * as blank paper rather than as an obvious white patch.
+ *
+ * @returns {{image: {width, height, data}, removed: number}} removed is the
+ *          fraction of the page that was painted out (0 when no hand was found)
+ */
+export function removeHands (img, options = {}) {
+  const opts = { ...DEFAULTS, ...options }
+  const small = downscaleRGBA(img, opts.maskMaxDim)
+  const { width: mw, height: mh } = small
+  const mask = new Uint8Array(mw * mh)
+
+  for (let i = 0, p = 0; i < small.data.length; i += 4, p++) {
+    if (isSkin(small.data[i], small.data[i + 1], small.data[i + 2])) mask[p] = 1
+  }
+
+  const borderMargin = Math.round(Math.min(mw, mh) * opts.borderMarginFraction)
+  const minArea = mw * mh * opts.minAreaFraction
+  const keep = new Uint8Array(mw * mh)
+  let kept = 0
+  for (const comp of components(mask, mw, mh, borderMargin)) {
+    if (!comp.touchesBorder || comp.size < minArea) continue
+    for (const p of comp.pixels) keep[p] = 1
+    kept += comp.size
+  }
+  if (!kept) return { image: img, removed: 0 }
+
+  const grown = dilate(keep, mw, mh, Math.max(1, Math.round(Math.min(mw, mh) * opts.dilateFraction)))
+
+  // Paper colour: the median-ish brightness of everything the mask did not
+  // claim. Using the real page keeps the patch consistent with a warm photo.
+  let sum = 0
+  let count = 0
+  for (let p = 0; p < grown.length; p++) {
+    if (grown[p]) continue
+    const i = p * 4
+    const v = Math.max(small.data[i], small.data[i + 1], small.data[i + 2])
+    if (v > 120) { sum += v; count++ }
+  }
+  const paper = count ? Math.round(sum / count) : 245
+
+  const data = new Uint8ClampedArray(img.data)
+  const sx = mw / img.width
+  const sy = mh / img.height
+  let removed = 0
+  for (let y = 0; y < img.height; y++) {
+    const my = Math.min(mh - 1, (y * sy) | 0)
+    for (let x = 0; x < img.width; x++) {
+      const mx = Math.min(mw - 1, (x * sx) | 0)
+      if (!grown[my * mw + mx]) continue
+      const i = (y * img.width + x) * 4
+      data[i] = paper
+      data[i + 1] = paper
+      data[i + 2] = paper
+      data[i + 3] = 255
+      removed++
+    }
+  }
+  return { image: { width: img.width, height: img.height, data }, removed: removed / (img.width * img.height) }
+}
+
+/** flattenPage + removeHands, in the order that makes each work best. */
+export function cleanPage (img, options = {}) {
+  // Hands first: flattening amplifies a shadowed finger toward skin tone and
+  // makes the mask messier, while removing it first leaves flat paper behind.
+  const handsResult = options.removeHands === false ? { image: img, removed: 0 } : removeHands(img, options)
+  const image = options.flatten === false ? handsResult.image : flattenPage(handsResult.image, options)
+  return { image, handsRemoved: handsResult.removed }
+}
+
+export const __debug = { components, dilate, downscaleRGBA }

--- a/app/lib/doc-capture/cleanup.js
+++ b/app/lib/doc-capture/cleanup.js
@@ -21,6 +21,9 @@ const DEFAULTS = {
   // Fingers enter from outside, so only blobs that reach the paper's edge are
   // treated as hands. A face drawn in the middle of the sheet never qualifies.
   borderMarginFraction: 0.035,
+  // How much of the page edge a blob must run along before it counts as a hand
+  // rather than a drawing that reaches the margin.
+  minBorderContactFraction: 0.05,
   // Grow the mask to swallow the shadow and the slightly-out-of-gamut fringe
   // around a finger, in units of the downscaled mask's smaller dimension.
   dilateFraction: 0.012,
@@ -56,6 +59,23 @@ export function isSkin (r, g, b) {
   return rgbRule || ycbcrRule
 }
 
+/**
+ * Does this pixel look like something a child deliberately put on the page?
+ *
+ * Used to protect drawings from the margin of tolerance around a detected hand.
+ * Anything strongly coloured, or dark enough to be pencil or marker, is treated
+ * as a mark and never painted over — so a purple crayon line running right up
+ * to the edge of the paper survives a thumb sitting next to it.
+ */
+export function isDrawnMark (r, g, b) {
+  if (isSkin(r, g, b)) return false
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  const saturation = max === 0 ? 0 : (max - min) / max
+  if (saturation > 0.3) return true // crayon, marker, coloured pencil
+  return max < 95 // graphite and black marker, but not a soft grey shadow
+}
+
 /** Nearest-neighbour downscale of an RGBA buffer into a smaller RGBA buffer. */
 function downscaleRGBA (img, maxDim) {
   const scale = Math.min(1, maxDim / Math.max(img.width, img.height))
@@ -89,7 +109,7 @@ function components (mask, width, height, borderMargin) {
     stack[top++] = start
     labels[start] = id
     let size = 0
-    let touchesBorder = false
+    let borderContact = 0
     const pixels = []
     while (top > 0) {
       const p = stack[--top]
@@ -99,14 +119,14 @@ function components (mask, width, height, borderMargin) {
       pixels.push(p)
       if (x <= borderMargin || y <= borderMargin ||
           x >= width - 1 - borderMargin || y >= height - 1 - borderMargin) {
-        touchesBorder = true
+        borderContact++
       }
       if (x > 0 && mask[p - 1] && labels[p - 1] === -1) { labels[p - 1] = id; stack[top++] = p - 1 }
       if (x < width - 1 && mask[p + 1] && labels[p + 1] === -1) { labels[p + 1] = id; stack[top++] = p + 1 }
       if (y > 0 && mask[p - width] && labels[p - width] === -1) { labels[p - width] = id; stack[top++] = p - width }
       if (y < height - 1 && mask[p + width] && labels[p + width] === -1) { labels[p + width] = id; stack[top++] = p + width }
     }
-    found.push({ id, size, touchesBorder, pixels })
+    found.push({ id, size, borderContact, touchesBorder: borderContact > 0, pixels })
   }
   return found
 }
@@ -249,10 +269,16 @@ export function removeHands (img, options = {}) {
 
   const borderMargin = Math.round(Math.min(mw, mh) * opts.borderMarginFraction)
   const minArea = mw * mh * opts.minAreaFraction
+  // A hand enters the frame, so it meets the edge along a real span. A drawing
+  // that merely runs out to the edge of the paper touches it at a few pixels.
+  // Requiring a span rather than a touch is what tells a thumb from a child who
+  // drew all the way to the margin.
+  const minBorderContact = Math.max(4, Math.round(Math.min(mw, mh) * opts.minBorderContactFraction))
   const keep = new Uint8Array(mw * mh)
   let kept = 0
   for (const comp of components(mask, mw, mh, borderMargin)) {
-    if (!comp.touchesBorder || comp.size < minArea) continue
+    if (comp.size < minArea) continue
+    if (comp.borderContact < minBorderContact) continue
     for (const p of comp.pixels) keep[p] = 1
     kept += comp.size
   }
@@ -280,8 +306,14 @@ export function removeHands (img, options = {}) {
     const my = Math.min(mh - 1, (y * sy) | 0)
     for (let x = 0; x < img.width; x++) {
       const mx = Math.min(mw - 1, (x * sx) | 0)
-      if (!grown[my * mw + mx]) continue
+      const m = my * mw + mx
+      if (!grown[m]) continue
       const i = (y * img.width + x) * 4
+      // Inside the detected hand itself, paint unconditionally. In the halo of
+      // tolerance grown around it — there to swallow the shadow and the fringe —
+      // leave anything that looks drawn. Painting the whole halo flat is what
+      // erased the end of a drawing that ran up against a finger.
+      if (!keep[m] && isDrawnMark(data[i], data[i + 1], data[i + 2])) continue
       data[i] = paper
       data[i + 1] = paper
       data[i + 2] = paper

--- a/app/lib/doc-capture/cleanup.js
+++ b/app/lib/doc-capture/cleanup.js
@@ -18,6 +18,14 @@ const DEFAULTS = {
   maskMaxDim: 640,
   // A hand has to be a real chunk of the page, not a skin-coloured crayon mark.
   minAreaFraction: 0.0016,
+  // ...but a thumb on a letter page is a few percent. Anything bigger is not a
+  // hand: it is the desk, because the page corners were found in the wrong
+  // place and the warp pulled the surroundings in. Painting that out turns a
+  // recoverable bad crop into a destroyed worksheet.
+  maxAreaFraction: 0.12,
+  // Likewise in total. If this much of the "page" looks like skin, the page is
+  // not what we think it is, and doing nothing is much safer than guessing.
+  maxTotalAreaFraction: 0.22,
   // Fingers enter from outside, so only blobs that reach the paper's edge are
   // treated as hands. A face drawn in the middle of the sheet never qualifies.
   borderMarginFraction: 0.035,
@@ -274,13 +282,22 @@ export function removeHands (img, options = {}) {
   // Requiring a span rather than a touch is what tells a thumb from a child who
   // drew all the way to the margin.
   const minBorderContact = Math.max(4, Math.round(Math.min(mw, mh) * opts.minBorderContactFraction))
+  const maxArea = mw * mh * opts.maxAreaFraction
   const keep = new Uint8Array(mw * mh)
   let kept = 0
+  let oversized = false
   for (const comp of components(mask, mw, mh, borderMargin)) {
     if (comp.size < minArea) continue
     if (comp.borderContact < minBorderContact) continue
+    if (comp.size > maxArea) { oversized = true; continue }
     for (const p of comp.pixels) keep[p] = 1
     kept += comp.size
+  }
+  // Either guard tripping says the same thing: this is not a page with a hand
+  // on it. Report it so the capture page can suggest checking the corners.
+  const TOO_MUCH = 'a large area looked like skin — the page edges may be wrong'
+  if (oversized || kept > mw * mh * opts.maxTotalAreaFraction) {
+    return { image: img, removed: 0, skipped: TOO_MUCH }
   }
   if (!kept) return { image: img, removed: 0 }
 

--- a/app/lib/doc-capture/cleanup.js
+++ b/app/lib/doc-capture/cleanup.js
@@ -59,6 +59,16 @@ function clamp255 (v) {
 export function isSkin (r, g, b) {
   const max = Math.max(r, g, b)
   const min = Math.min(r, g, b)
+
+  // Warm-lit white paper passes every clause of the classic skin rule — a sheet
+  // photographed under a tungsten bulb sits around (245, 225, 205), which is
+  // redder than green, redder than blue, and spread more than 15 apart. On a
+  // corpus of real scans that made the paper itself the biggest "hand" on the
+  // page. What separates them is that paper is bright *and* almost colourless,
+  // while skin at that brightness still carries real chroma.
+  const saturation = max === 0 ? 0 : (max - min) / max
+  if (max > 235 && saturation < 0.25) return false
+
   const rgbRule = r > 95 && g > 40 && b > 20 && (max - min) > 15 &&
     Math.abs(r - g) > 15 && r > g && r > b
   const cb = 128 - 0.168736 * r - 0.331264 * g + 0.5 * b
@@ -118,6 +128,7 @@ function components (mask, width, height, borderMargin) {
     labels[start] = id
     let size = 0
     let borderContact = 0
+    const sides = { left: false, right: false, top: false, bottom: false }
     const pixels = []
     while (top > 0) {
       const p = stack[--top]
@@ -125,16 +136,14 @@ function components (mask, width, height, borderMargin) {
       const y = (p / width) | 0
       size++
       pixels.push(p)
-      if (x <= borderMargin || y <= borderMargin ||
-          x >= width - 1 - borderMargin || y >= height - 1 - borderMargin) {
-        borderContact++
-      }
+      if (x <= borderMargin) { sides.left = true; borderContact++ } else if (x >= width - 1 - borderMargin) { sides.right = true; borderContact++ } else if (y <= borderMargin) { sides.top = true; borderContact++ } else if (y >= height - 1 - borderMargin) { sides.bottom = true; borderContact++ }
       if (x > 0 && mask[p - 1] && labels[p - 1] === -1) { labels[p - 1] = id; stack[top++] = p - 1 }
       if (x < width - 1 && mask[p + 1] && labels[p + 1] === -1) { labels[p + 1] = id; stack[top++] = p + 1 }
       if (y > 0 && mask[p - width] && labels[p - width] === -1) { labels[p - width] = id; stack[top++] = p - width }
       if (y < height - 1 && mask[p + width] && labels[p + width] === -1) { labels[p + width] = id; stack[top++] = p + width }
     }
-    found.push({ id, size, borderContact, touchesBorder: borderContact > 0, pixels })
+    const sideCount = Object.values(sides).filter(Boolean).length
+    found.push({ id, size, borderContact, sideCount, touchesBorder: borderContact > 0, pixels })
   }
   return found
 }
@@ -289,6 +298,12 @@ export function removeHands (img, options = {}) {
   for (const comp of components(mask, mw, mh, borderMargin)) {
     if (comp.size < minArea) continue
     if (comp.borderContact < minBorderContact) continue
+    // A blob running along three or four sides of the page is not a hand, it is
+    // the surface the page is lying on, included because the detected corners
+    // were a little outside the paper. Painting that frame out is not merely
+    // pointless: grown inward by the tolerance halo it reaches over the title
+    // and the name line.
+    if (comp.sideCount >= 3) { oversized = true; continue }
     if (comp.size > maxArea) { oversized = true; continue }
     for (const p of comp.pixels) keep[p] = 1
     kept += comp.size

--- a/app/lib/doc-capture/cleanup.js
+++ b/app/lib/doc-capture/cleanup.js
@@ -45,6 +45,14 @@ const DEFAULTS = {
   // Below this the "paper" is really a dark photo and flattening would only
   // amplify noise.
   minBackground: 24,
+  // What counts as paper when trimming a rectified page back to the sheet.
+  paperMinBrightness: 150,
+  paperMaxSaturation: 0.28,
+  paperLineShare: 0.6,
+  // Corrections smaller than this are noise; larger than this mean the page was
+  // not really found, and cropping on a bad guess is worse than leaving it.
+  minTrimFraction: 0.004,
+  maxTrimFraction: 0.09,
 }
 
 function clamp255 (v) {
@@ -356,13 +364,99 @@ export function removeHands (img, options = {}) {
   return { image: { width: img.width, height: img.height, data }, removed: removed / (img.width * img.height) }
 }
 
+/**
+ * Crop a rectified page back to the paper.
+ *
+ * Detected corners land a little outside the sheet often enough to matter: the
+ * warp then carries a band of whatever the page was lying on around one or two
+ * edges. Measured over a corpus of real scans that band, not any hand, was the
+ * biggest thing the cleanup pass was painting out — and painting it reached
+ * inward over the title. Cropping it away first is both more honest and
+ * cheaper, and it leaves the output still meaning "exactly the sheet", which
+ * everything downstream assumes when it maps field percentages onto the page.
+ *
+ * Only small corrections are made. A large inset means the page was not found
+ * at all, and guessing then is worse than doing nothing.
+ *
+ * @returns {{image, trimmed: number}} trimmed is the fraction of each edge
+ *   removed, 0 when the page already filled the frame
+ */
+export function trimToPaper (img, options = {}) {
+  const opts = { ...DEFAULTS, ...options }
+  const small = downscaleRGBA(img, opts.backgroundMaxDim)
+  const { width: w, height: h, data } = small
+
+  // Paper is the bright, barely-coloured majority of a rectified worksheet.
+  const paper = new Uint8Array(w * h)
+  for (let i = 0, p = 0; i < data.length; i += 4, p++) {
+    const max = Math.max(data[i], data[i + 1], data[i + 2])
+    const min = Math.min(data[i], data[i + 1], data[i + 2])
+    const saturation = max === 0 ? 0 : (max - min) / max
+    if (max > opts.paperMinBrightness && saturation < opts.paperMaxSaturation) paper[p] = 1
+  }
+
+  // Rows and columns that are mostly paper. Working per line rather than per
+  // component keeps this to an inset on each side, which is the only correction
+  // that leaves the page a rectangle.
+  const edge = (length, other, at) => {
+    const solid = []
+    for (let a = 0; a < length; a++) {
+      let count = 0
+      for (let b = 0; b < other; b++) count += paper[at(a, b)]
+      solid.push(count / other >= opts.paperLineShare)
+    }
+    let lo = 0
+    while (lo < length && !solid[lo]) lo++
+    let hi = length - 1
+    while (hi > lo && !solid[hi]) hi--
+    return { lo, hi }
+  }
+  const cols = edge(w, h, (x, y) => y * w + x)
+  const rows = edge(h, w, (y, x) => y * w + x)
+  if (cols.hi <= cols.lo || rows.hi <= rows.lo) return { image: img, trimmed: 0 }
+
+  const inset = Math.max(
+    cols.lo / w, (w - 1 - cols.hi) / w,
+    rows.lo / h, (h - 1 - rows.hi) / h,
+  )
+  if (inset < opts.minTrimFraction || inset > opts.maxTrimFraction) return { image: img, trimmed: 0 }
+
+  // One inset all round keeps the aspect ratio, which the page's own 11:8.5 is.
+  const dx = Math.round(inset * img.width)
+  const dy = Math.round(inset * img.height)
+  const srcW = img.width - 2 * dx
+  const srcH = img.height - 2 * dy
+  if (srcW < img.width * 0.7 || srcH < img.height * 0.7) return { image: img, trimmed: 0 }
+
+  // Rescale back to the original size so the page still means the whole sheet.
+  const out = new Uint8ClampedArray(img.data.length)
+  for (let y = 0; y < img.height; y++) {
+    const sy = Math.min(img.height - 1, dy + Math.round((y * srcH) / img.height))
+    for (let x = 0; x < img.width; x++) {
+      const sx = Math.min(img.width - 1, dx + Math.round((x * srcW) / img.width))
+      const si = (sy * img.width + sx) * 4
+      const di = (y * img.width + x) * 4
+      out[di] = img.data[si]
+      out[di + 1] = img.data[si + 1]
+      out[di + 2] = img.data[si + 2]
+      out[di + 3] = 255
+    }
+  }
+  return { image: { width: img.width, height: img.height, data: out }, trimmed: inset }
+}
+
 /** flattenPage + removeHands, in the order that makes each work best. */
 export function cleanPage (img, options = {}) {
-  // Hands first: flattening amplifies a shadowed finger toward skin tone and
+  // Trim first: the surroundings carried in by a slightly oversized quad look
+  // like a hand to the next step, and like uneven lighting to the one after.
+  const trimResult = options.trim === false ? { image: img, trimmed: 0 } : trimToPaper(img, options)
+  // Hands next: flattening amplifies a shadowed finger toward skin tone and
   // makes the mask messier, while removing it first leaves flat paper behind.
-  const handsResult = options.removeHands === false ? { image: img, removed: 0 } : removeHands(img, options)
+  const handsResult = options.removeHands === false
+    ? { image: trimResult.image, removed: 0 }
+    : removeHands(trimResult.image, options)
   const image = options.flatten === false ? handsResult.image : flattenPage(handsResult.image, options)
-  return { image, handsRemoved: handsResult.removed }
+  return { image, handsRemoved: handsResult.removed, trimmed: trimResult.trimmed, skipped: handsResult.skipped }
 }
 
 export const __debug = { components, dilate, downscaleRGBA }

--- a/app/lib/doc-capture/detect.js
+++ b/app/lib/doc-capture/detect.js
@@ -205,6 +205,7 @@ function measureEdges (quad, grads, polarity, maxSamples) {
   const R = 2.5
   let supportSum = 0
   let straightSum = 0
+  let worstEdge = Infinity
 
   for (let e = 0; e < 4; e++) {
     const a = quad[e]
@@ -236,10 +237,22 @@ function measureEdges (quad, grads, polarity, maxSamples) {
     }
     residuals.sort((u, v) => u - v)
     const median = residuals.length ? residuals[Math.floor(residuals.length / 2)] : R + 1
-    supportSum += found ? sum / count : 0
-    straightSum += Math.exp(-median / 1.2) * (found / count)
+    const edgeSupport = found ? sum / count : 0
+    const edgeStraight = Math.exp(-median / 1.2) * (found / count)
+    supportSum += edgeSupport
+    straightSum += edgeStraight
+    // Per-edge quality, kept separately: see minEdgeQuality below.
+    worstEdge = Math.min(worstEdge, Math.min(1, edgeSupport / 18) * edgeStraight)
   }
-  return { edgeSupport: supportSum / 4, straightness: straightSum / 4 }
+  return {
+    edgeSupport: supportSum / 4,
+    straightness: straightSum / 4,
+    // The weakest of the four edges. Averaging hides exactly the case that
+    // matters here: a hand gripping one edge leaves three perfect edges and one
+    // bad one, which still averages high enough to look trustworthy. A page is
+    // only truly located when *every* edge is backed by the image.
+    minEdgeQuality: worstEdge,
+  }
 }
 
 function scoreQuad (quad, w, h, edgeSupport, straightness, opts) {
@@ -429,7 +442,7 @@ export function detectQuad (img, options = {}) {
     const m = measureEdges(ordered, grads, polarity, opts.samplesPerEdge)
     const score = scoreQuad(ordered, w, h, m.edgeSupport, m.straightness, opts)
     if (score <= 0) return 0
-    const confidence = Math.min(1, m.edgeSupport / 18) * m.straightness
+    const confidence = m.minEdgeQuality
     const dup = candidates.find(c => quadsSimilar(c.quad, ordered, 2.5))
     if (dup) {
       if (score > dup.score) { dup.score = score; dup.quad = ordered; dup.tag = tag; dup.refined = refined }
@@ -516,6 +529,11 @@ export function detectQuad (img, options = {}) {
     quad,
     quadNormalized: quad.map(p => ({ x: p.x / img.width, y: p.y / img.height })),
     score: best.score,
+    // How strongly the image backs these edges (step strength x straightness),
+    // independent of shape plausibility. Auto-capture gates on this: "the
+    // outline stopped moving" is not the same as "the outline is right".
+    confidence: best.confidence ?? 0,
+    areaFraction: Math.abs(polygonArea(best.quad)) / (w * h),
     tag: best.tag,
     refined: best.refined,
     touchesBorder: best.touchesBorder,

--- a/app/lib/doc-capture/detect.js
+++ b/app/lib/doc-capture/detect.js
@@ -1,0 +1,620 @@
+/**
+ * detect.js -- hand-rolled page-quadrilateral detection.
+ *
+ * Pipeline, per frame:
+ *   1. grayscale, downscale to ~320px on the long side, light Gaussian blur
+ *   2. build several binary masks (Otsu, percentile sweep, illumination-
+ *      flattened Otsu, plus the inverted polarity for dark-page-on-light)
+ *   3. per mask: morphological open, largest connected blob, convex hull,
+ *      collapse the hull to 4 circumscribing corners
+ *   4. refine each of the 4 edges by walking the local intensity gradient,
+ *      robustly fitting a line to the found edge points, and re-intersecting
+ *   5. score every candidate on edge support / edge straightness / area /
+ *      corner angles, and keep the winner
+ *
+ * Step 4 is what makes this accurate: the mask only has to be roughly right,
+ * because the corners come from sub-pixel line fits, not from the blob outline.
+ */
+
+import {
+  grayFromImage, gaussBlur, sobel, otsuThreshold,
+  percentileThreshold, flattenIllumination, threshold, open, largestComponent,
+} from './imageops.js'
+import {
+  convexHull, reduceHullToQuad, orderQuad, polygonArea, quadAngles, isConvex,
+  fitLine, lineDistance, lineThrough, intersectLines, dist,
+} from './geom.js'
+
+const DEFAULTS = {
+  workingSize: 320,
+  blurSigma: 1.2,
+  searchRadius: 10,
+  samplesPerEdge: 40,
+  minAreaFraction: 0.06,
+  minAngle: 45,
+  maxAngle: 135,
+  openLevels: [1, 3],
+  // Stop sweeping thresholds once a candidate is this convincing, and only pay
+  // for the straight-edge search when the best candidate is below the second.
+  earlyExitScore: 0.97,
+  lineSearchScore: 0.9,
+  fillsFrameCoverage: 0.3,
+  lineSearchBlobs: 3,
+  lineTolerance: 1.7,
+  maxLines: 6,
+  ransacIterations: 220,
+}
+
+/** Unit inward normal of edge a->b for a quad with the given centroid. */
+function inwardNormal (a, b, centroid) {
+  const dx = b.x - a.x
+  const dy = b.y - a.y
+  const len = Math.hypot(dx, dy) || 1
+  let nx = -dy / len
+  let ny = dx / len
+  const mx = (a.x + b.x) / 2
+  const my = (a.y + b.y) / 2
+  if ((centroid.x - mx) * nx + (centroid.y - my) * ny < 0) { nx = -nx; ny = -ny }
+  return { x: nx, y: ny }
+}
+
+function sampleField (field, w, h, x, y) {
+  const x0 = Math.min(w - 1, Math.max(0, Math.floor(x)))
+  const y0 = Math.min(h - 1, Math.max(0, Math.floor(y)))
+  const x1 = Math.min(w - 1, x0 + 1)
+  const y1 = Math.min(h - 1, y0 + 1)
+  const fx = x - x0
+  const fy = y - y0
+  return field[y0 * w + x0] * (1 - fx) * (1 - fy) +
+         field[y0 * w + x1] * fx * (1 - fy) +
+         field[y1 * w + x0] * (1 - fx) * fy +
+         field[y1 * w + x1] * fx * fy
+}
+
+/**
+ * One refinement pass: walk each edge's normal looking for the intensity step
+ * of the expected polarity, then fit a line through the hits.
+ *
+ * The search is weighted by a Gaussian centred on the current edge estimate.
+ * Without that prior the strongest step near a page border is often *printed
+ * content* -- a title bar or a border rule a few millimetres inside the paper
+ * has far more contrast than paper-against-table -- and the fit slides inward.
+ * The blob outline is already accurate to a couple of pixels, so trusting it
+ * as a prior and only letting the gradient nudge the line is much steadier.
+ *
+ * Returns { quad, edgeSupport, straightness } or null.
+ */
+function refinePass (quad, grads, polarity, R, priorSigma, maxSamples) {
+  const { gx, gy, width: w, height: h } = grads
+  const cx = (quad[0].x + quad[1].x + quad[2].x + quad[3].x) / 4
+  const cy = (quad[0].y + quad[1].y + quad[2].y + quad[3].y) / 4
+  const centroid = { x: cx, y: cy }
+  const lines = []
+  const supports = []
+  const straightnesses = []
+  const twoSigmaSq = 2 * priorSigma * priorSigma
+
+  const deriv = (px, py, n, o) => {
+    const sx = px + n.x * o
+    const sy = py + n.y * o
+    if (sx < 1 || sy < 1 || sx > w - 2 || sy > h - 2) return 0
+    return polarity * (sampleField(gx, w, h, sx, sy) * n.x + sampleField(gy, w, h, sx, sy) * n.y)
+  }
+
+  for (let e = 0; e < 4; e++) {
+    const a = quad[e]
+    const b = quad[(e + 1) % 4]
+    const n = inwardNormal(a, b, centroid)
+    const len = dist(a, b)
+    const count = Math.max(8, Math.min(maxSamples, Math.round(len / 2)))
+    const hits = []
+    let supportSum = 0
+    for (let s = 0; s < count; s++) {
+      const t = 0.06 + 0.88 * (s / (count - 1))
+      const px = a.x + (b.x - a.x) * t
+      const py = a.y + (b.y - a.y) * t
+      let bestScore = -Infinity
+      let bestVal = 0
+      let bestOff = 0
+      for (let o = -R; o <= R; o += 0.5) {
+        const dd = deriv(px, py, n, o)
+        if (dd <= 0) continue
+        const sc = dd * Math.exp(-(o * o) / twoSigmaSq)
+        if (sc > bestScore) { bestScore = sc; bestVal = dd; bestOff = o }
+      }
+      if (bestVal < 2.5) continue
+      // Parabolic sub-pixel peak from the neighbours of the winning offset.
+      const vm = deriv(px, py, n, bestOff - 0.5)
+      const vp = deriv(px, py, n, bestOff + 0.5)
+      const denom = vm - 2 * bestVal + vp
+      const shift = Math.abs(denom) > 1e-6 ? 0.25 * (vm - vp) / denom : 0
+      const off = bestOff + Math.max(-0.5, Math.min(0.5, shift))
+      hits.push({ x: px + n.x * off, y: py + n.y * off })
+      supportSum += bestVal
+    }
+    if (hits.length < 6) return null
+
+    // Robust fit: two rounds of trimming the worst residuals.
+    let line = fitLine(hits)
+    if (!line) return null
+    let keep = hits
+    for (let round = 0; round < 2; round++) {
+      const withRes = keep.map(p => ({ p, r: lineDistance(line, p) })).sort((u, v) => u.r - v.r)
+      keep = withRes.slice(0, Math.max(5, Math.round(withRes.length * 0.75))).map(o => o.p)
+      line = fitLine(keep) || line
+    }
+    const residuals = keep.map(p => lineDistance(line, p)).sort((u, v) => u - v)
+    const median = residuals[Math.floor(residuals.length / 2)]
+    lines.push(line)
+    supports.push(supportSum / hits.length)
+    straightnesses.push(Math.exp(-median / 1.2) * (hits.length / count))
+  }
+
+  const corners = []
+  for (let i = 0; i < 4; i++) {
+    const p = intersectLines(lines[(i + 3) % 4], lines[i])
+    if (!p || !isFinite(p.x) || !isFinite(p.y)) return null
+    corners.push(p)
+  }
+  return {
+    quad: corners,
+    edgeSupport: supports.reduce((a, b) => a + b, 0) / 4,
+    straightness: straightnesses.reduce((a, b) => a + b, 0) / 4,
+  }
+}
+
+/**
+ * Iterated edge refinement. Each pass re-centres on the previous estimate with
+ * a tighter search window, so the lines converge onto the paper boundary
+ * without ever being able to jump to high-contrast content further inside.
+ */
+function refineQuad (quad, grads, polarity, opts) {
+  const diag = Math.hypot(grads.width, grads.height)
+  let cur = quad
+  let best = null
+  for (const factor of [1, 0.6, 0.4]) {
+    const R = Math.max(2.5, opts.searchRadius * factor)
+    const pass = refinePass(cur, grads, polarity, R, R / 2.5, opts.samplesPerEdge)
+    if (!pass) break
+    // Reject a pass that ran away (near-parallel lines, mostly-missing hits).
+    let ran = false
+    for (let i = 0; i < 4; i++) {
+      if (dist(pass.quad[i], quad[i]) > diag * 0.12) ran = true
+    }
+    if (ran) break
+    cur = pass.quad
+    best = pass
+  }
+  return best ? { ...best, quad: cur } : null
+}
+
+/**
+ * Measure how much image evidence actually sits on a quad's edges, without
+ * moving them. Every candidate is scored through this, refined or not, so the
+ * comparison between candidates is apples to apples.
+ *
+ * `support` is the mean strength of the intensity step found on the edge;
+ * `straightness` falls off when the hits scatter away from the edge line,
+ * which is what exposes a quad that cuts across background clutter.
+ */
+function measureEdges (quad, grads, polarity, maxSamples) {
+  const { gx, gy, width: w, height: h } = grads
+  const cx = (quad[0].x + quad[1].x + quad[2].x + quad[3].x) / 4
+  const cy = (quad[0].y + quad[1].y + quad[2].y + quad[3].y) / 4
+  const centroid = { x: cx, y: cy }
+  const R = 2.5
+  let supportSum = 0
+  let straightSum = 0
+
+  for (let e = 0; e < 4; e++) {
+    const a = quad[e]
+    const b = quad[(e + 1) % 4]
+    const n = inwardNormal(a, b, centroid)
+    const line = lineThrough(a, b)
+    const len = dist(a, b)
+    const count = Math.max(8, Math.min(maxSamples, Math.round(len / 2)))
+    let found = 0
+    let sum = 0
+    const residuals = []
+    for (let s = 0; s < count; s++) {
+      const t = 0.06 + 0.88 * (s / (count - 1))
+      const px = a.x + (b.x - a.x) * t
+      const py = a.y + (b.y - a.y) * t
+      let bestVal = 0
+      let bestOff = 0
+      for (let o = -R; o <= R; o += 0.5) {
+        const sx = px + n.x * o
+        const sy = py + n.y * o
+        if (sx < 1 || sy < 1 || sx > w - 2 || sy > h - 2) continue
+        const dd = polarity * (sampleField(gx, w, h, sx, sy) * n.x + sampleField(gy, w, h, sx, sy) * n.y)
+        if (dd > bestVal) { bestVal = dd; bestOff = o }
+      }
+      if (bestVal < 2.5) { residuals.push(R + 1); continue }
+      found++
+      sum += bestVal
+      residuals.push(Math.abs(lineDistance(line, { x: px + n.x * bestOff, y: py + n.y * bestOff })))
+    }
+    residuals.sort((u, v) => u - v)
+    const median = residuals.length ? residuals[Math.floor(residuals.length / 2)] : R + 1
+    supportSum += found ? sum / count : 0
+    straightSum += Math.exp(-median / 1.2) * (found / count)
+  }
+  return { edgeSupport: supportSum / 4, straightness: straightSum / 4 }
+}
+
+function scoreQuad (quad, w, h, edgeSupport, straightness, opts) {
+  if (!isConvex(quad)) return 0
+  const area = Math.abs(polygonArea(quad))
+  const areaFrac = area / (w * h)
+  if (areaFrac < opts.minAreaFraction || areaFrac > 1.6) return 0
+  const angles = quadAngles(quad)
+  for (const a of angles) {
+    if (a < opts.minAngle || a > opts.maxAngle) return 0
+  }
+  // Opposite sides of a rectangle stay similar in length under mild perspective.
+  const sides = [dist(quad[0], quad[1]), dist(quad[1], quad[2]), dist(quad[2], quad[3]), dist(quad[3], quad[0])]
+  const ratioA = Math.min(sides[0], sides[2]) / Math.max(sides[0], sides[2])
+  const ratioB = Math.min(sides[1], sides[3]) / Math.max(sides[1], sides[3])
+  const shape = Math.min(1, (ratioA * ratioB + 0.35))
+  const areaScore = 0.35 + 0.65 * Math.min(1, areaFrac / 0.45)
+  const supportScore = Math.min(1, edgeSupport / 18)
+  return supportScore * straightness * areaScore * shape
+}
+
+/**
+ * Find the dominant straight lines in a set of blob-boundary points by
+ * repeated RANSAC, removing each line's inliers before searching for the next.
+ *
+ * This is what rescues the case where the page is touching or overlapping
+ * another sheet: thresholding merges them into one blob, and a circumscribing
+ * hull-to-quad fit then bulges out to swallow the intruder. The page's own
+ * edges are still the *longest straight runs* on that merged boundary, so
+ * fitting lines finds them and ignores the appendage.
+ */
+function dominantLines (points, opts) {
+  const step = Math.max(1, Math.ceil(points.length / 700))
+  const pts = step === 1 ? points.slice() : points.filter((_, i) => i % step === 0)
+  if (pts.length < 40) return []
+  let minX = Infinity; let minY = Infinity; let maxX = -Infinity; let maxY = -Infinity
+  for (const p of pts) {
+    if (p.x < minX) minX = p.x
+    if (p.x > maxX) maxX = p.x
+    if (p.y < minY) minY = p.y
+    if (p.y > maxY) maxY = p.y
+  }
+  const diag = Math.hypot(maxX - minX, maxY - minY)
+  const minSep = diag * 0.15
+  const tol = opts.lineTolerance
+  // A straight run of length L contributes about L/step sampled points, so the
+  // inlier floor has to be expressed in the subsampled pool's units.
+  const minInliers = Math.max(14, Math.round(diag * 0.25 / step))
+
+  // A cheap deterministic PRNG keeps detection reproducible frame to frame.
+  let seed = 0x2f6e2b1 ^ pts.length
+  const rnd = () => {
+    seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+    return seed / 4294967296
+  }
+
+  const lines = []
+  let pool = pts
+  for (let round = 0; round < opts.maxLines && pool.length >= minInliers; round++) {
+    let bestLine = null
+    let bestCount = 0
+    for (let it = 0; it < opts.ransacIterations; it++) {
+      const a = pool[(rnd() * pool.length) | 0]
+      const b = pool[(rnd() * pool.length) | 0]
+      if (dist(a, b) < minSep) continue
+      const line = lineThrough(a, b)
+      let count = 0
+      for (let i = 0; i < pool.length; i++) {
+        if (lineDistance(line, pool[i]) < tol) count++
+      }
+      if (count > bestCount) { bestCount = count; bestLine = line }
+    }
+    if (!bestLine || bestCount < minInliers) break
+    const inliers = pool.filter(p => lineDistance(bestLine, p) < tol)
+    const refit = fitLine(inliers) || bestLine
+    // Span matters more than raw count: a long edge beats a dense short one.
+    let lo = Infinity
+    let hi = -Infinity
+    const dx = -refit.b
+    const dy = refit.a
+    for (const p of inliers) {
+      const t = p.x * dx + p.y * dy
+      if (t < lo) lo = t
+      if (t > hi) hi = t
+    }
+    lines.push({ line: refit, count: inliers.length, span: hi - lo })
+    pool = pool.filter(p => lineDistance(refit, p) >= tol * 1.6)
+  }
+  return lines.sort((a, b) => b.span - a.span)
+}
+
+/** Circular difference between two line-normal angles, in radians (0..PI/2). */
+function angleDelta (l1, l2) {
+  const a1 = Math.atan2(l1.a, l1.b)
+  const a2 = Math.atan2(l2.a, l2.b)
+  let d = Math.abs(a1 - a2) % Math.PI
+  if (d > Math.PI / 2) d = Math.PI - d
+  return d
+}
+
+/**
+ * Build quads from pairs of near-parallel lines: two lines from each of the
+ * two orientation families, intersected crosswise.
+ */
+function quadsFromLines (found, w, h) {
+  if (found.length < 4) return []
+  const top = found.slice(0, 6)
+  const famA = []
+  const famB = []
+  for (const entry of top) {
+    if (!famA.length || angleDelta(famA[0].line, entry.line) < 0.61) famA.push(entry)
+    else famB.push(entry)
+  }
+  if (famA.length < 2 || famB.length < 2) return []
+  const quads = []
+  const pick = (arr) => arr.slice(0, 3)
+  const A = pick(famA)
+  const B = pick(famB)
+  for (let i = 0; i < A.length; i++) {
+    for (let j = i + 1; j < A.length; j++) {
+      for (let k = 0; k < B.length; k++) {
+        for (let l = k + 1; l < B.length; l++) {
+          const corners = []
+          let ok = true
+          for (const p of [A[i], A[j]]) {
+            for (const q of [B[k], B[l]]) {
+              const c = intersectLines(p.line, q.line)
+              if (!c || !isFinite(c.x) || !isFinite(c.y) ||
+                  c.x < -w * 0.6 || c.x > w * 1.6 || c.y < -h * 0.6 || c.y > h * 1.6) { ok = false } else corners.push(c)
+            }
+          }
+          if (!ok || corners.length !== 4) continue
+          const quad = orderQuad(corners)
+          if (!isConvex(quad)) continue
+          quads.push(quad)
+        }
+      }
+    }
+  }
+  return quads
+}
+
+function quadsSimilar (a, b, tol) {
+  for (let i = 0; i < 4; i++) if (dist(a[i], b[i]) > tol) return false
+  return true
+}
+
+/**
+ * @param {{data: Uint8ClampedArray, width: number, height: number}} img RGBA frame
+ * @returns {{quad, quadNormalized, score, touchesBorder, workingSize, candidates}|null}
+ *          quad corners are in the input image's pixel coordinates, ordered
+ *          TL, TR, BR, BL.
+ */
+export function detectQuad (img, options = {}) {
+  const opts = { ...DEFAULTS, ...options }
+  const { gray: small, scale } = grayFromImage(img, opts.workingSize)
+  const blurred = gaussBlur(small, opts.blurSigma)
+  const grads = sobel(blurred)
+  const w = blurred.width
+  const h = blurred.height
+
+  const otsu = otsuThreshold(blurred)
+  const flat = flattenIllumination(blurred)
+  const otsuFlat = otsuThreshold(flat)
+  const sources = [
+    { gray: blurred, t: otsu, bright: true, tag: 'otsu' },
+    { gray: blurred, t: otsu - 14, bright: true, tag: 'otsu-14' },
+    { gray: blurred, t: otsu + 14, bright: true, tag: 'otsu+14' },
+    { gray: blurred, t: percentileThreshold(blurred, 0.35), bright: true, tag: 'p35' },
+    { gray: blurred, t: percentileThreshold(blurred, 0.55), bright: true, tag: 'p55' },
+    { gray: flat, t: otsuFlat, bright: true, tag: 'flat-otsu' },
+    { gray: flat, t: otsuFlat - 10, bright: true, tag: 'flat-otsu-10' },
+    { gray: blurred, t: otsu, bright: false, tag: 'otsu-dark' },
+  ]
+
+  const candidates = []
+  /**
+   * Score a candidate and file it. Returns the *confidence* -- how strongly the
+   * image backs these particular edges -- which is deliberately separate from
+   * the ranking score. The score also folds in shape plausibility, and a page
+   * seen at a steep angle is legitimately less rectangular, so ranking by score
+   * but stopping early on confidence keeps skewed pages from being re-searched
+   * to no purpose.
+   */
+  const consider = (quad, rough, polarity, tag, refined, touchesBorder) => {
+    const ordered = orderQuad(quad)
+    const m = measureEdges(ordered, grads, polarity, opts.samplesPerEdge)
+    const score = scoreQuad(ordered, w, h, m.edgeSupport, m.straightness, opts)
+    if (score <= 0) return 0
+    const confidence = Math.min(1, m.edgeSupport / 18) * m.straightness
+    const dup = candidates.find(c => quadsSimilar(c.quad, ordered, 2.5))
+    if (dup) {
+      if (score > dup.score) { dup.score = score; dup.quad = ordered; dup.tag = tag; dup.refined = refined }
+      return confidence
+    }
+    candidates.push({ quad: ordered, rough, score, confidence, tag, refined, touchesBorder })
+    return confidence
+  }
+
+  const blobs = []
+  let bestConfidence = 0
+  let fillsFrame = false
+  const rawMasks = new Map()
+
+  // Cheap openings for every threshold first, stronger (and pricier) openings
+  // only if nothing convincing turned up. A clean shot of paper on a contrasting
+  // surface is settled by the first source or two, so most frames stop early.
+  for (const level of opts.openLevels) {
+    for (const src of sources) {
+      let raw = rawMasks.get(src.tag)
+      if (!raw) { raw = threshold(src.gray, src.t, src.bright); rawMasks.set(src.tag, raw) }
+      const polarity = src.bright ? 1 : -1
+      const mask = open(raw, level)
+      const comp = largestComponent(mask)
+      if (!comp) continue
+      // A bright region reaching all four frame edges means no page border is
+      // visible anywhere -- either the sheet overruns the viewport, or it is
+      // indistinguishable from the surface under it. Either way the quad that
+      // comes back will be some printed box inside the page, so flag it.
+      if (src.bright && comp.coverage > opts.fillsFrameCoverage &&
+          comp.sides.left && comp.sides.right && comp.sides.top && comp.sides.bottom) {
+        fillsFrame = true
+      }
+      if (comp.size < w * h * opts.minAreaFraction * 0.6) continue
+      const hull = convexHull(comp.points)
+      if (hull.length < 4) continue
+      const rough = reduceHullToQuad(hull)
+      if (!rough) continue
+      const ordered = orderQuad(rough)
+      const tag = level === 1 ? src.tag : `${src.tag}/o${level}`
+      const refined = refineQuad(ordered, grads, polarity, opts)
+      // Keep both the refined and the raw blob quad as competing candidates:
+      // refinement usually wins, but it can be dragged by printed content.
+      const refConf = refined
+        ? consider(refined.quad, ordered, polarity, tag, true, comp.touchesBorder)
+        : 0
+      const rawConf = consider(ordered, ordered, polarity, `${tag}=raw`, false, comp.touchesBorder)
+      blobs.push({ comp, polarity, tag, confidence: Math.max(refConf, rawConf) })
+      bestConfidence = Math.max(bestConfidence, refConf, rawConf)
+      if (bestConfidence >= opts.earlyExitScore) break
+    }
+    if (bestConfidence >= opts.earlyExitScore) break
+  }
+
+  // Straight-edge pass, for blobs that swallowed something they should not
+  // have. Only worth its cost when no threshold produced a convincing quad.
+  if (bestConfidence < opts.lineSearchScore) {
+    blobs.sort((a, b) => b.confidence - a.confidence)
+    for (const blob of blobs.slice(0, opts.lineSearchBlobs)) {
+      const lines = dominantLines(blob.comp.boundary, opts)
+      for (const quad of quadsFromLines(lines, w, h)) {
+        const refined = refineQuad(quad, grads, blob.polarity, opts)
+        if (refined) consider(refined.quad, quad, blob.polarity, `${blob.tag}/lines`, true, blob.comp.touchesBorder)
+        consider(quad, quad, blob.polarity, `${blob.tag}/lines=raw`, false, blob.comp.touchesBorder)
+      }
+    }
+  }
+
+  if (!candidates.length) return null
+  candidates.sort((a, b) => b.score - a.score)
+  const best = candidates[0]
+  const inv = 1 / scale
+  // Working-grid index -> input-image continuous coordinate. Working pixel X
+  // covers input span [X*inv, (X+1)*inv), so its centre sits at (X+0.5)*inv;
+  // dropping that half-pixel biases every corner up and to the left.
+  const toInput = p => ({ x: (p.x + 0.5) * inv, y: (p.y + 0.5) * inv })
+  const quad = best.quad.map(toInput)
+  // Corners at or past the frame edge mean the page is cropped by the viewport.
+  const margin = 0.004
+  const clipped = quad.some(p =>
+    p.x < img.width * margin || p.x > img.width * (1 - margin) ||
+    p.y < img.height * margin || p.y > img.height * (1 - margin))
+  return {
+    quad,
+    quadNormalized: quad.map(p => ({ x: p.x / img.width, y: p.y / img.height })),
+    score: best.score,
+    tag: best.tag,
+    refined: best.refined,
+    touchesBorder: best.touchesBorder,
+    clipped,
+    fillsFrame,
+    workingSize: { width: w, height: h },
+    candidates: candidates.map(c => ({
+      tag: c.tag,
+      score: c.score,
+      quad: c.quad.map(toInput),
+      rough: c.rough.map(toInput),
+    })),
+  }
+}
+
+/** Internals exposed for the test harness only. */
+export const __debug = { dominantLines, quadsFromLines, measureEdges, refineQuad, scoreQuad, DEFAULTS }
+
+/**
+ * Snap a user-dragged quad onto nearby image edges. Used by the manual corner
+ * handles so hand placement still lands on the true paper boundary.
+ */
+export function snapQuad (img, quad, options = {}) {
+  // A wider search than live detection uses: this runs once, on demand, from a
+  // hand-placed quad that may be several percent of the frame off. Measured on
+  // the synthetic suite, radius 22 is never worse than a tighter search and is
+  // markedly better once the hand placement is more than ~3% off.
+  const opts = { ...DEFAULTS, searchRadius: 22, ...options }
+  const { gray: small, scale } = grayFromImage(img, opts.workingSize)
+  const blurred = gaussBlur(small, opts.blurSigma)
+  const grads = sobel(blurred)
+  const inv = 1 / scale
+  const scaled = orderQuad(quad.map(p => ({ x: p.x / inv - 0.5, y: p.y / inv - 0.5 })))
+  const refined = refineQuad(scaled, grads, 1, opts)
+  if (!refined) return null
+  return orderQuad(refined.quad.map(p => ({ x: (p.x + 0.5) * inv, y: (p.y + 0.5) * inv })))
+}
+
+/**
+ * Fires once the detected quad has held still long enough.
+ * Corners are also exponentially smoothed so the overlay does not jitter.
+ */
+export class QuadTracker {
+  constructor (options = {}) {
+    this.stableMs = options.stableMs ?? 1000
+    this.tolFraction = options.tolFraction ?? 0.02
+    this.minFrames = options.minFrames ?? 5
+    this.smoothing = options.smoothing ?? 0.45
+    this.reset()
+  }
+
+  reset () {
+    this.smoothed = null
+    this.stableSince = null
+    this.frames = 0
+    this.lastSeen = 0
+  }
+
+  /**
+   * @param {Array|null} quad detected corners, or null when nothing was found
+   * @param {number} now timestamp in ms
+   * @param {number} frameDiag diagonal of the frame in the same units as quad
+   */
+  update (quad, now, frameDiag) {
+    if (!quad) {
+      // Tolerate a couple of dropped frames before giving up on stability.
+      if (this.lastSeen && now - this.lastSeen < 400) {
+        return { quad: this.smoothed, stable: false, progress: 0 }
+      }
+      this.reset()
+      return { quad: null, stable: false, progress: 0 }
+    }
+    this.lastSeen = now
+    const tol = frameDiag * this.tolFraction
+    if (!this.smoothed) {
+      this.smoothed = quad.map(p => ({ ...p }))
+      this.stableSince = now
+      this.frames = 1
+      return { quad: this.smoothed, stable: false, progress: 0 }
+    }
+    let moved = 0
+    for (let i = 0; i < 4; i++) moved = Math.max(moved, dist(quad[i], this.smoothed[i]))
+    const k = this.smoothing
+    this.smoothed = this.smoothed.map((p, i) => ({
+      x: p.x + (quad[i].x - p.x) * k,
+      y: p.y + (quad[i].y - p.y) * k,
+    }))
+    if (moved > tol) {
+      this.stableSince = now
+      this.frames = 1
+    } else {
+      this.frames++
+    }
+    const held = now - this.stableSince
+    const stable = held >= this.stableMs && this.frames >= this.minFrames
+    return {
+      quad: this.smoothed,
+      stable,
+      progress: Math.min(1, held / this.stableMs),
+    }
+  }
+}

--- a/app/lib/doc-capture/geom.js
+++ b/app/lib/doc-capture/geom.js
@@ -1,0 +1,281 @@
+/**
+ * geom.js -- small geometry + linear algebra helpers for document capture.
+ * No DOM access and no dependencies, so this imports cleanly in Node and the browser.
+ *
+ * Points are plain {x, y} objects. Quads are arrays of 4 points ordered
+ * top-left, top-right, bottom-right, bottom-left (clockwise in image
+ * coordinates, where y grows downward).
+ */
+
+export function dist (a, b) {
+  return Math.hypot(a.x - b.x, a.y - b.y)
+}
+
+/** Signed area; positive means clockwise in image coordinates. */
+export function polygonArea (pts) {
+  let s = 0
+  for (let i = 0; i < pts.length; i++) {
+    const p = pts[i]
+    const q = pts[(i + 1) % pts.length]
+    s += p.x * q.y - q.x * p.y
+  }
+  return s / 2
+}
+
+/** Gaussian elimination with partial pivoting. Returns null if singular. */
+export function solveLinear (A, b) {
+  const n = b.length
+  const M = A.map((row, i) => row.slice().concat(b[i]))
+  for (let col = 0; col < n; col++) {
+    let piv = col
+    for (let r = col + 1; r < n; r++) {
+      if (Math.abs(M[r][col]) > Math.abs(M[piv][col])) piv = r
+    }
+    if (Math.abs(M[piv][col]) < 1e-12) return null
+    if (piv !== col) { const t = M[piv]; M[piv] = M[col]; M[col] = t }
+    const d = M[col][col]
+    for (let c = col; c <= n; c++) M[col][c] /= d
+    for (let r = 0; r < n; r++) {
+      if (r === col) continue
+      const f = M[r][col]
+      if (f === 0) continue
+      for (let c = col; c <= n; c++) M[r][c] -= f * M[col][c]
+    }
+  }
+  return M.map(row => row[n])
+}
+
+/**
+ * Homography mapping the four src points onto the four dst points.
+ * Returns a row-major 9-element array with h33 fixed at 1.
+ */
+export function solveHomography (src, dst) {
+  const A = []
+  const b = []
+  for (let i = 0; i < 4; i++) {
+    const { x, y } = src[i]
+    const u = dst[i].x
+    const v = dst[i].y
+    A.push([x, y, 1, 0, 0, 0, -u * x, -u * y])
+    b.push(u)
+    A.push([0, 0, 0, x, y, 1, -v * x, -v * y])
+    b.push(v)
+  }
+  const h = solveLinear(A, b)
+  if (!h) return null
+  return [h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7], 1]
+}
+
+export function applyHomography (H, x, y) {
+  const w = H[6] * x + H[7] * y + H[8]
+  if (Math.abs(w) < 1e-12) return { x: 0, y: 0 }
+  return {
+    x: (H[0] * x + H[1] * y + H[2]) / w,
+    y: (H[3] * x + H[4] * y + H[5]) / w,
+  }
+}
+
+export function invert3x3 (m) {
+  const [a, b, c, d, e, f, g, h, i] = m
+  const A = e * i - f * h
+  const B = -(d * i - f * g)
+  const C = d * h - e * g
+  const det = a * A + b * B + c * C
+  if (Math.abs(det) < 1e-12) return null
+  const id = 1 / det
+  return [
+    A * id, (c * h - b * i) * id, (b * f - c * e) * id,
+    B * id, (a * i - c * g) * id, (c * d - a * f) * id,
+    C * id, (b * g - a * h) * id, (a * e - b * d) * id,
+  ]
+}
+
+/**
+ * Order four arbitrary points as TL, TR, BR, BL.
+ * Sorts by angle about the centroid (giving a consistent ring), forces
+ * clockwise winding, then rotates so the most top-left corner leads.
+ */
+export function orderQuad (pts) {
+  const cx = (pts[0].x + pts[1].x + pts[2].x + pts[3].x) / 4
+  const cy = (pts[0].y + pts[1].y + pts[2].y + pts[3].y) / 4
+  const ring = pts.slice().sort(
+    (p, q) => Math.atan2(p.y - cy, p.x - cx) - Math.atan2(q.y - cy, q.x - cx),
+  )
+  if (polygonArea(ring) < 0) ring.reverse()
+  let best = 0
+  let bestScore = Infinity
+  for (let i = 0; i < 4; i++) {
+    const s = ring[i].x + ring[i].y
+    if (s < bestScore) { bestScore = s; best = i }
+  }
+  return [ring[best], ring[(best + 1) % 4], ring[(best + 2) % 4], ring[(best + 3) % 4]]
+}
+
+/** Interior angles of a quad, in degrees. */
+export function quadAngles (quad) {
+  const out = []
+  for (let i = 0; i < 4; i++) {
+    const p = quad[(i + 3) % 4]
+    const c = quad[i]
+    const n = quad[(i + 1) % 4]
+    const a1 = Math.atan2(p.y - c.y, p.x - c.x)
+    const a2 = Math.atan2(n.y - c.y, n.x - c.x)
+    let d = Math.abs(a1 - a2) * 180 / Math.PI
+    if (d > 180) d = 360 - d
+    out.push(d)
+  }
+  return out
+}
+
+export function isConvex (pts) {
+  let sign = 0
+  const n = pts.length
+  for (let i = 0; i < n; i++) {
+    const a = pts[i]
+    const b = pts[(i + 1) % n]
+    const c = pts[(i + 2) % n]
+    const cross = (b.x - a.x) * (c.y - b.y) - (b.y - a.y) * (c.x - b.x)
+    if (Math.abs(cross) < 1e-9) continue
+    const s = cross > 0 ? 1 : -1
+    if (sign === 0) sign = s
+    else if (s !== sign) return false
+  }
+  return sign !== 0
+}
+
+/** Line through two points as normalized {a, b, c} with a*x + b*y + c = 0. */
+export function lineThrough (p, q) {
+  const a = q.y - p.y
+  const b = p.x - q.x
+  const n = Math.hypot(a, b) || 1
+  return { a: a / n, b: b / n, c: -(a * p.x + b * p.y) / n }
+}
+
+/** Total least squares line fit through >= 2 points. */
+export function fitLine (pts) {
+  const n = pts.length
+  if (n < 2) return null
+  let mx = 0
+  let my = 0
+  for (const p of pts) { mx += p.x; my += p.y }
+  mx /= n
+  my /= n
+  let sxx = 0
+  let syy = 0
+  let sxy = 0
+  for (const p of pts) {
+    const dx = p.x - mx
+    const dy = p.y - my
+    sxx += dx * dx
+    syy += dy * dy
+    sxy += dx * dy
+  }
+  // Principal direction is the eigenvector of the scatter matrix with the
+  // larger eigenvalue; the line normal is the perpendicular one.
+  const theta = 0.5 * Math.atan2(2 * sxy, sxx - syy)
+  const dx = Math.cos(theta)
+  const dy = Math.sin(theta)
+  const a = -dy
+  const b = dx
+  return { a, b, c: -(a * mx + b * my) }
+}
+
+export function lineDistance (line, p) {
+  return Math.abs(line.a * p.x + line.b * p.y + line.c)
+}
+
+export function intersectLines (l1, l2) {
+  const det = l1.a * l2.b - l2.a * l1.b
+  if (Math.abs(det) < 1e-9) return null
+  return {
+    x: (l1.b * l2.c - l2.b * l1.c) / det,
+    y: (l2.a * l1.c - l1.a * l2.c) / det,
+  }
+}
+
+/** Andrew's monotone chain. Returns hull vertices, counter-clockwise in math coords. */
+export function convexHull (points) {
+  if (points.length < 3) return points.slice()
+  const pts = points.slice().sort((p, q) => (p.x - q.x) || (p.y - q.y))
+  const cross = (o, a, b) => (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x)
+  const lower = []
+  for (const p of pts) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) lower.pop()
+    lower.push(p)
+  }
+  const upper = []
+  for (let i = pts.length - 1; i >= 0; i--) {
+    const p = pts[i]
+    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) upper.pop()
+    upper.push(p)
+  }
+  lower.pop()
+  upper.pop()
+  return lower.concat(upper)
+}
+
+/**
+ * Collapse a convex polygon down to its 4 best-fitting circumscribing corners.
+ *
+ * Repeatedly drops the vertex whose removal grows the polygon the least: the
+ * two edges adjacent to it are extended until they meet, and that intersection
+ * replaces it. This tolerates rounded/frayed paper corners far better than
+ * picking the four extreme hull points.
+ */
+export function reduceHullToQuad (hull) {
+  let poly = hull.slice()
+  if (poly.length < 4) return null
+  const triArea = (a, b, c) =>
+    Math.abs((b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)) / 2
+
+  while (poly.length > 4) {
+    const n = poly.length
+    let bestI = -1
+    let bestCost = Infinity
+    let bestPt = null
+    for (let i = 0; i < n; i++) {
+      // Drop edge (b, c) by extending its neighbouring edges until they meet.
+      const a = poly[(i - 1 + n) % n]
+      const b = poly[i]
+      const c = poly[(i + 1) % n]
+      const d = poly[(i + 2) % n]
+      const p = intersectLines(lineThrough(a, b), lineThrough(c, d))
+      if (!p || !isFinite(p.x) || !isFinite(p.y)) continue
+      // The meeting point must lie beyond b and beyond c, otherwise the edges
+      // converge inward and the "reduction" would eat into the polygon.
+      const ab = { x: b.x - a.x, y: b.y - a.y }
+      const dc = { x: c.x - d.x, y: c.y - d.y }
+      const lab = ab.x * ab.x + ab.y * ab.y
+      const ldc = dc.x * dc.x + dc.y * dc.y
+      if (lab < 1e-9 || ldc < 1e-9) continue
+      const t = ((p.x - a.x) * ab.x + (p.y - a.y) * ab.y) / lab
+      const s = ((p.x - d.x) * dc.x + (p.y - d.y) * dc.y) / ldc
+      if (t <= 1 || s <= 1) continue
+      const cost = triArea(b, p, c)
+      if (cost < bestCost) { bestCost = cost; bestI = i; bestPt = p }
+    }
+    if (bestI < 0) return null
+    // Replace the two endpoints of the dropped edge with their meeting point.
+    const drop = (bestI + 1) % n
+    const next = []
+    for (let i = 0; i < n; i++) {
+      if (i === bestI) { next.push(bestPt); continue }
+      if (i === drop) continue
+      next.push(poly[i])
+    }
+    poly = next
+  }
+  return poly.length === 4 ? poly : null
+}
+
+/** Mean corner-to-corner distance between two quads, assumed same ordering. */
+export function quadCornerError (a, b) {
+  let sum = 0
+  let max = 0
+  for (let i = 0; i < 4; i++) {
+    const d = dist(a[i], b[i])
+    sum += d
+    if (d > max) max = d
+  }
+  return { mean: sum / 4, max }
+}

--- a/app/lib/doc-capture/imageops.js
+++ b/app/lib/doc-capture/imageops.js
@@ -1,0 +1,403 @@
+/**
+ * imageops.js -- grayscale / blur / gradient / threshold primitives.
+ *
+ * Everything works on plain objects shaped like ImageData
+ * ({ data: Uint8ClampedArray RGBA, width, height }) or on Gray buffers
+ * ({ data: Float32Array, width, height }), so Node and the browser share code.
+ */
+
+/**
+ * RGBA -> downscaled grayscale in a single box-filtered pass.
+ * Detection never needs the full-resolution gray, and doing this in one step
+ * rather than toGray()+downscaleGray() saves a full-frame intermediate.
+ *
+ * @returns {{gray, scale}} scale converts input pixels to working pixels
+ */
+export function grayFromImage (img, maxDim) {
+  const { width, height, data } = img
+  const longest = Math.max(width, height)
+  const factor = Math.min(1, maxDim / longest)
+  const w = Math.max(1, Math.round(width * factor))
+  const h = Math.max(1, Math.round(height * factor))
+  const out = new Float32Array(w * h)
+  const sx = width / w
+  const sy = height / h
+  for (let y = 0; y < h; y++) {
+    const y0 = Math.floor(y * sy)
+    const y1 = Math.min(height, Math.max(y0 + 1, Math.floor((y + 1) * sy)))
+    for (let x = 0; x < w; x++) {
+      const x0 = Math.floor(x * sx)
+      const x1 = Math.min(width, Math.max(x0 + 1, Math.floor((x + 1) * sx)))
+      let sum = 0
+      let n = 0
+      for (let yy = y0; yy < y1; yy++) {
+        let p = (yy * width + x0) * 4
+        for (let xx = x0; xx < x1; xx++, p += 4) {
+          sum += 0.299 * data[p] + 0.587 * data[p + 1] + 0.114 * data[p + 2]
+          n++
+        }
+      }
+      out[y * w + x] = sum / n
+    }
+  }
+  return { gray: { data: out, width: w, height: h }, scale: w / width }
+}
+
+export function toGray (img) {
+  const { width, height, data } = img
+  const out = new Float32Array(width * height)
+  for (let i = 0, p = 0; i < out.length; i++, p += 4) {
+    out[i] = 0.299 * data[p] + 0.587 * data[p + 1] + 0.114 * data[p + 2]
+  }
+  return { data: out, width, height }
+}
+
+/** Box-average downscale so the longest side is at most maxDim. Returns {gray, scale}. */
+export function downscaleGray (gray, maxDim) {
+  const { width, height } = gray
+  const longest = Math.max(width, height)
+  if (longest <= maxDim) return { gray, scale: 1 }
+  const scale = maxDim / longest
+  const w = Math.max(1, Math.round(width * scale))
+  const h = Math.max(1, Math.round(height * scale))
+  const out = new Float32Array(w * h)
+  const sx = width / w
+  const sy = height / h
+  for (let y = 0; y < h; y++) {
+    const y0 = Math.floor(y * sy)
+    const y1 = Math.min(height, Math.max(y0 + 1, Math.floor((y + 1) * sy)))
+    for (let x = 0; x < w; x++) {
+      const x0 = Math.floor(x * sx)
+      const x1 = Math.min(width, Math.max(x0 + 1, Math.floor((x + 1) * sx)))
+      let sum = 0
+      let n = 0
+      for (let yy = y0; yy < y1; yy++) {
+        const row = yy * width
+        for (let xx = x0; xx < x1; xx++) { sum += gray.data[row + xx]; n++ }
+      }
+      out[y * w + x] = sum / n
+    }
+  }
+  return { gray: { data: out, width: w, height: h }, scale: w / width }
+}
+
+function gaussKernel (sigma) {
+  const r = Math.max(1, Math.ceil(sigma * 3))
+  const k = new Float32Array(2 * r + 1)
+  let sum = 0
+  for (let i = -r; i <= r; i++) {
+    const v = Math.exp(-(i * i) / (2 * sigma * sigma))
+    k[i + r] = v
+    sum += v
+  }
+  for (let i = 0; i < k.length; i++) k[i] /= sum
+  return { k, r }
+}
+
+export function gaussBlur (gray, sigma) {
+  const { width: w, height: h, data } = gray
+  const { k, r } = gaussKernel(sigma)
+  const tmp = new Float32Array(w * h)
+  const out = new Float32Array(w * h)
+  for (let y = 0; y < h; y++) {
+    const row = y * w
+    for (let x = 0; x < w; x++) {
+      let s = 0
+      for (let i = -r; i <= r; i++) {
+        const xx = Math.min(w - 1, Math.max(0, x + i))
+        s += data[row + xx] * k[i + r]
+      }
+      tmp[row + x] = s
+    }
+  }
+  for (let x = 0; x < w; x++) {
+    for (let y = 0; y < h; y++) {
+      let s = 0
+      for (let i = -r; i <= r; i++) {
+        const yy = Math.min(h - 1, Math.max(0, y + i))
+        s += tmp[yy * w + x] * k[i + r]
+      }
+      out[y * w + x] = s
+    }
+  }
+  return { data: out, width: w, height: h }
+}
+
+/** Constant-time box blur via a summed-area table. radius is in pixels. */
+export function boxBlur (gray, radius) {
+  const { width: w, height: h, data } = gray
+  const sat = new Float64Array((w + 1) * (h + 1))
+  for (let y = 0; y < h; y++) {
+    let rowSum = 0
+    for (let x = 0; x < w; x++) {
+      rowSum += data[y * w + x]
+      sat[(y + 1) * (w + 1) + (x + 1)] = sat[y * (w + 1) + (x + 1)] + rowSum
+    }
+  }
+  const out = new Float32Array(w * h)
+  for (let y = 0; y < h; y++) {
+    const y0 = Math.max(0, y - radius)
+    const y1 = Math.min(h - 1, y + radius)
+    for (let x = 0; x < w; x++) {
+      const x0 = Math.max(0, x - radius)
+      const x1 = Math.min(w - 1, x + radius)
+      const area = (x1 - x0 + 1) * (y1 - y0 + 1)
+      const s = sat[(y1 + 1) * (w + 1) + (x1 + 1)] -
+                sat[y0 * (w + 1) + (x1 + 1)] -
+                sat[(y1 + 1) * (w + 1) + x0] +
+                sat[y0 * (w + 1) + x0]
+      out[y * w + x] = s / area
+    }
+  }
+  return { data: out, width: w, height: h }
+}
+
+/** Sobel derivatives, scaled to approximate intensity change per pixel. */
+export function sobel (gray) {
+  const { width: w, height: h, data } = gray
+  const gx = new Float32Array(w * h)
+  const gy = new Float32Array(w * h)
+  for (let y = 1; y < h - 1; y++) {
+    for (let x = 1; x < w - 1; x++) {
+      const i = y * w + x
+      const tl = data[i - w - 1]; const tc = data[i - w]; const tr = data[i - w + 1]
+      const ml = data[i - 1]; const mr = data[i + 1]
+      const bl = data[i + w - 1]; const bc = data[i + w]; const br = data[i + w + 1]
+      gx[i] = ((tr + 2 * mr + br) - (tl + 2 * ml + bl)) / 8
+      gy[i] = ((bl + 2 * bc + br) - (tl + 2 * tc + tr)) / 8
+    }
+  }
+  return { gx, gy, width: w, height: h }
+}
+
+export function histogram (gray, bins = 256) {
+  const hist = new Float64Array(bins)
+  const d = gray.data
+  for (let i = 0; i < d.length; i++) {
+    let v = Math.round(d[i])
+    if (v < 0) v = 0
+    if (v > bins - 1) v = bins - 1
+    hist[v]++
+  }
+  return hist
+}
+
+/** Otsu's between-class-variance threshold on a 0..255 gray buffer. */
+export function otsuThreshold (gray) {
+  const hist = histogram(gray)
+  const total = gray.data.length
+  let sum = 0
+  for (let i = 0; i < 256; i++) sum += i * hist[i]
+  let sumB = 0
+  let wB = 0
+  let best = 0
+  let bestVar = -1
+  for (let t = 0; t < 256; t++) {
+    wB += hist[t]
+    if (wB === 0) continue
+    const wF = total - wB
+    if (wF === 0) break
+    sumB += t * hist[t]
+    const mB = sumB / wB
+    const mF = (sum - sumB) / wF
+    const between = wB * wF * (mB - mF) * (mB - mF)
+    if (between > bestVar) { bestVar = between; best = t }
+  }
+  return best
+}
+
+/** Gray value at the given percentile (0..1). */
+export function percentileThreshold (gray, p) {
+  const hist = histogram(gray)
+  const target = gray.data.length * p
+  let acc = 0
+  for (let i = 0; i < 256; i++) {
+    acc += hist[i]
+    if (acc >= target) return i
+  }
+  return 255
+}
+
+/**
+ * Illumination-flattened copy: divide by a heavily blurred version so a smooth
+ * lighting gradient cancels out while paper-vs-table contrast survives.
+ */
+export function flattenIllumination (gray) {
+  const radius = Math.max(8, Math.round(Math.max(gray.width, gray.height) / 4))
+  const bg = boxBlur(gray, radius)
+  const out = new Float32Array(gray.data.length)
+  for (let i = 0; i < out.length; i++) {
+    out[i] = Math.min(255, Math.max(0, (gray.data[i] / Math.max(1, bg.data[i])) * 128))
+  }
+  return { data: out, width: gray.width, height: gray.height }
+}
+
+/** mask[i] = 1 where (bright ? value > t : value < t). */
+export function threshold (gray, t, bright = true) {
+  const out = new Uint8Array(gray.data.length)
+  const d = gray.data
+  if (bright) {
+    for (let i = 0; i < d.length; i++) out[i] = d[i] > t ? 1 : 0
+  } else {
+    for (let i = 0; i < d.length; i++) out[i] = d[i] < t ? 1 : 0
+  }
+  return { data: out, width: gray.width, height: gray.height }
+}
+
+/**
+ * Separable morphology with a square structuring element. A square min/max is
+ * separable, so this is exact and much cheaper than the 2D neighbourhood scan
+ * (2*(2r+1) samples per pixel instead of (2r+1)^2) -- which matters because the
+ * detector runs this once per threshold candidate, per frame.
+ */
+function morph (mask, radius, isErode) {
+  const { width: w, height: h } = mask
+  const src = mask.data
+  const tmp = new Uint8Array(w * h)
+  const out = new Uint8Array(w * h)
+  for (let y = 0; y < h; y++) {
+    const row = y * w
+    for (let x = 0; x < w; x++) {
+      let v = isErode ? 1 : 0
+      for (let d = -radius; d <= radius; d++) {
+        const xx = Math.min(w - 1, Math.max(0, x + d))
+        const s = src[row + xx]
+        if (isErode) { if (!s) { v = 0; break } } else if (s) { v = 1; break }
+      }
+      tmp[row + x] = v
+    }
+  }
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      let v = isErode ? 1 : 0
+      for (let d = -radius; d <= radius; d++) {
+        const yy = Math.min(h - 1, Math.max(0, y + d))
+        const s = tmp[yy * w + x]
+        if (isErode) { if (!s) { v = 0; break } } else if (s) { v = 1; break }
+      }
+      out[y * w + x] = v
+    }
+  }
+  return { data: out, width: w, height: h }
+}
+
+export const erode = (mask, n = 1) => morph(mask, n, true)
+export const dilate = (mask, n = 1) => morph(mask, n, false)
+/** Opening: knock out thin bridges between the page and bright background junk. */
+export const open = (mask, n = 1) => (n <= 0 ? mask : dilate(erode(mask, n), n))
+
+/**
+ * Largest 4-connected blob of set pixels.
+ *
+ * `points` holds only the leftmost/rightmost pixel of each row: the convex hull
+ * of those is identical to the hull of the whole blob, at a fraction of the
+ * cost. `boundary` holds every pixel with a neighbour outside the blob, which
+ * is what the straight-edge search fits lines to.
+ */
+export function largestComponent (mask) {
+  const { width: w, height: h, data } = mask
+  const labels = new Int32Array(w * h).fill(-1)
+  const stack = new Int32Array(w * h)
+  let bestSize = 0
+  let bestLabel = -1
+  let label = 0
+  for (let start = 0; start < data.length; start++) {
+    if (!data[start] || labels[start] >= 0) continue
+    let sp = 0
+    stack[sp++] = start
+    labels[start] = label
+    let size = 0
+    while (sp > 0) {
+      const i = stack[--sp]
+      size++
+      const x = i % w
+      const y = (i / w) | 0
+      if (x > 0 && data[i - 1] && labels[i - 1] < 0) { labels[i - 1] = label; stack[sp++] = i - 1 }
+      if (x < w - 1 && data[i + 1] && labels[i + 1] < 0) { labels[i + 1] = label; stack[sp++] = i + 1 }
+      if (y > 0 && data[i - w] && labels[i - w] < 0) { labels[i - w] = label; stack[sp++] = i - w }
+      if (y < h - 1 && data[i + w] && labels[i + w] < 0) { labels[i + w] = label; stack[sp++] = i + w }
+    }
+    if (size > bestSize) { bestSize = size; bestLabel = label }
+    label++
+  }
+  if (bestLabel < 0) return null
+
+  // Fill holes: flood the background inward from the frame edge, then anything
+  // still unvisited is enclosed by the blob. Printed text punches thousands of
+  // little holes in the page mask, and their rims would otherwise swamp the
+  // outer outline that the straight-edge search fits lines to.
+  const filled = new Uint8Array(w * h)
+  for (let i = 0; i < filled.length; i++) filled[i] = labels[i] === bestLabel ? 1 : 0
+  const outside = new Uint8Array(w * h)
+  let sp = 0
+  const pushOut = (i) => { if (!filled[i] && !outside[i]) { outside[i] = 1; stack[sp++] = i } }
+  for (let x = 0; x < w; x++) { pushOut(x); pushOut((h - 1) * w + x) }
+  for (let y = 0; y < h; y++) { pushOut(y * w); pushOut(y * w + w - 1) }
+  while (sp > 0) {
+    const i = stack[--sp]
+    const x = i % w
+    const y = (i / w) | 0
+    if (x > 0) pushOut(i - 1)
+    if (x < w - 1) pushOut(i + 1)
+    if (y > 0) pushOut(i - w)
+    if (y < h - 1) pushOut(i + w)
+  }
+  for (let i = 0; i < filled.length; i++) if (!outside[i]) filled[i] = 1
+
+  const pts = []
+  const boundary = []
+  let touchesBorder = false
+  const sides = { left: false, right: false, top: false, bottom: false }
+  let filledCount = 0
+  for (let y = 0; y < h; y++) {
+    let lo = -1
+    let hi = -1
+    const row = y * w
+    const onFrameRow = y === 0 || y === h - 1
+    for (let x = 0; x < w; x++) {
+      const i = row + x
+      if (!filled[i]) continue
+      filledCount++
+      if (lo < 0) lo = x
+      hi = x
+      if (x === 0) sides.left = true
+      if (x === w - 1) sides.right = true
+      if (y === 0) sides.top = true
+      if (y === h - 1) sides.bottom = true
+      // Skip pixels lying on the frame edge: a page running out of shot has an
+      // apparent "edge" there that is the viewport, not the paper.
+      if (onFrameRow || x === 0 || x === w - 1) continue
+      if (!filled[i - 1] || !filled[i + 1] || !filled[i - w] || !filled[i + w]) {
+        boundary.push({ x, y })
+      }
+    }
+    if (lo < 0) continue
+    if (lo === 0 || hi === w - 1 || onFrameRow) touchesBorder = true
+    pts.push({ x: lo, y })
+    if (hi !== lo) pts.push({ x: hi, y })
+  }
+  return {
+    size: bestSize,
+    points: pts,
+    boundary,
+    touchesBorder,
+    sides,
+    coverage: filledCount / (w * h),
+  }
+}
+
+/** Bilinear sample of a gray buffer, clamped at the edges. */
+export function sampleGray (gray, x, y) {
+  const { width: w, height: h, data } = gray
+  const x0 = Math.min(w - 1, Math.max(0, Math.floor(x)))
+  const y0 = Math.min(h - 1, Math.max(0, Math.floor(y)))
+  const x1 = Math.min(w - 1, x0 + 1)
+  const y1 = Math.min(h - 1, y0 + 1)
+  const fx = Math.min(1, Math.max(0, x - x0))
+  const fy = Math.min(1, Math.max(0, y - y0))
+  const a = data[y0 * w + x0]
+  const b = data[y0 * w + x1]
+  const c = data[y1 * w + x0]
+  const d = data[y1 * w + x1]
+  return a * (1 - fx) * (1 - fy) + b * fx * (1 - fy) + c * (1 - fx) * fy + d * fx * fy
+}

--- a/app/lib/doc-capture/qr.js
+++ b/app/lib/doc-capture/qr.js
@@ -54,15 +54,45 @@ export async function decodeQR (source, imageData) {
   return decodeQRFromImageData(imageData)
 }
 
+// How many leading hex characters of the scenario id go in a short code. There
+// are single-digit numbers of scenarios, so this is unambiguous with enormous
+// margin, and every character saved makes the printed modules bigger.
+export const SCENARIO_PREFIX_LENGTH = 6
+
+/**
+ * The compact form printed on a worksheet.
+ *
+ * Written entirely in uppercase on purpose. QR has an alphanumeric mode that
+ * packs digits, uppercase letters and a handful of symbols (including `:` `/`
+ * and `.`) at 11 bits per two characters instead of 8 bits per character, and a
+ * single lowercase letter anywhere in the payload forces the whole thing into
+ * byte mode. Uppercasing the URL costs nothing — scheme and host are
+ * case-insensitive, and the route matching the path is too — and it takes this
+ * payload from 33 modules to 29.
+ *
+ * @param {string} origin e.g. https://codecombat.com
+ * @param {string} scenarioId 24-character hex ObjectId
+ * @param {string|null} userId 24-character hex ObjectId, when the sheet is for
+ *   a particular child
+ */
+export function worksheetQRText (origin, scenarioId, userId) {
+  const scenario = String(scenarioId || '').slice(0, SCENARIO_PREFIX_LENGTH)
+  const token = `${scenario}${userId || ''}`
+  return `${origin}/s/${token}`.toUpperCase()
+}
+
 /**
  * Pull the scenario and student out of a worksheet QR code.
  *
- * Worksheets encode a full URL. Both the scan form and the older project form
- * are accepted so that sheets printed before the QR target changed still work:
+ * Three forms are accepted. The short one is what worksheets print now; the
+ * other two keep sheets printed earlier working:
+ *   /s/<scenarioIdPrefix>[<userId>]
  *   /ai-junior/scan/<scenarioHandle>[/<userId>]
  *   /ai-junior/project/<scenarioHandle>[/<userId>[/<projectId>]]
  *
- * @returns {{scenarioHandle: string, userId: string|null}|null}
+ * @returns {{scenarioHandle: string, userId: string|null, isPrefix: boolean}|null}
+ *   `isPrefix` marks a scenario identified by the leading characters of its id
+ *   rather than by a slug or a whole id, so the caller knows to resolve it.
  */
 export function parseWorksheetQR (text) {
   if (!text || typeof text !== 'string') return null
@@ -74,10 +104,24 @@ export function parseWorksheetQR (text) {
   } catch (err) {
     return null
   }
+
+  const short = /^\/s\/([0-9a-f]{6})([0-9a-f]{24})?$/i.exec(path)
+  if (short) {
+    return {
+      scenarioHandle: short[1].toLowerCase(),
+      userId: short[2] ? short[2].toLowerCase() : null,
+      isPrefix: true,
+    }
+  }
+
   const match = /^\/ai-junior\/(?:scan|project)\/([^/]+)(?:\/([^/]+))?/.exec(path)
   if (!match) return null
   const scenarioHandle = decodeURIComponent(match[1])
   const userId = match[2] ? decodeURIComponent(match[2]) : null
   if (!scenarioHandle) return null
-  return { scenarioHandle, userId: /^[a-f0-9]{24}$/i.test(userId || '') ? userId : null }
+  return {
+    scenarioHandle,
+    userId: /^[a-f0-9]{24}$/i.test(userId || '') ? userId : null,
+    isPrefix: false,
+  }
 }

--- a/app/lib/doc-capture/qr.js
+++ b/app/lib/doc-capture/qr.js
@@ -1,0 +1,83 @@
+/**
+ * qr.js -- finding and interpreting the QR code printed on a worksheet.
+ *
+ * Decoding uses the browser's native BarcodeDetector when it exists (fast, off
+ * the main thread) and falls back to jsQR everywhere else — notably iOS Safari,
+ * which is the most likely device to be pointed at a piece of paper.
+ */
+import jsQR from 'jsqr'
+
+let nativeDetector
+let nativeChecked = false
+
+function getNativeDetector () {
+  if (!nativeChecked) {
+    nativeChecked = true
+    try {
+      if (typeof window !== 'undefined' && window.BarcodeDetector) {
+        nativeDetector = new window.BarcodeDetector({ formats: ['qr_code'] })
+      }
+    } catch (err) {
+      nativeDetector = null
+    }
+  }
+  return nativeDetector
+}
+
+/**
+ * Read a QR code out of an ImageData buffer.
+ * @returns {string|null} the encoded text
+ */
+export function decodeQRFromImageData (imageData) {
+  if (!imageData) return null
+  // `attemptBoth` also tries an inverted image, which costs a second pass but
+  // catches worksheets photographed against glare.
+  const result = jsQR(imageData.data, imageData.width, imageData.height, { inversionAttempts: 'attemptBoth' })
+  return result?.data || null
+}
+
+/**
+ * Read a QR code from anything drawable, preferring the native detector.
+ * @param {CanvasImageSource} source video, image or canvas
+ * @param {ImageData} [imageData] already-read pixels for the jsQR path
+ */
+export async function decodeQR (source, imageData) {
+  const detector = getNativeDetector()
+  if (detector && source) {
+    try {
+      const codes = await detector.detect(source)
+      if (codes && codes.length) return codes[0].rawValue
+    } catch (err) {
+      // Some sources (a detached canvas, a paused video) throw; fall through.
+    }
+  }
+  return decodeQRFromImageData(imageData)
+}
+
+/**
+ * Pull the scenario and student out of a worksheet QR code.
+ *
+ * Worksheets encode a full URL. Both the scan form and the older project form
+ * are accepted so that sheets printed before the QR target changed still work:
+ *   /ai-junior/scan/<scenarioHandle>[/<userId>]
+ *   /ai-junior/project/<scenarioHandle>[/<userId>[/<projectId>]]
+ *
+ * @returns {{scenarioHandle: string, userId: string|null}|null}
+ */
+export function parseWorksheetQR (text) {
+  if (!text || typeof text !== 'string') return null
+  let path = text.trim()
+  try {
+    // Accept a bare path as well as an absolute URL from another host: a sheet
+    // printed from localhost should still scan on the phone's LAN address.
+    path = new URL(path, 'http://worksheet.invalid').pathname
+  } catch (err) {
+    return null
+  }
+  const match = /^\/ai-junior\/(?:scan|project)\/([^/]+)(?:\/([^/]+))?/.exec(path)
+  if (!match) return null
+  const scenarioHandle = decodeURIComponent(match[1])
+  const userId = match[2] ? decodeURIComponent(match[2]) : null
+  if (!scenarioHandle) return null
+  return { scenarioHandle, userId: /^[a-f0-9]{24}$/i.test(userId || '') ? userId : null }
+}

--- a/app/lib/doc-capture/warp.js
+++ b/app/lib/doc-capture/warp.js
@@ -8,6 +8,45 @@ import { solveHomography, applyHomography, dist } from './geom.js'
 /** Landscape US Letter at ~200 dpi. */
 export const LETTER_LANDSCAPE = { width: 2200, height: 1700 }
 
+/** Region percentages measured against the whole rectified page. */
+export const FULL_PAGE_FRAME = { left: 0, top: 0, width: 1, height: 1 }
+
+/**
+ * Where a worksheet's field percentages actually live.
+ *
+ * Scenario inputs are absolutely positioned inside `.worksheet-inner-container`,
+ * so `left/top/width/height` are percentages of THAT box -- not of the sheet.
+ * The inner container is inset by the page margins on three sides and by the
+ * margin plus the header band on top. Mirrors the SCSS constants in
+ * app/components/common/elements/AIJuniorWorksheet.vue:
+ *
+ *   $paper-width: 11in;  $paper-height: 8.5in;
+ *   $top/bottom/left/right-margin: 0.5in;  $header-height: 0.85in;
+ *
+ * Treating these percentages as fractions of the full page instead shifts every
+ * crop up and left and oversizes it by ~10-28%.
+ *
+ * (The sheet's 4px printed border sits just outside the 11x8.5in content box,
+ * about 0.04in -- 0.4% of the page. That is an order of magnitude below the
+ * corrections here and is deliberately ignored.)
+ */
+export const WORKSHEET_GEOMETRY = {
+  paperWidthIn: 11,
+  paperHeightIn: 8.5,
+  marginIn: 0.5,
+  headerHeightIn: 0.85,
+}
+
+export const WORKSHEET_CONTENT_FRAME = (() => {
+  const { paperWidthIn: w, paperHeightIn: h, marginIn: m, headerHeightIn: hdr } = WORKSHEET_GEOMETRY
+  return {
+    left: m / w,
+    top: (m + hdr) / h,
+    width: (w - 2 * m) / w,
+    height: (h - 2 * m - hdr) / h,
+  }
+})()
+
 function makeImage (width, height) {
   return { data: new Uint8ClampedArray(width * height * 4), width, height }
 }
@@ -111,13 +150,16 @@ export function suggestOutputSize (quad, maxDim = 2200) {
  *
  * @param {{data, width, height}} page rectified page image
  * @param {Array<{id, left, top, width, height}>} regions all values are
- *        PERCENTAGES (0-100) of the page's width/height
+ *        PERCENTAGES (0-100) of the frame named by `frame`
+ * @param {{left, top, width, height}} frame the sub-rectangle of the page those
+ *        percentages are relative to, as fractions of the page. Defaults to the
+ *        whole page; worksheets want WORKSHEET_CONTENT_FRAME.
  * @returns {Array<{id, image, rect}>}
  */
-export function cropRegions (page, regions) {
+export function cropRegions (page, regions, frame = FULL_PAGE_FRAME) {
   const out = []
   for (const r of regions) {
-    const rect = regionToPixels(r, page.width, page.height)
+    const rect = regionToPixels(r, page.width, page.height, frame)
     if (rect.width < 1 || rect.height < 1) continue
     const img = makeImage(rect.width, rect.height)
     for (let y = 0; y < rect.height; y++) {
@@ -139,11 +181,15 @@ export function cropRegions (page, regions) {
   return out
 }
 
-export function regionToPixels (r, pageW, pageH) {
-  const x = Math.round((r.left / 100) * pageW)
-  const y = Math.round((r.top / 100) * pageH)
-  const width = Math.round((r.width / 100) * pageW)
-  const height = Math.round((r.height / 100) * pageH)
+export function regionToPixels (r, pageW, pageH, frame = FULL_PAGE_FRAME) {
+  const fx = frame.left * pageW
+  const fy = frame.top * pageH
+  const fw = frame.width * pageW
+  const fh = frame.height * pageH
+  const x = Math.round(fx + (r.left / 100) * fw)
+  const y = Math.round(fy + (r.top / 100) * fh)
+  const width = Math.round((r.width / 100) * fw)
+  const height = Math.round((r.height / 100) * fh)
   return {
     x: Math.max(0, Math.min(pageW - 1, x)),
     y: Math.max(0, Math.min(pageH - 1, y)),

--- a/app/lib/doc-capture/warp.js
+++ b/app/lib/doc-capture/warp.js
@@ -1,0 +1,153 @@
+/**
+ * warp.js -- perspective rectification and percentage-based region cropping.
+ * Pure math on ImageData-shaped buffers; no DOM.
+ */
+
+import { solveHomography, applyHomography, dist } from './geom.js'
+
+/** Landscape US Letter at ~200 dpi. */
+export const LETTER_LANDSCAPE = { width: 2200, height: 1700 }
+
+function makeImage (width, height) {
+  return { data: new Uint8ClampedArray(width * height * 4), width, height }
+}
+
+function bilinear (src, cx, cy, out) {
+  const { width: w, height: h, data } = src
+  // Continuous coordinates put pixel centres at (i + 0.5); shift to texel indices.
+  const x = cx - 0.5
+  const y = cy - 0.5
+  const x0 = Math.floor(x)
+  const y0 = Math.floor(y)
+  const fx = x - x0
+  const fy = y - y0
+  const cx0 = Math.min(w - 1, Math.max(0, x0))
+  const cy0 = Math.min(h - 1, Math.max(0, y0))
+  const cx1 = Math.min(w - 1, Math.max(0, x0 + 1))
+  const cy1 = Math.min(h - 1, Math.max(0, y0 + 1))
+  const i00 = (cy0 * w + cx0) * 4
+  const i10 = (cy0 * w + cx1) * 4
+  const i01 = (cy1 * w + cx0) * 4
+  const i11 = (cy1 * w + cx1) * 4
+  const w00 = (1 - fx) * (1 - fy)
+  const w10 = fx * (1 - fy)
+  const w01 = (1 - fx) * fy
+  const w11 = fx * fy
+  for (let c = 0; c < 4; c++) {
+    out[c] = data[i00 + c] * w00 + data[i10 + c] * w10 + data[i01 + c] * w01 + data[i11 + c] * w11
+  }
+}
+
+/**
+ * Rectify the quad region of `src` into a fresh outW x outH image.
+ *
+ * Works by solving the homography from the *destination* rectangle to the
+ * source quad and inverse-mapping every output pixel, so there are no holes.
+ * When the source region is much larger than the output (high-res photo, small
+ * target) it supersamples to avoid aliasing.
+ *
+ * @param {{data: Uint8ClampedArray, width, height}} src
+ * @param {Array<{x,y}>} quad TL, TR, BR, BL in src pixel coordinates
+ */
+export function warpQuad (src, quad, outW = LETTER_LANDSCAPE.width, outH = LETTER_LANDSCAPE.height) {
+  const dstCorners = [
+    { x: 0, y: 0 }, { x: outW, y: 0 }, { x: outW, y: outH }, { x: 0, y: outH },
+  ]
+  const H = solveHomography(dstCorners, quad)
+  if (!H) return null
+  const out = makeImage(outW, outH)
+  const od = out.data
+
+  // Estimate minification to decide on supersampling.
+  const srcArea = Math.abs(
+    (quad[1].x - quad[0].x) * (quad[3].y - quad[0].y) -
+    (quad[3].x - quad[0].x) * (quad[1].y - quad[0].y),
+  )
+  const ratio = srcArea / (outW * outH)
+  const ss = ratio > 2.2 ? 3 : (ratio > 1.1 ? 2 : 1)
+  const px = new Float32Array(4)
+  const acc = new Float32Array(4)
+
+  for (let y = 0; y < outH; y++) {
+    for (let x = 0; x < outW; x++) {
+      acc[0] = acc[1] = acc[2] = acc[3] = 0
+      for (let sy = 0; sy < ss; sy++) {
+        for (let sx = 0; sx < ss; sx++) {
+          const u = x + (sx + 0.5) / ss
+          const v = y + (sy + 0.5) / ss
+          const p = applyHomography(H, u, v)
+          bilinear(src, p.x, p.y, px)
+          acc[0] += px[0]; acc[1] += px[1]; acc[2] += px[2]; acc[3] += px[3]
+        }
+      }
+      const n = ss * ss
+      const o = (y * outW + x) * 4
+      od[o] = acc[0] / n
+      od[o + 1] = acc[1] / n
+      od[o + 2] = acc[2] / n
+      od[o + 3] = acc[3] / n
+    }
+  }
+  return out
+}
+
+/**
+ * Suggest an output size that preserves the page's real aspect ratio, capped
+ * to maxDim. Useful when the page is not letter-shaped.
+ */
+export function suggestOutputSize (quad, maxDim = 2200) {
+  const wTop = dist(quad[0], quad[1])
+  const wBottom = dist(quad[3], quad[2])
+  const hLeft = dist(quad[0], quad[3])
+  const hRight = dist(quad[1], quad[2])
+  const w = Math.max(wTop, wBottom)
+  const h = Math.max(hLeft, hRight)
+  const scale = maxDim / Math.max(w, h)
+  return { width: Math.round(w * scale), height: Math.round(h * scale) }
+}
+
+/**
+ * Crop scenario-style regions out of a rectified page.
+ *
+ * @param {{data, width, height}} page rectified page image
+ * @param {Array<{id, left, top, width, height}>} regions all values are
+ *        PERCENTAGES (0-100) of the page's width/height
+ * @returns {Array<{id, image, rect}>}
+ */
+export function cropRegions (page, regions) {
+  const out = []
+  for (const r of regions) {
+    const rect = regionToPixels(r, page.width, page.height)
+    if (rect.width < 1 || rect.height < 1) continue
+    const img = makeImage(rect.width, rect.height)
+    for (let y = 0; y < rect.height; y++) {
+      const sy = rect.y + y
+      if (sy < 0 || sy >= page.height) continue
+      let si = (sy * page.width + rect.x) * 4
+      let di = y * rect.width * 4
+      for (let x = 0; x < rect.width; x++, si += 4, di += 4) {
+        const sx = rect.x + x
+        if (sx < 0 || sx >= page.width) continue
+        img.data[di] = page.data[si]
+        img.data[di + 1] = page.data[si + 1]
+        img.data[di + 2] = page.data[si + 2]
+        img.data[di + 3] = page.data[si + 3]
+      }
+    }
+    out.push({ id: r.id, image: img, rect })
+  }
+  return out
+}
+
+export function regionToPixels (r, pageW, pageH) {
+  const x = Math.round((r.left / 100) * pageW)
+  const y = Math.round((r.top / 100) * pageH)
+  const width = Math.round((r.width / 100) * pageW)
+  const height = Math.round((r.height / 100) * pageH)
+  return {
+    x: Math.max(0, Math.min(pageW - 1, x)),
+    y: Math.max(0, Math.min(pageH - 1, y)),
+    width: Math.max(1, Math.min(pageW - x, width)),
+    height: Math.max(1, Math.min(pageH - y, height)),
+  }
+}

--- a/app/schemas/models/ai_junior_project.schema.js
+++ b/app/schemas/models/ai_junior_project.schema.js
@@ -46,7 +46,7 @@ _.extend(AIJuniorProjectSchema.properties, {
   spokenLanguage: {
     type: 'string',
     title: 'Spoken Language',
-    description: 'The spoken language of the player, when this project was made'
+    description: 'The spoken language of the player, when this project was made',
   },
   processingStatus: {
     type: 'string',
@@ -55,11 +55,23 @@ _.extend(AIJuniorProjectSchema.properties, {
     title: 'Processing Status',
   },
   processingStartTime: c.stringDate({ title: 'Processing Start Time' }),
+  processingError: {
+    type: 'string',
+    title: 'Processing Error',
+    description: 'Error message from the most recent failed processing attempt',
+  },
   uploadedWorksheet: {
     type: 'string',
     format: 'image-file',
     title: 'Uploaded Worksheet',
     description: 'Path to the uploaded worksheet file',
+  },
+  shared: {
+    type: 'string',
+    enum: ['none', 'result', 'full'],
+    default: 'none',
+    title: 'Shared',
+    description: 'Whether anyone with the link may view this creation: just the result, or the worksheet inputs too',
   },
   created: c.date({ title: 'Date Created' }),
 })

--- a/app/schemas/models/ai_junior_project.schema.js
+++ b/app/schemas/models/ai_junior_project.schema.js
@@ -66,6 +66,22 @@ _.extend(AIJuniorProjectSchema.properties, {
     title: 'Uploaded Worksheet',
     description: 'Path to the uploaded worksheet file',
   },
+  rawCapture: {
+    type: 'string',
+    format: 'image-file',
+    title: 'Raw Capture',
+    description: 'The camera frame before straightening, kept so page detection can be measured against real captures',
+  },
+  captureQuad: {
+    type: 'string',
+    title: 'Capture Quad',
+    description: 'JSON array of the four normalized page corners the detector chose for the raw capture',
+  },
+  captureSource: {
+    type: 'string',
+    title: 'Capture Source',
+    description: 'How the capture was triggered: auto, manual, or image',
+  },
   shared: {
     type: 'string',
     enum: ['none', 'result', 'full'],

--- a/app/styles/editor/ai-junior-scenario/edit.sass
+++ b/app/styles/editor/ai-junior-scenario/edit.sass
@@ -15,12 +15,120 @@
     margin-bottom: 15px
     margin-left: 10px
 
+    &.active
+      background-color: #337ab7
+      border-color: #2e6da4
+      color: #fff
+
   .treema-image-file
     img
       max-width: 25%
+
+  .treema-percent
+    .treema-shortened
+      color: #31708f
+
+  .scenario-validation
+    display: none
+    margin-bottom: 15px
+    padding: 8px 12px
+    border: 1px solid #faebcc
+    border-radius: 3px
+    background-color: #fcf8e3
+    color: #8a6d3b
+
+    &.scenario-validation-active
+      display: block
+
+    h4
+      margin: 0 0 5px 0
+      font-size: 14px
+      font-weight: bold
+
+    ul
+      margin: 0
+      padding-left: 18px
+
+    li
+      font-size: 12px
+      line-height: 16px
 
   .right-col
     position: -webkit-sticky
     position: sticky
     top: 100px
     height: calc(100vh - 100px - 20px)
+
+  #worksheet-preview-container
+    position: relative
+    width: 100%
+    height: 100%
+
+  // Sits on top of the scaled worksheet preview, lined up with its printable area, so that every box
+  // can use the same left/top/width/height percentages the worksheet itself uses.
+  .layout-overlay
+    display: none
+    position: absolute
+    z-index: 5
+
+    &.layout-overlay-active
+      display: block
+
+  .layout-box
+    position: absolute
+    box-sizing: border-box
+    border: 2px solid rgba(51, 122, 183, 0.9)
+    background-color: rgba(51, 122, 183, 0.12)
+    cursor: move
+
+    &:hover
+      background-color: rgba(51, 122, 183, 0.22)
+
+    &.layout-box-active
+      border-color: #f0ad4e
+      background-color: rgba(240, 173, 78, 0.25)
+
+    &.layout-box-incomplete
+      border-style: dashed
+      border-color: #d9534f
+      background-color: rgba(217, 83, 79, 0.15)
+
+  .layout-box-label
+    position: absolute
+    top: 0
+    left: 0
+    max-width: 100%
+    padding: 1px 4px
+    overflow: hidden
+    font-size: 11px
+    line-height: 14px
+    white-space: nowrap
+    text-overflow: ellipsis
+    color: #fff
+    background-color: rgba(51, 122, 183, 0.85)
+    pointer-events: none
+
+  .layout-handle
+    position: absolute
+    background-color: rgba(51, 122, 183, 0.9)
+
+    &[data-handle="e"]
+      top: 25%
+      bottom: 25%
+      right: -3px
+      width: 6px
+      cursor: ew-resize
+
+    &[data-handle="s"]
+      left: 25%
+      right: 25%
+      bottom: -3px
+      height: 6px
+      cursor: ns-resize
+
+    &[data-handle="se"]
+      right: -5px
+      bottom: -5px
+      width: 10px
+      height: 10px
+      cursor: nwse-resize

--- a/app/templates/editor/ai-junior-scenario/edit.pug
+++ b/app/templates/editor/ai-junior-scenario/edit.pug
@@ -14,6 +14,7 @@ block content
   button.ai-junior-scenario-tool-button.btn.btn-primary#i18n-button(data-i18n="editor.pop_i18n", disabled=authorized === true ? undefined : "true")
   button.ai-junior-scenario-tool-button.btn.btn-primary#delete-button(data-i18n="editor.delete", disabled=me.isAdmin() === true ? undefined : "true")
   button.ai-junior-scenario-tool-button.btn.btn-primary#save-button(data-i18n="common.save", disabled=authorized === true ? undefined : "true")
+  button.ai-junior-scenario-tool-button.btn.btn-default#layout-mode-button(title="Drag input boxes on the worksheet to move them, or drag their right/bottom edges to resize.", disabled=authorized === true ? undefined : "true") Layout Mode
 
   h3
     span(data-i18n="editor.ai_junior_scenario_edit_title")
@@ -21,7 +22,9 @@ block content
 
   .row
     .col-md-6.col-lg-5.left-col
+      #scenario-validation.scenario-validation
       #ai-junior-scenario-treema
     .col-md-6.col-lg-7.right-col
-      #ai-junior-worksheet
-
+      #worksheet-preview-container
+        #ai-junior-worksheet
+        #layout-overlay.layout-overlay

--- a/app/views/ai-junior/AIJuniorCaptureView.vue
+++ b/app/views/ai-junior/AIJuniorCaptureView.vue
@@ -121,6 +121,15 @@
           </button>
 
           <button
+            v-if="cameraOn && !stillLoaded"
+            type="button"
+            class="btn btn-big btn-default"
+            @click="toggleAutoCapture"
+          >
+            {{ autoCaptureWanted ? '⏱ Auto: on' : '⏱ Auto: off' }}
+          </button>
+
+          <button
             v-if="canAdjust"
             type="button"
             class="btn btn-big btn-default"
@@ -222,13 +231,46 @@
           {{ submitError }}
         </p>
       </div>
+
+      <!-- Sheets sent this session. They generate on the server whatever this
+           page is doing, so a stack can be scanned straight through. -->
+      <section
+        v-if="batch.length"
+        class="batch"
+      >
+        <h3 class="batch-heading">
+          {{ batch.length }} sent<span v-if="stillGenerating"> · {{ stillGenerating }} still generating</span>
+        </h3>
+        <div class="batch-strip">
+          <a
+            v-for="entry in batch"
+            :key="entry.id"
+            class="batch-item"
+            :class="entry.status"
+            :href="entry.url"
+            target="_blank"
+            rel="noopener"
+            :title="entry.name"
+          >
+            <img
+              v-if="entry.thumb"
+              :src="entry.thumb"
+              alt=""
+            >
+            <span class="batch-status">{{ statusIcon(entry.status) }}</span>
+          </a>
+        </div>
+        <p class="batch-hint">
+          Keep scanning — each one finishes on its own. Tap any to open it.
+        </p>
+      </section>
     </template>
   </div>
 </template>
 
 <script>
-import { getAIJuniorScenario } from 'app/core/api/ai-junior-scenarios'
-import { createNewAIJuniorProject, processAIJuniorProject } from 'app/core/api/ai-junior-projects'
+import { getAIJuniorScenario, getAIJuniorScenarios } from 'app/core/api/ai-junior-scenarios'
+import { createNewAIJuniorProject, processAIJuniorProject, getAIJuniorProject } from 'app/core/api/ai-junior-projects'
 import usersApi from 'app/core/api/users'
 import { DocumentScanner, drawOverlay, pickCorner } from 'app/lib/doc-capture/capture'
 
@@ -265,6 +307,10 @@ export default {
       regionThumbs: [],
       submitting: false,
       submitError: null,
+      // Sheets sent during this session, newest first. They generate on the
+      // server independently of this page.
+      batch: [],
+      batchTimer: null,
       dragging: -1,
       handsRemoved: 0,
       // Filled in from the QR code when the route did not name a scenario.
@@ -272,6 +318,10 @@ export default {
       qrUserId: null,
       qrUserName: null,
       qrSearching: false,
+      // User-facing toggle; the confidence gate below is what actually decides
+      // whether any given frame is good enough to fire on.
+      autoCaptureWanted: true,
+      holdingSteady: false,
     }
   },
   computed: {
@@ -283,6 +333,9 @@ export default {
     },
     isSecure () {
       return window.isSecureContext
+    },
+    stillGenerating () {
+      return this.batch.filter((entry) => entry.status === 'processing').length
     },
     canAdjust () {
       return this.cameraOn || this.stillLoaded
@@ -311,7 +364,11 @@ export default {
       if (this.warning) return this.warning
       if (this.manual) return 'Drag the four circles onto the corners of the paper.'
       if (this.stillLoaded) return this.hasQuad ? 'Found the worksheet! Tap "Use this photo".' : 'Could not find the paper edges — tap "Adjust corners" to place them yourself.'
-      if (this.cameraOn) return this.hasQuad ? 'Hold still — snapping automatically…' : 'Point the camera at the whole worksheet.'
+      if (this.cameraOn) {
+        if (!this.hasQuad) return 'Point the camera at the whole worksheet.'
+        if (!this.holdingSteady) return 'Show all four edges of the paper — move your fingers off the edges.'
+        return this.autoCaptureWanted ? 'Hold still — snapping automatically…' : 'Looks good — tap Capture.'
+      }
       return null
     },
   },
@@ -331,10 +388,14 @@ export default {
     this.scanner = new DocumentScanner({
       video: this.$refs.video,
       wantQR: this.awaitingQR,
-      // Auto-capture fired on frames that were not actually good, which is
-      // worse than asking for a tap: a bad scan costs a whole AI run to find
-      // out about. The outline and hold-still hint stay; the shutter is manual.
-      autoCapture: false,
+      // Auto-capture used to fire on frames that were not actually good, which
+      // is worse than asking for a tap: a bad scan costs a whole AI run to find
+      // out about. It now additionally requires that the *weakest* of the four
+      // detected edges is genuinely backed by the image, which is what a hand
+      // gripping the page breaks -- so a held-still-but-wrong outline no longer
+      // fires. Off until a QR has named the activity, so nothing is captured
+      // before we know what it is.
+      autoCapture: !this.awaitingQR && this.autoCaptureWanted,
       onUpdate: this.onScannerUpdate,
       onCapture: this.onScannerCapture,
       onQR: this.onQRFound,
@@ -354,6 +415,7 @@ export default {
     if (this.cameraSupported && window.isSecureContext) this.startCamera()
   },
   beforeDestroy () {
+    if (this.batchTimer) clearInterval(this.batchTimer)
     window.removeEventListener('resize', this.sizeOverlay)
     if (this.scanner) {
       this.scanner.stop()
@@ -378,8 +440,21 @@ export default {
 
     // The worksheet's QR code names both the activity and the child it was
     // printed for, which is everything a bare /ai-junior/scan page needs.
-    async onQRFound ({ scenarioHandle, userId }) {
+    async onQRFound ({ scenarioHandle, userId, isPrefix }) {
       if (this.activeScenarioHandle) return
+      // A short code names the scenario by the leading characters of its id, so
+      // resolve it against the (very small) scenario list before loading.
+      if (isPrefix) {
+        try {
+          const scenarios = await getAIJuniorScenarios()
+          const match = (scenarios || []).find((s) => String(s._id).startsWith(scenarioHandle))
+          if (!match) return
+          scenarioHandle = match.slug || String(match._id)
+        } catch (error) {
+          console.error('Could not resolve the worksheet code:', error)
+          return
+        }
+      }
       this.qrSearching = true
       const loaded = await this.loadScenario(scenarioHandle)
       this.qrSearching = false
@@ -388,7 +463,7 @@ export default {
       this.qrUserId = userId
       if (this.scanner) {
         this.scanner.wantQR = false
-        this.scanner.autoCapture = true
+        this.scanner.autoCapture = this.autoCaptureWanted
         this.scanner.regions = this.imageFieldInputs
         this.scanner.tracker.reset()
       }
@@ -511,14 +586,26 @@ export default {
       })
     },
 
-    onScannerUpdate ({ quad, progress, warning }) {
+    onScannerUpdate ({ quad, progress, warning, trustworthy }) {
       this.hasQuad = !!quad
       this.warning = warning || null
       this.overlayProgress = progress || 0
+      // `trustworthy` is the scanner's own verdict on this frame: no warning,
+      // every edge backed by the image, plausible size. Drives the wording so
+      // the user is told to hold still only when holding still will help.
+      this.holdingSteady = !!trustworthy
       this.redrawOverlay()
     },
 
     // --- manual corners ---------------------------------------------------
+
+    toggleAutoCapture () {
+      this.autoCaptureWanted = !this.autoCaptureWanted
+      if (this.scanner) {
+        this.scanner.autoCapture = this.autoCaptureWanted && !this.awaitingQR
+        this.scanner.tracker.reset()
+      }
+    },
 
     toggleManual () {
       if (this.manual) {
@@ -634,6 +721,15 @@ export default {
         // and vision-extracts the text/checkbox/radio answers from it, which is
         // why nothing tries to read those fields here.
         inputValues.scannedWorksheet = this.lastCapture.canvas.toDataURL('image/jpeg', SCAN_JPEG_QUALITY)
+        // Diagnostics: the frame before straightening, and the corners chosen
+        // for it. The archived page is already rectified, so it cannot show
+        // whether the corners were right — these are what make it possible to
+        // measure detection against real captures rather than synthetic ones.
+        if (this.lastCapture.rawDataUrl) {
+          inputValues.rawCapture = this.lastCapture.rawDataUrl
+          inputValues.captureQuad = JSON.stringify(this.lastCapture.quad)
+          inputValues.captureSource = this.lastCapture.source
+        }
 
         const project = await createNewAIJuniorProject({
           scenarioId: this.scenario._id,
@@ -644,20 +740,70 @@ export default {
           inputValues,
           name: this.qrUserName ? `${this.scenario.name} — ${this.qrUserName}` : `${this.scenario.name} (scanned)`,
         })
-        // Kick off processing before navigating: the server returns 202 as soon
-        // as it has queued the work, and leaving the page first would abort the
-        // request. A failure here is not fatal — the project exists, and its
-        // page can retry — so it must not block the redirect.
+        // Kick off processing before going anywhere: the server returns 202 as
+        // soon as it has queued the work, and leaving the page first would
+        // abort the request. A failure here is not fatal — the project exists
+        // and its page can retry — so it must not block what follows.
         try {
           await processAIJuniorProject({ projectHandle: project._id, force: true })
         } catch (error) {
           console.error('Could not start processing; the project page can retry:', error)
         }
-        window.location.href = `/ai-junior/project/${this.activeScenarioHandle}/${project.user || me.id}/${project._id}`
+
+        const url = `/ai-junior/project/${this.activeScenarioHandle}/${project.user || me.id}/${project._id}`
+
+        // Scanning a stack is the normal case, so stay put and take the next
+        // sheet. Each project generates on the server regardless of what this
+        // page is doing; the strip below keeps track of them.
+        this.batch.unshift({
+          id: project._id,
+          url,
+          name: project.name,
+          thumb: this.lastCapture.regions[0]?.dataUrl || this.pageDataUrl,
+          status: 'processing',
+        })
+        this.submitting = false
+        this.retake()
+        this.startBatchPolling()
       } catch (error) {
         console.error('Error submitting scanned worksheet:', error)
         this.submitting = false
         this.submitError = 'Something went wrong sending your worksheet. Please try again.'
+      }
+    },
+
+    statusIcon (status) {
+      if (status === 'completed') return '✓'
+      if (status === 'failed') return '!'
+      return '…'
+    },
+
+    // --- batch ------------------------------------------------------------
+
+    startBatchPolling () {
+      if (this.batchTimer) return
+      this.batchTimer = setInterval(this.refreshBatch, 5000)
+    },
+
+    async refreshBatch () {
+      const pending = this.batch.filter((entry) => entry.status === 'processing')
+      if (!pending.length) {
+        clearInterval(this.batchTimer)
+        this.batchTimer = null
+        return
+      }
+      // One at a time: this runs while the user is lining up the next sheet,
+      // and the camera loop matters more than the status dots.
+      for (const entry of pending.slice(0, 3)) {
+        try {
+          const project = await getAIJuniorProject({ projectHandle: entry.id })
+          if (project.processingStatus && project.processingStatus !== 'processing') {
+            entry.status = project.processingStatus
+            entry.name = project.name || entry.name
+          }
+        } catch (error) {
+          // Leave it pending; the next tick tries again.
+        }
       }
     },
   },
@@ -868,5 +1014,64 @@ export default {
 
 @keyframes spin {
   100% { transform: rotate(360deg); }
+}
+
+.batch {
+  margin-top: 1.6rem;
+  border-top: 1px solid #e2e2e2;
+  padding-top: 1rem;
+}
+
+.batch-heading {
+  font-size: 1.4rem;
+  color: #666;
+  margin: 0 0 0.6rem;
+  text-align: center;
+}
+
+.batch-strip {
+  display: flex;
+  gap: 0.6rem;
+  overflow-x: auto;
+  padding-bottom: 0.4rem;
+}
+
+.batch-item {
+  position: relative;
+  flex: 0 0 auto;
+  width: 74px;
+  height: 74px;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 2px solid #ddd;
+  background: #fff;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  &.completed { border-color: #3ddc84; }
+  &.failed { border-color: #d94a4a; }
+}
+
+.batch-status {
+  position: absolute;
+  right: 2px;
+  bottom: 0;
+  font-size: 1.3rem;
+  line-height: 1;
+  padding: 1px 5px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+}
+
+.batch-hint {
+  text-align: center;
+  font-size: 1.3rem;
+  color: #888;
+  margin: 0.5rem 0 0;
 }
 </style>

--- a/app/views/ai-junior/AIJuniorCaptureView.vue
+++ b/app/views/ai-junior/AIJuniorCaptureView.vue
@@ -1,0 +1,872 @@
+<template>
+  <div class="ai-junior-capture">
+    <div
+      v-if="!hasAccess"
+      class="notice"
+    >
+      <p>You need AI Junior access to scan a worksheet.</p>
+    </div>
+
+    <template v-else>
+      <header class="capture-header">
+        <h1>Scan your worksheet</h1>
+        <p v-if="scenario">
+          {{ scenario.name }}<span
+            v-if="qrUserName"
+            class="owner-name"
+          > · {{ qrUserName }}</span>
+        </p>
+        <p
+          v-else-if="awaitingQR"
+          class="muted"
+        >
+          Point at any worksheet — I'll work out which one it is.
+        </p>
+        <p
+          v-else-if="!loadError"
+          class="muted"
+        >
+          Loading…
+        </p>
+        <p
+          v-if="loadError"
+          class="error-text"
+        >
+          {{ loadError }}
+        </p>
+      </header>
+
+      <!-- Stage: live camera, or the photo that was taken/uploaded. -->
+      <div
+        v-show="stage === 'capture'"
+        class="stage-wrap"
+      >
+        <div class="stage">
+          <video
+            v-show="cameraOn && !stillLoaded"
+            ref="video"
+            playsinline
+            muted
+          />
+          <img
+            v-show="stillLoaded"
+            ref="still"
+            class="still"
+            alt=""
+          >
+          <canvas
+            ref="overlay"
+            class="overlay"
+            @pointerdown="onPointerDown"
+            @pointermove="onPointerMove"
+            @pointerup="onPointerUp"
+            @pointercancel="onPointerUp"
+          />
+          <div
+            v-if="!cameraOn && !stillLoaded"
+            class="stage-empty"
+          >
+            <p>Take a photo of your worksheet, or turn on the camera to scan it live.</p>
+            <p
+              v-if="!cameraSupported || !isSecure"
+              class="stage-empty-note"
+            >
+              Live camera needs a secure (https) connection — the photo button works either way.
+            </p>
+          </div>
+        </div>
+
+        <p
+          v-if="statusMessage"
+          class="status-line"
+          :class="{ warn: !!warning }"
+        >
+          {{ statusMessage }}
+        </p>
+
+        <div class="controls">
+          <!-- With the camera live by default, the shutter leads. The photo
+               path stays available for phones on plain HTTP, where
+               getUserMedia does not exist at all. -->
+          <button
+            v-if="cameraOn && !stillLoaded"
+            type="button"
+            class="btn btn-big btn-primary"
+            :disabled="!hasQuad || awaitingQR"
+            @click="captureNow"
+          >
+            📸 Capture
+          </button>
+
+          <label
+            class="btn btn-big file-btn"
+            :class="cameraOn ? 'btn-default' : 'btn-primary'"
+          >
+            📷 {{ cameraOn ? 'Use a photo instead' : 'Take / upload photo' }}
+            <input
+              type="file"
+              accept="image/*"
+              capture="environment"
+              @change="onFileChosen"
+            >
+          </label>
+
+          <button
+            v-if="!cameraOn && cameraSupported"
+            type="button"
+            class="btn btn-big btn-default"
+            @click="startCamera"
+          >
+            🎥 Use live camera
+          </button>
+
+          <button
+            v-if="canAdjust"
+            type="button"
+            class="btn btn-big btn-default"
+            @click="toggleManual"
+          >
+            {{ manual ? 'Done adjusting' : '✥ Adjust corners' }}
+          </button>
+
+          <button
+            v-if="manual"
+            type="button"
+            class="btn btn-big btn-default"
+            @click="snapCorners"
+          >
+            Snap to edges
+          </button>
+
+          <button
+            v-if="stillLoaded"
+            type="button"
+            class="btn btn-big btn-primary"
+            :disabled="awaitingQR"
+            @click="captureNow"
+          >
+            Use this photo
+          </button>
+        </div>
+
+        <p
+          v-if="cameraError"
+          class="error-text"
+        >
+          {{ cameraError }}
+        </p>
+      </div>
+
+      <!-- Stage: review the straightened page before sending it. -->
+      <div
+        v-show="stage === 'review'"
+        class="review"
+      >
+        <h2>Does this look right?</h2>
+        <p class="muted">
+          Check that the whole worksheet is here and the writing is easy to read.
+          <span v-if="handsRemoved > 0.002">Fingers holding the page were painted out.</span>
+        </p>
+
+        <div class="page-preview">
+          <img
+            v-if="pageDataUrl"
+            :src="pageDataUrl"
+            alt="Straightened worksheet"
+          >
+        </div>
+
+        <div
+          v-if="regionThumbs.length"
+          class="thumbs"
+        >
+          <figure
+            v-for="thumb in regionThumbs"
+            :key="thumb.id"
+            class="thumb"
+          >
+            <img
+              :src="thumb.dataUrl"
+              :alt="thumb.id"
+            >
+            <figcaption>{{ thumb.label }}</figcaption>
+          </figure>
+        </div>
+
+        <div class="controls">
+          <button
+            type="button"
+            class="btn btn-big btn-default"
+            :disabled="submitting"
+            @click="retake"
+          >
+            ↺ Retake
+          </button>
+          <button
+            type="button"
+            class="btn btn-big btn-primary"
+            :disabled="submitting"
+            @click="submit"
+          >
+            <span v-if="submitting">
+              <span class="spinner" /> Sending…
+            </span>
+            <span v-else>✨ Make my project</span>
+          </button>
+        </div>
+
+        <p
+          v-if="submitError"
+          class="error-text"
+        >
+          {{ submitError }}
+        </p>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script>
+import { getAIJuniorScenario } from 'app/core/api/ai-junior-scenarios'
+import { createNewAIJuniorProject, processAIJuniorProject } from 'app/core/api/ai-junior-projects'
+import usersApi from 'app/core/api/users'
+import { DocumentScanner, drawOverlay, pickCorner } from 'app/lib/doc-capture/capture'
+
+// The scan is archived and vision-read server-side, so it wants to be legible
+// but not enormous; JPEG at this quality keeps a 2200x1700 page near ~400KB.
+const SCAN_JPEG_QUALITY = 0.85
+
+export default {
+  name: 'AIJuniorCaptureView',
+  props: {
+    // Optional: /ai-junior/scan with no scenario reads the worksheet's own QR
+    // code to work out which activity and which student the sheet belongs to.
+    scenarioHandle: {
+      type: String,
+      default: null,
+    },
+    forUserId: {
+      type: String,
+      default: null,
+    },
+  },
+  data () {
+    return {
+      scenario: null,
+      loadError: null,
+      stage: 'capture',
+      cameraOn: false,
+      cameraError: null,
+      stillLoaded: false,
+      manual: false,
+      hasQuad: false,
+      warning: null,
+      pageDataUrl: null,
+      regionThumbs: [],
+      submitting: false,
+      submitError: null,
+      dragging: -1,
+      handsRemoved: 0,
+      // Filled in from the QR code when the route did not name a scenario.
+      qrScenarioHandle: null,
+      qrUserId: null,
+      qrUserName: null,
+      qrSearching: false,
+    }
+  },
+  computed: {
+    hasAccess () {
+      return me.hasAiJuniorAccess()
+    },
+    cameraSupported () {
+      return !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)
+    },
+    isSecure () {
+      return window.isSecureContext
+    },
+    canAdjust () {
+      return this.cameraOn || this.stillLoaded
+    },
+    imageFieldInputs () {
+      return (this.scenario?.inputs || []).filter((input) => input.type === 'image-field')
+    },
+    // Which activity this scan belongs to, from the route or from the QR code.
+    activeScenarioHandle () {
+      return this.scenarioHandle || this.qrScenarioHandle
+    },
+    ownerId () {
+      return this.forUserId || this.qrUserId || me.id
+    },
+    // Without a scenario there are no regions to crop, so firing the shutter
+    // early would produce a page nothing could be done with.
+    awaitingQR () {
+      return !this.activeScenarioHandle
+    },
+    statusMessage () {
+      if (this.awaitingQR) {
+        if (this.stillLoaded) return 'No worksheet code found in that photo — try again with the code in frame.'
+        if (this.cameraOn) return 'Looking for the code in the corner of the worksheet…'
+        return null
+      }
+      if (this.warning) return this.warning
+      if (this.manual) return 'Drag the four circles onto the corners of the paper.'
+      if (this.stillLoaded) return this.hasQuad ? 'Found the worksheet! Tap "Use this photo".' : 'Could not find the paper edges — tap "Adjust corners" to place them yourself.'
+      if (this.cameraOn) return this.hasQuad ? 'Hold still — snapping automatically…' : 'Point the camera at the whole worksheet.'
+      return null
+    },
+  },
+  async created () {
+    if (!this.scenarioHandle) return // Waiting on the QR code instead.
+    await this.loadScenario(this.scenarioHandle)
+  },
+  mounted () {
+    if (!this.hasAccess) return
+    // These four stay off `data` deliberately: the scanner holds canvases and
+    // typed arrays and the capture result holds a 2200x1700 canvas, so making
+    // Vue observe them costs a lot and buys nothing — the template only ever
+    // reads the small derived values (pageDataUrl, regionThumbs).
+    this.lastCapture = null
+    this.objectUrl = null
+    this.overlayProgress = 0
+    this.scanner = new DocumentScanner({
+      video: this.$refs.video,
+      wantQR: this.awaitingQR,
+      // Auto-capture fired on frames that were not actually good, which is
+      // worse than asking for a tap: a bad scan costs a whole AI run to find
+      // out about. The outline and hold-still hint stay; the shutter is manual.
+      autoCapture: false,
+      onUpdate: this.onScannerUpdate,
+      onCapture: this.onScannerCapture,
+      onQR: this.onQRFound,
+      onError: (err) => console.error('Scanner error:', err),
+    })
+    // Regions come from the scenario, which may still be loading.
+    this.$watch('imageFieldInputs', (inputs) => {
+      if (this.scanner) this.scanner.regions = inputs
+    }, { immediate: true })
+    window.addEventListener('resize', this.sizeOverlay)
+    this.sizeOverlay()
+
+    // Open the camera straight away — pointing a page at a worksheet is the
+    // whole job, so making that a second tap is pure friction. Only where
+    // getUserMedia can actually work: over plain HTTP it is absent, and asking
+    // for it there just produces an error the user cannot do anything about.
+    if (this.cameraSupported && window.isSecureContext) this.startCamera()
+  },
+  beforeDestroy () {
+    window.removeEventListener('resize', this.sizeOverlay)
+    if (this.scanner) {
+      this.scanner.stop()
+      this.scanner = null
+    }
+    if (this.objectUrl) URL.revokeObjectURL(this.objectUrl)
+  },
+  methods: {
+    // --- scenario / QR ----------------------------------------------------
+
+    async loadScenario (handle) {
+      try {
+        this.scenario = await getAIJuniorScenario({ scenarioHandle: handle })
+        this.loadError = null
+        return true
+      } catch (error) {
+        console.error('Error fetching scenario:', error)
+        this.loadError = 'Could not load this activity. Please go back and try again.'
+        return false
+      }
+    },
+
+    // The worksheet's QR code names both the activity and the child it was
+    // printed for, which is everything a bare /ai-junior/scan page needs.
+    async onQRFound ({ scenarioHandle, userId }) {
+      if (this.activeScenarioHandle) return
+      this.qrSearching = true
+      const loaded = await this.loadScenario(scenarioHandle)
+      this.qrSearching = false
+      if (!loaded) return
+      this.qrScenarioHandle = scenarioHandle
+      this.qrUserId = userId
+      if (this.scanner) {
+        this.scanner.wantQR = false
+        this.scanner.autoCapture = true
+        this.scanner.regions = this.imageFieldInputs
+        this.scanner.tracker.reset()
+      }
+      if (userId && userId !== me.id) this.loadOwnerName(userId)
+    },
+
+    async loadOwnerName (userId) {
+      try {
+        const user = await usersApi.getByHandle(userId)
+        this.qrUserName = user?.name || user?.firstName || null
+      } catch (error) {
+        // Not fatal — the scan works whether or not we can show a name.
+        this.qrUserName = null
+      }
+    },
+
+    // --- camera / photo sources -------------------------------------------
+
+    async startCamera () {
+      this.cameraError = null
+      try {
+        await this.scanner.start()
+        this.cameraOn = true
+        this.$nextTick(this.sizeOverlay)
+      } catch (error) {
+        console.error('Could not open camera:', error)
+        this.cameraError = window.isSecureContext
+          ? 'Could not open the camera. You can still take a photo with the button above.'
+          : 'The camera needs a secure (https) connection. Use "Take / upload photo" instead — it works the same way.'
+      }
+    },
+
+    onFileChosen (event) {
+      const file = event.target.files && event.target.files[0]
+      if (!file) return
+      this.cameraError = null
+      if (this.objectUrl) URL.revokeObjectURL(this.objectUrl)
+      this.objectUrl = URL.createObjectURL(file)
+
+      const image = new Image()
+      image.onload = () => {
+        this.scanner.stop()
+        this.cameraOn = false
+        const still = this.$refs.still
+        still.src = this.objectUrl
+        this.stillLoaded = true
+        this.$nextTick(async () => {
+          this.sizeOverlay()
+          this.scanner.useStill(image)
+          // A photo picked on a phone is often the only shot we get, so read
+          // the code straight out of it rather than asking for a live preview.
+          if (this.awaitingQR) {
+            this.qrSearching = true
+            await this.scanner.scanQROnce()
+            this.qrSearching = false
+            this.scanner.detectOnce()
+          }
+        })
+      }
+      image.onerror = () => {
+        this.cameraError = 'Could not read that picture. Please try taking it again.'
+      }
+      image.src = this.objectUrl
+      // Allow re-picking the same file.
+      event.target.value = ''
+    },
+
+    // --- overlay ----------------------------------------------------------
+
+    sizeOverlay () {
+      const overlay = this.$refs.overlay
+      if (!overlay) return
+      const rect = overlay.getBoundingClientRect()
+      if (!rect.width || !rect.height) return
+      const dpr = Math.min(2, window.devicePixelRatio || 1)
+      const width = Math.round(rect.width * dpr)
+      const height = Math.round(rect.height * dpr)
+      if (overlay.width !== width || overlay.height !== height) {
+        overlay.width = width
+        overlay.height = height
+      }
+      this.redrawOverlay()
+    },
+
+    // The video/photo is letterboxed by `object-fit: contain`, so normalized
+    // frame coordinates have to be mapped through the displayed rectangle or
+    // the outline drifts off the paper when the aspect ratios differ.
+    displayRect () {
+      const overlay = this.$refs.overlay
+      const frame = this.scanner ? this.scanner.frameSize : { width: 0, height: 0 }
+      const fw = frame.width || 4
+      const fh = frame.height || 3
+      const scale = Math.min(overlay.width / fw, overlay.height / fh)
+      const w = fw * scale
+      const h = fh * scale
+      return { x: (overlay.width - w) / 2, y: (overlay.height - h) / 2, w, h }
+    },
+
+    redrawOverlay () {
+      const overlay = this.$refs.overlay
+      if (!overlay || !this.scanner) return
+      const ctx = overlay.getContext('2d')
+      const quad = this.manual ? this.scanner.manualQuad : this.scanner.lastQuad
+      if (!quad) {
+        ctx.clearRect(0, 0, overlay.width, overlay.height)
+        return
+      }
+      const rect = this.displayRect()
+      const points = quad.map((p) => ({
+        x: (rect.x + p.x * rect.w) / overlay.width,
+        y: (rect.y + p.y * rect.h) / overlay.height,
+      }))
+      drawOverlay(ctx, points, {
+        stable: !this.warning,
+        progress: this.manual ? 0 : this.overlayProgress,
+        handles: this.manual,
+        handleRadius: 16,
+        lineWidth: 4,
+        ...(this.warning ? { lineColor: '#f0932b', searchColor: 'rgba(240,147,43,0.45)' } : {}),
+      })
+    },
+
+    onScannerUpdate ({ quad, progress, warning }) {
+      this.hasQuad = !!quad
+      this.warning = warning || null
+      this.overlayProgress = progress || 0
+      this.redrawOverlay()
+    },
+
+    // --- manual corners ---------------------------------------------------
+
+    toggleManual () {
+      if (this.manual) {
+        this.manual = false
+        this.scanner.exitManualMode()
+      } else {
+        this.scanner.enterManualMode()
+        this.manual = true
+      }
+      this.redrawOverlay()
+    },
+
+    snapCorners () {
+      this.scanner.snapManualQuad()
+      this.redrawOverlay()
+    },
+
+    pointerToFrame (event) {
+      const overlay = this.$refs.overlay
+      const bounds = overlay.getBoundingClientRect()
+      const rect = this.displayRect()
+      const dpr = overlay.width / bounds.width
+      const x = (event.clientX - bounds.left) * dpr
+      const y = (event.clientY - bounds.top) * dpr
+      return { x: (x - rect.x) / rect.w, y: (y - rect.y) / rect.h }
+    },
+
+    onPointerDown (event) {
+      if (!this.manual || !this.scanner.manualQuad) return
+      this.dragging = pickCorner(this.scanner.manualQuad, this.pointerToFrame(event), 0.1)
+      if (this.dragging >= 0) {
+        this.$refs.overlay.setPointerCapture(event.pointerId)
+        event.preventDefault()
+      }
+    },
+
+    onPointerMove (event) {
+      if (this.dragging < 0 || !this.scanner.manualQuad) return
+      const next = this.scanner.manualQuad.map((p) => ({ ...p }))
+      next[this.dragging] = this.pointerToFrame(event)
+      this.scanner.setManualQuad(next)
+      this.redrawOverlay()
+      event.preventDefault()
+    },
+
+    onPointerUp (event) {
+      if (this.dragging >= 0) {
+        try { this.$refs.overlay.releasePointerCapture(event.pointerId) } catch (e) { /* already released */ }
+      }
+      this.dragging = -1
+    },
+
+    // --- capture / review -------------------------------------------------
+
+    captureNow () {
+      const result = this.scanner.capture(this.manual ? this.scanner.manualQuad : null, 'manual')
+      if (!result) {
+        this.cameraError = 'Could not find the worksheet corners. Tap "Adjust corners" and place them yourself.'
+      }
+    },
+
+    onScannerCapture (result) {
+      this.lastCapture = result
+      this.pageDataUrl = result.dataUrl
+      this.handsRemoved = result.handsRemoved || 0
+      const labelFor = (id) => {
+        const input = this.imageFieldInputs.find((i) => i.id === id)
+        return (input && (input.label || input.text)) || id
+      }
+      this.regionThumbs = result.regions.map((region) => ({
+        id: region.id,
+        label: labelFor(region.id),
+        dataUrl: region.dataUrl,
+      }))
+      this.stage = 'review'
+      this.submitError = null
+      if (this.scanner.stream) this.scanner.stop()
+      this.cameraOn = false
+    },
+
+    retake () {
+      this.stage = 'capture'
+      this.pageDataUrl = null
+      this.regionThumbs = []
+      this.lastCapture = null
+      this.manual = false
+      if (!this.scanner) return
+      this.scanner.exitManualMode()
+      if (this.stillLoaded) {
+        // Re-run detection on the photo that is still on screen.
+        this.scanner.detectOnce()
+      } else if (this.cameraSupported) {
+        // Capturing stopped the stream; bring it back so retake is one tap.
+        this.startCamera()
+      }
+      this.$nextTick(this.sizeOverlay)
+    },
+
+    async submit () {
+      if (!this.lastCapture || this.submitting) return
+      if (!this.scenario) {
+        this.submitError = 'This activity did not finish loading. Please reload the page and try again.'
+        return
+      }
+      this.submitting = true
+      this.submitError = null
+      try {
+        const inputValues = {}
+        for (const region of this.lastCapture.regions) {
+          inputValues[region.id] = region.dataUrl
+        }
+        // The whole straightened page goes along as well: the server archives it
+        // and vision-extracts the text/checkbox/radio answers from it, which is
+        // why nothing tries to read those fields here.
+        inputValues.scannedWorksheet = this.lastCapture.canvas.toDataURL('image/jpeg', SCAN_JPEG_QUALITY)
+
+        const project = await createNewAIJuniorProject({
+          scenarioId: this.scenario._id,
+          // Whose sheet this was, per the QR code or the route. The server
+          // decides whether the scanning account is allowed to file it under
+          // that child; if not, it stays with the scanner.
+          forUserId: this.ownerId,
+          inputValues,
+          name: this.qrUserName ? `${this.scenario.name} — ${this.qrUserName}` : `${this.scenario.name} (scanned)`,
+        })
+        // Kick off processing before navigating: the server returns 202 as soon
+        // as it has queued the work, and leaving the page first would abort the
+        // request. A failure here is not fatal — the project exists, and its
+        // page can retry — so it must not block the redirect.
+        try {
+          await processAIJuniorProject({ projectHandle: project._id, force: true })
+        } catch (error) {
+          console.error('Could not start processing; the project page can retry:', error)
+        }
+        window.location.href = `/ai-junior/project/${this.activeScenarioHandle}/${project.user || me.id}/${project._id}`
+      } catch (error) {
+        console.error('Error submitting scanned worksheet:', error)
+        this.submitting = false
+        this.submitError = 'Something went wrong sending your worksheet. Please try again.'
+      }
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.ai-junior-capture {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 1rem 1rem 3rem;
+}
+
+.capture-header {
+  text-align: center;
+  margin-bottom: 1.2rem;
+
+  h1 {
+    font-size: 2.6rem;
+    margin: 0 0 0.3rem;
+  }
+
+  p {
+    font-size: 1.7rem;
+    color: #555;
+    margin: 0;
+  }
+}
+
+.muted { color: #777; }
+
+.error-text {
+  color: #b3261e;
+  font-size: 1.5rem;
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.notice {
+  text-align: center;
+  padding: 4rem 1rem;
+  font-size: 1.8rem;
+}
+
+.stage {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  background: #11141a;
+  border-radius: 14px;
+  overflow: hidden;
+
+  video,
+  .still,
+  .overlay {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  video,
+  .still {
+    object-fit: contain;
+  }
+
+  .overlay {
+    touch-action: none;
+  }
+}
+
+@media (min-width: 720px) {
+  .stage { aspect-ratio: 4 / 3; }
+}
+
+// The stage is near-black, so every piece of text inside it needs its colour
+// stated on the element itself. Setting it on the container alone is not
+// enough: the site's global stylesheet colours `p` directly, and an explicit
+// rule beats an inherited value, which left dark text on a dark background.
+.stage-empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  text-align: center;
+  font-size: 1.6rem;
+
+  p {
+    color: #eef2f8;
+    margin: 0;
+  }
+
+  .stage-empty-note {
+    font-size: 1.3rem;
+    color: #b9c2d0;
+    margin-top: 0.8rem;
+  }
+}
+
+.owner-name {
+  color: #2c662d;
+  font-weight: bold;
+}
+
+.status-line {
+  text-align: center;
+  font-size: 1.6rem;
+  margin: 0.9rem 0 0;
+  color: #2c662d;
+
+  &.warn { color: #a15c00; }
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  justify-content: center;
+  margin-top: 1.2rem;
+}
+
+.btn-big {
+  font-size: 1.7rem;
+  padding: 0.9rem 1.6rem;
+  border-radius: 10px;
+  min-height: 52px;
+}
+
+.file-btn {
+  display: inline-flex;
+  align-items: center;
+  margin: 0;
+  cursor: pointer;
+
+  input { display: none; }
+}
+
+.review {
+  h2 {
+    text-align: center;
+    font-size: 2.2rem;
+    margin: 0 0 0.3rem;
+  }
+
+  .muted {
+    text-align: center;
+    font-size: 1.5rem;
+    margin: 0 0 1.2rem;
+  }
+}
+
+.page-preview {
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+  border: 1px solid #ddd;
+
+  img {
+    display: block;
+    width: 100%;
+  }
+}
+
+.thumbs {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 0.8rem;
+  margin-top: 1rem;
+}
+
+.thumb {
+  margin: 0;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 0.4rem;
+  background: #fff;
+
+  img {
+    display: block;
+    width: 100%;
+    border-radius: 4px;
+  }
+
+  figcaption {
+    font-size: 1.2rem;
+    color: #666;
+    margin-top: 0.3rem;
+    text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  vertical-align: -2px;
+}
+
+@keyframes spin {
+  100% { transform: rotate(360deg); }
+}
+</style>

--- a/app/views/ai-junior/AIJuniorClassPrintView.vue
+++ b/app/views/ai-junior/AIJuniorClassPrintView.vue
@@ -1,0 +1,199 @@
+<template>
+  <div class="ai-junior-class-print">
+    <div class="print-toolbar no-print">
+      <h2 v-if="scenario && classroom">
+        Print "{{ scenario.name }}" for {{ classroom.name }}
+      </h2>
+      <p
+        v-if="members.length"
+        class="member-count"
+      >
+        {{ members.length }} student worksheet{{ members.length === 1 ? '' : 's' }}, each with its own QR code.
+        Use landscape US Letter paper.
+      </p>
+      <div class="toolbar-actions">
+        <button
+          class="btn btn-primary btn-lg"
+          :disabled="loading || !members.length"
+          @click="printAll"
+        >
+          🖨 Print All
+        </button>
+        <a
+          v-if="classroom"
+          class="btn btn-default"
+          :href="`/ai-junior/print/${scenarioHandle}`"
+        >Choose a different class</a>
+      </div>
+    </div>
+
+    <div
+      v-if="loading"
+      class="loading no-print"
+    >
+      <div class="spinner" />
+      <p>Loading…</p>
+    </div>
+
+    <div
+      v-else-if="!classroomId"
+      class="classroom-picker no-print"
+    >
+      <h3>Which class is this for?</h3>
+      <p v-if="!classrooms.length">
+        You don't have any classes yet.
+      </p>
+      <ul>
+        <li
+          v-for="c in classrooms"
+          :key="c._id"
+        >
+          <a
+            class="btn btn-default"
+            :href="`/ai-junior/print/${scenarioHandle}/${c._id}`"
+          >
+            {{ c.name }} ({{ (c.members || []).length }} students)
+          </a>
+        </li>
+      </ul>
+    </div>
+
+    <div
+      v-else
+      class="sheets"
+    >
+      <div
+        v-for="member in members"
+        :key="member._id"
+        class="sheet-wrapper"
+      >
+        <AIJuniorWorksheet
+          :scenario="scenario"
+          :print-user="member"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import AIJuniorWorksheet from 'app/components/common/elements/AIJuniorWorksheet.vue'
+import { getAIJuniorScenario } from 'app/core/api/ai-junior-scenarios'
+const classroomsApi = require('app/core/api/classrooms')
+
+export default {
+  name: 'AIJuniorClassPrintView',
+  components: {
+    AIJuniorWorksheet,
+  },
+  data: () => ({
+    loading: true,
+    scenario: null,
+    classroom: null,
+    classrooms: [],
+    members: [],
+  }),
+  computed: {
+    scenarioHandle () {
+      return this.$route.params.scenarioHandle
+    },
+    classroomId () {
+      return this.$route.params.classroomId
+    },
+  },
+  async created () {
+    try {
+      this.scenario = await getAIJuniorScenario({ scenarioHandle: this.scenarioHandle })
+      if (this.classroomId) {
+        this.classroom = await classroomsApi.get({ classroomID: this.classroomId })
+        const members = await classroomsApi.getMembers({ classroom: this.classroom }, { removeDeleted: true })
+        this.members = _.sortBy(members, (m) => (m.name || m.firstName || '').toLowerCase())
+      } else {
+        this.classrooms = await fetch(`/db/classroom?ownerID=${me.id}`, { credentials: 'same-origin' }).then((res) => res.json())
+      }
+    } catch (err) {
+      console.error('Failed to load class print data:', err)
+      noty({ text: 'Failed to load class data', type: 'error', timeout: 5000 })
+    } finally {
+      this.loading = false
+    }
+  },
+  methods: {
+    printAll () {
+      window.print()
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.ai-junior-class-print {
+  max-width: 1150px;
+  margin: 0 auto;
+}
+
+.print-toolbar {
+  text-align: center;
+  margin-bottom: 2rem;
+
+  .member-count {
+    color: #555;
+  }
+
+  .toolbar-actions {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    margin-top: 1rem;
+  }
+}
+
+.loading {
+  text-align: center;
+  padding: 4rem 0;
+  color: #666;
+}
+
+.spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #3498db;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  margin: 0 auto 1rem;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.classroom-picker {
+  text-align: center;
+
+  ul {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+    align-items: center;
+  }
+}
+
+.sheet-wrapper {
+  margin-bottom: 3rem;
+}
+
+@media print {
+  .sheet-wrapper {
+    margin-bottom: 0;
+    page-break-after: always;
+  }
+
+  .sheet-wrapper:last-child {
+    page-break-after: auto;
+  }
+}
+</style>

--- a/app/views/ai-junior/AIJuniorLandingView.vue
+++ b/app/views/ai-junior/AIJuniorLandingView.vue
@@ -1,12 +1,402 @@
 <template>
   <div class="ai-junior-landing">
-    <h1>Welcome to AI Junior</h1>
-    <p>This is a placeholder for the AI Junior product landing page.</p>
+    <div class="hero">
+      <h1>Turn paper crafts into AI magic</h1>
+      <p class="tagline">
+        Print a worksheet, draw and write on paper, then scan it to make
+        artwork, stories, games, and more from your creation.
+      </p>
+    </div>
+
+    <div class="toolbar">
+      <input
+        v-model="searchText"
+        type="search"
+        class="search-input"
+        placeholder="Search activities…"
+      >
+      <select
+        v-model="subjectFilter"
+        class="subject-select"
+      >
+        <option value="">
+          All subjects
+        </option>
+        <option
+          v-for="subject in allSubjects"
+          :key="subject"
+          :value="subject"
+        >
+          {{ subjectLabel(subject) }}
+        </option>
+      </select>
+      <a
+        v-if="isAdmin"
+        class="btn btn-primary admin-new"
+        href="/editor/ai-junior-scenario"
+      >
+        Scenario Editor
+      </a>
+    </div>
+
+    <div
+      v-if="loading"
+      class="loading"
+    >
+      <div class="spinner" />
+      <p>Loading activities…</p>
+    </div>
+
+    <div
+      v-else-if="filteredScenarios.length === 0"
+      class="empty"
+    >
+      <p>No activities found.</p>
+    </div>
+
+    <div
+      v-else
+      class="scenario-grid"
+    >
+      <div
+        v-for="scenario in filteredScenarios"
+        :key="scenario._id"
+        class="scenario-card"
+      >
+        <a
+          :href="worksheetUrl(scenario)"
+          class="card-cover"
+        >
+          <img
+            v-if="scenario.coverImage"
+            :src="`/file/${scenario.coverImage}`"
+            :alt="scenario.name"
+          >
+          <div
+            v-else
+            class="cover-placeholder"
+          >
+            ✏️
+          </div>
+        </a>
+        <div class="card-body">
+          <h3>
+            <a :href="worksheetUrl(scenario)">{{ scenario.name }}</a>
+            <span
+              v-if="scenario.releasePhase !== 'released'"
+              class="phase-badge"
+            >{{ scenario.releasePhase }}</span>
+          </h3>
+          <p class="description">
+            {{ scenario.description }}
+          </p>
+          <div class="card-meta">
+            <span
+              v-if="gradeRange(scenario)"
+              class="grades"
+            >Grades {{ gradeRange(scenario) }}</span>
+            <span
+              v-for="subject in scenario.subjects || []"
+              :key="subject"
+              class="subject-chip"
+            >{{ subjectLabel(subject) }}</span>
+          </div>
+          <div class="card-actions">
+            <a
+              class="btn btn-primary"
+              :href="worksheetUrl(scenario)"
+            >Start</a>
+            <a
+              class="btn btn-default"
+              :href="scanUrl(scenario)"
+            >📷 Scan</a>
+            <a
+              class="btn btn-default"
+              :href="`${worksheetUrl(scenario)}/${meId}`"
+            >My projects</a>
+            <a
+              v-if="isTeacher"
+              class="btn btn-default"
+              :href="`/ai-junior/print/${scenario.slug || scenario._id}`"
+            >Print for class</a>
+            <a
+              v-if="isAdmin"
+              class="btn btn-default"
+              :href="`/editor/ai-junior-scenario/${scenario.slug || scenario._id}`"
+            >Edit</a>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script>
+import { getAIJuniorScenarios } from 'app/core/api/ai-junior-scenarios'
+
+const SUBJECT_LABELS = {
+  math: 'Math',
+  ela: 'ELA',
+  science: 'Science',
+  'social-studies': 'Social Studies',
+  art: 'Art',
+  technology: 'Technology',
+  sel: 'SEL',
+  music: 'Music',
+  'computer-science': 'Computer Science',
+  misc: 'Miscellaneous',
+}
+
 export default {
-  name: 'AIJuniorLandingView'
+  name: 'AIJuniorLandingView',
+  data () {
+    return {
+      scenarios: [],
+      loading: true,
+      searchText: '',
+      subjectFilter: '',
+    }
+  },
+  computed: {
+    isAdmin () {
+      return me.isAdmin()
+    },
+    isTeacher () {
+      return me.isAdmin() || me.isTeacher()
+    },
+    meId () {
+      return me.id
+    },
+    visibleScenarios () {
+      // Everyone sees released scenarios; admins also see drafts/betas so
+      // they can test before release.
+      if (this.isAdmin) return this.scenarios
+      return this.scenarios.filter((s) => s.releasePhase === 'released')
+    },
+    allSubjects () {
+      const subjects = new Set()
+      for (const scenario of this.visibleScenarios) {
+        for (const subject of scenario.subjects || []) subjects.add(subject)
+      }
+      return [...subjects].sort()
+    },
+    filteredScenarios () {
+      const search = this.searchText.trim().toLowerCase()
+      return this.visibleScenarios.filter((scenario) => {
+        if (this.subjectFilter && !(scenario.subjects || []).includes(this.subjectFilter)) return false
+        if (search) {
+          const haystack = `${scenario.name} ${scenario.description || ''}`.toLowerCase()
+          if (!haystack.includes(search)) return false
+        }
+        return true
+      })
+    },
+  },
+  async created () {
+    try {
+      this.scenarios = await getAIJuniorScenarios()
+    } catch (err) {
+      console.error('Failed to load AI Junior scenarios:', err)
+    } finally {
+      this.loading = false
+    }
+  },
+  methods: {
+    worksheetUrl (scenario) {
+      return `/ai-junior/project/${scenario.slug || scenario._id}`
+    },
+    scanUrl (scenario) {
+      return `/ai-junior/scan/${scenario.slug || scenario._id}`
+    },
+    gradeRange (scenario) {
+      const levels = scenario.gradeLevels
+      if (!levels || (!levels.start && !levels.end)) return null
+      if (levels.start === levels.end) return levels.start
+      return `${levels.start}–${levels.end}`
+    },
+    subjectLabel (subject) {
+      return SUBJECT_LABELS[subject] || subject
+    },
+  },
 }
 </script>
+
+<style lang="scss" scoped>
+.ai-junior-landing {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.hero {
+  text-align: center;
+  margin-bottom: 2.5rem;
+
+  h1 {
+    font-size: 3.2rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .tagline {
+    font-size: 1.8rem;
+    color: #555;
+    max-width: 600px;
+    margin: 0 auto;
+  }
+}
+
+.toolbar {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 2rem;
+
+  .search-input {
+    flex: 1;
+    max-width: 320px;
+    padding: 0.6rem 1rem;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    font-size: 1.5rem;
+  }
+
+  .subject-select {
+    padding: 0.6rem 1rem;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    font-size: 1.5rem;
+  }
+
+  .admin-new {
+    margin-left: auto;
+  }
+}
+
+.loading,
+.empty {
+  text-align: center;
+  padding: 4rem 0;
+  color: #666;
+}
+
+.spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #3498db;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  margin: 0 auto 1rem;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.scenario-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 2rem;
+}
+
+.scenario-card {
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+  display: flex;
+  flex-direction: column;
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+
+  &:hover {
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+    transform: translateY(-2px);
+  }
+}
+
+.card-cover {
+  display: block;
+  aspect-ratio: 16 / 10;
+  background: #f5f2ec;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .cover-placeholder {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 4rem;
+  }
+}
+
+.card-body {
+  padding: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+
+  h3 {
+    margin: 0 0 0.6rem;
+    font-size: 1.9rem;
+
+    a {
+      color: #222;
+      text-decoration: none;
+    }
+  }
+
+  .phase-badge {
+    display: inline-block;
+    margin-left: 0.6rem;
+    padding: 0.1rem 0.7rem;
+    font-size: 1.1rem;
+    text-transform: uppercase;
+    background: #fff3cd;
+    color: #856404;
+    border-radius: 10px;
+    vertical-align: middle;
+  }
+
+  .description {
+    color: #555;
+    font-size: 1.4rem;
+    flex: 1;
+  }
+}
+
+.card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin: 0.8rem 0;
+
+  .grades {
+    font-size: 1.2rem;
+    color: #333;
+    background: #e8f4fd;
+    padding: 0.2rem 0.8rem;
+    border-radius: 10px;
+  }
+
+  .subject-chip {
+    font-size: 1.2rem;
+    color: #2c662d;
+    background: #e6f4e6;
+    padding: 0.2rem 0.8rem;
+    border-radius: 10px;
+  }
+}
+
+.card-actions {
+  display: flex;
+  gap: 0.8rem;
+}
+</style>

--- a/app/views/ai-junior/AIJuniorScenarioUserProjectView.vue
+++ b/app/views/ai-junior/AIJuniorScenarioUserProjectView.vue
@@ -1,14 +1,37 @@
 <template>
   <div class="ai-junior-scenario-user-project">
-    <h2>User Project for Scenario: {{ scenario?.name }}</h2>
+    <div class="project-header">
+      <h2>{{ project?.name || 'Project' }}</h2>
+      <!-- Scanning a stack of worksheets is the common case, so getting back to
+           the scanner is a button rather than a trip through the browser's
+           history. It goes to the argument-less scanner, which reads the next
+           sheet's QR code and works out its scenario and student by itself. -->
+      <p
+        v-if="scenario"
+        class="header-links no-print"
+      >
+        <a
+          class="btn btn-primary scan-again"
+          href="/ai-junior/scan"
+        >📷 Scan another worksheet</a>
+      </p>
+      <p
+        v-if="scenario"
+        class="header-links no-print"
+      >
+        <a :href="`/ai-junior/project/${scenarioHandle}`">{{ scenario.name }}</a>
+        ·
+        <a :href="`/ai-junior/project/${scenarioHandle}/${userId}`">All my projects</a>
+      </p>
+    </div>
     <AIJuniorWorksheet
-      v-if="!project || project.processingStatus === 'pending'"
+      v-if="showWorksheet"
       :scenario="scenario"
       :project="project"
       @process-project="processProject"
     />
     <AIJuniorProjectOutput
-      v-else
+      v-else-if="project && scenario"
       :project="project"
       :scenario="scenario"
       @reprocess-project="processProject"
@@ -22,32 +45,46 @@ import AIJuniorProjectOutput from 'components/common/elements/AIJuniorProjectOut
 import { getAIJuniorProject, processAIJuniorProject } from 'core/api/ai-junior-projects'
 import { getAIJuniorScenario } from 'core/api/ai-junior-scenarios'
 
+// Well past the server's own processing timeout, so a run that is genuinely
+// still going is never cut off by the page giving up on it.
+const MAX_POLL_MS = 15 * 60 * 1000
+
 export default {
   name: 'AIJuniorScenarioUserProjectView',
   components: {
     AIJuniorWorksheet,
-    AIJuniorProjectOutput
+    AIJuniorProjectOutput,
   },
   props: {
     scenarioId: {
       type: String,
-      required: true
+      required: true,
     },
     userId: {
       type: String,
-      required: true
+      required: true,
     },
     projectId: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
   data () {
     return {
       project: null,
       scenario: null,
-      pollingInterval: null
+      pollingInterval: null,
     }
+  },
+  computed: {
+    scenarioHandle () {
+      return this.scenario?.slug || this.scenarioId
+    },
+    // Show the filled-in worksheet only for a project that hasn't started
+    // processing; once it's running (or done), show the live output view.
+    showWorksheet () {
+      return this.scenario && this.project && this.project.processingStatus === 'pending'
+    },
   },
   mounted () {
     this.fetchData()
@@ -60,7 +97,7 @@ export default {
       try {
         [this.project, this.scenario] = await Promise.all([
           getAIJuniorProject({ projectHandle: this.projectId }),
-          getAIJuniorScenario({ scenarioHandle: this.scenarioId })
+          getAIJuniorScenario({ scenarioHandle: this.scenarioId }),
         ])
 
         if (!this.project.processingStatus || this.project.processingStatus === 'pending') {
@@ -82,7 +119,8 @@ export default {
     },
     startPolling () {
       this.stopPolling() // Clear any existing interval
-      this.pollingInterval = setInterval(this.checkProjectStatus, 5000) // Poll every 5 seconds
+      this.pollingStartedAt = Date.now()
+      this.pollingInterval = setInterval(this.checkProjectStatus, 3000)
     },
     stopPolling () {
       if (this.pollingInterval) {
@@ -91,16 +129,52 @@ export default {
       }
     },
     async checkProjectStatus () {
+      // A project whose server died mid-run stays "processing" for ever. The
+      // page already offers a restart once it looks stalled, so stop asking
+      // rather than polling this project until the tab is closed.
+      if (this.pollingStartedAt && Date.now() - this.pollingStartedAt > MAX_POLL_MS) {
+        this.stopPolling()
+        return
+      }
       try {
+        // Update every poll so partial results (images finishing one by one)
+        // appear as soon as the server saves them.
         const updatedProject = await getAIJuniorProject({ projectHandle: this.projectId })
+        this.project = updatedProject
         if (updatedProject.processingStatus !== 'processing') {
-          this.project = updatedProject
           this.stopPolling()
         }
       } catch (error) {
         console.error('Error checking project status:', error)
       }
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.project-header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+
+  h2 {
+    margin-bottom: 0.3rem;
+  }
+
+  .header-links {
+    color: #777;
+    margin-bottom: 0.5rem;
+
+    a {
+      color: #337ab7;
+    }
+
+    .scan-again {
+      color: #fff;
+      font-size: 1.6rem;
+      padding: 0.6rem 1.4rem;
+      border-radius: 10px;
     }
   }
 }
-</script>
+</style>

--- a/app/views/ai-junior/AIJuniorScenarioUserView.vue
+++ b/app/views/ai-junior/AIJuniorScenarioUserView.vue
@@ -59,26 +59,26 @@ export default {
   props: {
     scenarioId: {
       type: String,
-      required: true
+      required: true,
     },
     userId: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
   data () {
     return {
       scenario: null,
       projects: [],
       loading: true,
-      error: null
+      error: null,
     }
   },
   async created () {
     try {
       const [scenarioResponse, projectsResponse] = await Promise.all([
         getAIJuniorScenario({ scenarioHandle: this.scenarioId }),
-        getAIJuniorProjectsForScenarioAndUser({ scenarioHandle: this.scenarioId, userId: this.userId })
+        getAIJuniorProjectsForScenarioAndUser({ scenarioHandle: this.scenarioId, userId: this.userId }),
       ])
 
       this.scenario = scenarioResponse
@@ -89,7 +89,7 @@ export default {
       this.error = 'An error occurred while fetching the projects. Please try again later.'
       this.loading = false
     }
-  }
+  },
 }
 </script>
 

--- a/app/views/ai-junior/AIJuniorScenarioView.vue
+++ b/app/views/ai-junior/AIJuniorScenarioView.vue
@@ -1,6 +1,16 @@
 <template>
   <div class="ai-junior-scenario">
     <div
+      v-if="hasAccess() && scenario"
+      class="scan-cta no-print"
+    >
+      <a
+        class="btn btn-primary"
+        :href="`/ai-junior/scan/${scenarioId}`"
+      >📷 Scan a paper worksheet</a>
+      <span class="scan-hint">Already filled one in on paper? Photograph it instead of drawing here.</span>
+    </div>
+    <div
       v-if="hasAccess()"
       class="main-column"
     >
@@ -30,13 +40,13 @@ import { getAIJuniorScenario } from 'app/core/api/ai-junior-scenarios'
 export default {
   name: 'AIJuniorScenarioView',
   components: {
-    AIJuniorWorksheet
+    AIJuniorWorksheet,
   },
   props: {
     scenarioId: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
   data () {
     return {
@@ -74,6 +84,20 @@ export default {
   width: 100%;
   display: flex;
   justify-content: center;
+}
+
+.scan-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1rem;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.scan-hint {
+  font-size: 1.4rem;
+  color: #666;
 }
 
 .curriculum-info {

--- a/app/views/ai-junior/AIJuniorSharedView.vue
+++ b/app/views/ai-junior/AIJuniorSharedView.vue
@@ -1,0 +1,165 @@
+<template>
+  <div class="ai-junior-shared">
+    <div
+      v-if="loadError"
+      class="shared-missing"
+    >
+      <h1>🔍 Creation not found</h1>
+      <p>This link may have expired, or the creation was made private again.</p>
+      <a
+        class="btn btn-lg btn-primary"
+        href="/ai-junior"
+      >Make your own</a>
+    </div>
+
+    <template v-else-if="project && scenario">
+      <header class="shared-header">
+        <h1 class="creation-name">
+          {{ project.name || 'A creation' }}
+        </h1>
+        <p class="creation-sub">
+          made with <strong>{{ scenario.name }}</strong> · CodeCombat AI Junior
+        </p>
+      </header>
+
+      <AIJuniorProjectOutput
+        :project="project"
+        :scenario="scenario"
+        :hide-reprocess-button="true"
+        :read-only="true"
+      />
+
+      <section class="make-your-own">
+        <h2>Want to make one?</h2>
+        <p>
+          Print a worksheet, draw on it with a pencil, and watch it come to life.
+        </p>
+        <a
+          class="btn btn-lg btn-primary"
+          :href="scenario.slug ? `/ai-junior/project/${scenario.slug}` : '/ai-junior'"
+        >Make your own</a>
+        <p class="make-your-own-alt">
+          <a href="/ai-junior">See all the activities</a>
+        </p>
+      </section>
+    </template>
+
+    <div
+      v-else
+      class="shared-loading"
+    >
+      Loading…
+    </div>
+  </div>
+</template>
+
+<script>
+import AIJuniorProjectOutput from 'components/common/elements/AIJuniorProjectOutput.vue'
+import { getSharedAIJuniorProject } from 'core/api/ai-junior-projects'
+
+// A share link is meant to be handed to a grandparent, so the page strips the
+// site's nav and footer down to just the creation and one call to action. The
+// chrome is owned by the surrounding Backbone RootView rather than this
+// component, so hiding it means injecting a stylesheet and taking it away again
+// on the way out — the same approach the worksheet uses for printing.
+const CHROME_CSS = `
+  nav#main-nav, footer#site-footer { display: none !important; }
+  #site-content-area { padding-top: 0 !important; }
+`
+
+export default {
+  name: 'AIJuniorSharedView',
+  components: {
+    AIJuniorProjectOutput,
+  },
+  props: {
+    projectId: {
+      type: String,
+      required: true,
+    },
+  },
+  data () {
+    return {
+      project: null,
+      scenario: null,
+      loadError: null,
+      styleElement: null,
+    }
+  },
+  async created () {
+    try {
+      const { project, scenario } = await getSharedAIJuniorProject({ projectHandle: this.projectId })
+      this.project = project
+      this.scenario = scenario
+      if (project.name) document.title = `${project.name} — CodeCombat AI Junior`
+    } catch (error) {
+      console.error('Error fetching shared creation:', error)
+      this.loadError = 'not-found'
+    }
+  },
+  mounted () {
+    this.styleElement = document.createElement('style')
+    this.styleElement.setAttribute('data-ai-junior-shared', '')
+    this.styleElement.textContent = CHROME_CSS
+    document.head.appendChild(this.styleElement)
+  },
+  beforeDestroy () {
+    if (this.styleElement) this.styleElement.remove()
+  },
+}
+</script>
+
+<style scoped>
+.ai-junior-shared {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.shared-header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.creation-name {
+  font-size: 3.2rem;
+  margin: 0 0 0.3rem;
+}
+
+.creation-sub {
+  color: #888;
+  font-size: 1.5rem;
+  margin: 0;
+}
+
+.shared-loading,
+.shared-missing {
+  text-align: center;
+  padding: 5rem 1rem;
+  font-size: 1.8rem;
+}
+
+.make-your-own {
+  margin-top: 3.5rem;
+  padding: 2.2rem 1.5rem;
+  text-align: center;
+  background: #f5f9ff;
+  border-radius: 16px;
+}
+
+.make-your-own h2 {
+  margin: 0 0 0.5rem;
+  font-size: 2.4rem;
+}
+
+.make-your-own p {
+  color: #666;
+  font-size: 1.6rem;
+  margin-bottom: 1.4rem;
+}
+
+.make-your-own-alt {
+  margin: 1.2rem 0 0;
+  font-size: 1.4rem;
+}
+</style>

--- a/app/views/ai-junior/AIJuniorView.vue
+++ b/app/views/ai-junior/AIJuniorView.vue
@@ -2,7 +2,7 @@
   <div class="ai-junior-view">
     <header class="ai-junior-header">
       <a
-        href="/ai-junior/demo"
+        href="/ai-junior"
         class="ai-junior-logo"
       >
         AI Junior

--- a/app/views/editor/ai-junior-scenario/AIJuniorScenarioEditView.js
+++ b/app/views/editor/ai-junior-scenario/AIJuniorScenarioEditView.js
@@ -21,6 +21,20 @@ require('lib/game-libraries')
 require('lib/setupTreema')
 require('core/treema-ext')
 
+// Input geometry is stored as percentages of the worksheet's printable area, so layout mode works
+// entirely in percentages and only touches pixels to measure the scaled sheet on screen.
+const GEOMETRY_KEYS = ['left', 'top', 'width', 'height']
+const MIN_INPUT_SIZE = 2
+// Given to inputs that have no geometry yet, so that they show up somewhere draggable.
+const DEFAULT_GEOMETRY = { left: 0, top: 0, width: 20, height: 20 }
+// Only bare `<%= someId %>` references get checked; anything with an expression in it is left alone.
+const TEMPLATE_REFERENCE = /<%[=-]([^%]*?)%>/g
+const BARE_IDENTIFIER = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), Math.max(min, max))
+const roundPercent = value => Math.round(value * 100) / 100
+const isPercent = value => typeof value === 'number' && isFinite(value)
+
 module.exports = (AIJuniorScenarioEditView = (function () {
   AIJuniorScenarioEditView = class AIJuniorScenarioEditView extends RootView {
     static initClass () {
@@ -31,8 +45,8 @@ module.exports = (AIJuniorScenarioEditView = (function () {
         'click #save-button': 'onClickSaveButton',
         'click #i18n-button': 'onPopulateI18N',
         'click #delete-button': 'confirmDeletion',
-        'click #fix-button': 'onFix',
-        'click #diff-button': 'onAddDiff'
+        'click #layout-mode-button': 'onClickLayoutModeButton',
+        'mousedown .layout-box': 'onLayoutBoxMouseDown',
       }
     }
 
@@ -41,29 +55,51 @@ module.exports = (AIJuniorScenarioEditView = (function () {
       this.pushChangesToPreview = this.pushChangesToPreview.bind(this)
       this.pushChangesToPreview = _.throttle(this.pushChangesToPreview, 500)
       this.deleteAIJuniorScenario = this.deleteAIJuniorScenario.bind(this)
+      this.onLayoutDragMove = this.onLayoutDragMove.bind(this)
+      this.onLayoutDragEnd = this.onLayoutDragEnd.bind(this)
+      this.onWindowResize = _.debounce(this.onWindowResize.bind(this), 150)
+      this.layoutMode = false
+      this.layoutDrag = null
       this.scenarioID = scenarioID
       this.scenario = new AIJuniorScenario({ _id: this.scenarioID })
       this.scenario.saveBackups = true
       this.propsData = {
-        slug: scenarioID
+        slug: scenarioID,
       }
       this.supermodel.loadModel(this.scenario)
+      $(window).on('resize.ai-junior-layout', this.onWindowResize)
     }
 
     afterRender () {
-      this.initVueComponent()
+      this.attachVueComponent()
+      this.renderLayoutOverlay()
+      this.renderValidationWarnings()
       return super.afterRender(...arguments)
     }
 
-    initVueComponent () {
-      if (this.vueComponent) {
-        this.$el.find('#ai-junior-worksheet').replaceWith(this.vueComponent.$el)
-      } else {
+    // The worksheet is mounted once and then kept alive for the life of the view. Backbone empties
+    // the view element on every render, so the component's element gets moved back into the fresh
+    // placeholder rather than being mounted again.
+    attachVueComponent () {
+      const placeholder = this.$el.find('#ai-junior-worksheet')[0]
+      if (!this.vueComponent) {
+        if (!placeholder) { return }
         this.vueComponent = new AIJuniorWorksheet({
-          el: this.$el.find('#ai-junior-worksheet')[0],
+          el: placeholder,
           propsData: this.propsData,
         })
+        return
       }
+      const el = this.vueComponent.$el
+      if (!el || document.body.contains(el)) { return }
+      if (!placeholder) { return }
+      $(placeholder).replaceWith(el)
+      // The sheet scales itself to whatever container it is in, and it just changed containers.
+      _.defer(() => {
+        if (this.destroyed) { return }
+        this.vueComponent.scaleWorksheet?.()
+        this.renderLayoutOverlay()
+      })
     }
 
     onLoaded () {
@@ -81,16 +117,16 @@ module.exports = (AIJuniorScenarioEditView = (function () {
       const data = $.extend(true, {}, this.scenario.attributes)
       const options = {
         data,
-        filePath: `db/ai_junior__scenario/${this.scenario.get('_id')}`,
+        filePath: `db/ai_junior_scenario/${this.scenario.get('_id')}`,
         schema: AIJuniorScenario.schema,
         readOnly: me.get('anonymous'),
         supermodel: this.supermodel,
         nodeClasses: {
-          'chat-message-link': nodes.ChatMessageLinkNode
+          'chat-message-link': nodes.ChatMessageLinkNode,
         },
         callbacks: {
-          change: this.pushChangesToPreview
-        }
+          change: this.pushChangesToPreview,
+        },
       }
       this.treema = this.$el.find('#ai-junior-scenario-treema').treema(options)
       this.treema.build()
@@ -100,13 +136,287 @@ module.exports = (AIJuniorScenarioEditView = (function () {
 
     pushChangesToPreview () {
       this.updateVueComponent()
+      this.renderLayoutOverlay()
+      this.renderValidationWarnings()
     }
 
     updateVueComponent () {
-      const updatedScenario = this.treema.get('/')
-      this.propsData.scenario = updatedScenario
-      this.vueComponent.scenario = updatedScenario
+      if (!this.treema || !this.vueComponent) { return }
+      // A fresh copy each time: Treema edits its data in place, and Vue only notices a new object.
+      this.propsData.scenario = $.extend(true, {}, this.treema.get('/'))
+      this.vueComponent.scenario = this.propsData.scenario
     }
+
+    // Layout mode ---------------------------------------------------------------
+
+    onClickLayoutModeButton (e) {
+      this.layoutMode = !this.layoutMode
+      this.$el.find('#layout-mode-button').toggleClass('active', this.layoutMode)
+      this.renderLayoutOverlay()
+      // The overlay is measured off the worksheet, which may still be scaling itself into place.
+      _.defer(() => {
+        if (!this.destroyed) { this.renderLayoutOverlay() }
+      })
+    }
+
+    // The inputs are positioned within the sheet's printable area, inside the page margins, so that
+    // is the box the overlay has to line up with.
+    getWorksheetSheetEl () {
+      const root = this.vueComponent != null ? this.vueComponent.$el : null
+      if (!root || !root.querySelector) { return null }
+      return root.querySelector('.worksheet-inner-container') || root
+    }
+
+    getScenarioInputs () {
+      if (!this.treema) { return [] }
+      const inputs = this.treema.get('/inputs')
+      return _.isArray(inputs) ? inputs : []
+    }
+
+    inputGeometry (input) {
+      const geometry = {}
+      for (const key of GEOMETRY_KEYS) {
+        geometry[key] = isPercent(input != null ? input[key] : null) ? input[key] : DEFAULT_GEOMETRY[key]
+      }
+      return geometry
+    }
+
+    hasCompleteGeometry (input) {
+      return _.every(GEOMETRY_KEYS, key => isPercent(input != null ? input[key] : null))
+    }
+
+    renderLayoutOverlay () {
+      const overlay = this.$el.find('#layout-overlay')
+      if (!overlay.length) { return }
+      // Never yank the box out from under a drag in progress.
+      if (this.layoutDrag) { return }
+      if (!this.layoutMode) {
+        return overlay.removeClass('layout-overlay-active').empty()
+      }
+
+      const sheet = this.getWorksheetSheetEl()
+      const container = this.$el.find('#worksheet-preview-container')[0]
+      if (!sheet || !container) { return overlay.removeClass('layout-overlay-active').empty() }
+      const sheetRect = sheet.getBoundingClientRect()
+      const containerRect = container.getBoundingClientRect()
+      if (!(sheetRect.width > 0) || !(sheetRect.height > 0)) {
+        return overlay.removeClass('layout-overlay-active').empty()
+      }
+
+      overlay.addClass('layout-overlay-active').css({
+        left: sheetRect.left - containerRect.left,
+        top: sheetRect.top - containerRect.top,
+        width: sheetRect.width,
+        height: sheetRect.height,
+      })
+
+      overlay.empty()
+      this.getScenarioInputs().forEach((input, index) => {
+        overlay.append(this.buildLayoutBox(input, index))
+      })
+    }
+
+    buildLayoutBox (input, index) {
+      const geometry = this.inputGeometry(input)
+      const box = $('<div class="layout-box"></div>')
+        .attr('data-index', index)
+        .css({
+          left: `${geometry.left}%`,
+          top: `${geometry.top}%`,
+          width: `${geometry.width}%`,
+          height: `${geometry.height}%`,
+        })
+      if (!this.hasCompleteGeometry(input)) {
+        box.addClass('layout-box-incomplete')
+      }
+      const label = [(input != null ? input.id : null) || '(no id)', (input != null ? input.type : null) || '(no type)'].join(' · ')
+      box.append($('<span class="layout-box-label"></span>').text(label))
+      for (const handle of ['e', 's', 'se']) {
+        box.append($('<div class="layout-handle"></div>').attr('data-handle', handle))
+      }
+      return box
+    }
+
+    onLayoutBoxMouseDown (e) {
+      if (!this.layoutMode || this.layoutDrag) { return }
+      const box = $(e.target).closest('.layout-box')
+      if (!box.length) { return }
+      const index = parseInt(box.attr('data-index'), 10)
+      const input = this.getScenarioInputs()[index]
+      if (!input) { return }
+      const sheet = this.getWorksheetSheetEl()
+      const sheetRect = sheet != null ? sheet.getBoundingClientRect() : null
+      if (!sheetRect || !(sheetRect.width > 0) || !(sheetRect.height > 0)) { return }
+      e.preventDefault()
+
+      this.layoutDrag = {
+        index,
+        box,
+        mode: $(e.target).attr('data-handle') || 'move',
+        startX: e.pageX,
+        startY: e.pageY,
+        sheetWidth: sheetRect.width,
+        sheetHeight: sheetRect.height,
+        origin: this.inputGeometry(input),
+        geometry: null,
+      }
+      box.addClass('layout-box-active')
+      $(document).on('mousemove.ai-junior-layout', this.onLayoutDragMove)
+      $(document).on('mouseup.ai-junior-layout', this.onLayoutDragEnd)
+    }
+
+    onLayoutDragMove (e) {
+      const drag = this.layoutDrag
+      if (!drag) { return }
+      e.preventDefault()
+      const dx = ((e.pageX - drag.startX) / drag.sheetWidth) * 100
+      const dy = ((e.pageY - drag.startY) / drag.sheetHeight) * 100
+      drag.geometry = this.dragGeometry(drag, dx, dy)
+      drag.box.css({
+        left: `${drag.geometry.left}%`,
+        top: `${drag.geometry.top}%`,
+        width: `${drag.geometry.width}%`,
+        height: `${drag.geometry.height}%`,
+      })
+    }
+
+    dragGeometry (drag, dx, dy) {
+      const origin = drag.origin
+      const geometry = _.pick(origin, GEOMETRY_KEYS)
+      if (drag.mode === 'move') {
+        geometry.left = clamp(origin.left + dx, 0, 100 - origin.width)
+        geometry.top = clamp(origin.top + dy, 0, 100 - origin.height)
+      } else {
+        if (drag.mode.indexOf('e') !== -1) {
+          geometry.width = clamp(origin.width + dx, MIN_INPUT_SIZE, 100 - origin.left)
+        }
+        if (drag.mode.indexOf('s') !== -1) {
+          geometry.height = clamp(origin.height + dy, MIN_INPUT_SIZE, 100 - origin.top)
+        }
+      }
+      for (const key of GEOMETRY_KEYS) {
+        geometry[key] = roundPercent(geometry[key])
+      }
+      return geometry
+    }
+
+    onLayoutDragEnd (e) {
+      const drag = this.layoutDrag
+      $(document).off('.ai-junior-layout')
+      this.layoutDrag = null
+      if (!drag) { return }
+      drag.box.removeClass('layout-box-active')
+      if (drag.geometry) {
+        this.saveInputGeometry(drag.index, drag.geometry)
+      }
+      this.renderLayoutOverlay()
+      this.renderValidationWarnings()
+    }
+
+    saveInputGeometry (index, geometry) {
+      if (!this.treema) { return }
+      let saved = true
+      for (const key of GEOMETRY_KEYS) {
+        saved = this.treema.set(`/inputs/${index}/${key}`, geometry[key]) && saved
+      }
+      if (!saved) {
+        // Treema could not reach the leaves (collapsed nodes, say), so hand it the whole array back.
+        const inputs = this.getScenarioInputs()
+        if (inputs[index]) {
+          _.assign(inputs[index], geometry)
+          this.treema.set('/inputs', inputs)
+        }
+      }
+      this.updateVueComponent()
+    }
+
+    onWindowResize () {
+      if (this.destroyed || !this.layoutMode) { return }
+      this.renderLayoutOverlay()
+    }
+
+    // Validation ----------------------------------------------------------------
+
+    getValidationWarnings () {
+      if (!this.treema) { return [] }
+      const scenario = this.treema.get('/') || {}
+      const inputs = _.isArray(scenario.inputs) ? scenario.inputs : []
+      const prompts = _.isArray(scenario.prompts) ? scenario.prompts : []
+      const inputIds = _.compact(_.map(inputs, 'id'))
+      const promptIds = _.compact(_.map(prompts, 'id'))
+      const warnings = []
+
+      for (const [id, count] of Object.entries(_.countBy(inputIds.concat(promptIds)))) {
+        if (count > 1) {
+          warnings.push(`The id "${id}" is used ${count} times; input and prompt ids should be unique.`)
+        }
+      }
+
+      inputs.forEach((rawInput, index) => {
+        const input = rawInput || {}
+        const name = input.id || `input ${index}`
+        if (!input.id) {
+          warnings.push(`Input ${index} (${input.type || 'no type'}) has no id, so prompts and output templates cannot reference it.`)
+        }
+        if (!this.hasCompleteGeometry(input)) {
+          const missing = GEOMETRY_KEYS.filter(key => !isPercent(input[key]))
+          warnings.push(`Input "${name}" is missing geometry: ${missing.join(', ')}. Turn on layout mode to place it.`)
+        }
+      })
+
+      for (const prompt of prompts) {
+        const name = (prompt != null ? prompt.id : null) || 'unnamed prompt'
+        for (const file of (prompt != null ? prompt.files : null) || []) {
+          if (!inputIds.includes(file)) {
+            warnings.push(`Prompt "${name}" includes file "${file}", which is not an input id.`)
+          }
+        }
+      }
+
+      const known = inputIds.concat(promptIds)
+      for (const reference of this.getTemplateReferences(scenario.output != null ? scenario.output.html : null)) {
+        if (!known.includes(reference)) {
+          warnings.push(`Output HTML uses <%= ${reference} %>, which is neither a prompt id nor an input id. It will only resolve if a prompt returns it as a JSON key.`)
+        }
+      }
+
+      return warnings
+    }
+
+    getTemplateReferences (html) {
+      if (!_.isString(html)) { return [] }
+      const references = []
+      let match = TEMPLATE_REFERENCE.exec(html)
+      while (match) {
+        const expression = match[1].trim()
+        if (BARE_IDENTIFIER.test(expression) && !references.includes(expression)) {
+          references.push(expression)
+        }
+        match = TEMPLATE_REFERENCE.exec(html)
+      }
+      TEMPLATE_REFERENCE.lastIndex = 0
+      return references
+    }
+
+    renderValidationWarnings () {
+      const panel = this.$el.find('#scenario-validation')
+      if (!panel.length) { return }
+      const warnings = this.getValidationWarnings()
+      panel.empty()
+      if (!warnings.length) {
+        return panel.removeClass('scenario-validation-active')
+      }
+      const list = $('<ul></ul>')
+      for (const warning of warnings) {
+        list.append($('<li></li>').text(warning))
+      }
+      return panel
+        .addClass('scenario-validation-active')
+        .append($('<h4></h4>').text(`${warnings.length} thing${warnings.length === 1 ? '' : 's'} to look at`))
+        .append(list)
+    }
+
+    // ---------------------------------------------------------------------------
 
     onPopulateI18N () {
       this.scenario.populateI18N()
@@ -137,7 +447,7 @@ module.exports = (AIJuniorScenarioEditView = (function () {
         title: 'Are you really sure?',
         body: 'This will completely delete the scenario.',
         decline: 'Not really',
-        confirm: 'Definitely'
+        confirm: 'Definitely',
       }
 
       const confirmModal = new ConfirmModal(renderData)
@@ -153,7 +463,7 @@ module.exports = (AIJuniorScenarioEditView = (function () {
             timeout: 5000,
             text: 'Aaaand it\'s gone.',
             type: 'success',
-            layout: 'topCenter'
+            layout: 'topCenter',
           })
           _.delay(() => application.router.navigate('/editor/ai-junior-scenario', { trigger: true })
             , 500)
@@ -164,15 +474,17 @@ module.exports = (AIJuniorScenarioEditView = (function () {
             timeout: 5000,
             text: `Deleting scenario message failed with error code ${jqXHR.status}`,
             type: 'error',
-            layout: 'topCenter'
+            layout: 'topCenter',
           })
         },
-        url: `/db/ai_junior_scenario/${this.scenario.id}`
+        url: `/db/ai_junior_scenario/${this.scenario.id}`,
       })
     }
 
     destroy () {
-      this.vueComponent.$destroy()
+      $(document).off('.ai-junior-layout')
+      $(window).off('resize.ai-junior-layout', this.onWindowResize)
+      if (this.vueComponent) { this.vueComponent.$destroy() }
       return super.destroy()
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "jshint": "~2.3.0",
         "json-loader": "^0.5.4",
         "jsondiffpatch": "^0.4.1",
+        "jsqr": "^1.4.0",
         "jwt-decode": "^3.1.2",
         "lodash": "^2.4.2",
         "lodash-4": "npm:lodash@^4.18.1",
@@ -25537,6 +25538,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
     },
     "node_modules/jstransformer": {
       "version": "1.0.0",
@@ -55543,6 +55550,11 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
       "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
       "dev": true
+    },
+    "jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A=="
     },
     "jstransformer": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "jshint": "~2.3.0",
     "json-loader": "^0.5.4",
     "jsondiffpatch": "^0.4.1",
+    "jsqr": "^1.4.0",
     "jwt-decode": "^3.1.2",
     "lodash": "^2.4.2",
     "lodash-4": "npm:lodash@^4.18.1",

--- a/test/app/lib/doc-capture.spec.js
+++ b/test/app/lib/doc-capture.spec.js
@@ -3,7 +3,7 @@
  * here is plain maths over pixel buffers, so it runs without a camera, a
  * canvas or a network.
  */
-const { parseWorksheetQR } = require('lib/doc-capture/qr')
+const { parseWorksheetQR, worksheetQRText } = require('lib/doc-capture/qr')
 const { isSkin, isDrawnMark, removeHands, flattenPage, cleanPage } = require('lib/doc-capture/cleanup')
 const { orderQuad } = require('lib/doc-capture/geom')
 
@@ -78,6 +78,26 @@ describe('parseWorksheetQR', () => {
     expect(parseWorksheetQR('/ai-junior/scan/make-a-game/not-an-id').userId).toBe(null)
   })
 
+  it('reads a short code, with and without a student', () => {
+    const withUser = parseWorksheetQR('HTTPS://CODECOMBAT.COM/S/6600A6512EF4805A67A8C507000001')
+    expect(withUser.scenarioHandle).toBe('6600a6')
+    expect(withUser.userId).toBe('512ef4805a67a8c507000001')
+    expect(withUser.isPrefix).toBe(true)
+
+    const without = parseWorksheetQR('https://codecombat.com/s/6600a6')
+    expect(without.scenarioHandle).toBe('6600a6')
+    expect(without.userId).toBe(null)
+  })
+
+  it('marks full paths as not being prefixes, so they are not re-resolved', () => {
+    expect(parseWorksheetQR('/ai-junior/scan/make-a-game').isPrefix).toBe(false)
+  })
+
+  it('rejects a short code that is not the right shape', () => {
+    expect(parseWorksheetQR('/s/zzzzzz')).toBe(null)
+    expect(parseWorksheetQR('/s/6600')).toBe(null)
+  })
+
   it('rejects anything that is not an AI Junior worksheet', () => {
     expect(parseWorksheetQR('https://example.com/hello')).toBe(null)
     expect(parseWorksheetQR('https://codecombat.com/play')).toBe(null)
@@ -85,6 +105,39 @@ describe('parseWorksheetQR', () => {
     expect(parseWorksheetQR('')).toBe(null)
     expect(parseWorksheetQR(null)).toBe(null)
     expect(parseWorksheetQR(undefined)).toBe(null)
+  })
+})
+
+describe('worksheetQRText', () => {
+  const SCENARIO = '6600a6c23a9490c3f23997af'
+  const USER = '512ef4805a67a8c507000001'
+
+  it('is entirely uppercase, so the QR uses its compact alphanumeric mode', () => {
+    const text = worksheetQRText('https://codecombat.com', SCENARIO, USER)
+    expect(text).toBe(text.toUpperCase())
+  })
+
+  it('identifies the scenario by a short prefix of its id', () => {
+    expect(worksheetQRText('https://codecombat.com', SCENARIO, USER))
+      .toBe('HTTPS://CODECOMBAT.COM/S/6600A6512EF4805A67A8C507000001')
+  })
+
+  it('leaves the student out when the sheet is not for one', () => {
+    expect(worksheetQRText('https://codecombat.com', SCENARIO, null))
+      .toBe('HTTPS://CODECOMBAT.COM/S/6600A6')
+  })
+
+  it('round-trips through the parser', () => {
+    const parsed = parseWorksheetQR(worksheetQRText('https://codecombat.com', SCENARIO, USER))
+    expect(parsed.scenarioHandle).toBe(SCENARIO.slice(0, 6))
+    expect(parsed.userId).toBe(USER)
+    expect(parsed.isPrefix).toBe(true)
+  })
+
+  it('stays far shorter than the path it replaces', () => {
+    const short = worksheetQRText('https://codecombat.com', SCENARIO, USER)
+    const long = `https://codecombat.com/ai-junior/scan/design-a-character/${USER}`
+    expect(short.length).toBeLessThan(long.length * 0.75)
   })
 })
 

--- a/test/app/lib/doc-capture.spec.js
+++ b/test/app/lib/doc-capture.spec.js
@@ -4,7 +4,7 @@
  * canvas or a network.
  */
 const { parseWorksheetQR } = require('lib/doc-capture/qr')
-const { isSkin, removeHands, flattenPage, cleanPage } = require('lib/doc-capture/cleanup')
+const { isSkin, isDrawnMark, removeHands, flattenPage, cleanPage } = require('lib/doc-capture/cleanup')
 const { orderQuad } = require('lib/doc-capture/geom')
 
 /** An RGBA buffer of a given flat colour. */
@@ -40,6 +40,7 @@ function pixel (img, x, y) {
 const PAPER = [253, 251, 245]
 const SKIN = [216, 160, 116]
 const INK = [30, 40, 160]
+const PURPLE = [126, 46, 196]
 
 describe('parseWorksheetQR', () => {
   it('reads the scenario and student out of a scan URL', () => {
@@ -102,6 +103,21 @@ describe('isSkin', () => {
   })
 })
 
+describe('isDrawnMark', () => {
+  it('recognises crayon, pencil and marker as deliberate marks', () => {
+    expect(isDrawnMark(...PURPLE)).toBe(true)
+    expect(isDrawnMark(...INK)).toBe(true)
+    expect(isDrawnMark(40, 160, 60)).toBe(true)
+    expect(isDrawnMark(20, 20, 20)).toBe(true)
+  })
+
+  it('does not treat paper, skin or a soft shadow as a mark', () => {
+    expect(isDrawnMark(...PAPER)).toBe(false)
+    expect(isDrawnMark(...SKIN)).toBe(false)
+    expect(isDrawnMark(150, 148, 145)).toBe(false)
+  })
+})
+
 describe('removeHands', () => {
   it('paints out a finger that reaches in from the edge of the page', () => {
     const page = blank(300, 200, PAPER)
@@ -134,6 +150,30 @@ describe('removeHands', () => {
 
     expect(isSkin(...pixel(image, 20, 150))).toBe(false)
     expect(isSkin(...pixel(image, 165, 65))).toBe(true)
+  })
+
+  it('keeps a coloured drawing that runs right up against a finger', () => {
+    // The halo of tolerance grown around a hand used to be painted flat, which
+    // erased the end of any drawing that reached the finger.
+    const page = blank(300, 200, PAPER)
+    fillRect(page, 0, 120, 60, 60, SKIN) // thumb on the left edge
+    fillRect(page, 60, 140, 90, 16, PURPLE) // crayon line running into it
+    const { image } = removeHands(page)
+
+    expect(isSkin(...pixel(image, 20, 150))).toBe(false) // thumb gone
+    const [r, g, b] = pixel(image, 70, 148) // crayon just past the thumb
+    expect(`${r},${g},${b}`).toBe(`${PURPLE[0]},${PURPLE[1]},${PURPLE[2]}`)
+    expect(pixel(image, 140, 148)[2]).toBeGreaterThan(150) // and further along
+  })
+
+  it('keeps a drawing that reaches the edge of the paper', () => {
+    // Drawing to the very edge is not the same as a hand coming in from
+    // outside: a hand meets the edge along a span, a drawing grazes it.
+    const page = blank(300, 200, PAPER)
+    fillRect(page, 0, 90, 120, 14, PURPLE)
+    const { image, removed } = removeHands(page)
+    expect(removed).toBe(0)
+    expect(pixel(image, 5, 96)[2]).toBeGreaterThan(150)
   })
 
   it('ignores a skin-coloured speck too small to be a hand', () => {

--- a/test/app/lib/doc-capture.spec.js
+++ b/test/app/lib/doc-capture.spec.js
@@ -1,0 +1,212 @@
+/**
+ * Pure-logic tests for the worksheet capture pipeline. Everything exercised
+ * here is plain maths over pixel buffers, so it runs without a camera, a
+ * canvas or a network.
+ */
+const { parseWorksheetQR } = require('lib/doc-capture/qr')
+const { isSkin, removeHands, flattenPage, cleanPage } = require('lib/doc-capture/cleanup')
+const { orderQuad } = require('lib/doc-capture/geom')
+
+/** An RGBA buffer of a given flat colour. */
+function blank (width, height, [r, g, b]) {
+  const data = new Uint8ClampedArray(width * height * 4)
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = r
+    data[i + 1] = g
+    data[i + 2] = b
+    data[i + 3] = 255
+  }
+  return { width, height, data }
+}
+
+function fillRect (img, x0, y0, w, h, [r, g, b]) {
+  for (let y = y0; y < y0 + h; y++) {
+    for (let x = x0; x < x0 + w; x++) {
+      if (x < 0 || y < 0 || x >= img.width || y >= img.height) continue
+      const i = (y * img.width + x) * 4
+      img.data[i] = r
+      img.data[i + 1] = g
+      img.data[i + 2] = b
+      img.data[i + 3] = 255
+    }
+  }
+}
+
+function pixel (img, x, y) {
+  const i = (y * img.width + x) * 4
+  return [img.data[i], img.data[i + 1], img.data[i + 2]]
+}
+
+const PAPER = [253, 251, 245]
+const SKIN = [216, 160, 116]
+const INK = [30, 40, 160]
+
+describe('parseWorksheetQR', () => {
+  it('reads the scenario and student out of a scan URL', () => {
+    const parsed = parseWorksheetQR('https://codecombat.com/ai-junior/scan/make-a-game/512ef4805a67a8c507000001')
+    expect(parsed.scenarioHandle).toBe('make-a-game')
+    expect(parsed.userId).toBe('512ef4805a67a8c507000001')
+  })
+
+  it('still reads sheets printed before the QR target changed', () => {
+    const parsed = parseWorksheetQR('https://codecombat.com/ai-junior/project/design-a-character/512ef4805a67a8c507000001')
+    expect(parsed.scenarioHandle).toBe('design-a-character')
+    expect(parsed.userId).toBe('512ef4805a67a8c507000001')
+  })
+
+  it('accepts a scenario with no student', () => {
+    const parsed = parseWorksheetQR('https://codecombat.com/ai-junior/scan/make-a-game')
+    expect(parsed.scenarioHandle).toBe('make-a-game')
+    expect(parsed.userId).toBe(null)
+  })
+
+  it('ignores the host, so a sheet printed on one machine scans on another', () => {
+    // Worksheets are routinely printed from localhost and scanned from a phone
+    // on the LAN address.
+    const a = parseWorksheetQR('http://localhost:3000/ai-junior/scan/make-a-game')
+    const b = parseWorksheetQR('http://192.168.0.84:3000/ai-junior/scan/make-a-game')
+    expect(a.scenarioHandle).toBe('make-a-game')
+    expect(b.scenarioHandle).toBe('make-a-game')
+  })
+
+  it('accepts a bare path', () => {
+    expect(parseWorksheetQR('/ai-junior/scan/make-a-game').scenarioHandle).toBe('make-a-game')
+  })
+
+  it('drops a user segment that is not an id, rather than trusting it', () => {
+    expect(parseWorksheetQR('/ai-junior/scan/make-a-game/not-an-id').userId).toBe(null)
+  })
+
+  it('rejects anything that is not an AI Junior worksheet', () => {
+    expect(parseWorksheetQR('https://example.com/hello')).toBe(null)
+    expect(parseWorksheetQR('https://codecombat.com/play')).toBe(null)
+    expect(parseWorksheetQR('not a url at all')).toBe(null)
+    expect(parseWorksheetQR('')).toBe(null)
+    expect(parseWorksheetQR(null)).toBe(null)
+    expect(parseWorksheetQR(undefined)).toBe(null)
+  })
+})
+
+describe('isSkin', () => {
+  it('recognises a range of skin tones', () => {
+    expect(isSkin(216, 160, 116)).toBe(true)
+    expect(isSkin(241, 194, 165)).toBe(true)
+    expect(isSkin(160, 110, 75)).toBe(true)
+  })
+
+  it('does not classify paper, ink or foliage as skin', () => {
+    expect(isSkin(253, 251, 245)).toBe(false)
+    expect(isSkin(30, 40, 160)).toBe(false)
+    expect(isSkin(40, 160, 60)).toBe(false)
+    expect(isSkin(0, 0, 0)).toBe(false)
+  })
+})
+
+describe('removeHands', () => {
+  it('paints out a finger that reaches in from the edge of the page', () => {
+    const page = blank(300, 200, PAPER)
+    fillRect(page, 0, 120, 70, 60, SKIN) // a thumb intruding from the left
+    const { image, removed } = removeHands(page)
+
+    expect(removed).toBeGreaterThan(0)
+    const [r, g, b] = pixel(image, 20, 150)
+    expect(isSkin(r, g, b)).toBe(false)
+    expect(r).toBeGreaterThan(200)
+  })
+
+  it("leaves a child's skin-toned drawing alone when it does not touch the edge", () => {
+    // The whole point of the border rule: a face drawn in the middle of the
+    // sheet is exactly the same colour as the thumb holding the corner.
+    const page = blank(300, 200, PAPER)
+    fillRect(page, 120, 70, 60, 60, SKIN)
+    const { image, removed } = removeHands(page)
+
+    expect(removed).toBe(0)
+    const [r, g, b] = pixel(image, 150, 100)
+    expect(isSkin(r, g, b)).toBe(true)
+  })
+
+  it('keeps the drawing even when a finger is removed from the same page', () => {
+    const page = blank(300, 200, PAPER)
+    fillRect(page, 0, 120, 70, 60, SKIN) // thumb at the edge
+    fillRect(page, 140, 40, 50, 50, SKIN) // drawing in the middle
+    const { image } = removeHands(page)
+
+    expect(isSkin(...pixel(image, 20, 150))).toBe(false)
+    expect(isSkin(...pixel(image, 165, 65))).toBe(true)
+  })
+
+  it('ignores a skin-coloured speck too small to be a hand', () => {
+    const page = blank(300, 200, PAPER)
+    fillRect(page, 0, 0, 3, 3, SKIN)
+    expect(removeHands(page).removed).toBe(0)
+  })
+
+  it('returns the page untouched when there is no hand at all', () => {
+    const page = blank(300, 200, PAPER)
+    fillRect(page, 100, 100, 40, 20, INK)
+    const { image, removed } = removeHands(page)
+    expect(removed).toBe(0)
+    expect(image).toBe(page)
+  })
+})
+
+describe('flattenPage', () => {
+  it('evens out a lighting gradient so the paper reads white throughout', () => {
+    const page = blank(400, 200, [255, 255, 255])
+    // A shadow falling across the right-hand side of the sheet.
+    for (let y = 0; y < page.height; y++) {
+      for (let x = 0; x < page.width; x++) {
+        const shade = 255 - Math.round((x / page.width) * 130)
+        const i = (y * page.width + x) * 4
+        page.data[i] = shade
+        page.data[i + 1] = shade
+        page.data[i + 2] = shade
+      }
+    }
+    const before = pixel(page, 380, 100)[0]
+    const flat = flattenPage(page)
+    const afterLeft = pixel(flat, 20, 100)[0]
+    const afterRight = pixel(flat, 380, 100)[0]
+
+    expect(before).toBeLessThan(160)
+    expect(afterRight).toBeGreaterThan(230)
+    expect(Math.abs(afterLeft - afterRight)).toBeLessThan(20)
+  })
+
+  it('keeps marks darker than the paper around them', () => {
+    const page = blank(300, 200, [240, 240, 240])
+    fillRect(page, 100, 80, 40, 40, [40, 40, 40])
+    const flat = flattenPage(page)
+    expect(pixel(flat, 120, 100)[0]).toBeLessThan(pixel(flat, 20, 20)[0])
+  })
+})
+
+describe('cleanPage', () => {
+  it('flattens and de-hands in one pass, and reports what it removed', () => {
+    const page = blank(300, 200, PAPER)
+    fillRect(page, 0, 120, 70, 60, SKIN)
+    const { image, handsRemoved } = cleanPage(page)
+    expect(handsRemoved).toBeGreaterThan(0)
+    expect(image.width).toBe(300)
+    expect(image.height).toBe(200)
+  })
+
+  it('can be asked to skip either pass', () => {
+    const page = blank(300, 200, PAPER)
+    fillRect(page, 0, 120, 70, 60, SKIN)
+    expect(cleanPage(page, { removeHands: false }).handsRemoved).toBe(0)
+  })
+})
+
+describe('orderQuad', () => {
+  it('puts corners in a consistent order however they arrive', () => {
+    const corners = [{ x: 10, y: 10 }, { x: 90, y: 12 }, { x: 88, y: 70 }, { x: 8, y: 68 }]
+    for (const rotation of [0, 1, 2, 3]) {
+      const rotated = corners.slice(rotation).concat(corners.slice(0, rotation))
+      const ordered = orderQuad(rotated)
+      expect(ordered[0].x).toBeLessThan(ordered[1].x) // top-left before top-right
+      expect(ordered[0].y).toBeLessThan(ordered[3].y) // top-left above bottom-left
+    }
+  })
+})


### PR DESCRIPTION

Pairs with codecombat-server PR https://github.com/codecombat/codecombat-server/pull/1494 —
the two must ship together.

As AI Junior isn't active, is admin-gated, and is unlinked from navigation, this should be low risk.
**Everything here is either under `app/views/ai-junior/`,
`app/lib/doc-capture/`, or an `AIJunior*` component.** The four files that are
not are listed first; the rest is internal to the feature and summarised.

## Interface points (the parts worth reviewing)

**`app/core/treema-ext.js` — a new Treema node subclass.** Registers
`percent`, rendering a number as `42%`. Purely additive: nothing selects it
unless a schema asks for `format: 'percent'`, which only the AI Junior worksheet
geometry does. Touched because every editor shares this file.

**`app/core/Router.js` and `app/core/vueRouter.js` — route registration.**
All new paths live under `/ai-junior/`. One is worth noting: `/ai-junior/creation/:projectId`
is registered as a **sibling** of the `/ai-junior` route rather than a child, so
the public share page renders without the AI Junior header and its "you do not
have access" banner for logged-out visitors.

**`package.json` — one new runtime dependency, `jsqr` (~40KB, Apache-2.0).**
Reads the QR code printed on a worksheet where `BarcodeDetector` is unavailable,
which is most notably iOS Safari — the device most likely to be pointed at a
piece of paper. Loaded only by `app/lib/doc-capture/qr.js`, which only the scan
view imports, so it lands in the `aiJunior` chunk rather than the main bundle.
The lockfile change is 12 lines.

**`test/app/lib/doc-capture.spec.js` — new karma spec.** 74 assertions over pure
maths: QR parsing, skin/mark classification, hand removal, illumination
flattening, corner ordering. No camera, no canvas, no network.

## What changed inside AI Junior (summary)

The loop now runs end to end: browse → print a sheet per student with its own QR
→ draw on paper → scan it with a phone → watch it generate → share it.

- **`app/lib/doc-capture/`** — page detection, rectification, cleanup and QR
  reading, all pure maths over pixel buffers with no browser dependency except
  in `capture.js`. Hand removal only takes skin-toned regions that are large
  *and* run along the paper's edge, so a child's crayon drawing of a person —
  the same colour as the thumb holding the corner — survives. There is a test
  for exactly that.
- **Worksheet** — pointer-based drawing with a stroke model in normalised
  coordinates (which makes the full-screen "Draw Big" surface nearly free),
  a crayon palette, undo/redo, stylus pressure. Drawings are composited onto
  white before being sent: a transparent PNG gives an image model no page to
  reason about, which is most of why on-screen drawings matched worse than
  scanned paper.
- **Results page** — one canonical rendering of a creation instead of two, the
  child's worksheet beside it, a progress bar that eases toward its estimate
  rather than guessing, and a working fullscreen.
- **Share page** — public, minimal chrome, one "make your own" call to action.
- **Scenario editor** — a visual layout mode for dragging field boxes over the
  live preview, which is what the `percent` Treema node is for.

## Testing

Karma spec above. Lint clean. Worksheet layout and print rendering are checked
by scripts in the server repo (they need DB access) — 9/9 scenarios lay out
without collisions and print what they draw.

Note: `npm install` is needed on this branch to pick up `phaser`, added upstream
by #8400 — unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an AI Junior scenario browser with search, filtering, worksheet, scanning, project, and printing options.
  - Added worksheet scanning from camera or uploaded photos, including QR setup, corner adjustment, previews, and batch submission.
  - Added printable classroom worksheets and print-all support.
  - Added project sharing with private, result-only, or full-creation visibility and read-only shared pages.
  - Added richer progress, previews, retry, download, fullscreen, and response-detail controls.
  - Added worksheet layout editing, validation warnings, drawing tools, and improved print styling.
- **Bug Fixes**
  - Improved processing updates, partial-result display, stalled-run handling, and error recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->