### PR TITLE
rmeove cpp/java in ozaria course

### DIFF
--- a/ozaria/site/components/teacher-dashboard/modals/edit-class-components-v2/CodeLanguageFormatSelect.vue
+++ b/ozaria/site/components/teacher-dashboard/modals/edit-class-components-v2/CodeLanguageFormatSelect.vue
@@ -214,6 +214,9 @@ export default {
     enableBlocks () {
       return this.hasJunior && ['python', 'javascript'].includes(this.codeLanguage || 'python')
     },
+    hasOzaria () {
+      return this.courses.includes(utils.allCourseIDs.CHAPTER_ONE)
+    },
     hasJunior () {
       return this.hasCourse(utils.courseIDs.JUNIOR)
     },
@@ -257,6 +260,10 @@ export default {
         for (const lang of Object.values(languages)) {
           lang.disabled = true
         }
+      }
+      if (this.hasOzaria) {
+        delete languages.cpp
+        delete languages.java
       }
 
       return Object.values(languages)


### PR DESCRIPTION
<img width="689" height="282" alt="image" src="https://github.com/user-attachments/assets/8335012b-430a-454d-a5bf-1bc36adb1e25" />
fix ENG-2728

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * For classes including Chapter One courses, C++ and Java are no longer available as selectable coding languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->