### PR TITLE
AI Junior: start new scenario prompts with Flare

### DIFF
--- a/app/schemas/models/ai_junior_scenario.schema.js
+++ b/app/schemas/models/ai_junior_scenario.schema.js
@@ -31,15 +31,15 @@ _.extend(AIJuniorScenarioSchema.properties, {
   priority: {
     title: 'Priority',
     description: 'Lower numbers will show earlier.',
-    type: 'integer'
+    type: 'integer',
   },
   gradeLevels: c.object({ title: 'Grade Levels', description: 'Grade range this scenario is appropriate for' }, {
     start: { type: 'string', enum: ['Pre-K', 'K', '1', '2', '3', '4', '5'] },
-    end: { type: 'string', enum: ['Pre-K', 'K', '1', '2', '3', '4', '5'] }
+    end: { type: 'string', enum: ['Pre-K', 'K', '1', '2', '3', '4', '5'] },
   }),
   subjects: c.array({ title: 'Subjects', description: 'Subjects this scenario is appropriate for' }, {
     type: 'string',
-    enum: ['math', 'ela', 'science', 'social-studies', 'art', 'technology', 'sel', 'music', 'computer-science', 'misc']
+    enum: ['math', 'ela', 'science', 'social-studies', 'art', 'technology', 'sel', 'music', 'computer-science', 'misc'],
   }),
   concepts: c.array({ title: 'Learning Concepts', uniqueItems: true }, c.concept),
   inputs: c.array({ title: 'Input Elements', description: 'The AI project worksheets are constructed from these input elements' }, c.object({
@@ -56,7 +56,7 @@ _.extend(AIJuniorScenarioSchema.properties, {
     choices: c.array({}, c.object({ required: ['id', 'text'], default: { id: '', text: '' } }, {
       id: c.shortString(),
       text: c.shortString(),
-      i18n: { type: 'object', format: 'i18n', props: ['text'] }
+      i18n: { type: 'object', format: 'i18n', props: ['text'] },
     })),
     freeChoice: { type: 'boolean', description: 'Whether to allow fill-in-the-blank free choice' },
     exampleValue: {
@@ -64,16 +64,16 @@ _.extend(AIJuniorScenarioSchema.properties, {
         { title: 'Value', type: 'string', maxLength: 30 },
         { title: 'Choices', type: 'array', items: { type: 'string' } },
         { title: 'Image', type: 'string', format: 'image-file', minLength: 31 },
-      ]
+      ],
     },
-    i18n: { type: 'object', format: 'i18n', props: ['label', 'text'] }
+    i18n: { type: 'object', format: 'i18n', props: ['label', 'text'] },
   })),
   inputCss: { type: 'string', format: 'code', aceMode: 'ace/mode/css', description: 'Add extra CSS styles here, like .scenario-input-image-field .input-label { font-size: 24px; }' },
   prompts: c.array({ title: 'Prompts', description: 'AI prompts that process the input fields' }, c.object({
-    required: ['id', 'model', 'text']
+    required: ['id', 'model', 'text'],
   }, {
     id: c.shortString(),
-    model: c.shortString(),
+    model: c.shortString({ default: 'gpt-image-2.5-flare' }),
     text: { type: 'string', format: 'markdown' },
     modelOptions: { type: 'object' },
     files: c.array({ title: 'Files', description: 'Files to include with this prompt' }, c.shortString()),


### PR DESCRIPTION
- `ai_junior_scenario.schema.js` → `prompts[].model`: Treema starts a newly added prompt with `gpt-image-2.5-flare` instead of an empty required model field.

Use the image model Nick selected after reviewing the real scans. Existing prompt models and options remain intact, and editors can still choose a text model or another image model. The remaining edits add the trailing commas required by scoped lint. Nothing outside AI Junior reads or writes this default.

This branch starts independently from `origin/master`. Deploy with https://github.com/codecombat/codecombat-server/pull/1530 so an omitted Flare quality explicitly uses medium; this schema change itself only supplies the model. Existing scenarios receive explicit model/medium-quality pins through a separate editor API update, not through this code diff.

Validation with Node 22.17.1:

- `node /private/tmp/ai-junior-codex/flare-default/check-editor.cjs` — isolated Chrome loaded the actual repository Treema, jQuery, tv4 and this schema. Adding two prompts prefills Flare, changing the first model leaves the next default intact, and opening an existing text prompt preserves its model and options. This is an external verification harness, not a committed test.
- All 15 proposed scenario prompt arrays validated against the actual schema using tv4.
- `./node_modules/.bin/eslint --max-warnings 0 app/schemas/models/ai_junior_scenario.schema.js`, `git diff --check`, and the commit hook — passed.

The full Karma suite was not run for this schema-default change. No browser login or production writes were used by the isolated editor check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Choice labels in AI junior scenarios now support translations.
  - Scenario prompts now include a required model setting, with a default image-generation model.

- **Improvements**
  - Priority values are now explicitly treated as integers.
  - Scenario schema examples and metadata definitions have been clarified for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->