### PR TITLE
hide cyber modal after 9.30

### DIFF
--- a/app/views/ai/CybersecurityAutoPromotion.vue
+++ b/app/views/ai/CybersecurityAutoPromotion.vue
@@ -12,7 +12,7 @@ export default {
   computed: {
     showPromotion () {
       const aweekago = dayjs().subtract(1, 'week')
-      return utils.isCodeCombat && aweekago.isAfter(me.get('dateCreated'))
+      return utils.isCodeCombat && aweekago.isAfter(me.get('dateCreated')) && dayjs().isBefore('2026-09-30')
     },
   },
   methods: {


### PR DESCRIPTION
fix ENG-2700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the cybersecurity promotion to stop displaying after September 30, 2026.
  * Existing eligibility conditions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->