### PR TITLE
[GD-813] Thang editor: keep portrait.png in sync on fork and save

### DIFF
--- a/app/models/ThangType.js
+++ b/app/models/ThangType.js
@@ -541,7 +541,16 @@ module.exports = (ThangType = (function () {
         b64png: src,
         force: 'true',
       }
-      return $.ajax('/file', { type: 'POST', data: body, success: callback || this.onFileUploaded })
+      // Callers chain navigation on the callback, so settle it on failure as well.
+      return $.ajax('/file', {
+        type: 'POST',
+        data: body,
+        success: callback || this.onFileUploaded,
+        error: (jqXHR) => {
+          console.warn(`Portrait upload failed for ${this.get('name')} (HTTP ${jqXHR.status}); level editor will show the generic wizard`)
+          if (typeof callback === 'function') { callback() }
+        },
+      })
     }
 
     onFileUploaded () {

--- a/app/views/editor/ForkModal.js
+++ b/app/views/editor/ForkModal.js
@@ -41,9 +41,43 @@ class ForkModal extends ModalView {
       forms.applyErrorsToForm(this.$el.find('form'), JSON.parse(res.responseText))
     })
     res.success(() => {
-      this.hide()
-      application.router.navigate(newPathPrefix + newModel.get('slug'), { trigger: true })
+      const navigate = () => {
+        this.hide()
+        application.router.navigate(newPathPrefix + newModel.get('slug'), { trigger: true })
+      }
+      if (this.editorPath === 'thang') {
+        return this.copyThangPortrait(newModel, navigate)
+      }
+      navigate()
     })
+  }
+
+  // portrait.png lives in file storage under the *original* id, and a fork gets a new one.
+  // Without this copy the level editor palette shows the generic wizard for every fork
+  // until someone re-saves it in the thang editor. Never blocks the fork: any failure
+  // just logs and navigates.
+  copyThangPortrait (newModel, done) {
+    const parentOriginal = this.model.get('original')
+    if (!parentOriginal || !newModel.get('original')) { return done() }
+    const url = `/file/db/thang.type/${parentOriginal}/portrait.png`
+    return fetch(url)
+      .then((response) => {
+        if (!response.ok) { throw new Error(`HTTP ${response.status}`) }
+        return response.blob()
+      })
+      .then(blob => new Promise((resolve, reject) => {
+        const reader = new FileReader()
+        reader.onload = () => resolve(reader.result)
+        reader.onerror = () => reject(reader.error)
+        reader.readAsDataURL(blob)
+      }))
+      .then(dataURL => new Promise((resolve) => {
+        newModel.uploadGenericPortrait(resolve, dataURL)
+      }))
+      .catch((err) => {
+        console.warn(`Could not copy portrait from ${this.model.get('name')} to fork:`, err)
+      })
+      .then(done)
   }
 }
 

--- a/app/views/editor/ForkModal.js
+++ b/app/views/editor/ForkModal.js
@@ -60,11 +60,14 @@ class ForkModal extends ModalView {
     const parentOriginal = this.model.get('original')
     if (!parentOriginal || !newModel.get('original')) { return done() }
     const url = `/file/db/thang.type/${parentOriginal}/portrait.png`
-    return fetch(url)
+    const controller = new AbortController()
+    const deadline = setTimeout(() => controller.abort(), ForkModal.portraitFetchTimeout)
+    return fetch(url, { signal: controller.signal })
       .then((response) => {
         if (!response.ok) { throw new Error(`HTTP ${response.status}`) }
         return response.blob()
       })
+      .finally(() => clearTimeout(deadline))
       .then(blob => new Promise((resolve, reject) => {
         const reader = new FileReader()
         reader.onload = () => resolve(reader.result)
@@ -80,6 +83,8 @@ class ForkModal extends ModalView {
       .then(done)
   }
 }
+
+ForkModal.portraitFetchTimeout = 15000 // ms before giving up on the parent portrait and forking without it
 
 ForkModal.prototype.id = 'fork-modal'
 ForkModal.prototype.template = template

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -960,6 +960,8 @@ module.exports = (ThangTypeEditView = (function () {
     }
 
     uploadPortrait (newThangType, callback) {
+      // The palette uses rasterIcon directly (ThangTypeLib.getPortraitURL), no portrait.png needed.
+      if (this.thangType.get('rasterIcon')) { return callback() }
       const portraitSource = this.getPortraitSourceForUpload()
       if (!portraitSource || !_.string.startsWith(portraitSource, 'data:')) {
         console.warn(`Portrait not uploaded for ${this.thangType.get('name')}: no rendered portrait; level editor will show the generic wizard`)

--- a/app/views/editor/thang/ThangTypeEditView.js
+++ b/app/views/editor/thang/ThangTypeEditView.js
@@ -938,19 +938,34 @@ module.exports = (ThangTypeEditView = (function () {
 
       return res.success(() => {
         const url = `/editor/thang/${newThangType.get('slug') || newThangType.id}`
-        let portraitSource = null
-        if (this.thangType.get('raster')) {
-          // image = @currentLank.sprite.image  # Doesn't work?
-          const image = this.currentLank.sprite.spriteSheet._images[0]
-          portraitSource = imageToPortrait(image)
-        }
-        // bit of a hacky way to get that portrait
         const success = () => {
           this.thangType.clearBackup()
           return document.location.href = url
         }
-        return newThangType.uploadGenericPortrait(success, portraitSource)
+        return this.uploadPortrait(newThangType, success)
       })
+    }
+
+    // The level editor palette shows the static /file/db/thang.type/<original>/portrait.png,
+    // which only exists once a save uploads it. Render the portrait from the loaded model
+    // (sprite sheets built, raster raw images loaded) rather than from the fresh clone, which
+    // has none of that and silently produces no image for raster-raw thangs.
+    getPortraitSourceForUpload () {
+      if (this.thangType.get('raster')) {
+        // image = @currentLank.sprite.image  # Doesn't work?
+        const image = this.currentLank?.sprite?.spriteSheet?._images?.[0]
+        return image ? imageToPortrait(image) : null
+      }
+      return this.thangType.getPortraitSource(this.getLankOptions())
+    }
+
+    uploadPortrait (newThangType, callback) {
+      const portraitSource = this.getPortraitSourceForUpload()
+      if (!portraitSource || !_.string.startsWith(portraitSource, 'data:')) {
+        console.warn(`Portrait not uploaded for ${this.thangType.get('name')}: no rendered portrait; level editor will show the generic wizard`)
+        return callback()
+      }
+      return newThangType.uploadGenericPortrait(callback, portraitSource)
     }
 
     clearRawData () {

--- a/test/app/models/ThangType.spec.js
+++ b/test/app/models/ThangType.spec.js
@@ -1,0 +1,38 @@
+/* eslint-env jasmine */
+const ThangType = require('models/ThangType')
+
+describe('ThangType.uploadGenericPortrait', function () {
+  const dataURL = 'data:image/png;base64,AAAA'
+  let thangType, callback
+
+  beforeEach(function () {
+    spyOn(console, 'warn')
+    thangType = new ThangType({ name: 'Beach Rock', original: '69f354bcbbc20557f9619c3a' })
+    callback = jasmine.createSpy('callback')
+  })
+
+  it('posts the png under the original id and calls back on success', function () {
+    thangType.uploadGenericPortrait(callback, dataURL)
+    const request = jasmine.Ajax.requests.mostRecent()
+    expect(request.url).toBe('/file')
+    expect(request.method).toBe('POST')
+    expect(decodeURIComponent(request.params)).toContain('path=db/thang.type/69f354bcbbc20557f9619c3a')
+    request.respondWith({ status: 200, responseText: '{}' })
+    expect(callback).toHaveBeenCalled()
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('warns and still calls back when the upload is rejected', function () {
+    thangType.uploadGenericPortrait(callback, dataURL)
+    jasmine.Ajax.requests.mostRecent().respondWith({ status: 403, responseText: '{}' })
+    expect(callback).toHaveBeenCalled()
+    expect(console.warn.calls.mostRecent().args[0]).toContain('Beach Rock')
+  })
+
+  it('calls back without a request when there is no data URL', function () {
+    const before = jasmine.Ajax.requests.count()
+    thangType.uploadGenericPortrait(callback, '/file/db/thang.type/abc/portrait.png')
+    expect(jasmine.Ajax.requests.count()).toBe(before)
+    expect(callback).toHaveBeenCalled()
+  })
+})

--- a/test/app/views/editor/ForkModal.spec.js
+++ b/test/app/views/editor/ForkModal.spec.js
@@ -40,7 +40,7 @@ describe('ForkModal.copyThangPortrait', function () {
     spyOn(window, 'fetch').and.returnValue(okResponse())
     const newModel = makeNewModel()
     proto.copyThangPortrait.call(makeModal(), newModel, function () {
-      expect(window.fetch).toHaveBeenCalledWith(`/file/db/thang.type/${parentOriginal}/portrait.png`)
+      expect(window.fetch.calls.mostRecent().args[0]).toBe(`/file/db/thang.type/${parentOriginal}/portrait.png`)
       const args = newModel.uploadGenericPortrait.calls.mostRecent().args
       expect(args[1]).toMatch(/^data:image\/png;base64,/)
       expect(console.warn).not.toHaveBeenCalled()
@@ -64,6 +64,32 @@ describe('ForkModal.copyThangPortrait', function () {
     proto.copyThangPortrait.call(makeModal(), newModel, function () {
       expect(newModel.uploadGenericPortrait).not.toHaveBeenCalled()
       expect(console.warn.calls.mostRecent().args[0]).toContain('Silver Door')
+      done()
+    })
+  })
+
+  it('gives up on a stalled parent portrait request and still finishes the fork', function (done) {
+    const originalTimeout = ForkModal.portraitFetchTimeout
+    ForkModal.portraitFetchTimeout = 10
+    spyOn(window, 'fetch').and.callFake((url, { signal }) => new Promise((resolve, reject) => {
+      signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')))
+    }))
+    const newModel = makeNewModel()
+    proto.copyThangPortrait.call(makeModal(), newModel, function () {
+      ForkModal.portraitFetchTimeout = originalTimeout
+      expect(newModel.uploadGenericPortrait).not.toHaveBeenCalled()
+      expect(console.warn).toHaveBeenCalled()
+      done()
+    })
+  })
+
+  it('still finishes the fork when the upload settles with a failure', function (done) {
+    spyOn(window, 'fetch').and.returnValue(okResponse())
+    const newModel = makeNewModel()
+    // uploadGenericPortrait settles its callback on failure too; the fork must not care which.
+    newModel.uploadGenericPortrait.and.callFake(callback => setTimeout(callback, 0))
+    proto.copyThangPortrait.call(makeModal(), newModel, function () {
+      expect(newModel.uploadGenericPortrait).toHaveBeenCalled()
       done()
     })
   })

--- a/test/app/views/editor/ForkModal.spec.js
+++ b/test/app/views/editor/ForkModal.spec.js
@@ -1,0 +1,80 @@
+/* eslint-env jasmine */
+const ForkModal = require('views/editor/ForkModal')
+
+// A fork gets a new `original`, but portrait.png in file storage is keyed by
+// original, so the level editor palette showed the generic wizard for every
+// forked thang. copyThangPortrait copies the parent's file across and must
+// never block the fork when anything fails.
+describe('ForkModal.copyThangPortrait', function () {
+  const proto = ForkModal.prototype
+  const parentOriginal = '59110754cc295f003eefd5df'
+  const pngBytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])
+
+  function makeModal (overrides = {}) {
+    return Object.assign({
+      editorPath: 'thang',
+      model: {
+        attributes: { name: 'Silver Door', original: parentOriginal },
+        get (key) { return this.attributes[key] },
+      },
+    }, overrides)
+  }
+
+  function makeNewModel (original = '68231ce5ff32ac1b7bcc3f95') {
+    return {
+      attributes: { original },
+      get (key) { return this.attributes[key] },
+      uploadGenericPortrait: jasmine.createSpy('uploadGenericPortrait').and.callFake(callback => callback()),
+    }
+  }
+
+  function okResponse () {
+    return Promise.resolve({ ok: true, status: 200, blob: () => Promise.resolve(new Blob([pngBytes], { type: 'image/png' })) })
+  }
+
+  beforeEach(function () {
+    spyOn(console, 'warn')
+  })
+
+  it('fetches the parent portrait and uploads it under the new original', function (done) {
+    spyOn(window, 'fetch').and.returnValue(okResponse())
+    const newModel = makeNewModel()
+    proto.copyThangPortrait.call(makeModal(), newModel, function () {
+      expect(window.fetch).toHaveBeenCalledWith(`/file/db/thang.type/${parentOriginal}/portrait.png`)
+      const args = newModel.uploadGenericPortrait.calls.mostRecent().args
+      expect(args[1]).toMatch(/^data:image\/png;base64,/)
+      expect(console.warn).not.toHaveBeenCalled()
+      done()
+    })
+  })
+
+  it('still finishes the fork when the parent has no portrait file', function (done) {
+    spyOn(window, 'fetch').and.returnValue(Promise.resolve({ ok: false, status: 404 }))
+    const newModel = makeNewModel()
+    proto.copyThangPortrait.call(makeModal(), newModel, function () {
+      expect(newModel.uploadGenericPortrait).not.toHaveBeenCalled()
+      expect(console.warn).toHaveBeenCalled()
+      done()
+    })
+  })
+
+  it('still finishes the fork when the fetch itself rejects', function (done) {
+    spyOn(window, 'fetch').and.returnValue(Promise.reject(new Error('offline')))
+    const newModel = makeNewModel()
+    proto.copyThangPortrait.call(makeModal(), newModel, function () {
+      expect(newModel.uploadGenericPortrait).not.toHaveBeenCalled()
+      expect(console.warn.calls.mostRecent().args[0]).toContain('Silver Door')
+      done()
+    })
+  })
+
+  it('skips the copy when the parent has no original', function (done) {
+    spyOn(window, 'fetch')
+    const modal = makeModal()
+    modal.model.attributes.original = undefined
+    proto.copyThangPortrait.call(modal, makeNewModel(), function () {
+      expect(window.fetch).not.toHaveBeenCalled()
+      done()
+    })
+  })
+})

--- a/test/app/views/editor/thang/ThangTypeEditView.spec.js
+++ b/test/app/views/editor/thang/ThangTypeEditView.spec.js
@@ -172,6 +172,18 @@ describe('ThangTypeEditView portrait upload on save', function () {
     expect(callback).toHaveBeenCalled()
   })
 
+  it('skips the upload without warning for a rasterIcon thang, which the palette shows directly', function () {
+    const view = makeView()
+    view.thangType.attributes.rasterIcon = 'db/thang.type/abc/icon.png'
+    const newThangType = makeNewThangType()
+    const callback = jasmine.createSpy('callback')
+    proto.uploadPortrait.call(view, newThangType, callback)
+    expect(view.thangType.getPortraitSource).not.toHaveBeenCalled()
+    expect(newThangType.uploadGenericPortrait).not.toHaveBeenCalled()
+    expect(callback).toHaveBeenCalled()
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
   it('warns and continues for a raster thang whose sprite sheet is not on screen', function () {
     const view = makeView()
     view.thangType.attributes.raster = 'db/thang.type/abc/rock.png'

--- a/test/app/views/editor/thang/ThangTypeEditView.spec.js
+++ b/test/app/views/editor/thang/ThangTypeEditView.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env jasmine */
 const ThangTypeEditView = require('views/editor/thang/ThangTypeEditView')
 
 // These specs exercise the multi-file Animate upload orchestration
@@ -106,5 +107,79 @@ describe('ThangTypeEditView Animate upload', function () {
       expect(view.hideLoading).toHaveBeenCalled()
       done()
     }).catch(done.fail)
+  })
+})
+
+// The level editor palette reads the static portrait.png that a save uploads.
+// These specs cover the source selection for that upload: it must come from the
+// loaded model (sprite sheets built, raster raw images loaded), and a missing
+// image must be reported instead of silently skipped.
+describe('ThangTypeEditView portrait upload on save', function () {
+  const proto = ThangTypeEditView.prototype
+  const dataURL = 'data:image/png;base64,AAAA'
+
+  function makeView (overrides = {}) {
+    const v = {
+      thangType: {
+        attributes: { name: 'Beach Rock' },
+        get (key) { return this.attributes[key] },
+        getPortraitSource: jasmine.createSpy('getPortraitSource').and.returnValue(dataURL),
+      },
+      getLankOptions () { return { resolutionFactor: 4 } },
+      getPortraitSourceForUpload: proto.getPortraitSourceForUpload,
+      currentLank: null,
+    }
+    return Object.assign(v, overrides)
+  }
+
+  function makeNewThangType () {
+    return { uploadGenericPortrait: jasmine.createSpy('uploadGenericPortrait') }
+  }
+
+  beforeEach(function () {
+    spyOn(console, 'warn')
+  })
+
+  it('renders the portrait from the loaded model with the editor lank options', function () {
+    const view = makeView()
+    const newThangType = makeNewThangType()
+    const callback = jasmine.createSpy('callback')
+    proto.uploadPortrait.call(view, newThangType, callback)
+    expect(view.thangType.getPortraitSource).toHaveBeenCalledWith({ resolutionFactor: 4 })
+    expect(newThangType.uploadGenericPortrait).toHaveBeenCalledWith(callback, dataURL)
+    expect(callback).not.toHaveBeenCalled()
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('warns and continues the save when no portrait could be rendered', function () {
+    const view = makeView()
+    view.thangType.getPortraitSource.and.returnValue(undefined)
+    const newThangType = makeNewThangType()
+    const callback = jasmine.createSpy('callback')
+    proto.uploadPortrait.call(view, newThangType, callback)
+    expect(newThangType.uploadGenericPortrait).not.toHaveBeenCalled()
+    expect(callback).toHaveBeenCalled()
+    expect(console.warn.calls.mostRecent().args[0]).toContain('Beach Rock')
+  })
+
+  it('does not upload a plain URL as a portrait', function () {
+    const view = makeView()
+    view.thangType.getPortraitSource.and.returnValue('/file/db/thang.type/abc/portrait.png')
+    const newThangType = makeNewThangType()
+    const callback = jasmine.createSpy('callback')
+    proto.uploadPortrait.call(view, newThangType, callback)
+    expect(newThangType.uploadGenericPortrait).not.toHaveBeenCalled()
+    expect(callback).toHaveBeenCalled()
+  })
+
+  it('warns and continues for a raster thang whose sprite sheet is not on screen', function () {
+    const view = makeView()
+    view.thangType.attributes.raster = 'db/thang.type/abc/rock.png'
+    const newThangType = makeNewThangType()
+    const callback = jasmine.createSpy('callback')
+    proto.uploadPortrait.call(view, newThangType, callback)
+    expect(view.thangType.getPortraitSource).not.toHaveBeenCalled()
+    expect(newThangType.uploadGenericPortrait).not.toHaveBeenCalled()
+    expect(callback).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Problem

The level editor "Add Thangs" palette shows the static `/file/db/thang.type/<original>/portrait.png`. The server substitutes the generic wizard portrait when that file is missing (server change from Dec 2023), so a missing file looks like a broken portrait setup even when `actions.portrait` is configured.

Scan of all 2571 thang types on prod: 152 serve the wizard fallback; 29 of them have a portrait configured. 25 of those are forks at v0.0 that were never re-saved (e.g. Beach Rock Orange 3, Metal Door Left); 4 were saved but the upload silently produced nothing (e.g. `blue-bubble`, a raster-raw thang).

## Fix

- **Fork** (`ForkModal`): a fork gets a new `original`, but nothing ever uploaded a portrait for it. After the fork saves, fetch the parent's `portrait.png` and upload it under the new original. Any failure only warns and the fork still navigates.
- **Save** (`ThangTypeEditView.saveNewThangType`): the portrait was rendered from the fresh clone, which has no sprite sheets or raster raw images loaded, so raster-raw thangs uploaded nothing. Render from the loaded model with the editor's lank options (the same call the editor's own portrait thumbnail uses). Warn in the console when no portrait could be produced instead of skipping silently.

## Existing broken thangs

Not backfilled here. Re-saving each thang in the thang editor (with this change for raster-raw ones) regenerates the file.

## Tests

- `ThangTypeEditView.spec.js`: 4 specs for portrait source selection / warn-and-continue.
- `ForkModal.spec.js` (new): 4 specs for parent portrait copy and non-blocking failure.
- Full Karma suite: 7379 executed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Forking a thang now preserves its parent portrait when available.
  - Portrait uploads continue for supported content, while raster icons skip unnecessary portrait generation.

- **Bug Fixes**
  - Missing, unavailable, or unsupported portrait sources no longer block saving or navigation.
  - Portrait requests now stop after a timeout, allowing forks to continue.
  - Failed portrait uploads still complete the save or fork workflow with a warning.

- **Tests**
  - Added coverage for portrait copying, uploads, timeouts, and graceful failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->