### PR TITLE
change order of oz and hs in courses

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -436,8 +436,7 @@ const WD_COURSE_IDS = [
   allCourseIDs.WEB_DEVELOPMENT_2,
 ]
 
-const freeCocoCourseIDs = [allCourseIDs.JUNIOR, allCourseIDs.INTRODUCTION_TO_COMPUTER_SCIENCE, allCourseIDs.INTRO_TO_AI]
-const allFreeCourseIDs = [...freeCocoCourseIDs, allCourseIDs.CHAPTER_ONE]
+const allFreeCourseIDs = [allCourseIDs.JUNIOR, allCourseIDs.INTRODUCTION_TO_COMPUTER_SCIENCE, allCourseIDs.CHAPTER_ONE, allCourseIDs.INTRO_TO_AI]
 
 const courseNumericalStatus = {};
 (function () {

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -2007,7 +2007,6 @@ module.exports = {
   otherCourseIDs,
   allCourseIDs,
   allFreeCourseIDs,
-  freeCocoCourseIDs,
   courseNumericalStatus,
   coursesWithProjects,
   CSCourseIDs,

--- a/ozaria/site/components/teacher-dashboard/modals/edit-class-components-v2/CourseSelect.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/edit-class-components-v2/CourseSelect.vue
@@ -68,9 +68,9 @@ export default {
       if (!this.isCodeCombat) {
         return []
       }
-      const freeCocoCourseIDs = [...utils.freeCocoCourseIDs, utils.OZ_COURSE_IDS_MAP.CHAPTER_ONE]
+      const freeCourseIDs = utils.allFreeCourseIDs
       return [
-        ...freeCocoCourseIDs.map(id => {
+        ...freeCourseIDs.map(id => {
           const course = this.courses.find(({ _id }) => _id === id)
           if (!course) {
             // computed value uses in template before mounted, so no courses yet

--- a/ozaria/site/components/teacher-dashboard/modals/modal-edit-class-components/CourseCodeLanguageFormatComponent.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/modal-edit-class-components/CourseCodeLanguageFormatComponent.vue
@@ -323,7 +323,7 @@ export default {
       if (!this.isCodeCombat) {
         return []
       }
-      const freeCocoCourseIDs = [...utils.freeCocoCourseIDs, utils.OZ_COURSE_IDS_MAP.CHAPTER_ONE]
+      const freeCocoCourseIDs = utils.allFreeCourseIDs
       return [
         ...freeCocoCourseIDs.map(id => {
           const course = this.courses.find(({ _id }) => _id === id)


### PR DESCRIPTION
<img width="529" height="493" alt="Screenshot 2026-09-01 at 4 56 21 PM" src="https://github.com/user-attachments/assets/29c47b56-9def-4c8d-af88-660670244073" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated free-course listings to consistently include Junior, Introduction to Computer Science, Chapter One, and Intro to AI courses.
  * Improved course selection in class-editing dialogs by using a unified set of available free courses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->