### PR TITLE
include other should not enabled for classroom kind

### DIFF
--- a/app/views/outcomes-report/PageOutcomesReport.vue
+++ b/app/views/outcomes-report/PageOutcomesReport.vue
@@ -27,7 +27,7 @@ const parameterDefaults = () => ({
   startDate: null,
   endDate: moment(new Date()).format('YYYY-MM-DD'),
   editing: me.isAdmin(),
-  includeOther: true,
+  includeOther: false,
   showOther: true,
 })
 
@@ -139,13 +139,18 @@ export default {
 
   created () {
     this.kind = this.$route.params.kind || null
+    if (this.kind !== 'classroom') {
+      this.includeOther = true
+    }
     this.orgIdOrSlug = this.$route.params.idOrSlug || null
     this.country = this.$route.params.country || null
     this.fetchCourses()
     if (me.isInternal() || me.isAdmin()) {
       this.showLicenseSummary = true
     }
-    this.fetchOtherCourses(this.otherProduct)
+    if (this.includeOther) {
+      this.fetchOtherCourses(this.otherProduct)
+    }
   },
 
   mounted () {


### PR DESCRIPTION
fix ENG-2758

<img width="1880" height="1136" alt="image" src="https://github.com/user-attachments/assets/1d0bd784-eefe-4f50-b146-1060baab44a7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Classroom outcomes reports no longer include “Other” courses by default.
  * Other-course data is fetched only when the “Other” option is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->