### PR TITLE
[GD-890] Move AI chat icon onto the playback bar

### DIFF
--- a/app/styles/play/level/level-playback-view.sass
+++ b/app/styles/play/level/level-playback-view.sass
@@ -158,13 +158,40 @@
         // Don't load jQuery UI background image here
         background: transparent none
 
-// AI chat icon (LevelChatView) sits absolutely at bottom-left over the playback bar,
-// ending at ~x59px incl. hover scale; shift the timeline start clear of it.
+// AI chat icon (LevelChatView) is re-parented onto this bar so it follows the
+// timeline in every layout; play button and scrubber start shift clear of it.
+#playback-view .ai-helper-chat-icon
+  position: absolute
+  left: 16px
+  top: 23px  // centers the 24px icon on the scrubber's vertical middle (y35)
+  line-height: 0  // no inline baseline gap: button is exactly the img's 24px
+  display: none
+  cursor: pointer
+  transition: transform 0.2s ease-in-out
+  pointer-events: auto  // clickable even when .controls-disabled cuts bar input
+  background: none
+  border: none
+  padding: 0
+  margin: 0
+  outline: none
+  // Counter the generic "#playback-view button" opacity/hover-background rules
+  @include opacity(1)
+  &:hover
+    background: none
+    transform: scale(1.1)
+  &:focus
+    outline: none
+  img
+    display: block
+    width: 24px
+    height: 24px
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3))
+
 #level-view.ai-chat-icon-shown #playback-view
   #play-button
-    margin-left: 65px
+    margin-left: 46px
   .scrubber
-    left: 115px
+    left: 100px
 
 body.ipad #playback-view
   // Counteract 50px height of absolutely positioned control bar, but overlap by 20px of jagged transparent top.

--- a/app/views/play/level/LevelChatView.coffee
+++ b/app/views/play/level/LevelChatView.coffee
@@ -72,9 +72,16 @@ module.exports = class LevelChatView extends CocoView
     @chatTables = $('.table', @$el)
     #@updateMultiplayerVisibility()
     @$el.toggle @visible
-    @$('.ai-helper-chat-icon').toggle @visible
-    # Playback timeline makes room for the chat icon so they don't overlap
-    @$el.closest('#level-view').toggleClass 'ai-chat-icon-shown', @visible
+    @$aiIcon?.remove()  # previous render may have re-parented it outside @$el
+    @$aiIcon = @$('.ai-helper-chat-icon')
+    @$aiIcon.toggle @visible
+    # Move the icon onto the playback bar so it tracks the timeline in every
+    # layout; delegated events don't reach it there, so bind click directly.
+    playbackView = @$el.closest('#level-view').find('#playback-view')
+    onPlaybackBar = @visible and playbackView.length > 0
+    if onPlaybackBar
+      @$aiIcon.appendTo(playbackView).on 'click', (e) => @onAIHelperChatClick(e)
+    @$el.closest('#level-view').toggleClass 'ai-chat-icon-shown', onPlaybackBar
     @onWindowResize {}
 
   regularlyClearOldMessages: ->
@@ -511,5 +518,6 @@ module.exports = class LevelChatView extends CocoView
     key.deleteScope('level')
     clearInterval @clearOldMessagesInterval if @clearOldMessagesInterval
     $(window).off 'resize', @onWindowResize
+    @$aiIcon?.remove()
     @$el.closest('#level-view').removeClass 'ai-chat-icon-shown'
     super()

--- a/app/views/play/level/LevelChatView.coffee
+++ b/app/views/play/level/LevelChatView.coffee
@@ -77,8 +77,10 @@ module.exports = class LevelChatView extends CocoView
     @$aiIcon.toggle @visible
     # Move the icon onto the playback bar so it tracks the timeline in every
     # layout; delegated events don't reach it there, so bind click directly.
+    # #playback-view is an empty placeholder when LevelPlaybackView doesn't
+    # render (web-dev levels), so check for its play button, not the div.
     playbackView = @$el.closest('#level-view').find('#playback-view')
-    onPlaybackBar = @visible and playbackView.length > 0
+    onPlaybackBar = @visible and playbackView.find('#play-button').length > 0
     if onPlaybackBar
       @$aiIcon.appendTo(playbackView).on 'click', (e) => @onAIHelperChatClick(e)
     @$el.closest('#level-view').toggleClass 'ai-chat-icon-shown', onPlaybackBar


### PR DESCRIPTION
Re-parent the icon from LevelChatView into #playback-view so it tracks the timeline in every layout (narrow layouts anchor #level-chat-view far below the bar). Direct click binding since delegated events no longer reach it; falls back to the old corner position when there is no playback bar (web-dev levels).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved placement of the AI chat icon on the playback bar.
  * Added hover, sizing, visibility, and interaction styling for the chat icon.

* **Bug Fixes**
  * Improved playback bar spacing and layout when chat is visible.
  * Ensured the chat icon appears in the correct location across supported playback views.
  * Prevented duplicate or misplaced chat icons from appearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->