### PR TITLE
[GD-832] Hub map plays the rpg campaign's ambient sound, menu music as fallback

### DIFF
--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -182,6 +182,7 @@ class CampaignView extends RootView {
     if (!this.terrain) {
       this.campaigns = this.supermodel.loadCollection(new CampaignsCollection(), 'campaigns', null, 1).model
       this.listenToOnce(this.campaigns, 'sync', this.onCampaignsLoaded)
+      this.loadHubCampaign()
       return
     }
     if (this.terrain) {
@@ -1819,9 +1820,23 @@ class CampaignView extends RootView {
   }
 
   onCampaignsLoaded (e) {
-    this.hubCampaign = this.campaigns.get(HUB_CAMPAIGN_ID)
-    this.playHubMusic()
     return this.render()
+  }
+
+  loadHubCampaign () {
+    // The overworld list only carries hero campaigns and a slim projection, so the hub campaign gets its own fetch.
+    // Kept outside the supermodel: the hub must still render if that campaign is ever missing.
+    const hubCampaign = new Campaign({ _id: HUB_CAMPAIGN_ID })
+    this.listenToOnce(hubCampaign, 'sync', () => {
+      this.stopListening(hubCampaign)
+      this.hubCampaign = hubCampaign
+      this.playHubMusic()
+    })
+    this.listenToOnce(hubCampaign, 'error', () => {
+      this.stopListening(hubCampaign)
+      this.playHubMusic()
+    })
+    hubCampaign.fetch()
   }
 
   preloadLevel (levelSlug) {

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -58,6 +58,10 @@ const SCENARIO_MARGIN_COMPENSATION_FACTOR = 0.33 // Compensates for bottom margi
 const COMPLETE_STATUS = 'complete'
 const STARTED_STATUS = 'started'
 
+// The hub map (/play with no campaign slug) has no campaign document of its own, so hub-level settings such as
+// ambientSound come from this campaign. Referenced by id: campaign slugs re-derive from `name` on every save.
+const HUB_CAMPAIGN_ID = '6a9fe655540e9017bfb987df' // rpg
+
 class LevelSessionsCollection extends CocoCollection {
   static initClass () {
     this.prototype.url = ''
@@ -178,14 +182,6 @@ class CampaignView extends RootView {
     if (!this.terrain) {
       this.campaigns = this.supermodel.loadCollection(new CampaignsCollection(), 'campaigns', null, 1).model
       this.listenToOnce(this.campaigns, 'sync', this.onCampaignsLoaded)
-      this.probablyCachedMusic = storage.load('loaded-menu-music')
-      const musicDelay = this.probablyCachedMusic ? 1000 : 10000
-      const delayMusicStart = () => setTimeout(() => {
-        if (!this.destroyed) {
-          this.playMusic()
-        }
-      }, musicDelay)
-      this.playMusicTimeout = delayMusicStart()
       return
     }
     if (this.terrain) {
@@ -1823,6 +1819,8 @@ class CampaignView extends RootView {
   }
 
   onCampaignsLoaded (e) {
+    this.hubCampaign = this.campaigns.get(HUB_CAMPAIGN_ID)
+    this.playHubMusic()
     return this.render()
   }
 
@@ -2079,7 +2077,7 @@ class CampaignView extends RootView {
   playAmbientSound () {
     if (!me.get('volume')) { return }
     if (this.ambientSound) { return }
-    const file = this.campaign?.get('ambientSound')?.[AudioPlayer.ext.substr(1)]
+    const file = this.getAmbientSoundFile()
     if (!file) { return }
     const src = `/file/${file}`
     if (!AudioPlayer.getStatus(src)?.loaded) {
@@ -2094,6 +2092,25 @@ class CampaignView extends RootView {
     }
     this.ambientSound = createjs.Sound.play(src, { loop: -1, volume: 0.1 })
     createjs.Tween.get(this.ambientSound).to({ volume: 0.5 }, 1000)
+  }
+
+  getAmbientSoundFile () {
+    const campaign = this.campaign || this.hubCampaign
+    return campaign?.get('ambientSound')?.[AudioPlayer.ext.substr(1)]
+  }
+
+  playHubMusic () {
+    if (this.getAmbientSoundFile()) {
+      return this.playAmbientSound()
+    }
+    // No hub track configured: fall back to the menu music, delayed so it doesn't compete with initial asset loading.
+    this.probablyCachedMusic = storage.load('loaded-menu-music')
+    const musicDelay = this.probablyCachedMusic ? 1000 : 10000
+    this.playMusicTimeout = setTimeout(() => {
+      if (!this.destroyed) {
+        this.playMusic()
+      }
+    }, musicDelay)
   }
 
   playMusic () {

--- a/test/app/views/play/CampaignView.spec.coco.js
+++ b/test/app/views/play/CampaignView.spec.coco.js
@@ -261,4 +261,52 @@ describe('CampaignView', () => describe('when 4 earned levels', function () {
       expect(this.campaignView.showRobloxModal).not.toHaveBeenCalled()
     })
   })
+
+  describe('hub music', function () {
+    const HUB_CAMPAIGN_ID = '6a9fe655540e9017bfb987df'
+    const ambientSound = name => ({ mp3: `db/campaign/x/${name}.mp3`, ogg: `db/campaign/x/${name}.ogg` })
+
+    beforeEach(function () {
+      jasmine.clock().install()
+      this.campaignView = new CampaignView()
+      spyOn(this.campaignView, 'render')
+      spyOn(this.campaignView, 'playAmbientSound')
+      spyOn(this.campaignView, 'playMusic')
+    })
+
+    afterEach(function () {
+      jasmine.clock().uninstall()
+    })
+
+    it('plays the hub campaign ambient sound instead of the menu music', function () {
+      this.campaignView.campaigns.reset([
+        factories.makeCampaign({ ambientSound: ambientSound('other') }),
+        factories.makeCampaign({ _id: HUB_CAMPAIGN_ID, ambientSound: ambientSound('hub') }),
+      ])
+      this.campaignView.onCampaignsLoaded()
+
+      expect(this.campaignView.getAmbientSoundFile()).toMatch(/\/hub\.(mp3|ogg)$/)
+      expect(this.campaignView.playAmbientSound).toHaveBeenCalled()
+      jasmine.clock().tick(10001)
+      expect(this.campaignView.playMusic).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the menu music when the hub campaign has no ambient sound', function () {
+      this.campaignView.campaigns.reset([factories.makeCampaign({ _id: HUB_CAMPAIGN_ID })])
+      this.campaignView.onCampaignsLoaded()
+
+      expect(this.campaignView.playAmbientSound).not.toHaveBeenCalled()
+      jasmine.clock().tick(10001)
+      expect(this.campaignView.playMusic).toHaveBeenCalled()
+    })
+
+    it('falls back to the menu music when the hub campaign is not in the list', function () {
+      this.campaignView.campaigns.reset([factories.makeCampaign({ ambientSound: ambientSound('other') })])
+      this.campaignView.onCampaignsLoaded()
+
+      expect(this.campaignView.playAmbientSound).not.toHaveBeenCalled()
+      jasmine.clock().tick(10001)
+      expect(this.campaignView.playMusic).toHaveBeenCalled()
+    })
+  })
 }))

--- a/test/app/views/play/CampaignView.spec.coco.js
+++ b/test/app/views/play/CampaignView.spec.coco.js
@@ -265,6 +265,11 @@ describe('CampaignView', () => describe('when 4 earned levels', function () {
   describe('hub music', function () {
     const HUB_CAMPAIGN_ID = '6a9fe655540e9017bfb987df'
     const ambientSound = name => ({ mp3: `db/campaign/x/${name}.mp3`, ogg: `db/campaign/x/${name}.ogg` })
+    const hubCampaignRequest = () => _.last(jasmine.Ajax.requests.filter(new RegExp(`/db/campaign/${HUB_CAMPAIGN_ID}`)))
+    const respondWithHubCampaign = attrs => hubCampaignRequest().respondWith({
+      status: 200,
+      responseText: JSON.stringify(_.extend({ _id: HUB_CAMPAIGN_ID, slug: 'rpg' }, attrs)),
+    })
 
     beforeEach(function () {
       jasmine.clock().install()
@@ -278,12 +283,12 @@ describe('CampaignView', () => describe('when 4 earned levels', function () {
       jasmine.clock().uninstall()
     })
 
+    it('fetches the hub campaign on its own, since the overworld list does not include it', function () {
+      expect(hubCampaignRequest()).toBeDefined()
+    })
+
     it('plays the hub campaign ambient sound instead of the menu music', function () {
-      this.campaignView.campaigns.reset([
-        factories.makeCampaign({ ambientSound: ambientSound('other') }),
-        factories.makeCampaign({ _id: HUB_CAMPAIGN_ID, ambientSound: ambientSound('hub') }),
-      ])
-      this.campaignView.onCampaignsLoaded()
+      respondWithHubCampaign({ ambientSound: ambientSound('hub') })
 
       expect(this.campaignView.getAmbientSoundFile()).toMatch(/\/hub\.(mp3|ogg)$/)
       expect(this.campaignView.playAmbientSound).toHaveBeenCalled()
@@ -292,17 +297,15 @@ describe('CampaignView', () => describe('when 4 earned levels', function () {
     })
 
     it('falls back to the menu music when the hub campaign has no ambient sound', function () {
-      this.campaignView.campaigns.reset([factories.makeCampaign({ _id: HUB_CAMPAIGN_ID })])
-      this.campaignView.onCampaignsLoaded()
+      respondWithHubCampaign({})
 
       expect(this.campaignView.playAmbientSound).not.toHaveBeenCalled()
       jasmine.clock().tick(10001)
       expect(this.campaignView.playMusic).toHaveBeenCalled()
     })
 
-    it('falls back to the menu music when the hub campaign is not in the list', function () {
-      this.campaignView.campaigns.reset([factories.makeCampaign({ ambientSound: ambientSound('other') })])
-      this.campaignView.onCampaignsLoaded()
+    it('falls back to the menu music when the hub campaign fails to load', function () {
+      hubCampaignRequest().respondWith({ status: 404, responseText: JSON.stringify({}) })
 
       expect(this.campaignView.playAmbientSound).not.toHaveBeenCalled()
       jasmine.clock().tick(10001)


### PR DESCRIPTION
## Summary
- `/play` hub now takes its music from the `rpg` campaign's `ambientSound` (campaign `6a9fe655540e9017bfb987df`), through the same `playAmbientSound` path campaign pages use: preload, autoplay-gesture wait, loop, fade-in.
- The hub campaign is fetched on its own (`loadHubCampaign`), outside the supermodel. The overworld list only carries hero-type campaigns with a slim projection, so `rpg` is never in it, and a missing document must not block the hub render.
- `/music/music-menu` stays as the fallback only when that campaign has no ambient sound or fails to load. The decision waits for that fetch instead of a fixed 1s/10s timer, so we never start one track and swap to another.
- Other campaign pages are unaffected: they play their own `ambientSound` or stay silent.
- Constant is `HUB_CAMPAIGN_ID` (by id, since slugs re-derive from `name`); the hub has no campaign doc of its own, so future hub-level settings can read from the same campaign via `this.hubCampaign`.

## Test plan
- [x] Karma: 4 new specs in `CampaignView.spec.coco.js` through jasmine.Ajax (hub campaign request is issued; 200 with a track plays it and menu music never fires; 200 without a track falls back; 404 falls back). Full suite green, 7364 specs.
- [x] Manual on this branch: open `/play`, expect the rpg campaign track (currently "00 - Islands of Wonder") looping after the first click/keypress; mute then unmute restarts it; a campaign page such as `/play/dungeon` still plays its own track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Hub campaigns are fetched independently when they are not included in overworld campaign data.
  - Hub music uses the hub campaign’s configured ambient sound when available.
  - Campaign ambient audio is selected from the active campaign or hub campaign, as applicable.

- **Bug Fixes**
  - Menu music now provides a fallback when hub ambient audio is unavailable or the hub campaign fails to load.

- **Tests**
  - Added coverage for hub campaign loading, ambient playback, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->