### PR TITLE
[GD-884] Remove galaxy-tutorial experiment getters

### DIFF
--- a/app/models/User.js
+++ b/app/models/User.js
@@ -26,7 +26,6 @@ const userUtils = require('lib/user-utils')
 const _ = require('lodash')
 const moment = window.moment
 const NAPERVILLE_UNIQUE_KEY = 'naperville'
-const GALAXY_TUTORIAL_EXPERIMENT = 'galaxy-tutorial'
 const JUNIOR_PET_ACCESS_EXPERIMENT = 'junior-pet-access'
 // Users created before this date are grandfathered out of junior-pet-access; set to the rollout date before enabling
 const JUNIOR_PET_ACCESS_CUTOFF_DATE = '2026-07-29'
@@ -1611,33 +1610,6 @@ module.exports = (User = (function () {
         return 'control'
       }
       return this.tryStartExperiment(JUNIOR_PET_ACCESS_EXPERIMENT)
-    }
-
-    getGalaxyTutorialExperimentValue () {
-      // Returns the value the user is already assigned to (or a query-string override),
-      // or null if the user has never been enrolled. This intentionally ignores the
-      // home-user gating so that anyone already enrolled keeps their assigned value.
-      return utils.getFirstNonNull(
-        utils.getExperimentValueFromQuery(GALAXY_TUTORIAL_EXPERIMENT),
-        me.getExperimentValue(GALAXY_TUTORIAL_EXPERIMENT, null),
-      ) ?? null
-    }
-
-    getOrStartGalaxyTutorialExperimentValue () {
-      // Home users only: exclude teachers/students and users on the China infrastructure
-      // up front, before even looking at an existing value.
-      if (me.isTeacher() || me.isStudent()) {
-        return 'control'
-      }
-      if (features?.chinaInfra) {
-        return 'control'
-      }
-      // Continue the experiment for anyone already enrolled.
-      const value = this.getGalaxyTutorialExperimentValue()
-      if (value != null) {
-        return value
-      }
-      return this.tryStartExperiment(GALAXY_TUTORIAL_EXPERIMENT)
     }
   }
 


### PR DESCRIPTION
The `galaxy-tutorial` experiment is retired — the trimmed HackStack tutorial ships to every audience. This removes the client-side machinery now that call sites have hit zero.

Deletes from `app/models/User.js`:
- the `GALAXY_TUTORIAL_EXPERIMENT` constant
- `getGalaxyTutorialExperimentValue` (read getter)
- `getOrStartGalaxyTutorialExperimentValue` (assignment trigger)

HackStack was the only caller and drops its call in codecombat/hackstack#TBD.

Stored `user.experiments` entries stay untouched — no migration, no cleanup, no backfill, so historical cohorts remain queryable. Same precedent as the `requires-sign-up-dungeon/junior` retirement in GD-875.

### Deploy order

**Land the HackStack PR first.** The call there is optional-chained, so removing this getter while HackStack still reads it yields `undefined`, which is never `'beta'` — the tutorial would be off for 100% of traffic until the client catches up.

### After deploy

Ops clears `serverConfig.experimentProbabilities['galaxy-tutorial']` in the Mandate document. There is no experiment-definition file in code; the probability lives only in Mongo, which is why nothing in this diff touches it.

### Testing

`npx eslint app/models/User.js` clean. No specs reference the removed getters, and `grep` finds no remaining `galaxy-tutorial` / `GalaxyTutorial` reference in `app/` or `test/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed support for the Galaxy tutorial experiment.
  * Existing junior pet access functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->