### PR TITLE
[GD-882] Admin panel: grant items to a player

### DIFF
--- a/app/core/api/users.js
+++ b/app/core/api/users.js
@@ -152,6 +152,15 @@ module.exports = {
     }))
   },
 
+  // Admin only: append item ThangType originals to the user's earned.items.
+  // Resolves to { added, alreadyOwned, earnedItems }.
+  grantItems ({ userId, items }, options = {}) {
+    return fetchJson(`/db/user/${userId}/grant-items`, _.assign({}, options, {
+      method: 'POST',
+      json: { items },
+    }))
+  },
+
   loginArapahoe (attrs, options) {
     if (options == null) { options = {} }
     return fetchJson('/auth/login-arapahoe', _.assign({}, options, {

--- a/app/models/CocoModel.js
+++ b/app/models/CocoModel.js
@@ -238,6 +238,7 @@ class CocoModel extends Backbone.Model {
         if (this.retries > 20) {
           msg = 'Your computer or our servers appear to be offline. Please try refreshing.'
           noty({ text: msg, layout: 'center', type: 'error', killer: true })
+          if (error) { error(this, res) } // let the caller release any in-flight state
           return
         } else {
           msg = $.i18n.t('loading_error.connection_failure', { defaultValue: 'Connection failed.' })

--- a/app/styles/admin/administer-user-modal.sass
+++ b/app/styles/admin/administer-user-modal.sass
@@ -26,10 +26,15 @@
       margin: 4px 0 0
 
       .item-search-result
+        display: block
+        width: 100%
+        text-align: left
+        background: none
+        border: 0
         padding: 3px 6px
         cursor: pointer
 
-        &:hover
+        &:hover, &:focus
           background: #f0f0f0
 
         .item-name

--- a/app/styles/admin/administer-user-modal.sass
+++ b/app/styles/admin/administer-user-modal.sass
@@ -7,6 +7,66 @@
 
   #edit-school-admins-link
     text-decoration: underline
+
+  #grant-items
+    .item-icon
+      width: 32px
+      height: 32px
+      object-fit: contain
+      margin-right: 6px
+      vertical-align: middle
+
+    #item-search
+      max-width: 400px
+
+    #item-search-results
+      max-width: 400px
+      max-height: 240px
+      overflow-y: auto
+      margin: 4px 0 0
+
+      .item-search-result
+        padding: 3px 6px
+        cursor: pointer
+
+        &:hover
+          background: #f0f0f0
+
+        .item-name
+          margin-right: 6px
+
+        .item-slug, .item-slots
+          margin-right: 6px
+
+    #selected-items
+      margin-top: 6px
+
+      .selected-item
+        display: inline-flex
+        align-items: center
+        font-size: 12px
+        margin: 2px 6px 2px 0
+        padding: 3px 6px
+
+        .remove-selected-item
+          margin-left: 6px
+          font-size: 16px
+          line-height: 1
+
+    .item-grant-status
+      margin-top: 6px
+
+    #owned-items
+      margin-top: 6px
+
+      summary
+        cursor: pointer
+
+      .owned-item
+        padding: 2px 0
+
+        .item-name, .item-slug, code
+          margin-right: 6px
   
   #license-type-select
     .license-type

--- a/app/templates/admin/administer-user-modal.pug
+++ b/app/templates/admin/administer-user-modal.pug
@@ -453,7 +453,7 @@ block modal-body-content
               span.selected-item.label.label-default(data-original=item.get('original'))
                 img.item-icon(src=item.getPortraitURL(), alt="", onerror="this.style.visibility='hidden'")
                 span= item.get('name')
-                button.remove-selected-item.close(type="button", data-original=item.get('original'), title="Remove") &times;
+                button.remove-selected-item.close(type="button", data-original=item.get('original'), title="Remove", aria-label="Remove " + item.get('name')) &times;
           if view.itemGrantMessage
             .item-grant-status.small(role="status", aria-live="polite", class=view.itemGrantState === 'error' ? 'text-danger' : (view.itemGrantState === 'saved' ? 'text-success' : 'text-muted'))= view.itemGrantMessage
           details#owned-items

--- a/app/templates/admin/administer-user-modal.pug
+++ b/app/templates/admin/administer-user-modal.pug
@@ -455,7 +455,7 @@ block modal-body-content
                 span= item.get('name')
                 button.remove-selected-item.close(type="button", data-original=item.get('original'), title="Remove") &times;
           if view.itemGrantMessage
-            .item-grant-status.small(class=view.itemGrantState === 'error' ? 'text-danger' : (view.itemGrantState === 'saved' ? 'text-success' : 'text-muted'))= view.itemGrantMessage
+            .item-grant-status.small(role="status", aria-live="polite", class=view.itemGrantState === 'error' ? 'text-danger' : (view.itemGrantState === 'saved' ? 'text-success' : 'text-muted'))= view.itemGrantMessage
           details#owned-items
             summary.small Owned items (#{ownedRows.length})
             ul.list-unstyled

--- a/app/templates/admin/administer-user-modal.pug
+++ b/app/templates/admin/administer-user-modal.pug
@@ -440,11 +440,12 @@ block modal-body-content
           input#item-search.form-control(type="text", placeholder="Search items by name or slug", autocomplete="off", disabled=view.itemCatalogLoading || !view.itemCatalog)
           ul#item-search-results.list-unstyled
             for item in view.itemSearchResults
-              li.item-search-result(data-original=item.get('original'), title="Add " + item.get('name'))
-                img.item-icon(src=item.getPortraitURL(), alt="", onerror="this.style.visibility='hidden'")
-                span.item-name= item.get('name')
-                small.text-muted.item-slug= item.get('slug')
-                small.text-muted.item-slots= item.getAllowedSlots().join(', ')
+              li
+                button.item-search-result(type="button", data-original=item.get('original'), title="Add " + item.get('name'))
+                  img.item-icon(src=item.getPortraitURL(), alt="", onerror="this.style.visibility='hidden'")
+                  span.item-name= item.get('name')
+                  small.text-muted.item-slug= item.get('slug')
+                  small.text-muted.item-slots= item.getAllowedSlots().join(', ')
           #selected-items
             if view.selectedItems.length
               .small Will be granted on Save Changes:

--- a/app/templates/admin/administer-user-modal.pug
+++ b/app/templates/admin/administer-user-modal.pug
@@ -431,6 +431,42 @@ block modal-body-content
             =" "
             input#stripe-add-gems(type="number", name="addGems", value=0)
             |  (they have #{view.user.gems().toLocaleString()})
+        #grant-items.form-group
+          - var ownedRows = view.ownedItemRows()
+          label(for="item-search")
+            span Items to add to user
+            if view.itemCatalogLoading
+              small.text-muted  (loading item list…)
+          input#item-search.form-control(type="text", placeholder="Search items by name or slug", autocomplete="off", disabled=view.itemCatalogLoading || !view.itemCatalog)
+          ul#item-search-results.list-unstyled
+            for item in view.itemSearchResults
+              li.item-search-result(data-original=item.get('original'), title="Add " + item.get('name'))
+                img.item-icon(src=item.getPortraitURL(), alt="", onerror="this.style.visibility='hidden'")
+                span.item-name= item.get('name')
+                small.text-muted.item-slug= item.get('slug')
+                small.text-muted.item-slots= item.getAllowedSlots().join(', ')
+          #selected-items
+            if view.selectedItems.length
+              .small Will be granted on Save Changes:
+            for item in view.selectedItems
+              span.selected-item.label.label-default(data-original=item.get('original'))
+                img.item-icon(src=item.getPortraitURL(), alt="", onerror="this.style.visibility='hidden'")
+                span= item.get('name')
+                button.remove-selected-item.close(type="button", data-original=item.get('original'), title="Remove") &times;
+          if view.itemGrantMessage
+            .item-grant-status.small(class=view.itemGrantState === 'error' ? 'text-danger' : (view.itemGrantState === 'saved' ? 'text-success' : 'text-muted'))= view.itemGrantMessage
+          details#owned-items
+            summary.small Owned items (#{ownedRows.length})
+            ul.list-unstyled
+              for row in ownedRows
+                li.owned-item
+                  if row.item
+                    img.item-icon(src=row.item.getPortraitURL(), alt="", onerror="this.style.visibility='hidden'")
+                    span.item-name= row.item.get('name')
+                    small.text-muted.item-slug= row.item.get('slug')
+                  else
+                    code= row.original
+                  span.label(class=row.source === 'earned' ? 'label-info' : 'label-primary')= row.source
         button#save-changes.btn.btn-primary Save Changes
       hr
     else if me.isOnlineTeacher()

--- a/app/views/admin/AdministerUserModal.js
+++ b/app/views/admin/AdministerUserModal.js
@@ -251,12 +251,15 @@ module.exports = (AdministerUserModal = (function () {
         this.user.set('purchased', purchased)
       }
 
-      this.grantSelectedItems()
-
       const options = {}
       options.success = () => {
         this.updateStripeStatus?.()
         return this.render?.()
+      }
+      if (this.selectedItems.length) {
+        // Grant first: the PUT response replaces the model, and a concurrent
+        // grant could otherwise be overwritten with a pre-grant copy of earned.
+        return this.grantSelectedItems().then(() => this.user.patch(options))
       }
       return this.user.patch(options)
     }
@@ -338,7 +341,7 @@ module.exports = (AdministerUserModal = (function () {
     }
 
     onClickItemSearchResult (e) {
-      const original = this.$(e.currentTarget).data('original')
+      const original = this.$(e.currentTarget).attr('data-original') // .data() would coerce all-digit ids to Number
       const item = this.itemCatalog?.[original]
       if (!item) { return }
       if (!this.selectedItems.some(selected => selected.get('original') === original)) {
@@ -352,13 +355,14 @@ module.exports = (AdministerUserModal = (function () {
     }
 
     onClickRemoveSelectedItem (e) {
-      const original = this.$(e.currentTarget).data('original')
+      const original = this.$(e.currentTarget).attr('data-original')
       this.selectedItems = this.selectedItems.filter(item => item.get('original') !== original)
       this.renderSelectors('#selected-items')
     }
 
+    // Always resolves; failures are shown in the panel, never thrown.
     grantSelectedItems () {
-      if (!this.selectedItems.length) { return }
+      if (!this.selectedItems.length) { return Promise.resolve() }
       const items = this.selectedItems.map(item => item.get('original'))
       this.itemGrantState = 'saving'
       this.itemGrantMessage = `Granting ${items.length} item(s)…`

--- a/app/views/admin/AdministerUserModal.js
+++ b/app/views/admin/AdministerUserModal.js
@@ -105,6 +105,8 @@ module.exports = (AdministerUserModal = (function () {
       this.classrooms = new Classrooms()
       this.supermodel.trackRequest(this.user.fetch({ cache: false }))
       this.listenTo(this.user, 'sync', () => {
+        // The item picker only renders for admins on home users; load its catalog only then, once.
+        if (me.isAdmin() && this.user.isHomeUser() && !this.itemCatalog) { this.loadItemCatalog() }
         if (this.user.isStudent()) {
           this.supermodel.loadCollection(this.classrooms, { data: { memberID: this.user.id }, cache: false })
           this.listenTo(this.classrooms, 'sync', this.loadClassroomTeacherNames)
@@ -140,7 +142,6 @@ module.exports = (AdministerUserModal = (function () {
       this.itemSearchResults = []
       this.itemGrantState = ''
       this.itemGrantMessage = ''
-      if (me.isAdmin()) { this.loadItemCatalog() }
       this.licenseType = 'all'
       this.licensePresets = LICENSE_PRESETS
       this.esportsType = 'basic'
@@ -289,7 +290,7 @@ module.exports = (AdministerUserModal = (function () {
       fetcher.skip = 0
       this.itemCatalogLoading = true
       this.itemCatalog = {}
-      this.listenTo(fetcher, 'sync', () => this.onItemCatalogPage(fetcher))
+      this.listenTo(fetcher, 'sync', (collection, response) => this.onItemCatalogPage(fetcher, response))
       this.listenTo(fetcher, 'error', () => {
         this.itemCatalogLoading = false
         this.itemGrantState = 'error'
@@ -299,11 +300,12 @@ module.exports = (AdministerUserModal = (function () {
       fetcher.fetch({ data: { skip: 0, limit: ITEM_CATALOG_PAGE_SIZE }, cache: false })
     }
 
-    onItemCatalogPage (fetcher) {
+    onItemCatalogPage (fetcher, response) {
       for (const item of fetcher.models) {
         this.itemCatalog[item.get('original')] = item
       }
-      if (fetcher.models.length === ITEM_CATALOG_PAGE_SIZE) {
+      // fetcher.models accumulates across pages, so page size must come from the response.
+      if ((response?.length ?? 0) === ITEM_CATALOG_PAGE_SIZE) {
         fetcher.skip += ITEM_CATALOG_PAGE_SIZE
         fetcher.fetch({ data: { skip: fetcher.skip, limit: ITEM_CATALOG_PAGE_SIZE }, cache: false })
         return
@@ -387,8 +389,12 @@ module.exports = (AdministerUserModal = (function () {
           const earned = _.clone(this.user.get('earned') ?? {})
           earned.items = earnedItems
           this.user.set('earned', earned)
+          // Treat the server's earned as the saved baseline so the following patch does not
+          // resend it (the server ignores it, but a stale snapshot in a PUT reads badly).
+          this.user.markToRevert()
           this.modelTreemas?.[this.user.id]?.set('earned', earned)
-          this.selectedItems = []
+          // Drop only what this request granted; anything picked meanwhile stays selected.
+          this.selectedItems = this.selectedItems.filter(item => !items.includes(item.get('original')))
           this.itemGrantState = 'saved'
           this.itemGrantMessage = `Granted ${added.length} item(s), ${alreadyOwned.length} already owned`
         })

--- a/app/views/admin/AdministerUserModal.js
+++ b/app/views/admin/AdministerUserModal.js
@@ -228,6 +228,24 @@ module.exports = (AdministerUserModal = (function () {
     }
 
     onClickSaveChanges () {
+      if (this.savingChanges) { return }
+      this.savingChanges = true
+      const finish = () => { this.savingChanges = false }
+      if (!this.selectedItems.length) { return this.saveSubscriptionAndGems(finish) }
+      // Grant first, before the model is mutated: the PUT response replaces the
+      // model (a concurrent grant could be overwritten with a pre-grant copy of
+      // earned), and a failed grant must not leave unsaved gems on the model.
+      return this.grantSelectedItems().then(
+        () => this.saveSubscriptionAndGems(finish),
+        () => {
+          finish()
+          this.itemGrantMessage += ' Subscription and gems changes were not saved; fix the items and save again.'
+          this.renderSelectors('#grant-items')
+        },
+      )
+    }
+
+    saveSubscriptionAndGems (finish) {
       const stripe = _.clone(this.user.get('stripe') || {})
       delete stripe.free
       delete stripe.couponID
@@ -253,14 +271,11 @@ module.exports = (AdministerUserModal = (function () {
 
       const options = {}
       options.success = () => {
+        finish()
         this.updateStripeStatus?.()
         return this.render?.()
       }
-      if (this.selectedItems.length) {
-        // Grant first: the PUT response replaces the model, and a concurrent
-        // grant could otherwise be overwritten with a pre-grant copy of earned.
-        return this.grantSelectedItems().then(() => this.user.patch(options))
-      }
+      options.error = finish
       return this.user.patch(options)
     }
 
@@ -360,7 +375,7 @@ module.exports = (AdministerUserModal = (function () {
       this.renderSelectors('#selected-items')
     }
 
-    // Always resolves; failures are shown in the panel, never thrown.
+    // Rejects on failure after showing the error in the panel, so callers can stop the save flow.
     grantSelectedItems () {
       if (!this.selectedItems.length) { return Promise.resolve() }
       const items = this.selectedItems.map(item => item.get('original'))
@@ -377,11 +392,15 @@ module.exports = (AdministerUserModal = (function () {
           this.itemGrantState = 'saved'
           this.itemGrantMessage = `Granted ${added.length} item(s), ${alreadyOwned.length} already owned`
         })
-        .catch(err => {
-          this.itemGrantState = 'error'
-          this.itemGrantMessage = err?.message || 'Granting items failed'
-        })
-        .then(() => this.renderSelectors('#grant-items'))
+        .then(
+          () => this.renderSelectors('#grant-items'),
+          err => {
+            this.itemGrantState = 'error'
+            this.itemGrantMessage = err?.message || 'Granting items failed'
+            this.renderSelectors('#grant-items')
+            throw err
+          },
+        )
     }
 
     onClickAddCreditsButton () {

--- a/app/views/admin/AdministerUserModal.js
+++ b/app/views/admin/AdministerUserModal.js
@@ -14,6 +14,8 @@ require('app/styles/admin/administer-user-modal.sass')
 const ModelModal = require('views/modal/ModelModal')
 const template = require('app/templates/admin/administer-user-modal')
 const User = require('models/User')
+const ThangType = require('models/ThangType')
+const CocoCollection = require('collections/CocoCollection')
 const Prepaid = require('models/Prepaid')
 const StripeCoupons = require('collections/StripeCoupons')
 const forms = require('core/forms')
@@ -27,6 +29,9 @@ const api = require('core/api')
 const NameLoader = require('core/NameLoader')
 const OnlineTeacherSchema = require('schemas/models/online_teacher')
 const { LICENSE_PRESETS, ESPORTS_PRODUCT_STATS } = require('core/constants')
+
+const ITEM_CATALOG_PAGE_SIZE = 200
+const ITEM_SEARCH_MAX_RESULTS = 20
 
 // TODO: the updateAdministratedTeachers method could be moved to an afterRender lifecycle method.
 // TODO: Then we could use @render in the finally method, and remove the repeated use of both of them through the file.
@@ -75,7 +80,11 @@ module.exports = (AdministerUserModal = (function () {
         'click .other-user-link': 'onClickOtherUserLink',
         'click .modal-nav-link': 'onClickModalNavLink',
         'click #volume-checkbox': 'onClickVolumeCheckbox',
-        'click #music-checkbox': 'onClickMusicCheckbox'
+        'click #music-checkbox': 'onClickMusicCheckbox',
+        'input #item-search': 'onItemSearchInput',
+        'keydown #item-search': 'onItemSearchKeydown',
+        'click .item-search-result': 'onClickItemSearchResult',
+        'click .remove-selected-item': 'onClickRemoveSelectedItem',
       }
     }
 
@@ -125,6 +134,13 @@ module.exports = (AdministerUserModal = (function () {
       if (me.isAdmin()) { this.supermodel.trackRequest(this.trialRequests.fetchByApplicant(this.userHandle)) }
       this.timeZone = features?.chinaInfra ? 'Asia/Shanghai' : 'America/Los_Angeles'
       this.userTimeZone = utils.getUserTimeZone(this.user)
+      this.itemCatalog = null // ThangType models for every store/inventory item, keyed by original
+      this.itemCatalogLoading = false
+      this.selectedItems = []
+      this.itemSearchResults = []
+      this.itemGrantState = ''
+      this.itemGrantMessage = ''
+      if (me.isAdmin()) { this.loadItemCatalog() }
       this.licenseType = 'all'
       this.licensePresets = LICENSE_PRESETS
       this.esportsType = 'basic'
@@ -235,12 +251,133 @@ module.exports = (AdministerUserModal = (function () {
         this.user.set('purchased', purchased)
       }
 
+      this.grantSelectedItems()
+
       const options = {}
       options.success = () => {
         this.updateStripeStatus?.()
         return this.render?.()
       }
       return this.user.patch(options)
+    }
+
+    // --- Item grants -------------------------------------------------------
+
+    loadItemCatalog () {
+      // Same set the store and inventory show: kind Item with a slug and a tier.
+      // Loaded outside the supermodel so the modal does not wait on it.
+      const project = ['name', 'slug', 'original', 'rasterIcon', 'kind', 'components.config', 'components.original']
+      const fetcher = new CocoCollection([], { url: '/db/thang.type?view=items', project, model: ThangType })
+      fetcher.skip = 0
+      this.itemCatalogLoading = true
+      this.itemCatalog = {}
+      this.listenTo(fetcher, 'sync', () => this.onItemCatalogPage(fetcher))
+      this.listenTo(fetcher, 'error', () => {
+        this.itemCatalogLoading = false
+        this.itemGrantState = 'error'
+        this.itemGrantMessage = 'Could not load the item list'
+        this.renderGrantItems()
+      })
+      fetcher.fetch({ data: { skip: 0, limit: ITEM_CATALOG_PAGE_SIZE }, cache: false })
+    }
+
+    onItemCatalogPage (fetcher) {
+      for (const item of fetcher.models) {
+        this.itemCatalog[item.get('original')] = item
+      }
+      if (fetcher.models.length === ITEM_CATALOG_PAGE_SIZE) {
+        fetcher.skip += ITEM_CATALOG_PAGE_SIZE
+        fetcher.fetch({ data: { skip: fetcher.skip, limit: ITEM_CATALOG_PAGE_SIZE }, cache: false })
+        return
+      }
+      this.itemCatalogLoading = false
+      this.renderGrantItems()
+    }
+
+    // The catalog can finish before the user has loaded; the full render on load picks it up then.
+    renderGrantItems () {
+      if (!this.supermodel.finished()) { return }
+      this.renderSelectors('#grant-items')
+    }
+
+    // Rows for the "owned items" list: earned first, then purchased, deduped.
+    ownedItemRows () {
+      const rows = []
+      const seen = new Set()
+      const sources = [['earned', this.user.get('earned')?.items ?? []], ['purchased', this.user.get('purchased')?.items ?? []]]
+      for (const [source, originals] of sources) {
+        for (const original of originals) {
+          if (seen.has(original)) { continue }
+          seen.add(original)
+          rows.push({ original, source, item: this.itemCatalog?.[original] ?? null })
+        }
+      }
+      return rows
+    }
+
+    onItemSearchInput (e) {
+      const term = this.$(e.currentTarget).val().trim()
+      if (!term || !this.itemCatalog) {
+        this.itemSearchResults = []
+      } else {
+        const selected = new Set(this.selectedItems.map(item => item.get('original')))
+        const matcher = new RegExp(term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') // lodash 2.x has no escapeRegExp
+        this.itemSearchResults = _.values(this.itemCatalog)
+          .filter(item => !selected.has(item.get('original')) && (matcher.test(item.get('name') ?? '') || matcher.test(item.get('slug') ?? '')))
+          .sort((a, b) => (a.get('name') ?? '').localeCompare(b.get('name') ?? ''))
+          .slice(0, ITEM_SEARCH_MAX_RESULTS)
+      }
+      this.renderSelectors('#item-search-results')
+    }
+
+    onItemSearchKeydown (e) {
+      if (e.key !== 'Escape') { return }
+      this.$(e.currentTarget).val('')
+      this.itemSearchResults = []
+      this.renderSelectors('#item-search-results')
+    }
+
+    onClickItemSearchResult (e) {
+      const original = this.$(e.currentTarget).data('original')
+      const item = this.itemCatalog?.[original]
+      if (!item) { return }
+      if (!this.selectedItems.some(selected => selected.get('original') === original)) {
+        this.selectedItems.push(item)
+      }
+      this.itemSearchResults = []
+      this.itemGrantState = ''
+      this.itemGrantMessage = ''
+      this.renderSelectors('#grant-items')
+      this.$('#item-search').val('').focus()
+    }
+
+    onClickRemoveSelectedItem (e) {
+      const original = this.$(e.currentTarget).data('original')
+      this.selectedItems = this.selectedItems.filter(item => item.get('original') !== original)
+      this.renderSelectors('#selected-items')
+    }
+
+    grantSelectedItems () {
+      if (!this.selectedItems.length) { return }
+      const items = this.selectedItems.map(item => item.get('original'))
+      this.itemGrantState = 'saving'
+      this.itemGrantMessage = `Granting ${items.length} item(s)…`
+      this.renderSelectors('#grant-items')
+      return api.users.grantItems({ userId: this.user.id, items })
+        .then(({ added, alreadyOwned, earnedItems }) => {
+          const earned = _.clone(this.user.get('earned') ?? {})
+          earned.items = earnedItems
+          this.user.set('earned', earned)
+          this.modelTreemas?.[this.user.id]?.set('earned', earned)
+          this.selectedItems = []
+          this.itemGrantState = 'saved'
+          this.itemGrantMessage = `Granted ${added.length} item(s), ${alreadyOwned.length} already owned`
+        })
+        .catch(err => {
+          this.itemGrantState = 'error'
+          this.itemGrantMessage = err?.message || 'Granting items failed'
+        })
+        .then(() => this.renderSelectors('#grant-items'))
     }
 
     onClickAddCreditsButton () {

--- a/app/views/admin/AdministerUserModal.js
+++ b/app/views/admin/AdministerUserModal.js
@@ -277,7 +277,9 @@ module.exports = (AdministerUserModal = (function () {
         return this.render?.()
       }
       options.error = finish
-      return this.user.patch(options)
+      const request = this.user.patch(options)
+      if (!request) { finish() } // nothing changed, no request sent, so no callback will run
+      return request
     }
 
     // --- Item grants -------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds an "Items to add to user" control to `AdministerUserModal`, under the gems field in the Modify Subscription section (admin + home user, same gate as gems).

- Searchable picker over the store/inventory item set (`/db/thang.type?view=items`), matched by name or slug, showing icon and slots. Client-side filter over a catalog loaded once (paginated, outside the supermodel so the modal does not wait on it).
- Multi-select with removable chips. Applied on **Save Changes**: the grant runs first, then the existing gems/subscription patch, so the PUT response cannot overwrite `earned` with a stale copy. With nothing selected the save path is unchanged.
- Success/failure status line in the panel; server 422 text is shown as-is.
- Collapsible "Owned items" list (earned + purchased, badged), refreshed from the grant response and synced into the user Treema.

Server side: https://github.com/codecombat/codecombat-server/pull/1534. Endpoint is `POST /db/user/:handle/grant-items`, admin only, writes `earned.items` deduped.

## Test plan

- [x] Karma suite via `scripts/test-codecombat-chromium.sh`: 7385 passed, 0 failed (bundle compiles with new pug/sass/js).
- [x] Manual, admin on a home test account: search by name and by slug, select two, remove one, Save. Status line shows counts; owned list shows the item as `earned`.
- [x] Reload: still owned; in-game inventory shows the item.
- [x] Grant same item again: "0 granted, 1 already owned", no duplicate in `earned.items`.
- [x] Gems + item in one save: both apply.
- [x] Existing gems / subscription / credits / products flows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Administrators can search the item catalog by name or slug when modifying a user.
  - Administrators can select multiple items to grant and remove selections before saving.
  - The user administration view displays items already owned by the user.
  - Grant success and error messages provide clear status feedback.
  - Search results support keyboard selection.
- **Bug Fixes**
  - Other user changes are not saved if granting items fails.
  - Concurrent saves are prevented while changes are being processed.
  - Grant status updates are announced to assistive technologies.
  - Save controls recover correctly after offline or failed requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->