### PR TITLE
update license presets

### DIFF
--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -18,10 +18,16 @@ const OZARIA_COURSE_IDS = [
 ]
 
 const LICENSE_PRESETS = {
-  'COCO-OLD(No HS, OZ)': [
+  'Coding License(JR, CC, OZ)': [
+    ...utils.JUNIOR_COURSE_IDS,
+    ...utils.COCO_COURSE_IDS,
+    ...OZARIA_COURSE_IDS,
+  ],
+  'CodeCombat(CS, WD, GD, JR)': [
     ...utils.COCO_COURSE_IDS,
     ...utils.JUNIOR_COURSE_IDS,
   ],
+  Ozaria: OZARIA_COURSE_IDS,
   'CS1+CS2+GD1+WD1': STARTER_LICENSE_COURSE_IDS,
   'CS1+GD1+WD1+JR': [
     '560f1a9f22961295f9427742', // Introduction to Computer Science
@@ -57,7 +63,6 @@ const LICENSE_PRESETS = {
     '5789587aad86a6efb573701e', // Game Development 1
     '57b621e7ad86a6efb5737e64' // GD 2
   ],
-  'CH1+CH2+CH3+CH4(OZ only)': OZARIA_COURSE_IDS
 }
 
 const FREE_COURSE_IDS = [

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -1965,10 +1965,10 @@ module.exports.courseDescription = (includedCourseIDs, credit = undefined) => {
     if (credit && courseSame(includedCourseIDs, hsCourses)) {
       return $.i18n.t('teacher.hackstack_license') + $.i18n.t('teacher.hackstack_credits', credit)
     }
-    if (courseSame(includedCourseIDs, LICENSE_PRESETS['COCO-OLD(No HS, OZ)'])) {
+    if (courseSame(includedCourseIDs, LICENSE_PRESETS['CodeCombat(CS, WD, GD, JR)'])) {
       return $.i18n.t('teacher.coco_full_license')
     }
-    if (courseSame(includedCourseIDs, LICENSE_PRESETS['CH1+CH2+CH3+CH4(OZ only)'])) {
+    if (courseSame(includedCourseIDs, LICENSE_PRESETS['Ozaria'])) {
       return $.i18n.t('teacher.ozar_full_license')
     }
     return $.i18n.t('teacher.customized_license') + ': ' + (includedCourseIDs.map(id => courseAcronyms[id])).join('+')


### PR DESCRIPTION
fix ENG-2744
<img width="740" height="833" alt="image" src="https://github.com/user-attachments/assets/260269eb-e863-46d5-a2c6-b8e66af38e3e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added license presets for Coding License, CodeCombat, and Ozaria.
  * Updated course descriptions to recognize the new CodeCombat and Ozaria full-license presets.

* **Updates**
  * Renamed an existing CodeCombat license preset for clearer identification.
  * Removed the obsolete Ozaria chapter-based license preset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->