### PR TITLE
Stop the level video page's CSS from leaking into the Curriculum Guide

### DIFF
--- a/app/views/play/level/PlayLevelVideoComponent.vue
+++ b/app/views/play/level/PlayLevelVideoComponent.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 flat-layout
-  .video-container.container
+  .play-level-video-container.container
     .video-background.container
       .row.title-row
         .col-sm-12(v-if="videoData")
@@ -162,7 +162,9 @@ export default Vue.extend({
       @include box-shadow(0px 0px 8px #333)
       color: white
 
-  .video-container
+  // This style block is unscoped, so the root class name must be unique
+  // app-wide (a generic name here leaks onto other pages after navigation)
+  .play-level-video-container
     z-index: 3
     width: 100%
     height: 100%


### PR DESCRIPTION
Fixes the giant dungeon-brick image on the Curriculum Guide after clicking the level control bar's Courses button.

Related to ENG-2674 (the guide image was suspected fallout of that fix; it is not).

**Cause.** `PlayLevelVideoComponent.vue` has an unscoped style block that defines a global `.video-container` rule (dungeon background, `position: absolute`, 100% width and height). The guide's `ChapterInfo.vue` uses the same class name for its CS1 video thumbnails row. Level chunk CSS stays loaded across in-app navigation, so after level -> guide the global rule paints the guide's row. A full page refresh never loads the level chunk, which is why refresh clears it.

**Fix.** Rename the video page's class to `play-level-video-container`, in the template and the style block. This is a rename only, no rule changes. I renamed at the source instead of in the guide because `.video-container` is also used on the parents, premium, roblox and home pages, so the global rule could leak into any of them the same way.

**Verified locally.**
- Before: teacher -> level -> Courses button -> guide renders a ~2900px brick background over the video row. Reproduces on master with and without the ENG-2674 icon clamp, so the clamp is unrelated.
- After: the same flow renders the guide identical to a fresh load (same document height, no brick background).
- `/play/video/level/...` still renders its own dungeon frame, video iframe and next-level button with the renamed class.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the video component’s styling identifier to improve consistency and prevent conflicts with other video containers.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->