### PR TITLE
[GD-889] Thang Editor: upload raster images and keyframe animations as action assets

### DIFF
--- a/app/lib/sprites/SpriteBuilder.coffee
+++ b/app/lib/sprites/SpriteBuilder.coffee
@@ -17,6 +17,8 @@ module.exports = class SpriteBuilder
     unless animData
       console.error 'couldn\'t find animData from', @animationStore, 'for', animationName
       return null
+    if animData.rasterSheet
+      return @buildRasterMovieClip animationName, animData, mode, startPosition, loops, labels
     locals = {}
     _.extend locals, @buildMovieClipShapes(animData.shapes)
     _.extend locals, @buildMovieClipContainers(animData.containers)
@@ -44,6 +46,60 @@ module.exports = class SpriteBuilder
     anim.nominalBounds = new createjs.Rectangle(animData.bounds...)
     if animData.frameBounds
       anim.frameBounds = (new createjs.Rectangle(bounds...) for bounds in animData.frameBounds)
+    anim
+
+  # Raster-backed animation: a MovieClip showing one source-rect crop of a
+  # packed raster sheet per timeline frame. Returns null until the sheet image
+  # is loaded, so callers skip it and a rebuild after 'raster-raw-images-loaded'
+  # picks it up. The bitmaps are timeline-managed (no addChild), like the
+  # tween targets of an Animate-published clip.
+  buildRasterMovieClip: (animationName, animData, mode, startPosition, loops, labels) ->
+    img = @thangType.getRasterRawImage? animData.rasterSheet
+    unless img
+      console.warn 'Raster sheet not loaded yet for animation', animationName, animData.rasterSheet
+      return null
+    rasterFrames = animData.rasterFrames or []
+    unless rasterFrames.length
+      console.error 'Raster animation has no rasterFrames', animationName
+      return null
+    anim = new createjs.MovieClip()
+    if not labels
+      labels = {}
+      labels[animationName] = 0
+    anim.initialize(mode ? createjs.MovieClip.INDEPENDENT, startPosition ? 0, loops ? true, labels)
+    numFrames = rasterFrames.length
+    frameBounds = []
+    for frameData, i in rasterFrames
+      [x, y, w, h, regX, regY] = frameData
+      regX ?= 0
+      regY ?= 0
+      bitmap = new createjs.Bitmap(img)
+      bitmap.sourceRect = new createjs.Rectangle(x, y, w, h)
+      bitmap.regX = regX
+      bitmap.regY = regY
+      bitmap._off = i isnt 0
+      frameBounds.push new createjs.Rectangle(-regX, -regY, w, h)
+      if numFrames is 1
+        tween = createjs.Tween.get(bitmap).wait(1)
+      else
+        tween = createjs.Tween.get(bitmap)
+        tween = tween.wait(i) if i > 0
+        tween = tween.to({_off: false}, 0).wait(1).to({_off: true}, 0)
+        remaining = numFrames - i - 1
+        tween = tween.wait(remaining) if remaining > 0
+      anim.timeline.addTween(tween)
+    if animData.bounds
+      anim.nominalBounds = new createjs.Rectangle(animData.bounds...)
+    else
+      left = _.min(b.x for b in frameBounds)
+      top = _.min(b.y for b in frameBounds)
+      right = _.max(b.x + b.width for b in frameBounds)
+      bottom = _.max(b.y + b.height for b in frameBounds)
+      anim.nominalBounds = new createjs.Rectangle(left, top, right - left, bottom - top)
+    if animData.frameBounds
+      anim.frameBounds = (new createjs.Rectangle(bounds...) for bounds in animData.frameBounds)
+    else
+      anim.frameBounds = frameBounds
     anim
 
   dereferenceArgs: (args, locals) ->
@@ -119,6 +175,8 @@ module.exports = class SpriteBuilder
   buildContainerFromStore: (containerKey) ->
     console.error 'Yo we don\'t have no containerKey' unless containerKey
     contData = @containerStore[containerKey]
+    if contData?.img
+      return @buildRasterContainer containerKey, contData
     cont = new createjs.Container()
     cont.initialize()
     for childData in contData.c
@@ -130,6 +188,27 @@ module.exports = class SpriteBuilder
         child.setTransform(childData.t...)
       cont.addChild(child)
     cont.bounds = new createjs.Rectangle(contData.b...)
+    cont
+
+  # Raster-backed container: a single Bitmap placed at the container's bounds
+  # offset instead of vector children. Returns null until the image is loaded.
+  buildRasterContainer: (containerKey, contData) ->
+    img = @thangType.getRasterRawImage? contData.img
+    unless img
+      console.warn 'Raster image not loaded yet for container', containerKey, contData.img
+      return null
+    naturalWidth = img.naturalWidth or img.width
+    naturalHeight = img.naturalHeight or img.height
+    b = contData.b or [0, 0, naturalWidth, naturalHeight]
+    cont = new createjs.Container()
+    cont.initialize()
+    bitmap = new createjs.Bitmap(img)
+    bitmap.x = b[0]
+    bitmap.y = b[1]
+    bitmap.scaleX = b[2] / naturalWidth if naturalWidth
+    bitmap.scaleY = b[3] / naturalHeight if naturalHeight
+    cont.addChild(bitmap)
+    cont.bounds = new createjs.Rectangle(b...)
     cont
 
   # Builds the spritesheet using the texture atlas images for each animation/action and updates its reference in the movieClip file

--- a/app/lib/sprites/SpriteBuilder.coffee
+++ b/app/lib/sprites/SpriteBuilder.coffee
@@ -75,8 +75,9 @@ module.exports = class SpriteBuilder
     frameBounds = []
     for frameData, i in rasterFrames
       [x, y, w, h, regX, regY] = frameData
-      regX ?= 0
-      regY ?= 0
+      # Frame-center default, matching the editor importer's convention.
+      regX ?= w / 2
+      regY ?= h / 2
       bitmap = new createjs.Bitmap(img)
       bitmap.sourceRect = new createjs.Rectangle(x, y, w, h)
       bitmap.regX = regX

--- a/app/lib/sprites/SpriteBuilder.coffee
+++ b/app/lib/sprites/SpriteBuilder.coffee
@@ -21,8 +21,12 @@ module.exports = class SpriteBuilder
       return @buildRasterMovieClip animationName, animData, mode, startPosition, loops, labels
     locals = {}
     _.extend locals, @buildMovieClipShapes(animData.shapes)
-    _.extend locals, @buildMovieClipContainers(animData.containers)
-    _.extend locals, @buildMovieClipAnimations(animData.animations)
+    containers = @buildMovieClipContainers(animData.containers)
+    return null unless containers  # nested raster image not loaded yet
+    _.extend locals, containers
+    animations = @buildMovieClipAnimations(animData.animations)
+    return null unless animations  # nested raster sheet not loaded yet
+    _.extend locals, animations
     _.extend locals, @buildMovieClipGraphics(animData.graphics)
     anim = new createjs.MovieClip()
     if not labels
@@ -131,6 +135,7 @@ module.exports = class SpriteBuilder
     map = {}
     for localContainer in localContainers
       container = @buildContainerFromStore(localContainer.gn)
+      return null unless container  # raster image not loaded yet
       container.setTransform(localContainer.t...)
       container._off = localContainer.o if localContainer.o?
       container.alpha = localContainer.al if localContainer.al?
@@ -141,6 +146,7 @@ module.exports = class SpriteBuilder
     map = {}
     for localAnimation in localAnimations
       animation = @buildMovieClip(localAnimation.gn, localAnimation.a...)
+      return null unless animation  # nested raster sheet not loaded yet
       animation.setTransform(localAnimation.t...)
       animation._off = true if localAnimation.off
       map[localAnimation.bn] = animation
@@ -185,6 +191,7 @@ module.exports = class SpriteBuilder
       else
         continue if not childData.gn
         child = @buildContainerFromStore(childData.gn)
+        return null unless child  # nested raster image not loaded yet
         child.setTransform(childData.t...)
       cont.addChild(child)
     cont.bounds = new createjs.Rectangle(contData.b...)

--- a/app/lib/sprites/SpriteExporter.coffee
+++ b/app/lib/sprites/SpriteExporter.coffee
@@ -20,9 +20,16 @@ class SpriteExporter extends CocoClass
     @resolutionFactor = options.resolutionFactor or 1
     @actionNames = options.actionNames or (action.name for action in @thangType.getDefaultActions())
     @spriteType = options.spriteType or @thangType.get('spriteType') or 'segmented'
+    # Raster keyframe animations only work through the singular path.
+    @spriteType = 'singular' if @thangType.hasRasterAnimations()
     super()
 
   build: ->
+    if @thangType.hasRasterRawAssets() and not @thangType.rasterRawImagesLoaded()
+      # Building with unloaded raster images would silently drop their frames.
+      @listenToOnce @thangType, 'raster-raw-images-loaded', @build
+      @thangType.loadRasterRawImages()
+      return
     spriteSheetBuilder = new createjs.SpriteSheetBuilder()
     if @spriteType is 'segmented'
       @renderSegmentedThangType(spriteSheetBuilder)
@@ -41,6 +48,7 @@ class SpriteExporter extends CocoClass
     spriteBuilder = new SpriteBuilder(@thangType, {colorConfig: @colorConfig})
     for containerGlobalName in containersToRender
       container = spriteBuilder.buildContainerFromStore(containerGlobalName)
+      continue unless container  # e.g. raster image failed to load
       frame = spriteSheetBuilder.addFrame(container, null, @resolutionFactor * (@thangType.get('scale') or 1))
       spriteSheetBuilder.addAnimation(containerGlobalName, [frame], false)
 
@@ -58,6 +66,7 @@ class SpriteExporter extends CocoClass
     for animationName, actions of animationGroups
       scale = actions[0].scale or @thangType.get('scale') or 1
       mc = spriteBuilder.buildMovieClip(animationName, null, null, null, {'temp':0})
+      continue unless mc  # e.g. raster sheet failed to load
       spriteSheetBuilder.addMovieClip(mc, null, scale * @resolutionFactor)
       frames = spriteSheetBuilder._animations['temp'].frames
       framesMap = _.zipObject _.range(frames.length), frames
@@ -78,6 +87,7 @@ class SpriteExporter extends CocoClass
     containerGroups = _.groupBy containerActions, (action) -> action.container
     for containerName, actions of containerGroups
       container = spriteBuilder.buildContainerFromStore(containerName)
+      continue unless container  # e.g. raster image failed to load
       scale = actions[0].scale or @thangType.get('scale') or 1
       frame = spriteSheetBuilder.addFrame(container, null, scale * @resolutionFactor)
       for action in actions

--- a/app/lib/sprites/SpriteOptimizer.coffee
+++ b/app/lib/sprites/SpriteOptimizer.coffee
@@ -123,12 +123,14 @@ module.exports = class SpriteOptimizer
         if relatedAction.container
           containerFrequencies[relatedAction.container] = (containerFrequencies[relatedAction.container] ? 0) + 1
     containersByFrequency = _.sortBy _.pairs(containerFrequencies), ([containerName, frequency]) -> -frequency
+    assignedContainerNames = new Set()
     for [container, frequency] in containersByFrequency
       if @raw.containers[container]?.img
         # Referenced raster-backed containers keep their artist-chosen names
         # (identity renaming). Unreferenced ones are dropped by the rebuild
         # below, exactly like unreferenced vector containers.
         containerRenamings[container] = container
+        assignedContainerNames.add container
         continue
       containerKey = @keyForContainer @raw.containers[container]
       if @aggressiveContainers and newContainerName = containerDuplicates[containerKey]
@@ -143,9 +145,10 @@ module.exports = class SpriteOptimizer
         n = _.size containerRenamings
         # Skip generated names already claimed by a kept-as-is raster container
         # (or by an earlier renaming, once skips shift the numbering).
-        assignedNames = _.values containerRenamings
-        n++ while @raw.containers[@nameContainer(n)]?.img or @nameContainer(n) in assignedNames
-        containerDuplicates[containerKey] = containerRenamings[container] = @nameContainer n
+        n++ while @raw.containers[@nameContainer(n)]?.img or assignedContainerNames.has(@nameContainer(n))
+        newName = @nameContainer n
+        containerDuplicates[containerKey] = containerRenamings[container] = newName
+        assignedContainerNames.add newName
         firstContainers[containerKey] = @raw.containers[container]
 
     if @debug

--- a/app/lib/sprites/SpriteOptimizer.coffee
+++ b/app/lib/sprites/SpriteOptimizer.coffee
@@ -124,6 +124,11 @@ module.exports = class SpriteOptimizer
           containerFrequencies[relatedAction.container] = (containerFrequencies[relatedAction.container] ? 0) + 1
     containersByFrequency = _.sortBy _.pairs(containerFrequencies), ([containerName, frequency]) -> -frequency
     for [container, frequency] in containersByFrequency
+      if @raw.containers[container]?.img
+        # Raster-backed containers keep their artist-chosen names; identity
+        # renaming so the rebuild below doesn't drop them.
+        containerRenamings[container] = container
+        continue
       containerKey = @keyForContainer @raw.containers[container]
       if @aggressiveContainers and newContainerName = containerDuplicates[containerKey]
         # TODO: fix issue where the same animation might have multiple tweens targeting the same container (which breaks) if we consolidate identical containers. Exmaple: Hero A Cinematic eatPopcorn animation, with three tweens referencing what would be c0 (most common container, a hand used 13 times overall)
@@ -134,7 +139,12 @@ module.exports = class SpriteOptimizer
         if @debug and not _.isEqual @raw.containers[container], firstContainers[containerKey]
           console.log container, _.cloneDeep(@raw.containers[container]), 'is the same as', _.cloneDeep(firstContainers[containerKey])
       else
-        containerDuplicates[containerKey] = containerRenamings[container] = @nameContainer _.size(containerRenamings)
+        n = _.size containerRenamings
+        # Skip generated names already claimed by a kept-as-is raster container
+        # (or by an earlier renaming, once skips shift the numbering).
+        assignedNames = _.values containerRenamings
+        n++ while @raw.containers[@nameContainer(n)]?.img or @nameContainer(n) in assignedNames
+        containerDuplicates[containerKey] = containerRenamings[container] = @nameContainer n
         firstContainers[containerKey] = @raw.containers[container]
 
     if @debug

--- a/app/lib/sprites/SpriteOptimizer.coffee
+++ b/app/lib/sprites/SpriteOptimizer.coffee
@@ -125,8 +125,9 @@ module.exports = class SpriteOptimizer
     containersByFrequency = _.sortBy _.pairs(containerFrequencies), ([containerName, frequency]) -> -frequency
     for [container, frequency] in containersByFrequency
       if @raw.containers[container]?.img
-        # Raster-backed containers keep their artist-chosen names; identity
-        # renaming so the rebuild below doesn't drop them.
+        # Referenced raster-backed containers keep their artist-chosen names
+        # (identity renaming). Unreferenced ones are dropped by the rebuild
+        # below, exactly like unreferenced vector containers.
         containerRenamings[container] = container
         continue
       containerKey = @keyForContainer @raw.containers[container]

--- a/app/lib/surface/LayerAdapter.coffee
+++ b/app/lib/surface/LayerAdapter.coffee
@@ -495,8 +495,12 @@ module.exports = LayerAdapter = class LayerAdapter extends CocoClass
 
     spriteBuilder = new SpriteBuilder(thangType, {colorConfig: colorConfig})
 
-    animationGroups = _.groupBy animationActions, (action) -> action.animation
-    for animationName, actions of animationGroups
+    # Group by animation AND effective scale: frames are baked at one scale,
+    # so actions sharing an animation at different scales need separate frames
+    # (the editor path already keys its frames map by scale, ThangType.js addGeneralFrames).
+    animationGroups = _.groupBy animationActions, (action) -> action.animation + '~' + (action.scale or thangType.get('scale') or 1)
+    for groupKey, actions of animationGroups
+      animationName = actions[0].animation
       renderAll = _.any actions, (action) -> action.frames is undefined
       scale = actions[0].scale or thangType.get('scale') or 1
 

--- a/app/lib/surface/LayerAdapter.coffee
+++ b/app/lib/surface/LayerAdapter.coffee
@@ -234,6 +234,11 @@ module.exports = LayerAdapter = class LayerAdapter extends CocoClass
       thangType.loadAllRasterTextureAtlases()
       @listenToOnce(thangType, 'texture-atlas-loaded', -> @somethingLoaded(thangType))
       @numThingsLoading++
+    else if thangType.hasRasterRawAssets() and not thangType.rasterRawImagesLoaded()
+      # Listen before loading in case cached images settle synchronously.
+      @listenToOnce(thangType, 'raster-raw-images-loaded', @somethingLoaded)
+      @numThingsLoading++
+      thangType.loadRasterRawImages()
     else if prerenderedSpriteSheet = thangType.getPrerenderedSpriteSheetToLoad()
       startedLoading = prerenderedSpriteSheet.loadImage()
       return if not startedLoading
@@ -459,6 +464,7 @@ module.exports = LayerAdapter = class LayerAdapter extends CocoClass
         frame = spriteSheetBuilder.addFrame(container, null, scale)
       else
         container = spriteBuilder.buildContainerFromStore(containerGlobalName)
+        continue unless container  # e.g. raster image not loaded yet; rebuild picks it up
         frame = spriteSheetBuilder.addFrame(container, null, @resolutionFactor * (thangType.get('scale') or 1))
       spriteSheetBuilder.addAnimation(containerKey, [frame], false)
 
@@ -519,6 +525,7 @@ module.exports = LayerAdapter = class LayerAdapter extends CocoClass
         continue
 
       mc = spriteBuilder.buildMovieClip(animationName, null, null, null, {'temp':0})
+      continue unless mc  # e.g. raster sheet not loaded yet; rebuild picks it up
 
       if renderAll
         res = spriteSheetBuilder.addMovieClip(mc, null, scale * @resolutionFactor)
@@ -559,6 +566,7 @@ module.exports = LayerAdapter = class LayerAdapter extends CocoClass
           spriteSheetBuilder.addAnimation(name, [frame], false)
         continue
       container = spriteBuilder.buildContainerFromStore(containerName)
+      continue unless container  # e.g. raster image not loaded yet; rebuild picks it up
       scale = actions[0].scale or thangType.get('scale') or 1
       frame = spriteSheetBuilder.addFrame(container, null, scale * @resolutionFactor)
       for action in actions

--- a/app/lib/surface/LayerAdapter.coffee
+++ b/app/lib/surface/LayerAdapter.coffee
@@ -331,7 +331,8 @@ module.exports = LayerAdapter = class LayerAdapter extends CocoClass
       actionNames = (bundle.actionName for bundle in bundleGrouping)
       args = [thangType, colorConfig, actionNames, builder]
       if thangType.get('raw') or thangType.get('prerenderedSpriteSheetData')
-        if (thangType.get('spriteType') or @defaultSpriteType) is 'segmented'
+        # Raster keyframe animations only work through the singular path.
+        if (thangType.get('spriteType') or @defaultSpriteType) is 'segmented' and not thangType.hasRasterAnimations()
           @renderSegmentedThangType(args...)
         else
           @renderSingularThangType(args...)
@@ -615,7 +616,9 @@ module.exports = LayerAdapter = class LayerAdapter extends CocoClass
       sprite = new RasterAtlasSprite(lank.thangType)
 
     else
-      SpriteClass = if (lank.thangType.get('spriteType') or @defaultSpriteType) is 'segmented' then SegmentedSprite else SingularSprite
+      # Raster keyframe animations only work through SingularSprite.
+      useSegmented = (lank.thangType.get('spriteType') or @defaultSpriteType) is 'segmented' and not lank.thangType.hasRasterAnimations()
+      SpriteClass = if useSegmented then SegmentedSprite else SingularSprite
       prefix = @renderGroupingKey(lank.thangType, null, lank.options.colorConfig) + '.'
       sprite = new SpriteClass(@spriteSheet, lank.thangType, prefix, @resolutionFactor)
 

--- a/app/lib/surface/SingularSprite.coffee
+++ b/app/lib/surface/SingularSprite.coffee
@@ -27,7 +27,8 @@ module.exports = class SingularSprite extends createjs.Sprite
     reg = action.positions?.registration or @thangType.get('positions')?.registration or {x:0, y:0}
 
     if action.animation
-      @framerate = (action.framerate ? 20) * (action.speed ? 1)
+      rawFramerate = @thangType.get('raw')?.animations?[action.animation]?.framerate  # raster sheets carry their import framerate
+      @framerate = (action.framerate ? rawFramerate ? 20) * (action.speed ? 1)
 
       func = if @paused then '_gotoAndStop' else '_gotoAndPlay'
       animationName = @spriteSheetPrefix + actionName
@@ -47,7 +48,7 @@ module.exports = class SingularSprite extends createjs.Sprite
         @regX = -reg.x * scale
         @regY = -reg.y * scale
         @scaleX = @scaleY = 1 / @resolutionFactor
-        @framerate = action.framerate or 20
+        @framerate = action.framerate ? rawFramerate ? 20
         if randomStart and frames = @spriteSheet.getAnimation(animationName)?.frames
           @currentAnimationFrame = Math.floor(Math.random() * frames.length)
 

--- a/app/lib/surface/SingularSprite.coffee
+++ b/app/lib/surface/SingularSprite.coffee
@@ -48,7 +48,7 @@ module.exports = class SingularSprite extends createjs.Sprite
         @regX = -reg.x * scale
         @regY = -reg.y * scale
         @scaleX = @scaleY = 1 / @resolutionFactor
-        @framerate = action.framerate ? rawFramerate ? 20
+        @framerate = (action.framerate ? rawFramerate ? 20) * (action.speed ? 1)
         if randomStart and frames = @spriteSheet.getAnimation(animationName)?.frames
           @currentAnimationFrame = Math.floor(Math.random() * frames.length)
 

--- a/app/models/ThangType.js
+++ b/app/models/ThangType.js
@@ -501,10 +501,11 @@ module.exports = (ThangType = (function () {
       const vectorParser = new SpriteBuilder(this, {})
       if (portrait.animation) {
         sprite = vectorParser.buildMovieClip(portrait.animation)
-        sprite.gotoAndStop(0)
+        if (sprite) { sprite.gotoAndStop(0) }
       } else if (portrait.container) {
         sprite = vectorParser.buildContainerFromStore(portrait.container)
       }
+      if (!sprite) { return } // e.g. raster asset not loaded yet
 
       const pt = portrait.positions != null ? portrait.positions.registration : undefined
       sprite.regX = ((pt != null ? pt.x : undefined) / scale) || 0

--- a/app/models/ThangType.js
+++ b/app/models/ThangType.js
@@ -75,6 +75,7 @@ module.exports = (ThangType = (function () {
       super.initialize()
       this.building = {}
       this.spriteSheets = {}
+      this.on('change:raw', this.clearRasterRawCaches, this)
       if (utils.showOzaria()) {
         this.textureAtlases = new Map()
 
@@ -108,6 +109,7 @@ module.exports = (ThangType = (function () {
       this.buildActions()
       this.spriteSheets = {}
       this.building = {}
+      this.clearRasterRawCaches() // editor mutates raw in place, so change:raw alone isn't enough
     }
 
     isFullyLoaded () {
@@ -144,6 +146,10 @@ module.exports = (ThangType = (function () {
     // is silently dropped by createjs.SpriteSheetBuilder).
 
     getRasterRawAssetPaths () {
+      // Memoized: called per lank add and per spritesheet rebuild, and the
+      // answer is a constant [] for every vector-only thang. Invalidated in
+      // clearRasterRawCaches (change:raw + resetSpriteSheetCache).
+      if (this._rasterRawAssetPaths != null) { return this._rasterRawAssetPaths }
       const raw = this.get('raw')
       if (!raw) { return [] }
       const paths = []
@@ -153,7 +159,8 @@ module.exports = (ThangType = (function () {
       for (const animation of _.values(raw.animations || {})) {
         if (animation.rasterSheet) { paths.push(animation.rasterSheet) }
       }
-      return _.uniq(paths)
+      this._rasterRawAssetPaths = _.uniq(paths)
+      return this._rasterRawAssetPaths
     }
 
     hasRasterRawAssets () {
@@ -165,9 +172,16 @@ module.exports = (ThangType = (function () {
     }
 
     hasRasterAnimations () {
+      if (this._hasRasterAnimations != null) { return this._hasRasterAnimations }
       const raw = this.get('raw')
       if (!raw) { return false }
-      return _.some(raw.animations || {}, animation => animation.rasterSheet)
+      this._hasRasterAnimations = _.some(raw.animations || {}, animation => animation.rasterSheet)
+      return this._hasRasterAnimations
+    }
+
+    clearRasterRawCaches () {
+      this._rasterRawAssetPaths = null
+      this._hasRasterAnimations = null
     }
 
     rasterRawImagesLoaded () {

--- a/app/models/ThangType.js
+++ b/app/models/ThangType.js
@@ -138,6 +138,66 @@ module.exports = (ThangType = (function () {
       })
     }
 
+    // Raster raw assets: images referenced from raw.containers[*].img and
+    // raw.animations[*].rasterSheet. These must be loaded before a spritesheet
+    // build can rasterize them (an unloaded Bitmap has no bounds and its frame
+    // is silently dropped by createjs.SpriteSheetBuilder).
+
+    getRasterRawAssetPaths () {
+      const raw = this.get('raw')
+      if (!raw) { return [] }
+      const paths = []
+      for (const container of _.values(raw.containers || {})) {
+        if (container.img) { paths.push(container.img) }
+      }
+      for (const animation of _.values(raw.animations || {})) {
+        if (animation.rasterSheet) { paths.push(animation.rasterSheet) }
+      }
+      return _.uniq(paths)
+    }
+
+    hasRasterRawAssets () {
+      return this.getRasterRawAssetPaths().length > 0
+    }
+
+    getRasterRawImage (path) {
+      return this.rasterRawImages != null ? this.rasterRawImages[path] : undefined
+    }
+
+    rasterRawImagesLoaded () {
+      if (!_.isEmpty(this.loadingRasterRawPaths)) { return false }
+      return _.every(this.getRasterRawAssetPaths(), path => {
+        return (this.rasterRawImages != null ? this.rasterRawImages[path] : undefined) || (this.failedRasterRawPaths != null ? this.failedRasterRawPaths[path] : undefined)
+      })
+    }
+
+    loadRasterRawImages () {
+      if (this.rasterRawImages == null) { this.rasterRawImages = {} }
+      if (this.loadingRasterRawPaths == null) { this.loadingRasterRawPaths = {} }
+      if (this.failedRasterRawPaths == null) { this.failedRasterRawPaths = {} }
+      const toLoad = this.getRasterRawAssetPaths().filter(path => !this.rasterRawImages[path] && !this.loadingRasterRawPaths[path])
+      for (const path of toLoad) {
+        this.loadingRasterRawPaths[path] = true
+        const img = new Image()
+        img.crossOrigin = 'Anonymous'
+        const settle = () => {
+          delete this.loadingRasterRawPaths[path]
+          if (_.isEmpty(this.loadingRasterRawPaths)) { this.trigger('raster-raw-images-loaded', this) }
+        }
+        img.onload = () => {
+          this.rasterRawImages[path] = img
+          settle()
+        }
+        img.onerror = event => {
+          console.error('Failed to load raster raw image', path, event)
+          this.failedRasterRawPaths[path] = true
+          this.trigger('raster-raw-images-load-errored', this, path)
+          settle()
+        }
+        img.src = `/file/${path}`
+      }
+    }
+
     getActions () {
       if (!this.isFullyLoaded()) { return {} }
       return this.actions || this.buildActions()
@@ -214,6 +274,7 @@ module.exports = (ThangType = (function () {
       const rect = new createjs.Rectangle(((pt != null ? pt.x : undefined) / scale) || 0, ((pt != null ? pt.y : undefined) / scale) || 0, 100 / scale, 100 / scale)
       if (portrait.animation) {
         const mc = this.vectorParser.buildMovieClip(portrait.animation)
+        if (!mc) { return } // e.g. raster sheet not loaded yet
         mc.nominalBounds = (mc.frameBounds = null) // override what the movie clip says on bounding
         this.builder.addMovieClip(mc, rect, scale)
         let { frames } = this.builder._animations[portrait.animation]
@@ -221,6 +282,7 @@ module.exports = (ThangType = (function () {
         return this.builder.addAnimation('portrait', frames, true)
       } else if (portrait.container) {
         const s = this.vectorParser.buildContainerFromStore(portrait.container)
+        if (!s) { return } // e.g. raster image not loaded yet
         const frame = this.builder.addFrame(s, rect, scale)
         return this.builder.addAnimation('portrait', [frame], false)
       }

--- a/app/models/ThangType.js
+++ b/app/models/ThangType.js
@@ -164,6 +164,12 @@ module.exports = (ThangType = (function () {
       return this.rasterRawImages != null ? this.rasterRawImages[path] : undefined
     }
 
+    hasRasterAnimations () {
+      const raw = this.get('raw')
+      if (!raw) { return false }
+      return _.some(raw.animations || {}, animation => animation.rasterSheet)
+    }
+
     rasterRawImagesLoaded () {
       if (!_.isEmpty(this.loadingRasterRawPaths)) { return false }
       return _.every(this.getRasterRawAssetPaths(), path => {
@@ -732,7 +738,9 @@ module.exports = (ThangType = (function () {
       const rawAnimation = this.get('raw').animations[animation]
       if (!rawAnimation) {
         console.error('thang type', this.get('name'), 'is missing animation', animation, 'from action', action)
+        return []
       }
+      if (rawAnimation.rasterSheet) { return [] } // raster animations have no vector containers
       let { containers } = rawAnimation
       for (animation of Array.from(this.get('raw').animations[animation].animations)) {
         containers = containers.concat(this.getContainersForAnimation(animation.gn, action))

--- a/app/models/ThangType.js
+++ b/app/models/ThangType.js
@@ -249,6 +249,15 @@ module.exports = (ThangType = (function () {
       const ss = this.spriteSheets[key]
       if (!this.isFullyLoaded() || !this.get('raw')) { return false }
       if (ss) { return ss }
+      if (this.hasRasterRawAssets() && !this.rasterRawImagesLoaded()) {
+        // Building now would silently drop raster frames (unloaded Bitmaps
+        // have no bounds). Load first; clearing the cache on arrival lets the
+        // next build attempt succeed. Portrait paths reach here without any
+        // LayerAdapter having loaded the images.
+        this.loadRasterRawImages()
+        this.listenToOnce(this, 'raster-raw-images-loaded', this.resetSpriteSheetCache)
+        return false
+      }
       if (this.building[key]) {
         this.options = null
         return key
@@ -366,7 +375,14 @@ module.exports = (ThangType = (function () {
     }
 
     finishBuild () {
-      if (_.isEmpty(this.builder._animations)) { return }
+      if (_.isEmpty(this.builder._animations)) {
+        // Nothing built (e.g. raster assets not loaded yet) — release the
+        // in-flight flag or this key would return the string key forever.
+        this.building[this.spriteSheetKey(this.options)] = false
+        this.builder = null
+        this.options = null
+        return
+      }
       const key = this.spriteSheetKey(this.options)
       let spriteSheet = null
       if (this.options.async) {

--- a/app/schemas/models/thang_type.js
+++ b/app/schemas/models/thang_type.js
@@ -20,6 +20,7 @@ const ShapeObjectSchema = c.object({ title: 'Shape' }, {
 
 const ContainerObjectSchema = c.object({ format: 'container' }, {
   b: c.array({ title: 'Bounds' }, { type: 'number' }),
+  img: { type: 'string', format: 'image-file', title: 'Raster Image', description: 'Raster image file backing this container instead of vector children.' },
   c: c.array({ title: 'Children' }, {
     anyOf: [
       { type: 'string', title: 'Shape Child' },
@@ -34,6 +35,10 @@ const ContainerObjectSchema = c.object({ format: 'container' }, {
 const RawAnimationObjectSchema = c.object({}, {
   bounds: c.array({ title: 'Bounds' }, { type: 'number' }),
   frameBounds: c.array({ title: 'Frame Bounds' }, c.array({ title: 'Bounds' }, { type: 'number' })),
+  rasterSheet: { type: 'string', format: 'image-file', title: 'Raster Sheet', description: 'Packed spritesheet image backing this animation instead of vector tweens.' },
+  rasterFrames: c.array({ title: 'Raster Frames', description: 'Per-frame source rects in the raster sheet: [x, y, w, h, regX, regY].' },
+    c.array({ title: 'Frame' }, { type: 'number' })),
+  framerate: { type: 'number', title: 'Framerate', description: 'Playback framerate for raster frames.' },
   shapes: c.array({}, {
     bn: { type: 'string', title: 'Block Name' },
     gn: { type: 'string', title: 'Global Name' },

--- a/app/templates/editor/thang/thang-type-edit-view.pug
+++ b/app/templates/editor/thang/thang-type-edit-view.pug
@@ -97,6 +97,12 @@ block outer_content
                 button(disabled=authorized === true ? undefined : "true").btn.btn-sm.btn-info#upload-button
                   span.glyphicon.glyphicon-upload
                   span.spl Upload Flash
+                button(disabled=authorized === true ? undefined : "true").btn.btn-sm.btn-info#upload-raster-image-button
+                  span.glyphicon.glyphicon-picture
+                  span.spl Upload Raster Image
+                button(disabled=authorized === true ? undefined : "true").btn.btn-sm.btn-info#upload-raster-animation-button
+                  span.glyphicon.glyphicon-film
+                  span.spl Upload Raster Anim
                 button(disabled=authorized === true ? undefined : "true").btn.btn-sm.btn-danger#clear-button
                   span.glyphicon.glyphicon-remove
                   span.spl Clear Data
@@ -115,6 +121,7 @@ block outer_content
                   button.reoptimize-btn.btn.btn-sm(type="button" disabled=authorized === true ? undefined : "true" data-containers="true" data-shapes="true") all
                 input#real-upload-button(type="file")
                 input#real-animate-upload-button(type="file", multiple=true)
+                input#real-raster-animation-json-input(type="file", accept=".json,application/json")
               #thang-type-file-size= fileSizeString
           div#thang-type-treema
           .clearfix

--- a/app/views/editor/thang/ThangTypeColorsTabView.js
+++ b/app/views/editor/thang/ThangTypeColorsTabView.js
@@ -217,6 +217,7 @@ module.exports = (ThangTypeColorsTabView = (function () {
       this.spriteBuilder.setOptions(options)
       this.spriteBuilder.buildColorMaps()
       this.movieClip = this.spriteBuilder.buildMovieClip(animation)
+      if (!this.movieClip) { return } // e.g. raster sheet not loaded yet
       const bounds = (this.movieClip.frameBounds != null ? this.movieClip.frameBounds[0] : undefined) != null ? (this.movieClip.frameBounds != null ? this.movieClip.frameBounds[0] : undefined) : this.movieClip.nominalBounds
       const larger = Math.min(400 / bounds.width, 400 / bounds.height)
       this.movieClip.scaleX = larger
@@ -239,6 +240,7 @@ module.exports = (ThangTypeColorsTabView = (function () {
       this.spriteBuilder.setOptions(options)
       this.spriteBuilder.buildColorMaps()
       this.container = this.spriteBuilder.buildContainerFromStore(idle.container)
+      if (!this.container) { return } // e.g. raster image not loaded yet
       const larger = Math.min(400 / this.container.bounds.width, 400 / this.container.bounds.height)
       this.container.scaleX = larger
       this.container.scaleY = larger

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -240,6 +240,10 @@ module.exports = (ThangTypeEditView = (function () {
         this.files = this.supermodel.loadCollection(new DocumentFiles(this.thangType), 'files').model
         return this.updateFileSize()
       })
+      this.listenTo(this.thangType, 'raster-raw-images-load-errored', (thangType, path) => {
+        // Otherwise a 404'd asset just renders a placeholder with no explanation.
+        noty({ text: `Raster image failed to load: /file/${_.escape(path)}`, type: 'error', timeout: 10000 })
+      })
     }
     //    @refreshAnimation = _.debounce @refreshAnimation, 500
 

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -673,7 +673,9 @@ module.exports = (ThangTypeEditView = (function () {
           result.push([x, y, frames.width, frames.height, frames.regX != null ? frames.regX : frames.width / 2, frames.regY != null ? frames.regY : frames.height / 2])
         }
       } else if (_.isObject(frames)) {
-        for (const key of _.keys(frames).sort()) {
+        // Natural sort: 'run_2' before 'run_10', matching artists' intent.
+        const naturally = (a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
+        for (const key of _.keys(frames).sort(naturally)) {
           const f = frames[key]
           if (f && f.frame) {
             const r = f.frame

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -541,9 +541,48 @@ module.exports = (ThangTypeEditView = (function () {
       return window.filepicker.pick({ mimetypes: ['image/png', 'image/webp'] }, callback)
     }
 
+    // Names of raw assets whose backing file is exactly this path.
+    rasterPathReferences (path) {
+      const raw = this.thangType.get('raw') || {}
+      const names = []
+      for (const [name, container] of _.pairs(raw.containers || {})) {
+        if (container.img === path) { names.push(name) }
+      }
+      for (const [name, animation] of _.pairs(raw.animations || {})) {
+        if (animation.rasterSheet === path) { names.push(name) }
+      }
+      return names
+    }
+
+    rasterFileExists (filename) {
+      const models = (this.files != null ? this.files.models : undefined) || []
+      return _.some(models, file => file.get('filename') === filename)
+    }
+
+    // Force-uploading a reused name would replace the bytes backing existing
+    // assets before any prompt — confirm the bulk update, or pick a fresh name.
+    chooseRasterFilename (desired) {
+      const filePath = `db/thang.type/${this.thangType.get('original')}`
+      const references = this.rasterPathReferences(`${filePath}/${desired}`)
+      if (references.length) {
+        const replaceAll = window.confirm(`'${desired}' already backs: ${references.join(', ')}.\nReplace the image for ALL of them (including past thang versions)?\nCancel stores your upload under a new name instead.`)
+        if (replaceAll) { return desired }
+      } else if (!this.rasterFileExists(desired)) {
+        return desired
+      }
+      const match = desired.match(/^(.*?)(\.[^.]*)?$/)
+      const base = match[1]
+      const ext = match[2] || ''
+      for (let n = 2; ; n++) {
+        const candidate = `${base}-${n}${ext}`
+        if (!this.rasterPathReferences(`${filePath}/${candidate}`).length && !this.rasterFileExists(candidate)) { return candidate }
+      }
+    }
+
     saveRasterFile (inkBlob) {
       // '#', '?' and '%' in a filename would truncate or misparse the /file/ image URL.
-      const filename = (inkBlob.filename || 'asset.png').replace(/[#?%]/g, '-')
+      const desired = (inkBlob.filename || 'asset.png').replace(/[#?%]/g, '-')
+      const filename = this.chooseRasterFilename(desired)
       const filePath = `db/thang.type/${this.thangType.get('original')}`
       return saveFile({ url: inkBlob.url, filename, mimetype: inkBlob.mimetype, path: filePath, force: true })
         .then(() => `${filePath}/${filename}`)

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -668,6 +668,10 @@ module.exports = (ThangTypeEditView = (function () {
         for (const f of frames) {
           if (_.isArray(f)) {
             const [x, y, w, h] = f
+            if (f[4]) {
+              // Single-sheet importer: a nonzero imageIndex references another image we don't have.
+              throw new Error(`frame references image index ${f[4]} — multi-image EaselJS sheets are not supported, repack to a single sheet`)
+            }
             result.push([x, y, w, h, f[5] != null ? f[5] : w / 2, f[6] != null ? f[6] : h / 2])
           } else if (f && f.frame) {
             rejectUnsupported(f)

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -583,6 +583,11 @@ module.exports = (ThangTypeEditView = (function () {
       let name = window.prompt(message, defaultName)
       if (!name) { return null }
       name = name.trim().replace(/\//g, '-') // slashes would corrupt treema paths
+      if (['__proto__', 'constructor', 'prototype'].includes(name)) {
+        // '__proto__' as a key mutates the raw object's prototype instead of adding an entry.
+        noty({ text: `'${_.escape(name)}' is a reserved name — pick another.`, type: 'error', timeout: 5000 })
+        return null
+      }
       return name || null
     }
 

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -526,13 +526,9 @@ module.exports = (ThangTypeEditView = (function () {
     }
 
     onClickUploadRasterAnimation () {
-      return this.pickRasterFile(inkBlob => {
-        return this.saveRasterFile(inkBlob).then(path => {
-          this.pendingRasterAnimation = { inkBlob, path }
-          noty({ text: 'Sheet uploaded. Now choose the frames JSON file.', type: 'information', timeout: 5000 })
-          return this.$el.find('input#real-raster-animation-json-input').click()
-        }).catch(error => noty({ text: `Raster upload failed: ${_.escape((error != null ? error.message : undefined) || error)}`, type: 'error', timeout: 10000 }))
-      })
+      // Frames JSON first (this click is the user gesture the native file
+      // dialog needs), then the filepicker modal for the sheet image.
+      return this.$el.find('input#real-raster-animation-json-input').click()
     }
 
     pickRasterFile (callback) {
@@ -602,37 +598,52 @@ module.exports = (ThangTypeEditView = (function () {
     async rasterAnimationJSONChosen (e) {
       const file = e.target.files[0]
       e.target.value = '' // allow re-selecting the same file later
-      const pending = this.pendingRasterAnimation
-      this.pendingRasterAnimation = null
-      if (!file || !pending) { return }
+      if (!file) { return }
+      let data
       try {
-        const text = await this.readFileAsText(file)
-        const data = JSON.parse(text)
-        const img = await this.loadRasterFileImage(pending.path)
-        this.cacheRasterRawImage(pending.path, img)
-        const sheetWidth = img.naturalWidth || img.width
-        const sheetHeight = img.naturalHeight || img.height
-        const { rasterFrames, framerate } = this.convertRasterFramesData(data, sheetWidth, sheetHeight)
-        if (!rasterFrames.length) { throw new Error('no frames found in JSON') }
-        const defaultName = (pending.inkBlob.filename || 'animation').replace(/\.[^.]+$/, '')
-        const name = this.promptRasterAssetName('Animation name for this raster sheet? Reference it from an action via animation: <name>.', defaultName)
-        if (!name) { return }
-        const raw = this.ensureRawData()
-        if (raw.animations[name] && !window.confirm(`Animation '${name}' already exists. Replace it?`)) { return }
-        const frameBounds = rasterFrames.map(([x, y, w, h, regX, regY]) => [-regX, -regY, w, h])
-        const left = _.min(frameBounds.map(b => b[0]))
-        const top = _.min(frameBounds.map(b => b[1]))
-        const right = _.max(frameBounds.map(b => b[0] + b[2]))
-        const bottom = _.max(frameBounds.map(b => b[1] + b[3]))
-        const entry = { bounds: [left, top, right - left, bottom - top], frameBounds, rasterSheet: pending.path, rasterFrames }
-        if (framerate) { entry.framerate = framerate }
-        raw.animations[name] = entry
-        this.fileLoaded()
-        return noty({ text: `Raster animation '${_.escape(name)}' added (${rasterFrames.length} frames).`, type: 'success', timeout: 5000 })
+        data = JSON.parse(await this.readFileAsText(file))
       } catch (error) {
-        console.error('Raster animation import failed:', error)
-        return noty({ text: `Raster animation import failed: ${_.escape((error != null ? error.message : undefined) || error)}`, type: 'error', timeout: 10000 })
+        return noty({ text: `Could not parse frames JSON: ${_.escape((error != null ? error.message : undefined) || error)}`, type: 'error', timeout: 10000 })
       }
+      noty({ text: 'Frames JSON loaded. Now choose the sheet image.', type: 'information', timeout: 5000 })
+      return this.pickRasterFile(inkBlob => {
+        return this.saveRasterFile(inkBlob)
+          .then(path => this.addRasterAnimation(data, inkBlob, path))
+          .catch(error => {
+            console.error('Raster animation import failed:', error)
+            return noty({ text: `Raster animation import failed: ${_.escape((error != null ? error.message : undefined) || error)}`, type: 'error', timeout: 10000 })
+          })
+      })
+    }
+
+    async addRasterAnimation (data, inkBlob, path) {
+      const img = await this.loadRasterFileImage(path)
+      this.cacheRasterRawImage(path, img)
+      const sheetWidth = img.naturalWidth || img.width
+      const sheetHeight = img.naturalHeight || img.height
+      const { rasterFrames, framerate } = this.convertRasterFramesData(data, sheetWidth, sheetHeight)
+      if (!rasterFrames.length) { throw new Error('no frames found in JSON') }
+      const defaultName = (inkBlob.filename || 'animation').replace(/\.[^.]+$/, '')
+      const name = this.promptRasterAssetName('Animation name for this raster sheet? Reference it from an action via animation: <name>.', defaultName)
+      if (!name) { return }
+      const raw = this.ensureRawData()
+      if (raw.animations[name] && !window.confirm(`Animation '${name}' already exists. Replace it?`)) { return }
+      const frameBounds = rasterFrames.map(([x, y, w, h, regX, regY]) => [-regX, -regY, w, h])
+      const left = _.min(frameBounds.map(b => b[0]))
+      const top = _.min(frameBounds.map(b => b[1]))
+      const right = _.max(frameBounds.map(b => b[0] + b[2]))
+      const bottom = _.max(frameBounds.map(b => b[1] + b[3]))
+      const entry = { bounds: [left, top, right - left, bottom - top], frameBounds, rasterSheet: path, rasterFrames }
+      if (framerate) { entry.framerate = framerate }
+      raw.animations[name] = entry
+      this.fileLoaded()
+      if (this.thangType.get('spriteType') !== 'singular') {
+        // Raster animations render only through the singular path; setting via
+        // treema (after fileLoaded synced raw) keeps model and treema in step.
+        this.treema.set('/spriteType', 'singular')
+        noty({ text: 'spriteType set to singular (required for raster animations).', type: 'information', timeout: 5000 })
+      }
+      return noty({ text: `Raster animation '${_.escape(name)}' added (${rasterFrames.length} frames).`, type: 'success', timeout: 5000 })
     }
 
     // Accepts EaselJS SpriteSheet frames (array of [x, y, w, h, imageIndex, regX, regY]

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -638,7 +638,7 @@ module.exports = (ThangTypeEditView = (function () {
       const right = _.max(frameBounds.map(b => b[0] + b[2]))
       const bottom = _.max(frameBounds.map(b => b[1] + b[3]))
       const entry = { bounds: [left, top, right - left, bottom - top], frameBounds, rasterSheet: path, rasterFrames }
-      if (framerate) { entry.framerate = framerate }
+      if (framerate != null) { entry.framerate = framerate }
       raw.animations[name] = entry
       this.fileLoaded()
       if (this.thangType.get('spriteType') !== 'singular') {

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -657,12 +657,18 @@ module.exports = (ThangTypeEditView = (function () {
       const framerate = data.framerate
       const frames = data.frames != null ? data.frames : data
       const result = []
+      const rejectUnsupported = f => {
+        // Silently importing these produces garbage crops / jittering frames.
+        if (f.rotated) { throw new Error("rotated frames are not supported — disable 'Allow rotation' in TexturePacker and re-export") }
+        if (f.trimmed) { throw new Error("trimmed frames are not supported — set Trim mode to 'None' in TexturePacker and re-export") }
+      }
       if (_.isArray(frames)) {
         for (const f of frames) {
           if (_.isArray(f)) {
             const [x, y, w, h] = f
             result.push([x, y, w, h, f[5] != null ? f[5] : w / 2, f[6] != null ? f[6] : h / 2])
           } else if (f && f.frame) {
+            rejectUnsupported(f)
             const r = f.frame
             result.push([r.x, r.y, r.w, r.h, r.w / 2, r.h / 2])
           }
@@ -682,6 +688,7 @@ module.exports = (ThangTypeEditView = (function () {
         for (const key of _.keys(frames).sort(naturally)) {
           const f = frames[key]
           if (f && f.frame) {
+            rejectUnsupported(f)
             const r = f.frame
             result.push([r.x, r.y, r.w, r.h, r.w / 2, r.h / 2])
           }

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -676,6 +676,10 @@ module.exports = (ThangTypeEditView = (function () {
           }
         }
       } else if (frames && frames.width && frames.height) {
+        if (sheetWidth % frames.width !== 0) {
+          // Columns are derived from the sheet width; padding makes the layout ambiguous.
+          throw new Error(`sheet width ${sheetWidth} is not a multiple of frame width ${frames.width} — grid format needs an unpadded sheet`)
+        }
         const cols = Math.max(1, Math.floor(sheetWidth / frames.width))
         const rows = Math.max(1, Math.floor(sheetHeight / frames.height))
         const count = frames.count || (cols * rows)

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -47,6 +47,7 @@ const RevertModal = require('views/modal/RevertModal')
 require('lib/game-libraries')
 
 const AnimateImporterWorker = require('./animate-import.worker.js')
+const initializeFilepicker = require('core/services/filepicker')
 
 const CENTER = { x: 200, y: 400 }
 
@@ -173,9 +174,12 @@ module.exports = (ThangTypeEditView = (function () {
         'click #clear-button': 'clearRawData',
         'click #upload-button' () { return this.$el.find('input#real-upload-button').click() },
         'click #upload-animate-button' () { return this.$el.find('input#real-animate-upload-button').click() },
+        'click #upload-raster-image-button': 'onClickUploadRasterImage',
+        'click #upload-raster-animation-button': 'onClickUploadRasterAnimation',
         'click #set-vector-icon': 'onClickSetVectorIcon',
         'change #real-upload-button': 'animationFileChosen',
         'change #real-animate-upload-button': 'animateAnimationFileChosen',
+        'change #real-raster-animation-json-input': 'rasterAnimationJSONChosen',
         'change #animations-select': 'showAnimation',
         'click #marker-button': 'toggleDots',
         'click #stop-button': 'stopAnimation',
@@ -509,6 +513,164 @@ module.exports = (ThangTypeEditView = (function () {
       const parser = new SpriteParser(this.thangType)
       parser.parse(result)
       return this.fileLoaded()
+    }
+
+    // raster upload
+
+    onClickUploadRasterImage () {
+      return this.pickRasterFile(inkBlob => {
+        return this.saveRasterFile(inkBlob)
+          .then(path => this.addRasterContainer(inkBlob, path))
+          .catch(error => noty({ text: `Raster upload failed: ${_.escape((error != null ? error.message : undefined) || error)}`, type: 'error', timeout: 10000 }))
+      })
+    }
+
+    onClickUploadRasterAnimation () {
+      return this.pickRasterFile(inkBlob => {
+        return this.saveRasterFile(inkBlob).then(path => {
+          this.pendingRasterAnimation = { inkBlob, path }
+          noty({ text: 'Sheet uploaded. Now choose the frames JSON file.', type: 'information', timeout: 5000 })
+          return this.$el.find('input#real-raster-animation-json-input').click()
+        }).catch(error => noty({ text: `Raster upload failed: ${_.escape((error != null ? error.message : undefined) || error)}`, type: 'error', timeout: 10000 }))
+      })
+    }
+
+    pickRasterFile (callback) {
+      initializeFilepicker()
+      return window.filepicker.pick({ mimetypes: ['image/png', 'image/webp'] }, callback)
+    }
+
+    saveRasterFile (inkBlob) {
+      const filePath = `db/thang.type/${this.thangType.get('original')}`
+      return new Promise((resolve, reject) => {
+        $.ajax('/file', {
+          type: 'POST',
+          data: { url: inkBlob.url, filename: inkBlob.filename, mimetype: inkBlob.mimetype, path: filePath, force: true },
+          success: () => resolve(`${filePath}/${inkBlob.filename}`),
+          error: jqxhr => reject(new Error((jqxhr.responseJSON != null ? jqxhr.responseJSON.message : undefined) || `upload failed (${jqxhr.status})`)),
+        })
+      })
+    }
+
+    loadRasterFileImage (path) {
+      return new Promise((resolve, reject) => {
+        const img = new Image()
+        img.crossOrigin = 'Anonymous'
+        img.onload = () => resolve(img)
+        img.onerror = () => reject(new Error(`could not load image /file/${path}`))
+        img.src = `/file/${path}`
+      })
+    }
+
+    cacheRasterRawImage (path, img) {
+      // Seed the model's raster image cache so preview/spritesheet builds
+      // don't need to wait for another network load.
+      if (this.thangType.rasterRawImages == null) { this.thangType.rasterRawImages = {} }
+      this.thangType.rasterRawImages[path] = img
+    }
+
+    ensureRawData () {
+      const raw = this.thangType.attributes.raw = this.thangType.attributes.raw || {}
+      if (raw.shapes == null) { raw.shapes = {} }
+      if (raw.containers == null) { raw.containers = {} }
+      if (raw.animations == null) { raw.animations = {} }
+      return raw
+    }
+
+    promptRasterAssetName (message, defaultName) {
+      let name = window.prompt(message, defaultName)
+      if (!name) { return null }
+      name = name.trim().replace(/\//g, '-') // slashes would corrupt treema paths
+      return name || null
+    }
+
+    async addRasterContainer (inkBlob, path) {
+      const defaultName = (inkBlob.filename || 'image').replace(/\.[^.]+$/, '')
+      const name = this.promptRasterAssetName('Container name for this raster image? Reference it from an action via container: <name>.', defaultName)
+      if (!name) { return }
+      const raw = this.ensureRawData()
+      if (raw.containers[name] && !window.confirm(`Container '${name}' already exists. Replace it?`)) { return }
+      const img = await this.loadRasterFileImage(path)
+      this.cacheRasterRawImage(path, img)
+      const w = img.naturalWidth || img.width
+      const h = img.naturalHeight || img.height
+      raw.containers[name] = { b: [-w / 2, -h / 2, w, h], img: path }
+      this.fileLoaded()
+      return noty({ text: `Raster image container '${_.escape(name)}' added (${w}×${h}).`, type: 'success', timeout: 5000 })
+    }
+
+    async rasterAnimationJSONChosen (e) {
+      const file = e.target.files[0]
+      e.target.value = '' // allow re-selecting the same file later
+      const pending = this.pendingRasterAnimation
+      this.pendingRasterAnimation = null
+      if (!file || !pending) { return }
+      try {
+        const text = await this.readFileAsText(file)
+        const data = JSON.parse(text)
+        const img = await this.loadRasterFileImage(pending.path)
+        this.cacheRasterRawImage(pending.path, img)
+        const sheetWidth = img.naturalWidth || img.width
+        const sheetHeight = img.naturalHeight || img.height
+        const { rasterFrames, framerate } = this.convertRasterFramesData(data, sheetWidth, sheetHeight)
+        if (!rasterFrames.length) { throw new Error('no frames found in JSON') }
+        const defaultName = (pending.inkBlob.filename || 'animation').replace(/\.[^.]+$/, '')
+        const name = this.promptRasterAssetName('Animation name for this raster sheet? Reference it from an action via animation: <name>.', defaultName)
+        if (!name) { return }
+        const raw = this.ensureRawData()
+        if (raw.animations[name] && !window.confirm(`Animation '${name}' already exists. Replace it?`)) { return }
+        const frameBounds = rasterFrames.map(([x, y, w, h, regX, regY]) => [-regX, -regY, w, h])
+        const left = _.min(frameBounds.map(b => b[0]))
+        const top = _.min(frameBounds.map(b => b[1]))
+        const right = _.max(frameBounds.map(b => b[0] + b[2]))
+        const bottom = _.max(frameBounds.map(b => b[1] + b[3]))
+        const entry = { bounds: [left, top, right - left, bottom - top], frameBounds, rasterSheet: pending.path, rasterFrames }
+        if (framerate) { entry.framerate = framerate }
+        raw.animations[name] = entry
+        this.fileLoaded()
+        return noty({ text: `Raster animation '${_.escape(name)}' added (${rasterFrames.length} frames).`, type: 'success', timeout: 5000 })
+      } catch (error) {
+        console.error('Raster animation import failed:', error)
+        return noty({ text: `Raster animation import failed: ${_.escape((error != null ? error.message : undefined) || error)}`, type: 'error', timeout: 10000 })
+      }
+    }
+
+    // Accepts EaselJS SpriteSheet frames (array of [x, y, w, h, imageIndex, regX, regY]
+    // arrays, or uniform grid {width, height, count, regX, regY}) and TexturePacker
+    // JSON (array or hash of {frame: {x, y, w, h}}). Registration defaults to frame center.
+    convertRasterFramesData (data, sheetWidth, sheetHeight) {
+      const framerate = data.framerate
+      const frames = data.frames != null ? data.frames : data
+      const result = []
+      if (_.isArray(frames)) {
+        for (const f of frames) {
+          if (_.isArray(f)) {
+            const [x, y, w, h] = f
+            result.push([x, y, w, h, f[5] != null ? f[5] : w / 2, f[6] != null ? f[6] : h / 2])
+          } else if (f && f.frame) {
+            const r = f.frame
+            result.push([r.x, r.y, r.w, r.h, r.w / 2, r.h / 2])
+          }
+        }
+      } else if (frames && frames.width && frames.height) {
+        const cols = Math.max(1, Math.floor(sheetWidth / frames.width))
+        const rows = Math.max(1, Math.floor(sheetHeight / frames.height))
+        const count = frames.count || (cols * rows)
+        for (let i = 0; i < count; i++) {
+          const x = (i % cols) * frames.width
+          const y = Math.floor(i / cols) * frames.height
+          result.push([x, y, frames.width, frames.height, frames.regX != null ? frames.regX : frames.width / 2, frames.regY != null ? frames.regY : frames.height / 2])
+        }
+      } else if (_.isObject(frames)) {
+        for (const key of _.keys(frames).sort()) {
+          const f = frames[key]
+          if (f && f.frame) {
+            const r = f.frame
+            result.push([r.x, r.y, r.w, r.h, r.w / 2, r.h / 2])
+          }
+        }
+      }
+      return { rasterFrames: result, framerate }
     }
 
     fileLoaded () {

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -541,12 +541,14 @@ module.exports = (ThangTypeEditView = (function () {
     }
 
     saveRasterFile (inkBlob) {
+      // '#', '?' and '%' in a filename would truncate or misparse the /file/ image URL.
+      const filename = (inkBlob.filename || 'asset.png').replace(/[#?%]/g, '-')
       const filePath = `db/thang.type/${this.thangType.get('original')}`
       return new Promise((resolve, reject) => {
         $.ajax('/file', {
           type: 'POST',
-          data: { url: inkBlob.url, filename: inkBlob.filename, mimetype: inkBlob.mimetype, path: filePath, force: true },
-          success: () => resolve(`${filePath}/${inkBlob.filename}`),
+          data: { url: inkBlob.url, filename, mimetype: inkBlob.mimetype, path: filePath, force: true },
+          success: () => resolve(`${filePath}/${filename}`),
           error: jqxhr => reject(new Error((jqxhr.responseJSON != null ? jqxhr.responseJSON.message : undefined) || `upload failed (${jqxhr.status})`)),
         })
       })

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -48,6 +48,7 @@ require('lib/game-libraries')
 
 const AnimateImporterWorker = require('./animate-import.worker.js')
 const initializeFilepicker = require('core/services/filepicker')
+const { saveFile } = require('core/api/files')
 
 const CENTER = { x: 200, y: 400 }
 
@@ -544,14 +545,8 @@ module.exports = (ThangTypeEditView = (function () {
       // '#', '?' and '%' in a filename would truncate or misparse the /file/ image URL.
       const filename = (inkBlob.filename || 'asset.png').replace(/[#?%]/g, '-')
       const filePath = `db/thang.type/${this.thangType.get('original')}`
-      return new Promise((resolve, reject) => {
-        $.ajax('/file', {
-          type: 'POST',
-          data: { url: inkBlob.url, filename, mimetype: inkBlob.mimetype, path: filePath, force: true },
-          success: () => resolve(`${filePath}/${filename}`),
-          error: jqxhr => reject(new Error((jqxhr.responseJSON != null ? jqxhr.responseJSON.message : undefined) || `upload failed (${jqxhr.status})`)),
-        })
-      })
+      return saveFile({ url: inkBlob.url, filename, mimetype: inkBlob.mimetype, path: filePath, force: true })
+        .then(() => `${filePath}/${filename}`)
     }
 
     loadRasterFileImage (path) {


### PR DESCRIPTION
The Thang Editor only accepted Adobe Animate vector `.js` exports. This adds an additive raster path: PNG/WebP images and pre-packed spritesheet animations usable through the normal action system, with no changes to existing vector, legacy-raster, or prerendered thangs.

## How it works
- Raster image → `raw.containers[name] = {b, img}` → `Action → container: <name>`
- Raster animation → `raw.animations[name] = {bounds, frameBounds, rasterSheet, rasterFrames}` → `Action → animation: <name>`; per-action `frames`/`loops`/`goesTo`/`framerate`/`scale` work as with vector assets, so one atlas can back several actions
- Frames JSON: TexturePacker (Array/Hash) or EaselJS (arrays / uniform grid); frame registration defaults to center
- Two new editor buttons (Upload Raster Image / Upload Raster Anim) upload via the existing filepicker + `/file` flow; JSON is picked first, then the sheet
- SpriteBuilder renders raster entries into the auto spritesheet (Bitmap container; `_off`-tween MovieClip per createjs's documented pattern); LayerAdapter preloads referenced images before builds
- Raster animations force the singular render path (segmented rebuilds vector tweens and can't represent them); editor auto-sets `spriteType: singular`
- SpriteOptimizer keeps raster container names and skips them in dedupe/rename

## Backward compatibility
All new fields are optional and additive; every new branch is dormant unless a thang carries them. Legacy `raster`, `prerenderedSpriteSheetData`, and Ozaria `rasterAtlas` paths untouched. Server validates via the shared client schema — no server-repo changes.

## Testing
- Verified live in the editor and level surface: static raster container and multi-frame raster animation both render, save, and reload correctly
- Vendor createjs contracts (SpriteSheetBuilder.addFrame/addMovieClip, MovieClip `_off` management) checked against source
- webpack build clean; coffee/js/pug syntax checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for raster images as containers and animated sprites.
  - Added editor controls for uploading raster images and importing raster animation data.
  - Added spritesheet frame bounds, playback speed, and scaled animation rendering.
  - Raster assets now load asynchronously before rendering, with automatic retry behavior.
  - Added validation and error notifications for invalid or unavailable raster assets.

- **Bug Fixes**
  - Prevented incomplete sprites from rendering when required raster assets are unavailable.
  - Preserved raster containers during sprite optimization.
  - Improved animation timing using imported playback settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->