### PR TITLE
[GD-899] Campaign editor: compact level markers, hover card, player-flags toggle

### DIFF
--- a/app/locale/en.js
+++ b/app/locale/en.js
@@ -3292,6 +3292,7 @@ module.exports = {
       achievement_query_goals: 'Key achievement off of level goals',
       level_completion: 'Level Completion',
       pop_i18n: 'Populate I18N',
+      campaign_show_player_flags: 'Show player-facing level flags',
       ai_translate: 'AI Translate',
       tasks: 'Tasks',
       clear_storage: 'Clear your local changes',

--- a/app/styles/editor/campaign/campaign-editor-view.sass
+++ b/app/styles/editor/campaign/campaign-editor-view.sass
@@ -1,3 +1,11 @@
+@use "sass:math"
+
+// Matches the map aspect used by app/styles/play/campaign-view.sass.
+$mapHeight: 1280
+$mapWidth: 1920
+$compactDotWidth: 1.1%
+$compactDotHeight: math.div($compactDotWidth * $mapWidth, $mapHeight)
+
 #campaign-editor-view
   #left-column
     position: absolute
@@ -24,12 +32,126 @@
     right: 0
     width: 75%
 
-    #campaign-view .map
-      .level:not(:hover)
-        .banner[src="/images/pages/play/level-banner-unstarted.png"]
-          display: none
-        .banner[src="/images/pages/play/level-banner-unstarted-subscriber.png"]
-          display: none
+    // Compact level markers: the editor default, so 100+ levels stay distinguishable.
+    // The player-facing flags come back through the navbar toggle (see CampaignView.showFullFlags).
+    #campaign-view.compact-level-markers .map
+      .level
+        width: $compactDotWidth
+        height: $compactDotHeight
+        margin-left: -0.5 * $compactDotWidth
+        margin-bottom: math.div(-$compactDotHeight, 3)
+        border-width: 1px
+        box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.6)
+
+        &:hover
+          margin-bottom: math.div(-$compactDotHeight, 3)
+          box-shadow: 0px 0px 12px skyblue
+
+        .level-acronym
+          font-size: 0.55vw
+          display: flex
+          align-items: center
+          justify-content: center
+
+        .level-kind
+          font-size: 0.6vw
+
+        .treasure-chest
+          width: 130%
+          transform: translateX(-50%) translateX(50%) translateY(-120%) scaleY(1.33) scale(0.8)
+
+      .level-shadow
+        width: $compactDotWidth * 0.8
+        height: $compactDotHeight * 0.8
+        margin-left: -0.5 * 0.8 * $compactDotWidth
+        margin-bottom: math.div(-$compactDotHeight, 3) * 0.8
+
+    // Hover card for a level marker (both marker modes).
+    #campaign-view .map .editor-level-card
+      display: none
+      position: absolute
+      z-index: 8
+      transform: translate(-50%, -100%)
+      min-width: 220px
+      max-width: 320px
+      padding: 8px 10px
+      border-radius: 4px
+      background: rgba(20, 20, 20, 0.92)
+      color: white
+      font-size: 12px
+      line-height: 1.3
+      text-align: left
+      pointer-events: none
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5)
+
+      &.below
+        transform: translate(-50%, 0)
+
+      .card-name
+        margin: 0 0 2px
+        font-size: 14px
+        font-weight: bold
+        color: white
+
+      .card-slug
+        color: #bbb
+        font-family: monospace
+        margin-bottom: 6px
+
+      .card-facts
+        display: grid
+        grid-template-columns: max-content 1fr
+        column-gap: 8px
+        row-gap: 2px
+        margin: 0
+
+        dt
+          color: #bbb
+          font-weight: normal
+
+        dd
+          margin: 0
+
+        // Same kind colors as the marker letters on the map.
+        .kind
+          &.demo
+            color: rgb(128, 255, 128)
+          &.usage
+            color: rgb(128, 128, 255)
+          &.mastery
+            color: rgb(255, 128, 128)
+          &.practice
+            color: rgb(128, 128, 255)
+          &.advanced
+            color: rgb(128, 255, 255)
+          &.challenge
+            color: rgb(255, 255, 128)
+
+      .card-rewards
+        margin-top: 6px
+        padding-top: 6px
+        border-top: 1px solid rgba(255, 255, 255, 0.2)
+
+      .card-rewards-title
+        color: #bbb
+        margin-bottom: 2px
+
+      .card-reward
+        display: flex
+        align-items: center
+        gap: 6px
+
+      .card-reward-portrait
+        width: 24px
+        height: 24px
+        object-fit: contain
+        flex: none
+
+      .card-reward-type
+        color: #bbb
+
+      .card-reward-name
+        font-weight: bold
 
   .patches-view
     position: absolute

--- a/app/templates/editor/campaign/campaign-editor-view.pug
+++ b/app/templates/editor/campaign/campaign-editor-view.pug
@@ -20,6 +20,9 @@ block header
           li#analytics-button
             a
               span.glyphicon-stats.glyphicon
+        li#toggle-flags-button(class=view.showFullFlags ? "active" : "")
+          a(data-i18n="[title]editor.campaign_show_player_flags")
+            span.glyphicon-flag.glyphicon
         if me.isAdmin()
           li#save-button
             a

--- a/app/templates/play/campaign-editor-level-card.pug
+++ b/app/templates/play/campaign-editor-level-card.pug
@@ -1,0 +1,31 @@
+//- Hover card for a level marker in the campaign editor (admin tool, English only).
+- var flags = []
+- if (requiresSubscription) flags.push('premium')
+- if (practice) flags.push('practice')
+- if (assessment) flags.push('assessment' + (assessment === true ? '' : ': ' + assessment))
+- if (replayable) flags.push('replayable')
+- if (adminOnly) flags.push('admin only')
+- var typeLabels = { item: 'Item', pet: 'Pet', hero: 'Hero', level: 'Level' }
+h4.card-name= name
+.card-slug= slug
+dl.card-facts
+  dt Kind
+  dd(class="kind " + (kind || ''))= kind || '—'
+  dt Type
+  dd= type || '—'
+  dt Release
+  dd= releasePhase || 'released'
+  if flags.length
+    dt Flags
+    dd= flags.join(', ')
+if rewards.length
+  .card-rewards
+    .card-rewards-title Rewards
+    each reward in rewards
+      .card-reward
+        if reward.type === 'pet'
+          img.card-reward-portrait(src="/db/thang.type/" + reward.original + "/toFile/dollImages.pet", alt="")
+        else if reward.type === 'item' || reward.type === 'hero'
+          img.card-reward-portrait(src="/file/db/thang.type/" + reward.original + "/portrait.png", alt="")
+        span.card-reward-type= typeLabels[reward.type]
+        span.card-reward-name= reward.name

--- a/app/templates/play/campaign-view.pug
+++ b/app/templates/play/campaign-view.pug
@@ -131,7 +131,7 @@ if !editorMode
             class="level" + (level.next || _.any(level.practiceLevels || [], { next: true }) ? " next" : "") + (level.disabled ? " disabled" : "") + (level.locked ? " locked" : "") + " " + levelStatus,
             data-level-slug=level.slug,
             data-level-original=level.original,
-            title=levelNumber + i18n(level, 'name') + (level.disabled ? " (" + translate('common.coming_soon') + ")" : (level.practice ? " (" + translate('courses.practice') + ")" : ""))
+            title=editorMode ? undefined : levelNumber + i18n(level, 'name') + (level.disabled ? " (" + translate('common.coming_soon') + ")" : (level.practice ? " (" + translate('courses.practice') + ")" : ""))
           )
             if level.unlocksHero && (!level.purchasedHero || editorMode) && (level.hidden || levelStatus === 'complete')
               img.hero-portrait(src="/file/db/thang.type/" + level.unlocksHero + "/portrait.png")
@@ -143,7 +143,14 @@ if !editorMode
               div(class="level-kind " + level.kind)= kindKey
               - var acronym = level.name.replace(/(A |The )/g, '').replace(/[^A-Z]/g, '');
               .level-acronym= acronym
-            if !level.hidden && !level.noFlag && !level.locked
+            //- Editor default is a compact marker: no flag banner, only the reward chest. The toggle brings the player flags back.
+            - var showFlags = !editorMode || showFullFlags
+            if !level.hidden && !level.noFlag && !level.locked && !showFlags
+              if level.unlocksHero && levelStatus !== 'complete'
+                img.treasure-chest(src="/images/pages/play/gold-chest.png")
+              else if level.unlocksItem && levelStatus !== 'complete'
+                img.treasure-chest(src="/images/pages/play/" + (level.requiresSubscription?'silver':'bronze') + "-chest.png")
+            if !level.hidden && !level.noFlag && !level.locked && showFlags
               if level.replayable
                 img.banner(src="/images/pages/play/level-banner-replayable.png")
               else if level.type === 'hero-ladder' || level.type === 'course-ladder' || level.type === 'ladder'

--- a/app/views/editor/campaign/CampaignEditorView.js
+++ b/app/views/editor/campaign/CampaignEditorView.js
@@ -782,8 +782,9 @@ class LevelNode extends TreemaObjectNode {
 
   buildValueForDisplay (valEl, data) {
     let { name } = data
-    if (data.requiresSubscription) {
-      name = '[P] ' + name
+    // Most levels are premium now, so the exception worth seeing is a free one.
+    if (!data.requiresSubscription) {
+      name = '[F] ' + name
     }
     if (data.displayName) {
       name = name + ' - ' + data.displayName

--- a/app/views/editor/campaign/CampaignEditorView.js
+++ b/app/views/editor/campaign/CampaignEditorView.js
@@ -32,6 +32,7 @@ const PatchesView = require('views/editor/PatchesView')
 const RevertModal = require('views/modal/RevertModal')
 const modelDeltas = require('lib/modelDeltas')
 const globalVar = require('core/globalVar')
+const storage = require('core/storage')
 const { HackstackScenarioIDNode } = require('views/editor/ai-scenario/AIScenarioNode')
 const { MiniGameOriginalNode } = require('views/editor/minigame/MiniGameNode')
 const { LevelOriginalNode } = require('views/editor/level/LevelOriginalNode')
@@ -43,6 +44,8 @@ require('lib/game-libraries')
 
 const achievementProject = ['related', 'rewards', 'name', 'slug']
 const thangTypeProject = ['name', 'original']
+// Remembers the "show player-facing level flags" toggle across editor reloads.
+const SHOW_FULL_FLAGS_STORAGE_KEY = 'campaign-editor-show-full-flags'
 
 module.exports = (CampaignEditorView = (function () {
   CampaignEditorView = class CampaignEditorView extends RootView {
@@ -54,6 +57,7 @@ module.exports = (CampaignEditorView = (function () {
       this.prototype.events = {
         'click #analytics-button': 'onClickAnalyticsButton',
         'click #save-button': 'onClickSaveButton',
+        'click #toggle-flags-button': 'onClickToggleFlagsButton',
         'click #patches-button': 'onClickPatches',
         'click [data-toggle="coco-modal"][data-target="modal/RevertModal"]': 'openRevertModal',
       }
@@ -84,6 +88,7 @@ module.exports = (CampaignEditorView = (function () {
       this.campaignHandle = campaignHandle
       this.campaignPage = campaignPage
       this.campaignPage = parseInt(this.campaignPage) || 1
+      this.showFullFlags = storage.load(SHOW_FULL_FLAGS_STORAGE_KEY) === true
       this.campaign = new Campaign({ _id: this.campaignHandle })
       this.supermodel.loadModel(this.campaign)
       this.listenToOnce(this.campaign, 'sync', function (model, response, jqXHR) {
@@ -433,6 +438,13 @@ module.exports = (CampaignEditorView = (function () {
       }
     }
 
+    onClickToggleFlagsButton (e) {
+      this.showFullFlags = !this.showFullFlags
+      storage.save(SHOW_FULL_FLAGS_STORAGE_KEY, this.showFullFlags)
+      this.$('#toggle-flags-button').toggleClass('active', this.showFullFlags)
+      this.campaignView?.setShowFullFlags(this.showFullFlags)
+    }
+
     onClickSaveButton (e) {
       if (this.openingModal) { return }
       this.openingModal = true
@@ -496,7 +508,7 @@ module.exports = (CampaignEditorView = (function () {
         this.treema.childrenTreemas.levels.open()
       }
 
-      this.campaignView = new CampaignView({ editorMode: true, supermodel: this.supermodel, campaignPage: this.campaignPage }, this.campaignHandle)
+      this.campaignView = new CampaignView({ editorMode: true, showFullFlags: this.showFullFlags, supermodel: this.supermodel, campaignPage: this.campaignPage }, this.campaignHandle)
       this.campaignView.highlightElement = _.noop // make it stop
       this.listenTo(this.campaignView, 'level-moved', this.onCampaignLevelMoved)
       this.listenTo(this.campaignView, 'scenario-moved', this.onCampaignScenarioMoved)

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -1092,12 +1092,15 @@ class CampaignView extends RootView {
   getEditorLevelCardData (levelOriginal) {
     const level = (this.campaign?.renderedLevels || []).find(l => l.original === levelOriginal)
     if (!level) { return null }
-    // Reward models are loaded by the editor; fall back to the id when one is still missing.
-    const nameOf = (Model, original) => this.supermodel?.getModelByOriginal(Model, original)?.get('name') || original
+    // Reward thang types are loaded by the editor; fall back to the id when one is still missing.
+    const thangTypeName = original => this.supermodel?.getModelByOriginal(ThangType, original)?.get('name') || original
+    // Rewarded levels are usually on this map already; otherwise the editor loaded them into the supermodel.
+    const levelName = original => this.campaign.renderedLevels.find(l => l.original === original)?.name ||
+      this.supermodel?.getModelByOriginal(Level, original)?.get('name') || original
     const rewards = (level.rewards || []).map(reward => {
-      if (reward.item) { return { type: level.unlocksPet && reward.item === level.unlocksItem ? 'pet' : 'item', original: reward.item, name: nameOf(ThangType, reward.item) } }
-      if (reward.hero) { return { type: 'hero', original: reward.hero, name: nameOf(ThangType, reward.hero) } }
-      if (reward.level) { return { type: 'level', original: reward.level, name: nameOf(Level, reward.level) } }
+      if (reward.item) { return { type: level.unlocksPet && reward.item === level.unlocksItem ? 'pet' : 'item', original: reward.item, name: thangTypeName(reward.item) } }
+      if (reward.hero) { return { type: 'hero', original: reward.hero, name: thangTypeName(reward.hero) } }
+      if (reward.level) { return { type: 'level', original: reward.level, name: levelName(reward.level) } }
       return null
     }).filter(Boolean)
     return {
@@ -1128,14 +1131,17 @@ class CampaignView extends RootView {
     }
     $card.html(editorLevelCardTemplate(data)).show()
     // Center the card above the marker; flip below it when there is no room at the top of the map.
-    const position = $level.position()
-    const centerX = position.left + ($level.outerWidth() / 2)
+    // Rendered rects, not CSS offsets: the marker sits on negative margins and a scaleY transform.
+    const mapRect = $map[0].getBoundingClientRect()
+    const levelRect = $level[0].getBoundingClientRect()
+    const centerX = levelRect.left - mapRect.left + (levelRect.width / 2)
+    const top = levelRect.top - mapRect.top
     const gap = 6
-    const above = position.top - gap
+    const above = top - gap
     const fitsAbove = above - $card.outerHeight() >= 0
     $card.toggleClass('below', !fitsAbove).css({
       left: `${centerX}px`,
-      top: `${fitsAbove ? above : position.top + $level.outerHeight() + gap}px`,
+      top: `${fitsAbove ? above : top + levelRect.height + gap}px`,
     })
   }
 

--- a/app/views/play/CampaignView.js
+++ b/app/views/play/CampaignView.js
@@ -1,6 +1,7 @@
 require('app/styles/play/campaign-view.sass')
 const RootView = require('views/core/RootView')
 const template = require('templates/play/campaign-view')
+const editorLevelCardTemplate = require('templates/play/campaign-editor-level-card')
 const LevelSession = require('models/LevelSession')
 const EarnedAchievement = require('models/EarnedAchievement')
 const CocoCollection = require('collections/CocoCollection')
@@ -106,6 +107,8 @@ class CampaignView extends RootView {
       'click .map-background': 'onClickMap',
       'click .level': 'onClickLevel',
       'dblclick .level': 'onDoubleClickLevel',
+      'mouseenter .level': 'onMouseEnterLevel',
+      'mouseleave .level': 'onMouseLeaveLevel',
       'click .level-info-container .start-level': 'onClickStartLevel',
       'click .level-info-container .home-version button': 'onClickStartLevel',
       'click .level-info-container .view-solutions': 'onClickViewSolutions',
@@ -152,6 +155,8 @@ class CampaignView extends RootView {
     }
 
     this.editorMode = options?.editorMode
+    // Editor only: render the player-facing flag banners instead of the compact level markers.
+    this.showFullFlags = Boolean(this.editorMode && options?.showFullFlags)
     this.requiresSubscription = !me.isPremium()
     if (this.editorMode && !this.terrain) {
       this.terrain = 'dungeon'
@@ -794,6 +799,7 @@ class CampaignView extends RootView {
     context.isIPadApp = application.isIPadApp
     context.requiresSubscription = this.requiresSubscription
     context.editorMode = this.editorMode
+    context.showFullFlags = this.showFullFlags
     context.scenarios = this.campaign?.get('scenarios') || []
     // Modules: child campaigns rendered as portals on the map.
     // Enrich each module with locked state: first by premium, then by levelToUnlock (complete that level to unlock).
@@ -961,9 +967,12 @@ class CampaignView extends RootView {
       _.defer(() => this.$el?.find('.game-controls .btn, .other-products .btn, .campaign.locked, .side-campaign.locked, .main-campaign.locked').addClass('has-tooltip').tooltip()) // Have to defer or i18n doesn't take effect.
       const view = this
       // Keep original behavior for levels and campaign switches
-      this.$el.find('.level, .campaign-switch').addClass('has-tooltip').tooltip().each(function () {
+      // In the editor the hover card replaces the level tooltip; the campaign switches keep theirs.
+      const $tooltipTargets = this.editorMode ? this.$el.find('.campaign-switch') : this.$el.find('.level, .campaign-switch')
+      $tooltipTargets.addClass('has-tooltip').tooltip()
+      this.$el.find('.level, .campaign-switch').each(function () {
         if (!me.isAdmin() || !view.editorMode) { return }
-        $(this).draggable().on('dragstop', function () {
+        $(this).draggable().on('dragstart', () => view.hideEditorLevelCard()).on('dragstop', function () {
           const bg = $('.map-background')
           const x = (($(this).offset().left - bg.offset().left) + ($(this).outerWidth() / 2)) / bg.width()
           const y = 1 - ((($(this).offset().top - bg.offset().top) + ($(this).outerHeight() / 2)) / bg.height())
@@ -1033,6 +1042,7 @@ class CampaignView extends RootView {
         })
       })
     }
+    this.$el.toggleClass('compact-level-markers', Boolean(this.editorMode && !this.showFullFlags))
     this.updateVolume()
     this.updateHero()
     if (!window.currentModal && this.fullyRendered) {
@@ -1067,6 +1077,75 @@ class CampaignView extends RootView {
     if (this.editorMode) {
       this.generateCompletionRates()
     }
+  }
+
+  // Editor only: switch between compact level markers and the player-facing flag banners.
+  setShowFullFlags (showFullFlags) {
+    if (!this.editorMode) { return }
+    showFullFlags = Boolean(showFullFlags)
+    if (showFullFlags === this.showFullFlags) { return }
+    this.showFullFlags = showFullFlags
+    this.render()
+  }
+
+  // Editor only: everything the hover card shows for one rendered level.
+  getEditorLevelCardData (levelOriginal) {
+    const level = (this.campaign?.renderedLevels || []).find(l => l.original === levelOriginal)
+    if (!level) { return null }
+    // Reward models are loaded by the editor; fall back to the id when one is still missing.
+    const nameOf = (Model, original) => this.supermodel?.getModelByOriginal(Model, original)?.get('name') || original
+    const rewards = (level.rewards || []).map(reward => {
+      if (reward.item) { return { type: level.unlocksPet && reward.item === level.unlocksItem ? 'pet' : 'item', original: reward.item, name: nameOf(ThangType, reward.item) } }
+      if (reward.hero) { return { type: 'hero', original: reward.hero, name: nameOf(ThangType, reward.hero) } }
+      if (reward.level) { return { type: 'level', original: reward.level, name: nameOf(Level, reward.level) } }
+      return null
+    }).filter(Boolean)
+    return {
+      name: level.name,
+      slug: level.slug,
+      kind: level.kind,
+      type: level.type,
+      releasePhase: level.releasePhase,
+      requiresSubscription: Boolean(level.requiresSubscription),
+      practice: Boolean(level.practice),
+      assessment: level.assessment,
+      adminOnly: Boolean(level.adminOnly),
+      replayable: Boolean(level.replayable),
+      rewards,
+    }
+  }
+
+  onMouseEnterLevel (e) {
+    if (!this.editorMode) { return }
+    const $level = $(e.currentTarget)
+    if ($level.hasClass('ui-draggable-dragging')) { return }
+    const data = this.getEditorLevelCardData($level.data('level-original'))
+    if (!data) { return }
+    const $map = this.$el.find('.map')
+    let $card = $map.find('.editor-level-card')
+    if (!$card.length) {
+      $card = $('<div class="editor-level-card"></div>').appendTo($map)
+    }
+    $card.html(editorLevelCardTemplate(data)).show()
+    // Center the card above the marker; flip below it when there is no room at the top of the map.
+    const position = $level.position()
+    const centerX = position.left + ($level.outerWidth() / 2)
+    const gap = 6
+    const above = position.top - gap
+    const fitsAbove = above - $card.outerHeight() >= 0
+    $card.toggleClass('below', !fitsAbove).css({
+      left: `${centerX}px`,
+      top: `${fitsAbove ? above : position.top + $level.outerHeight() + gap}px`,
+    })
+  }
+
+  onMouseLeaveLevel (e) {
+    if (!this.editorMode) { return }
+    this.hideEditorLevelCard()
+  }
+
+  hideEditorLevelCard () {
+    this.$el.find('.map .editor-level-card').hide()
   }
 
   generateCompletionRates () {

--- a/test/app/views/play/CampaignView.spec.coco.js
+++ b/test/app/views/play/CampaignView.spec.coco.js
@@ -10,7 +10,10 @@
 const factories = require('test/app/factories')
 const CampaignView = require('views/play/CampaignView')
 const Levels = require('collections/Levels')
+const ThangType = require('models/ThangType')
+const Level = require('models/Level')
 const storage = require('core/storage')
+const editorLevelCardTemplate = require('templates/play/campaign-editor-level-card')
 
 describe('CampaignView', () => describe('when 4 earned levels', function () {
   beforeEach(function () {
@@ -310,6 +313,91 @@ describe('CampaignView', () => describe('when 4 earned levels', function () {
       expect(this.campaignView.playAmbientSound).not.toHaveBeenCalled()
       jasmine.clock().tick(10001)
       expect(this.campaignView.playMusic).toHaveBeenCalled()
+    })
+  })
+
+  describe('campaign editor level markers', function () {
+    beforeEach(function () {
+      this.campaignView = new CampaignView({ editorMode: true }, 'dungeon')
+      spyOn(this.campaignView, 'render')
+    })
+
+    afterEach(function () {
+      // Otherwise the view keeps re-rendering on every `me` change in later specs.
+      this.campaignView.destroy()
+    })
+
+    it('starts with compact markers, not the player flags', function () {
+      expect(this.campaignView.showFullFlags).toBe(false)
+    })
+
+    it('re-renders once when the flag toggle actually changes', function () {
+      this.campaignView.setShowFullFlags(true)
+      this.campaignView.setShowFullFlags(true)
+      expect(this.campaignView.showFullFlags).toBe(true)
+      expect(this.campaignView.render.calls.count()).toBe(1)
+    })
+
+    it('can start with the player flags when the editor remembered that choice', function () {
+      const view = new CampaignView({ editorMode: true, showFullFlags: true }, 'dungeon')
+      expect(view.showFullFlags).toBe(true)
+      view.destroy()
+    })
+
+    it('never shows full flags on the player map', function () {
+      const view = new CampaignView()
+      spyOn(view, 'render')
+      view.setShowFullFlags(true)
+      expect(view.showFullFlags).toBe(false)
+      expect(view.render).not.toHaveBeenCalled()
+      view.destroy()
+    })
+
+    describe('hover card', function () {
+      beforeEach(function () {
+        const sword = new ThangType({ original: 'sword-original', name: 'Long Sword' })
+        sword.setURL('/db/thang.type/sword-original/version')
+        this.campaignView.supermodel.registerModel(sword)
+        const bonus = new Level({ original: 'bonus-original', name: 'Bonus Level' })
+        bonus.setURL('/db/level/bonus-original/version')
+        this.campaignView.supermodel.registerModel(bonus)
+        this.campaignView.campaign = factories.makeCampaign()
+        this.campaignView.campaign.renderedLevels = [{
+          original: 'level-original',
+          name: 'Treasure Cave',
+          slug: 'treasure-cave',
+          kind: 'mastery',
+          type: 'hero',
+          releasePhase: 'beta',
+          requiresSubscription: true,
+          practice: false,
+          unlocksItem: 'sword-original',
+          rewards: [{ item: 'sword-original' }, { level: 'bonus-original' }, { hero: 'missing-hero' }],
+        }]
+      })
+
+      it('names rewards from the loaded models and falls back to the original id', function () {
+        const data = this.campaignView.getEditorLevelCardData('level-original')
+        expect(data.name).toBe('Treasure Cave')
+        expect(data.kind).toBe('mastery')
+        expect(data.releasePhase).toBe('beta')
+        expect(data.requiresSubscription).toBe(true)
+        expect(_.pluck(data.rewards, 'name')).toEqual(['Long Sword', 'Bonus Level', 'missing-hero'])
+        expect(_.pluck(data.rewards, 'type')).toEqual(['item', 'level', 'hero'])
+      })
+
+      it('returns nothing for a level that is not on the map', function () {
+        expect(this.campaignView.getEditorLevelCardData('nope')).toBeNull()
+      })
+
+      it('renders the name, kind and reward names into the card', function () {
+        const $card = $('<div>').html(editorLevelCardTemplate(this.campaignView.getEditorLevelCardData('level-original')))
+        expect($card.find('.card-name').text()).toBe('Treasure Cave')
+        expect($card.find('.card-facts .kind').text()).toBe('mastery')
+        expect($card.find('.card-facts').text()).toContain('premium')
+        expect($card.find('.card-reward-name').map(function () { return $(this).text() }).get()).toEqual(['Long Sword', 'Bonus Level', 'missing-hero'])
+        expect($card.find('.card-reward-portrait').length).toBe(2)
+      })
     })
   })
 }))

--- a/test/app/views/play/CampaignView.spec.coco.js
+++ b/test/app/views/play/CampaignView.spec.coco.js
@@ -75,7 +75,7 @@ describe('CampaignView', () => describe('when 4 earned levels', function () {
       this.campaignView.classroom.isStudentOnOptionalLevel.and.callFake((id, courseId, original) => original.match(/optional/i))
       this.campaignView.courseInstance = { get (startLockedLevel) { return undefined } }
       this.campaignView.course = { get (slug) { return 'course1' } }
-      return this.campaignView.campaign = {
+      this.campaignView.campaign = {
         levelIsPractice (level) { return Boolean(level.practice) },
         levelIsAssessment (level) { return Boolean(level.assessment) },
       }

--- a/test/app/views/play/CampaignView.spec.coco.js
+++ b/test/app/views/play/CampaignView.spec.coco.js
@@ -363,6 +363,11 @@ describe('CampaignView', () => describe('when 4 earned levels', function () {
         this.campaignView.supermodel.registerModel(bonus)
         this.campaignView.campaign = factories.makeCampaign()
         this.campaignView.campaign.renderedLevels = [{
+          original: 'on-map-original',
+          name: 'Level On This Map',
+          slug: 'level-on-this-map',
+          rewards: [],
+        }, {
           original: 'level-original',
           name: 'Treasure Cave',
           slug: 'treasure-cave',
@@ -372,7 +377,7 @@ describe('CampaignView', () => describe('when 4 earned levels', function () {
           requiresSubscription: true,
           practice: false,
           unlocksItem: 'sword-original',
-          rewards: [{ item: 'sword-original' }, { level: 'bonus-original' }, { hero: 'missing-hero' }],
+          rewards: [{ item: 'sword-original' }, { level: 'bonus-original' }, { level: 'on-map-original' }, { hero: 'missing-hero' }],
         }]
       })
 
@@ -382,8 +387,8 @@ describe('CampaignView', () => describe('when 4 earned levels', function () {
         expect(data.kind).toBe('mastery')
         expect(data.releasePhase).toBe('beta')
         expect(data.requiresSubscription).toBe(true)
-        expect(_.pluck(data.rewards, 'name')).toEqual(['Long Sword', 'Bonus Level', 'missing-hero'])
-        expect(_.pluck(data.rewards, 'type')).toEqual(['item', 'level', 'hero'])
+        expect(_.pluck(data.rewards, 'name')).toEqual(['Long Sword', 'Bonus Level', 'Level On This Map', 'missing-hero'])
+        expect(_.pluck(data.rewards, 'type')).toEqual(['item', 'level', 'level', 'hero'])
       })
 
       it('returns nothing for a level that is not on the map', function () {
@@ -395,7 +400,7 @@ describe('CampaignView', () => describe('when 4 earned levels', function () {
         expect($card.find('.card-name').text()).toBe('Treasure Cave')
         expect($card.find('.card-facts .kind').text()).toBe('mastery')
         expect($card.find('.card-facts').text()).toContain('premium')
-        expect($card.find('.card-reward-name').map(function () { return $(this).text() }).get()).toEqual(['Long Sword', 'Bonus Level', 'missing-hero'])
+        expect($card.find('.card-reward-name').map(function () { return $(this).text() }).get()).toEqual(['Long Sword', 'Bonus Level', 'Level On This Map', 'missing-hero'])
         expect($card.find('.card-reward-portrait').length).toBe(2)
       })
     })


### PR DESCRIPTION
## Summary

The campaign editor rendered every level as the full player-facing flag banner, so dense campaigns (Cloudrip Mountain, 117 levels) were unreadable: level codes, positions and adjacency could not be told apart.

- **Compact markers by default.** The editor map renders a small dot with the level acronym and kind letter. The reward chest still sits next to the dot when a level unlocks an item or hero.
- **Hover card.** Hovering a marker shows name, slug, kind, type, release phase, flags (premium, practice, assessment, replayable, admin only) and the rewards by name with portrait. Replaces the old bootstrap tooltip in the editor only.
- **Player-flags toggle.** Flag button in the editor navbar (next to save) switches back to the full player-facing banners for a preview check. Remembered across reloads via local storage.
- **Treema labels.** Free levels are marked `[F]`; the `[P]` premium marker is gone, since almost every level is premium now.
- Drag-to-position, click-to-select and double-click-to-open are unchanged. The player-facing campaign map is unchanged.

Also removes a dead CSS rule that tried to hide the unstarted banner in the editor by an outdated image filename.

## Test plan

- [x] `CampaignView` spec: compact default, toggle re-renders once, player map ignores the toggle, hover card data (reward names from loaded thang types / on-map levels / id fallback), card template render
- [x] Full Karma suite green (7371 passed)
- [x] Open `/editor/campaign/mountain`: markers distinguishable, chest next to reward levels, hover shows card with reward name, flag button restores banners, drag still saves position
- [x] Open `/play/mountain`: no change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a campaign editor option to toggle between compact level markers and player-facing level flags, with the preference remembered.
  * Added hover cards displaying level details, flags, and available rewards.
  * Added localized labeling for the level-flags option.
  * Free levels are now clearly marked in editor displays.
  * Editor level markers now provide clearer visual information while preserving access to player-facing flag details.
* **Tests**
  * Added coverage for flag preferences, marker states, level hover cards, metadata, and rewards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->