### PR TITLE
AI Junior: keep fullscreen activity controls reachable

### DIFF
--- a/app/components/common/elements/AIJuniorProjectOutput.vue
+++ b/app/components/common/elements/AIJuniorProjectOutput.vue
@@ -462,18 +462,17 @@ export default {
       html = render(html)
       css = render(css)
       js = render(js)
-      // `.aij-fullscreen` is added to the iframe body while the preview is
-      // fullscreen: inline the preview is measured and sized to its content,
-      // but fullscreen it has to fill and centre inside a fixed viewport.
+      // Tall stories and activities must remain scrollable in fullscreen.
+      // Preserve their authored backgrounds and nested media layout; only
+      // standalone media should be fitted directly to the viewport.
       const baseCss = `
         body { margin: 8px; font-family: sans-serif; }
         img { max-width: 100%; height: auto; }
         body.aij-fullscreen {
-          margin: 0; width: 100vw; height: 100vh; background: #111;
-          display: flex; align-items: center; justify-content: center; overflow: hidden;
+          margin: 0; min-height: 100vh;
         }
-        body.aij-fullscreen > * { margin: 0 !important; }
-        body.aij-fullscreen img, body.aij-fullscreen canvas, body.aij-fullscreen video {
+        body.aij-fullscreen > img, body.aij-fullscreen > canvas, body.aij-fullscreen > video {
+          display: block; margin: auto;
           max-width: 100vw; max-height: 100vh; width: auto; height: auto; object-fit: contain;
         }
       `

--- a/test/app/components/common/elements/AIJuniorFullscreen.spec.js
+++ b/test/app/components/common/elements/AIJuniorFullscreen.spec.js
@@ -1,0 +1,65 @@
+import { shallowMount } from '@vue/test-utils'
+import AIJuniorProjectOutput from 'app/components/common/elements/AIJuniorProjectOutput.vue'
+
+describe('AI Junior fullscreen activities', () => {
+  const picture = 'data:image/svg+xml;base64,' + btoa('<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1200"><rect width="1600" height="1200" fill="purple"/></svg>')
+  const render = (output, type, verify, done) => {
+    const receive = event => {
+      if (event.source !== wrapper?.vm.$refs.previewFrame.contentWindow || event.data?.type !== type) return
+      window.removeEventListener('message', receive)
+      try { verify(event.data) } finally { wrapper.destroy(); done() }
+    }
+    window.addEventListener('message', receive)
+    const wrapper = shallowMount(AIJuniorProjectOutput, {
+      attachTo: document.body,
+      propsData: {
+        project: { processingStatus: 'completed', promptResponses: [] },
+        scenario: { output },
+        readOnly: true,
+      },
+    })
+  }
+
+  it('keeps a tall activity readable and its final control reachable', done => {
+    render({
+      html: '<main><h1>A long adventure</h1><div class="art-box"><img src="' + picture + '"></div><div style="height:150vh"></div><button id="finish">Finish</button></main>',
+      css: 'body { background: #fffaf0; } main { max-width: 350px; margin: auto; } .art-box { width: 80px; } .art-box img { width: 100%; }',
+      js: `addEventListener('load', () => {
+        document.body.classList.add('aij-fullscreen');
+        requestAnimationFrame(() => {
+          const top = document.querySelector('h1').getBoundingClientRect().top;
+          const pictureWidth = document.querySelector('img').getBoundingClientRect().width;
+          const style = getComputedStyle(document.body);
+          document.querySelector('#finish').scrollIntoView({block:'end'});
+          requestAnimationFrame(() => {
+            const finish = document.querySelector('#finish').getBoundingClientRect();
+            parent.postMessage({type:'fullscreen-activity-test', top, pictureWidth, background:style.backgroundColor, clipped:style.overflowY === 'hidden', reachable:finish.top >= 0 && finish.bottom <= innerHeight + 1}, '*');
+          });
+        });
+      });`,
+    }, 'fullscreen-activity-test', data => {
+      expect(data.top).not.toBeLessThan(0)
+      expect(data.pictureWidth).toBe(80)
+      expect(data.background).toBe('rgb(255, 250, 240)')
+      expect(data.clipped).toBe(false)
+      expect(data.reachable).toBe(true)
+    }, done)
+  })
+
+  it('still fits a standalone picture within the fullscreen viewport', done => {
+    render({
+      html: '<img src="' + picture + '">',
+      css: '',
+      js: `addEventListener('load', () => {
+        document.body.classList.add('aij-fullscreen');
+        requestAnimationFrame(() => {
+          const box = document.querySelector('img').getBoundingClientRect();
+          parent.postMessage({type:'fullscreen-picture-test', fits:box.width <= innerWidth && box.height <= innerHeight, ratio:box.width / box.height}, '*');
+        });
+      });`,
+    }, 'fullscreen-picture-test', data => {
+      expect(data.fits).toBe(true)
+      expect(data.ratio).toBeCloseTo(4 / 3, 2)
+    }, done)
+  })
+})

--- a/test/app/components/common/elements/AIJuniorFullscreen.spec.js
+++ b/test/app/components/common/elements/AIJuniorFullscreen.spec.js
@@ -12,6 +12,9 @@ describe('AI Junior fullscreen activities', () => {
     window.addEventListener('message', receive)
     const wrapper = shallowMount(AIJuniorProjectOutput, {
       attachTo: document.body,
+      // Fullscreen has a fixed iframe viewport. Inline preview resize
+      // messages must not change that viewport midway through a CSS test.
+      methods: { onPreviewLoad () {}, onPreviewMessage () {} },
       propsData: {
         project: { processingStatus: 'completed', promptResponses: [] },
         scenario: { output },


### PR DESCRIPTION
Interface points:
- `AIJuniorProjectOutput.vue`: fullscreen document styles preserve scrolling, authored backgrounds and nested image layout; only standalone media is fitted directly to the viewport.
- `AIJuniorFullscreen.spec.js`: browser regressions cover a tall activity, its final control, nested illustrations, background contrast and standalone media proportions.

The curated stories and games can be taller than the screen. Fullscreen previously centered the entire document in a fixed-height body with overflow hidden, putting titles above the viewport and controls below it. The forced dark background also overrode the activities' paper background. Preserve normal document flow so a child can reach the whole activity. Nothing outside AI Junior reads or writes this path.

This branch starts at `origin/master` and is independent of #8451's template-literal fix. Both are applied to the local cowboy integration branch for testing.

Validation:
- Node 22.17.1; `./node_modules/.bin/eslint --max-warnings 0 app/components/common/elements/AIJuniorProjectOutput.vue test/app/components/common/elements/AIJuniorFullscreen.spec.js` passed.
- `MOZ_HEADLESS=1 FIREFOX_BIN='/Applications/Firefox.app/Contents/MacOS/firefox' npm test` on this branch: 7,362 passed, 101 skipped, including both new specs.
- Final combined cowboy branch: the same full client test command passed 7,391 tests, with 101 skipped, including both new fixes and the earlier AI Junior changes.
- Local isolated Chrome harness checked all six published activities at 1100px and 390px using the actual results renderer with #8451 applied: no clipped titles or horizontal overflow; all game/story controls completed in fullscreen; Listen received readable story text, including touch taps at phone width. Repeated with fresh live-model text for all six (24 fullscreen playthroughs total).
- `git diff --check` passed. Scenario documents and the local snapshot harness remain outside the repository and are managed through the editor API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fullscreen preview behavior for tall stories and activities, preserving their backgrounds and allowing content to scroll naturally.
  * Standalone images, videos, and canvas content remain centered and fitted within the fullscreen viewport.
  * Ensured controls at the end of tall activities remain accessible.

* **Tests**
  * Added coverage for fullscreen layouts involving tall activities and standalone media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->