### PR TITLE
Make light bulb less threatening

### DIFF
--- a/ozaria/site/components/teacher-dashboard/common/buttons/IconButton.vue
+++ b/ozaria/site/components/teacher-dashboard/common/buttons/IconButton.vue
@@ -63,5 +63,10 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
+
+  img {
+    max-width: 100%;
+    max-height: 100%;
+  }
 }
 </style>


### PR DESCRIPTION
Closes ENG-2674

Fixes the giant light bulb on the curriculum guide in Safari.

The icon was ok - it's one of ~19 svg's that have a viewbox and no width/height. Technically we can fix all of them, but it would make many places have slightly smaller icons (they sit a little outside their container today it seems) from my tests so I'm keeping the fix small. Fixed in the Vue component with a max-width and max-height on the image. It can only shrink, so icons that already fit are unchanged.

If we add this type of icon in a place without that CSS, that can get big on Safari again.

Chrome & Firefox unchanged, Safari fixed.

## Before

<img width="991" height="1288" alt="image" src="https://github.com/user-attachments/assets/88f0372a-ec73-4a63-903d-141f98af6f7d" />


## After

<img width="991" height="1288" alt="image" src="https://github.com/user-attachments/assets/756d6c3f-31d9-43b0-aec6-6c4b74b8d0ad" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon sizing within buttons to prevent icons from exceeding button boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->