### PR TITLE
[GD-887] Author Star Lab mini-game tiles on the campaign

### DIFF
--- a/app/schemas/models/campaign.schema.js
+++ b/app/schemas/models/campaign.schema.js
@@ -241,7 +241,7 @@ _.extend(CampaignSchema.properties, {
             properties: {
               type: c.shortString({ title: 'Type', description: 'stars: earn stars. registered: be signed up.', enum: ['stars', 'registered'] }),
               campaign: c.shortString({ title: 'Send To Campaign', description: 'stars only: where clicking the locked tile sends the player to go earn stars, e.g. intro-to-ai. Stars count no matter which campaign they came from. Empty sends them to the galaxy map.' }),
-              amount: { type: 'number', title: 'Amount', description: 'stars only: how many stars are needed, across all campaigns.', minimum: 0 },
+              amount: { type: 'integer', title: 'Amount', description: 'stars only: how many stars are needed, across all campaigns.', minimum: 0 },
             },
           },
         },

--- a/app/schemas/models/campaign.schema.js
+++ b/app/schemas/models/campaign.schema.js
@@ -205,6 +205,49 @@ _.extend(CampaignSchema.properties, {
       },
     },
   },
+  miniGames: {
+    type: 'array',
+    title: 'Mini-Games',
+    description: 'Star Lab tiles: which mini-games this campaign shows, where they sit, and how they unlock.',
+    items: {
+      type: 'object',
+      title: 'Mini-Game Tile',
+      properties: {
+        miniGame: c.stringID({ title: 'Mini-Game', format: 'mini-game-original', description: 'The MiniGame original this tile plays.', links: [{ rel: 'db', href: '/db/mini_game/{{$}}/version', model: 'MiniGame' }] }),
+        // - denormalized from the referenced MiniGame on save; the route, the analytics
+        //   `gameName` and the tile identity all key off this.
+        slug: { type: 'string', format: 'hidden' },
+        displayName: { type: 'string', title: 'Display Name', description: 'Tile label. Falls back to the mini-game name.' },
+        icon: { type: 'string', format: 'image-file', title: 'Icon', description: 'The image to use for the tile on the interface.' },
+        position: {
+          type: 'object',
+          title: 'Position',
+          description: 'Position of the tile on the interface.',
+          properties: {
+            // same shape and precedence as modules[].position
+            row: { type: 'number', title: 'Row', description: 'The row of the tile on the interface.' },
+            column: { type: 'number', title: 'Column', description: 'The column of the tile on the interface.' },
+            x: { type: 'number', title: 'X', description: 'The x position of the tile on the interface.' },
+            y: { type: 'number', title: 'Y', description: 'The y position of the tile on the interface.' },
+          },
+        },
+        ruleToUnlock: {
+          type: 'array',
+          title: 'Rule To Unlock',
+          description: 'All rules must pass for the tile to unlock. Empty means always unlocked. The first unmet rule supplies the lock message, so order them the way a player should work through them.',
+          items: {
+            type: 'object',
+            title: 'Rule',
+            properties: {
+              type: c.shortString({ title: 'Type', description: 'stars: earn stars in a campaign. registered: be signed up.', enum: ['stars', 'registered'], default: 'stars' }),
+              campaign: c.shortString({ title: 'Campaign Slug', description: 'stars only: the campaign whose stars count, e.g. intro-to-ai.' }),
+              amount: { type: 'number', title: 'Amount', description: 'stars only: how many stars are needed.', minimum: 0 },
+            },
+          },
+        },
+      },
+    },
+  },
   parentCampaignSlug: { type: 'string', title: 'Parent Campaign Slug', description: 'The slug of the parent campaign.' },
   visualConnections: {
     type: 'array',

--- a/app/schemas/models/campaign.schema.js
+++ b/app/schemas/models/campaign.schema.js
@@ -212,9 +212,6 @@ _.extend(CampaignSchema.properties, {
     items: {
       type: 'object',
       title: 'Mini-Game Tile',
-      // Treema only renders a property of a fresh object when the object schema defaults it,
-      // so this is what makes a newly added tile show its fields instead of an empty row.
-      default: { miniGame: '', displayName: '', icon: '', position: { row: 0, column: 0 }, ruleToUnlock: [] },
       properties: {
         miniGame: { type: 'string', title: 'Mini-Game', format: 'mini-game-original', description: 'The MiniGame original this tile plays.', links: [{ rel: 'db', href: '/db/mini_game/{{$}}/version', model: 'MiniGame' }] },
         // - denormalized from the referenced MiniGame on save; the route, the analytics
@@ -241,11 +238,8 @@ _.extend(CampaignSchema.properties, {
           items: {
             type: 'object',
             title: 'Rule',
-            // Defaults double as the fields treema renders on a fresh rule; this one is the
-            // rule Star Lab ships with, so a new rule starts editable rather than empty.
-            default: { type: 'stars', campaign: 'intro-to-ai', amount: 1 },
             properties: {
-              type: c.shortString({ title: 'Type', description: 'stars: earn stars. registered: be signed up.', enum: ['stars', 'registered'], default: 'stars' }),
+              type: c.shortString({ title: 'Type', description: 'stars: earn stars. registered: be signed up.', enum: ['stars', 'registered'] }),
               campaign: c.shortString({ title: 'Send To Campaign', description: 'stars only: where clicking the locked tile sends the player to go earn stars, e.g. intro-to-ai. Stars count no matter which campaign they came from. Empty sends them to the galaxy map.' }),
               amount: { type: 'number', title: 'Amount', description: 'stars only: how many stars are needed, across all campaigns.', minimum: 0 },
             },

--- a/app/schemas/models/campaign.schema.js
+++ b/app/schemas/models/campaign.schema.js
@@ -237,7 +237,7 @@ _.extend(CampaignSchema.properties, {
         ruleToUnlock: {
           type: 'array',
           title: 'Rule To Unlock',
-          description: 'All rules must pass for the tile to unlock. Empty means always unlocked. The first unmet rule supplies the lock message, so order them the way a player should work through them.',
+          description: 'All rules must pass for the tile to unlock. Empty means always unlocked. The first unmet rule supplies the lock message and where its click leads, so order them the way a player should work through them.',
           items: {
             type: 'object',
             title: 'Rule',
@@ -245,9 +245,9 @@ _.extend(CampaignSchema.properties, {
             // rule Star Lab ships with, so a new rule starts editable rather than empty.
             default: { type: 'stars', campaign: 'intro-to-ai', amount: 1 },
             properties: {
-              type: c.shortString({ title: 'Type', description: 'stars: earn stars in a campaign. registered: be signed up.', enum: ['stars', 'registered'], default: 'stars' }),
-              campaign: c.shortString({ title: 'Campaign Slug', description: 'stars only: the campaign whose stars count, e.g. intro-to-ai.' }),
-              amount: { type: 'number', title: 'Amount', description: 'stars only: how many stars are needed.', minimum: 0 },
+              type: c.shortString({ title: 'Type', description: 'stars: earn stars. registered: be signed up.', enum: ['stars', 'registered'], default: 'stars' }),
+              campaign: c.shortString({ title: 'Send To Campaign', description: 'stars only: where clicking the locked tile sends the player to go earn stars, e.g. intro-to-ai. Stars count no matter which campaign they came from. Empty sends them to the galaxy map.' }),
+              amount: { type: 'number', title: 'Amount', description: 'stars only: how many stars are needed, across all campaigns.', minimum: 0 },
             },
           },
         },

--- a/app/schemas/models/campaign.schema.js
+++ b/app/schemas/models/campaign.schema.js
@@ -212,8 +212,11 @@ _.extend(CampaignSchema.properties, {
     items: {
       type: 'object',
       title: 'Mini-Game Tile',
+      // Treema only renders a property of a fresh object when the object schema defaults it,
+      // so this is what makes a newly added tile show its fields instead of an empty row.
+      default: { miniGame: '', displayName: '', icon: '', position: { row: 0, column: 0 }, ruleToUnlock: [] },
       properties: {
-        miniGame: c.stringID({ title: 'Mini-Game', format: 'mini-game-original', description: 'The MiniGame original this tile plays.', links: [{ rel: 'db', href: '/db/mini_game/{{$}}/version', model: 'MiniGame' }] }),
+        miniGame: { type: 'string', title: 'Mini-Game', format: 'mini-game-original', description: 'The MiniGame original this tile plays.', links: [{ rel: 'db', href: '/db/mini_game/{{$}}/version', model: 'MiniGame' }] },
         // - denormalized from the referenced MiniGame on save; the route, the analytics
         //   `gameName` and the tile identity all key off this.
         slug: { type: 'string', format: 'hidden' },
@@ -238,6 +241,9 @@ _.extend(CampaignSchema.properties, {
           items: {
             type: 'object',
             title: 'Rule',
+            // Defaults double as the fields treema renders on a fresh rule; this one is the
+            // rule Star Lab ships with, so a new rule starts editable rather than empty.
+            default: { type: 'stars', campaign: 'intro-to-ai', amount: 1 },
             properties: {
               type: c.shortString({ title: 'Type', description: 'stars: earn stars in a campaign. registered: be signed up.', enum: ['stars', 'registered'], default: 'stars' }),
               campaign: c.shortString({ title: 'Campaign Slug', description: 'stars only: the campaign whose stars count, e.g. intro-to-ai.' }),

--- a/app/views/editor/campaign/CampaignEditorView.js
+++ b/app/views/editor/campaign/CampaignEditorView.js
@@ -260,6 +260,10 @@ module.exports = (CampaignEditorView = (function () {
       return Promise.all(fetches).then(() => {
         if (_.isEqual(miniGames, this.campaign.get('miniGames'))) { return }
         this.campaign.set('miniGames', miniGames)
+        // Treema holds the authoritative copy: onTreemaChanged copies its data back over the
+        // model on the next edit, so a resolved slug written only to the model gets reverted,
+        // and the patch/delta views keep showing the tile without one.
+        if (this.treema) { this.treema.set('/miniGames', miniGames) }
         this.toSave.add(this.campaign)
       })
     }
@@ -435,16 +439,25 @@ module.exports = (CampaignEditorView = (function () {
       // Before saving, denormalize module campaign properties (name/fullName/slug) into modules,
       // and the referenced mini-game slugs into miniGames.
       this.updateModuleCampaigns()
-      return this.updateMiniGameSlugs().then(() => this.loadMissingLevelsAndRelatedModels()).then(() => {
+      // Only the preparation is caught here: a failure past this point is a bug worth an
+      // unhandled rejection in the console, not a "could not prepare the campaign" noty.
+      const prepared = this.updateMiniGameSlugs()
+        .then(() => this.loadMissingLevelsAndRelatedModels())
+        .then(() => true)
+        .catch(err => {
+          // Leave the editor usable: the save is abandoned, not half-applied.
+          console.error('Could not prepare the campaign for saving', err)
+          this.openingModal = false
+          noty({ timeout: 8000, text: err?.message || 'Could not prepare the campaign for saving.', type: 'error', layout: 'topCenter' })
+          return false
+        })
+      return prepared.then(ready => {
+        if (!ready) { return }
         this.openingModal = false
         this.propagateCampaignIndexes()
         this.updateCampaignLevels()
         this.toSave.set(this.toSave.filter(m => m.hasLocalChanges()))
         return this.openModalView(new SaveCampaignModal({}, this.toSave))
-      }).catch(err => {
-        // Leave the editor usable: the save is abandoned, not half-applied.
-        this.openingModal = false
-        noty({ timeout: 8000, text: err?.message || 'Could not prepare the campaign for saving.', type: 'error', layout: 'topCenter' })
       })
     }
 

--- a/app/views/editor/campaign/CampaignEditorView.js
+++ b/app/views/editor/campaign/CampaignEditorView.js
@@ -33,6 +33,7 @@ const RevertModal = require('views/modal/RevertModal')
 const modelDeltas = require('lib/modelDeltas')
 const globalVar = require('core/globalVar')
 const { HackstackScenarioIDNode } = require('views/editor/ai-scenario/AIScenarioNode')
+const { MiniGameOriginalNode } = require('views/editor/minigame/MiniGameNode')
 const { LevelOriginalNode } = require('views/editor/level/LevelOriginalNode')
 const { CampaignIDNode } = require('./CampaignIDNode')
 require('vendor/scripts/jquery-ui-1.11.1.custom')
@@ -231,6 +232,32 @@ module.exports = (CampaignEditorView = (function () {
       }
     }
 
+    // Denormalize the slug of each referenced mini-game into this.campaign.miniGames (GD-887).
+    // A tile stores the durable `original`, but Star Lab keys the route, the tile identity and
+    // the analytics gameName off the slug, so it has to be resolved and written at save time.
+    updateMiniGameSlugs () {
+      const miniGames = _.cloneDeep(this.campaign.get('miniGames') || [])
+      if (!miniGames.length) { return Promise.resolve() }
+
+      const fetches = miniGames.map((miniGameTile, i) => {
+        const original = miniGameTile && miniGameTile.miniGame
+        if (!original) { return Promise.resolve() }
+        return Promise.resolve($.ajax({ url: `/db/mini_game/${original}/version`, method: 'GET' }))
+          .then(doc => {
+            if (doc && doc.slug) { miniGames[i] = _.assign({}, miniGameTile, { slug: doc.slug }) }
+          })
+          .catch(() => {
+            // A lookup failure must not block the save; the previously stored slug stands.
+          })
+      })
+
+      return Promise.all(fetches).then(() => {
+        if (_.isEqual(miniGames, this.campaign.get('miniGames'))) { return }
+        this.campaign.set('miniGames', miniGames)
+        this.toSave.add(this.campaign)
+      })
+    }
+
     updateCampaignLevels () {
       let level, model
       if (this.campaign.hasLocalChanges()) { this.toSave.add(this.campaign) }
@@ -399,9 +426,10 @@ module.exports = (CampaignEditorView = (function () {
     onClickSaveButton (e) {
       if (this.openingModal) { return }
       this.openingModal = true
-      // Before saving, denormalize module campaign properties (name/fullName/slug) into modules.
+      // Before saving, denormalize module campaign properties (name/fullName/slug) into modules,
+      // and the referenced mini-game slugs into miniGames.
       this.updateModuleCampaigns()
-      return this.loadMissingLevelsAndRelatedModels().then(() => {
+      return this.updateMiniGameSlugs().then(() => this.loadMissingLevelsAndRelatedModels()).then(() => {
         this.openingModal = false
         this.propagateCampaignIndexes()
         this.updateCampaignLevels()
@@ -433,6 +461,7 @@ module.exports = (CampaignEditorView = (function () {
           rewards: RewardsNode,
           scenario: HackstackScenarioIDNode,
           'level-original': LevelOriginalNode,
+          'mini-game-original': MiniGameOriginalNode,
         },
         supermodel: this.supermodel,
       }

--- a/app/views/editor/campaign/CampaignEditorView.js
+++ b/app/views/editor/campaign/CampaignEditorView.js
@@ -241,14 +241,20 @@ module.exports = (CampaignEditorView = (function () {
 
       const fetches = miniGames.map((miniGameTile, i) => {
         const original = miniGameTile && miniGameTile.miniGame
-        if (!original) { return Promise.resolve() }
+        if (!original) {
+          // No reference, no route key: a slug left over from a previous reference would send
+          // Star Lab to whatever game used to be here.
+          if (miniGameTile && miniGameTile.slug) { miniGames[i] = _.omit(miniGameTile, 'slug') }
+          return Promise.resolve()
+        }
+        // Keeping the old slug when the lookup fails is how a tile ends up pointing at one
+        // mini-game by original and another by slug, so an unresolved tile blocks the save.
+        const failed = () => { throw new Error(`Could not resolve the mini-game slug for ${original}. Check the mini-game reference on tile ${i + 1} and save again.`) }
         return Promise.resolve($.ajax({ url: `/db/mini_game/${original}/version`, method: 'GET' }))
           .then(doc => {
-            if (doc && doc.slug) { miniGames[i] = _.assign({}, miniGameTile, { slug: doc.slug }) }
-          })
-          .catch(() => {
-            // A lookup failure must not block the save; the previously stored slug stands.
-          })
+            if (!doc || !doc.slug) { failed() }
+            miniGames[i] = _.assign({}, miniGameTile, { slug: doc.slug })
+          }, failed)
       })
 
       return Promise.all(fetches).then(() => {
@@ -435,6 +441,10 @@ module.exports = (CampaignEditorView = (function () {
         this.updateCampaignLevels()
         this.toSave.set(this.toSave.filter(m => m.hasLocalChanges()))
         return this.openModalView(new SaveCampaignModal({}, this.toSave))
+      }).catch(err => {
+        // Leave the editor usable: the save is abandoned, not half-applied.
+        this.openingModal = false
+        noty({ timeout: 8000, text: err?.message || 'Could not prepare the campaign for saving.', type: 'error', layout: 'topCenter' })
       })
     }
 

--- a/app/views/editor/minigame/MiniGameNode.js
+++ b/app/views/editor/minigame/MiniGameNode.js
@@ -59,7 +59,12 @@ class MiniGameOriginalNode extends treemaExt.LatestVersionOriginalReferenceNode 
       // The editor route takes a slug or an _id, so prefer the loaded doc's slug.
       const handle = this.instance?.get('slug') || originalId
       this.$el.find('.mini-game-link').remove()
-      this.$el.find('.treema-row').prepend($(`<span class='mini-game-link'><a href='/editor/minigame/${handle}' title='Edit Mini-Game' target='_blank' rel='noopener noreferrer'>(e)</a>&nbsp;</span>`))
+      // Built as elements, not markup: the original is whatever the campaign doc holds, and
+      // interpolating it into an href would let a quote in that value inject into the editor.
+      const link = $('<a></a>')
+        .attr({ href: `/editor/minigame/${encodeURIComponent(handle)}`, title: 'Edit Mini-Game', target: '_blank', rel: 'noopener noreferrer' })
+        .text('(e)')
+      this.$el.find('.treema-row').prepend($('<span></span>').addClass('mini-game-link').append(link).append(' '))
     }
     return valEl
   }

--- a/app/views/editor/minigame/MiniGameNode.js
+++ b/app/views/editor/minigame/MiniGameNode.js
@@ -45,9 +45,11 @@ class MiniGameOriginalNode extends treemaExt.LatestVersionOriginalReferenceNode 
   searchCallback () {
     const term = (this.getValEl().find('input').val() || '').trim().toLowerCase()
     if (term) {
-      this.collection.models = this.collection.models.filter(model => {
+      const matches = this.collection.models.filter(model => {
         return `${model.get('name') || ''} ${model.get('slug') || ''}`.toLowerCase().includes(term)
       })
+      // reset() rather than assigning models, so length and _byId stay in step with them.
+      this.collection.reset(matches)
     }
     return super.searchCallback()
   }

--- a/app/views/editor/minigame/MiniGameNode.js
+++ b/app/views/editor/minigame/MiniGameNode.js
@@ -1,0 +1,76 @@
+require('lib/setupTreema')
+const treemaExt = require('core/treema-ext')
+
+/**
+ * Picks a MiniGame for a campaign's Star Lab tile (GD-887) and stores its `original`.
+ * The referenced doc is fetched through the by-original version route, so a tile keeps
+ * resolving after the mini-game gets a new version.
+ */
+class MiniGameOriginalNode extends treemaExt.LatestVersionOriginalReferenceNode {
+  valueClass = 'treema-mini-game'
+
+  constructor (...args) {
+    super(...args)
+    this.url = '/db/mini_game'
+    this.model = require('models/MiniGame')
+
+    const data = this.getData()
+    if (data) {
+      this.getSearchResultsEl().empty().append('Loading mini-game...')
+      const Model = this.model
+      const model = new Model()
+      model.set('original', data)
+      model.setURL(`/db/mini_game/${data}/version`)
+      model.fetch({
+        success: () => {
+          this.instance = model
+          if (!this.isEditing()) { this.refreshDisplay() }
+        },
+        error: () => {
+          // Ignore fetch errors, keep showing the original
+        },
+      })
+    }
+  }
+
+  buildSearchURL (term) {
+    return `${this.url}?term=${encodeURIComponent(term)}&project=_id,original,name,slug&limit=10`
+  }
+
+  buildValueForDisplay (valEl, data) {
+    super.buildValueForDisplay(valEl, data)
+    const originalId = typeof data === 'string' ? data : data?.original
+    if (originalId) {
+      // The editor route takes a slug or an _id, so prefer the loaded doc's slug.
+      const handle = this.instance?.get('slug') || originalId
+      this.$el.find('.mini-game-link').remove()
+      this.$el.find('.treema-row').prepend($(`<span class='mini-game-link'><a href='/editor/minigame/${handle}' title='Edit Mini-Game' target='_blank' rel='noopener noreferrer'>(e)</a>&nbsp;</span>`))
+    }
+    return valEl
+  }
+
+  modelToString (model) {
+    const slug = model.get('slug')
+    const name = model.get('name') || slug || model.get('original')
+    return slug && slug !== name ? `${name} (${slug})` : `${name}`
+  }
+
+  formatDocument (docOrModel) {
+    if (docOrModel && docOrModel.get && docOrModel.attributes) {
+      return this.modelToString(docOrModel)
+    }
+    const data = this.getData()
+    if (!data) { return 'None' }
+    if (!this.settings.supermodel) { return '' + data }
+    let m = this.settings.supermodel.getModelByOriginal(this.model, data)
+    if (!m && this.instance) {
+      m = this.instance
+      this.settings.supermodel.registerModel(m)
+    }
+    return m ? this.modelToString(m) : '' + data
+  }
+}
+
+module.exports = {
+  MiniGameOriginalNode,
+}

--- a/app/views/editor/minigame/MiniGameNode.js
+++ b/app/views/editor/minigame/MiniGameNode.js
@@ -33,8 +33,23 @@ class MiniGameOriginalNode extends treemaExt.LatestVersionOriginalReferenceNode 
     }
   }
 
-  buildSearchURL (term) {
-    return `${this.url}?term=${encodeURIComponent(term)}&project=_id,original,name,slug&limit=10`
+  /**
+   * `mini_games` carries no text index (no SearchablePlugin), so the server answers
+   * `?term=` with a 500 on a `$text` query. The catalog is a handful of docs, so fetch it
+   * whole and match the term in the browser instead.
+   */
+  buildSearchURL () {
+    return `${this.url}?project=_id,original,name,slug&limit=100`
+  }
+
+  searchCallback () {
+    const term = (this.getValEl().find('input').val() || '').trim().toLowerCase()
+    if (term) {
+      this.collection.models = this.collection.models.filter(model => {
+        return `${model.get('name') || ''} ${model.get('slug') || ''}`.toLowerCase().includes(term)
+      })
+    }
+    return super.searchCallback()
   }
 
   buildValueForDisplay (valEl, data) {

--- a/app/views/editor/minigame/MiniGameNode.js
+++ b/app/views/editor/minigame/MiniGameNode.js
@@ -23,6 +23,9 @@ class MiniGameOriginalNode extends treemaExt.LatestVersionOriginalReferenceNode 
       model.setURL(`/db/mini_game/${data}/version`)
       model.fetch({
         success: () => {
+          // The author may have picked a different mini-game while this was in flight; taking
+          // the stale doc would leave the row displaying one game and linking to another.
+          if (this.getData() !== data) { return }
           this.instance = model
           if (!this.isEditing()) { this.refreshDisplay() }
         },


### PR DESCRIPTION
Star Lab's map was a hardcoded array in hackstack: adding a mini-game, moving a
tile or changing a star threshold meant a code change and a deploy. This puts
the tile set in campaign content instead, alongside `modules[]`.

## What's here

`miniGames[]` on the campaign schema. Per tile:

- `miniGame` — the MiniGame `original`, picked through a new `mini-game-original`
  treema node (a sibling of the AI-scenario picker)
- `slug` — hidden, denormalized from the referenced MiniGame when the campaign is
  saved. The `/mini-game/:slug` route, the tile identity and the analytics
  `gameName` all key off the slug, so hackstack must not have to resolve it at
  render time. Same idea as `modules[]` denormalizing name/slug/fullName.
- `displayName`, `icon` (`image-file`), `position` (identical shape to
  `modules[].position`)
- `ruleToUnlock` — an array of ANDed rules; empty or absent means always
  unlocked, and the first unmet rule is what the player is told to do next.
  Two types ship: `stars` (earn N stars, `campaign` names where a locked tile
  sends them to earn them) and `registered`. A third rule type is a new enum
  value plus one branch in hackstack's evaluator — no schema migration.

The picker fetches the whole mini-game list and matches the term in the browser:
`mini_games` carries no text index, so the server answers `?term=` with a `$text`
query and 500s. The catalog is a handful of docs. Giving MiniGame a
`SearchablePlugin` is the real fix and belongs with the model.

## Merge order

Needs the server PR first — without it `miniGames` is stripped on save and the
by-original lookup 404s, so tiles never get their slug.

## Testing

- authored two tiles on the `star-lab` campaign against a local stack; the picker
  resolves by name, and the saved doc carries the denormalized slug
- `node --check` on the touched files; no client specs cover the campaign schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Campaigns can now include Star Lab mini-game tiles with icons, display details, ordering, and unlock conditions based on star totals or registration status.
  * Campaign editors can select mini-games by original identity, search by name or slug, view clearer labels, and open the selected mini-game directly.
* **Bug Fixes**
  * Campaign saves now keep mini-game references current when slugs change.
  * Saves report an error instead of completing when a mini-game reference cannot be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->