### PR TITLE
when having session but not submitted, do not query myrank

### DIFF
--- a/app/views/payment/NewManageBillingView/index.vue
+++ b/app/views/payment/NewManageBillingView/index.vue
@@ -129,7 +129,7 @@ export default {
         return
       }
       const session = sessions[0]
-      const score = (session.stats || {}).totalScore
+      const score = session.totalScore
       if (score) {
         const mine = await leaderboardApi.getMyRank(arena.levelOriginal, sessions[0]._id, {
           totalScore: score,

--- a/app/views/payment/NewManageBillingView/index.vue
+++ b/app/views/payment/NewManageBillingView/index.vue
@@ -128,12 +128,19 @@ export default {
       if (!sessions?.length) {
         return
       }
-      const mine = await leaderboardApi.getMyRank(arena.levelOriginal, sessions[0]._id)
-      this.aileagueStats = {
-        slug: arena.slug,
-        total: parseInt(total),
-        myRank: parseInt(mine),
-        name: utils.i18n(level, 'name'),
+      const session = sessions[0]
+      const score = (session.stats || {}).totalScore
+      if (score) {
+        const mine = await leaderboardApi.getMyRank(arena.levelOriginal, sessions[0]._id, {
+          totalScore: score,
+          team: 'humans',
+        })
+        this.aileagueStats = {
+          slug: arena.slug,
+          total: parseInt(total),
+          myRank: parseInt(mine),
+          name: utils.i18n(level, 'name'),
+        }
       }
     },
   },


### PR DESCRIPTION
<img width="1666" height="869" alt="image" src="https://github.com/user-attachments/assets/7cc89145-910f-4fe1-874a-7857c1040e85" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AI League rank lookup now uses the first session’s total score.
  * Rank retrieval occurs only when a score is available and targets the human team.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->