### PR TITLE
[GD-855] Locale keys for the HackStack credit hint

### DIFF
--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -6823,7 +6823,7 @@ module.exports = {
       hint_output: 'Open Output to see and test results.',
       hint_choice: 'Choose a response to continue.',
       hint_prompt_input: 'Tell HackStack what to do.',
-      hint_prompt_credit: 'Each prompt uses 1 credit — make it count.',
+      hint_prompt_credit: 'Each prompt uses 1 credit —\nmake it count.',
       ready_to_review_helptext: 'Mark this when your project is complete. Your teacher will then see it as ready to review on their side.',
       ready_to_review_confirm_text: 'Ready to Submit? Click OK to notify your teacher to review your project.',
       no_course_instances: 'You do not have any course instances. Please contact your teacher to get access to the AI Hackstack.',

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -6823,7 +6823,7 @@ module.exports = {
       hint_output: 'Open Output to see and test results.',
       hint_choice: 'Choose a response to continue.',
       hint_prompt_input: 'Tell HackStack what to do.',
-      hint_prompt_credit: 'Each prompt uses 1 credit —\nmake it count.',
+      hint_prompt_credit: 'Each prompt uses 1 credit.\nMake it count.',
       ready_to_review_helptext: 'Mark this when your project is complete. Your teacher will then see it as ready to review on their side.',
       ready_to_review_confirm_text: 'Ready to Submit? Click OK to notify your teacher to review your project.',
       no_course_instances: 'You do not have any course instances. Please contact your teacher to get access to the AI Hackstack.',

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -6619,7 +6619,7 @@ module.exports = {
       'AlternatePromptChoicesForm_save-choices': 'Save Choices',
       App_alt: '',
       App_loading: 'Loading...',
-      'ChatInputForm_enter-your-prompt-here': 'enter your prompt here',
+      'ChatInputForm_enter-your-prompt-here': 'Tell HackStack what to do…',
       'ChatLayout_tw-fixed-tw-inset-0-tw-z-30-tw-bg-black5': 'tw-fixed tw-inset-0 tw-z-30 tw-bg-black/50 tw-transition-opacity tw-duration-300 tw-ease-in-out md:tw-hidden',
       'ChatMessage_are-you-sure-you-want-to-delete-this-mes': 'Are you sure you want to Delete this Message?',
       ChatMessage_delete: 'Delete',

--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -6823,6 +6823,7 @@ module.exports = {
       hint_output: 'Open Output to see and test results.',
       hint_choice: 'Choose a response to continue.',
       hint_prompt_input: 'Tell HackStack what to do.',
+      hint_prompt_credit: 'Each prompt uses 1 credit — make it count.',
       ready_to_review_helptext: 'Mark this when your project is complete. Your teacher will then see it as ready to review on their side.',
       ready_to_review_confirm_text: 'Ready to Submit? Click OK to notify your teacher to review your project.',
       no_course_instances: 'You do not have any course instances. Please contact your teacher to get access to the AI Hackstack.',


### PR DESCRIPTION
## What

Locale side of the HackStack credit hint (companion to codecombat/hackstack#469; repos deploy together).

- Adds `hackstack.hint_prompt_credit`: **"Each prompt uses 1 credit — make it count."** — headline for the new one-shot credit hint.
- Keeps `hackstack.hint_prompt_input` untouched: its hint is silenced on the hackstack side, and the key stays for analysis continuity.
- Repurposes the chat input placeholder (`ChatInputForm_enter-your-prompt-here`) from "enter your prompt here" to "Tell HackStack what to do…" — the retired hint's guidance lives on as the placeholder. The key is used only by the HackStack chat input; other locales keep their existing translation until the next i18n pass (stale copy, not a parity break — no keys removed).

## Testing

Pre-commit eslint-changed passed on both commits; keys added/edited in place, no removals, so no locale-mirror surgery needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **User Experience**
  * Updated the prompt input placeholder with clearer, direct instructions.
  * Added a hint explaining that each prompt uses one credit.
  * Improved credit hint readability by displaying it across two lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->