### PR TITLE
[GD-901] Starter-code comments fall back to English per key when a locale context is incomplete

### DIFF
--- a/app/core/store/modules/game.js
+++ b/app/core/store/modules/game.js
@@ -206,7 +206,7 @@ module.exports = {
           // eslint-disable-next-line camelcase
           const external_ch1_avatar = __guard__(rootState.me.ozariaUserOptions != null ? rootState.me.ozariaUserOptions.avatar : undefined, x3 => x3.avatarCodeString) != null ? __guard__(rootState.me.ozariaUserOptions != null ? rootState.me.ozariaUserOptions.avatar : undefined, x3 => x3.avatarCodeString) : 'crown'
           // eslint-disable-next-line camelcase
-          const context = _.merge({ external_ch1_avatar }, utils.i18n(plan, 'context'))
+          const context = _.merge({ external_ch1_avatar }, utils.i18nCommentContext(plan))
           source = _.template(rawSource)(context)
 
           if (!_.isEmpty(source)) {
@@ -269,7 +269,7 @@ module.exports = {
         }
 
         try {
-          source = _.template(rawSource)(utils.i18n(plan, 'context'))
+          source = _.template(rawSource)(utils.i18nCommentContext(plan))
         } catch (e) {
           console.error(`Cannot auto fill solution: ${e.message}`)
         }

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -713,6 +713,18 @@ var i18n = function (say, target, language, fallback) {
   return null // if we call i18n for a unexisting key
 }
 
+// Starter-code comment context for a programmable plan (anything with `context` + `i18n`).
+// Layers the localized context over the English one key by key. A locale whose context is
+// missing (or blank for) a key would otherwise make _.template throw and leave every
+// <%= placeholder %> raw for that locale; this way only the missing key falls back to English.
+const i18nCommentContext = function (plan) {
+  if (!plan) { return {} }
+  const english = removeAI(plan.context || {})
+  const localized = i18n(plan, 'context') || {}
+  const filled = _.pick(localized, value => !_.isString(value) || value.trim())
+  return _.merge({}, english, filled)
+}
+
 const getByPath = function (target, path) {
   if (!target) { throw new Error('Expected an object to match a query against, instead got null') }
   const pieces = path.split('.')
@@ -2073,6 +2085,7 @@ module.exports = {
   hourOfCodeOptions,
   hslToHex,
   i18n,
+  i18nCommentContext,
   inEU,
   injectCSS,
   internalCampaignIds,

--- a/app/models/Level.js
+++ b/app/models/Level.js
@@ -589,7 +589,13 @@ module.exports = (Level = (function () {
 
     getCodeContext (plan) {
       if (!plan) return {}
-      let context = utils.i18n(plan, 'context')
+      // Layer the localized context over the English one key by key. A locale whose context is
+      // missing (or blank for) a key would otherwise make _.template throw and leave every
+      // <%= placeholder %> raw for that locale; this way only the missing key falls back to English.
+      const english = utils.removeAI(plan.context || {})
+      const localized = utils.i18n(plan, 'context') || {}
+      const filled = _.pick(localized, value => !_.isString(value) || value.trim())
+      let context = _.merge({}, english, filled)
       if (utils.showOzaria()) {
         context = _.merge({
           external_ch1_avatar: store.getters?.['me/getCh1Avatar.avatarCodeString']?.crown,

--- a/app/models/Level.js
+++ b/app/models/Level.js
@@ -589,13 +589,7 @@ module.exports = (Level = (function () {
 
     getCodeContext (plan) {
       if (!plan) return {}
-      // Layer the localized context over the English one key by key. A locale whose context is
-      // missing (or blank for) a key would otherwise make _.template throw and leave every
-      // <%= placeholder %> raw for that locale; this way only the missing key falls back to English.
-      const english = utils.removeAI(plan.context || {})
-      const localized = utils.i18n(plan, 'context') || {}
-      const filled = _.pick(localized, value => !_.isString(value) || value.trim())
-      let context = _.merge({}, english, filled)
+      let context = utils.i18nCommentContext(plan)
       if (utils.showOzaria()) {
         context = _.merge({
           external_ch1_avatar: store.getters?.['me/getCh1Avatar.avatarCodeString']?.crown,

--- a/app/views/play/level/tome/Spell.coffee
+++ b/app/views/play/level/tome/Spell.coffee
@@ -115,7 +115,7 @@ module.exports = class Spell
         commentContext[k] = v.replace /\b([a-zA-Z]+)\.([a-zA-Z_]+\()/, '$1:$2'
 
     if commentI18N
-      commentContext = utils.i18n({context: commentContext, i18n: commentI18N, spokenLanguage: spokenLanguage}, 'context')
+      commentContext = utils.i18nCommentContext({context: commentContext, i18n: commentI18N})
     try
       translatedSource = _.template source, commentContext
     catch e

--- a/app/views/teachers/TeacherCourseSolutionView.js
+++ b/app/views/teachers/TeacherCourseSolutionView.js
@@ -220,7 +220,7 @@ ${translateUtils.translateJS(a.slice(13, +(a.length - 4) + 1 || undefined), this
             } else {
               defaultCode = programmableMethod.languages?.[level.get('primerLanguage') || this.language] || ((this.language === 'cpp') && translateUtils.translateJS(programmableMethod.source, 'cpp')) || programmableMethod.source
             }
-            translatedDefaultCode = _.template(defaultCode)(utils.i18n(programmableMethod, 'context'))
+            translatedDefaultCode = _.template(defaultCode)(utils.i18nCommentContext(programmableMethod))
             if (!translatedDefaultCode) {
               translatedDefaultCode = '\n' // Distinguish empty starter code from nothing so it's not falsy
             }

--- a/test/app/core/utils.spec.coco.js
+++ b/test/app/core/utils.spec.coco.js
@@ -429,6 +429,39 @@ describe('Utility library', function () {
     })
   })
 
+  describe('i18nCommentContext', function () {
+    const plan = {
+      context: { greet: 'Say hi', parens: 'Use parentheses' },
+      i18n: {
+        nl: { context: { greet: '[AI_TRANSLATION]Zeg hoi', parens: '  ' } },
+        de: { context: { greet: 'Sag hallo', parens: 'Benutze Klammern' } },
+      },
+    }
+    let previousLanguage
+    beforeEach(function () { previousLanguage = me.get('preferredLanguage') })
+    afterEach(function () { me.set('preferredLanguage', previousLanguage) })
+
+    it('layers the locale context over English key by key, treating blanks as missing', function () {
+      me.set('preferredLanguage', 'nl')
+      expect(utils.i18nCommentContext(plan)).toEqual({ greet: 'Zeg hoi', parens: 'Use parentheses' })
+    })
+
+    it('returns the full locale context when it is complete', function () {
+      me.set('preferredLanguage', 'de')
+      expect(utils.i18nCommentContext(plan)).toEqual({ greet: 'Sag hallo', parens: 'Benutze Klammern' })
+    })
+
+    it('returns the English context when the locale has none', function () {
+      me.set('preferredLanguage', 'fr')
+      expect(utils.i18nCommentContext(plan)).toEqual(plan.context)
+    })
+
+    it('handles plans without any context', function () {
+      expect(utils.i18nCommentContext({ source: '' })).toEqual({})
+      expect(utils.i18nCommentContext(undefined)).toEqual({})
+    })
+  })
+
   describe('inEU', function () {
     it('EU countries return true', function () {
       const euCountries = ['Austria', 'Belgium', 'Bulgaria', 'Croatia', 'Cyprus', 'Czech Republic', 'Denmark', 'Estonia', 'Finland', 'France', 'Germany', 'Greece', 'Hungary', 'Ireland', 'Italy', 'Latvia', 'Lithuania', 'Luxembourg', 'Malta', 'Netherlands', 'Poland', 'Portugal', 'Romania', 'Slovakia', 'Slovenia', 'Spain', 'Sweden', 'United Kingdom']

--- a/test/app/models/Level.spec.js
+++ b/test/app/models/Level.spec.js
@@ -4,61 +4,132 @@
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/main/docs/suggestions.md
  */
-const SuperModel = require('models/SuperModel');
-const Level = require('models/Level');
-const ThangType = require('models/ThangType');
+const SuperModel = require('models/SuperModel')
+const Level = require('models/Level')
+const ThangType = require('models/ThangType')
 
-describe('Level', () => describe('denormalize', function() {
+describe('Level', () => describe('denormalize', function () {
   const level = new Level({
     thangs: [
       {
-        "thangType": "A",
-        "id": "Tharin",
-        "components": [
-          {"original": "a", "majorVersion": 0},
-          {"original": "b", "majorVersion": 0, "config": {i: 2}},
-          {"original": "c", "majorVersion": 0, "config": {i: 1, ii: 2, nest: {iii: 3}}}
+        thangType: 'A',
+        id: 'Tharin',
+        components: [
+          { original: 'a', majorVersion: 0 },
+          { original: 'b', majorVersion: 0, config: { i: 2 } },
+          { original: 'c', majorVersion: 0, config: { i: 1, ii: 2, nest: { iii: 3 } } },
           // should add one more
-        ]
-      }
+        ],
+      },
     ],
-    type: 'hero'
-  });
+    type: 'hero',
+  })
 
   const thangType = new ThangType({
     original: 'A',
-    version: {major: 0, minor: 0},
+    version: { major: 0, minor: 0 },
     components: [
-      {"original": "a", "majorVersion": 0, "config": {i: 1}},
-      {"original": "c", "majorVersion": 0, "config": {i: 3, nest: {iv: 4}}},
-      {"original": "d", "majorVersion": 0, "config": {i: 1}}
-    ]
-  });
+      { original: 'a', majorVersion: 0, config: { i: 1 } },
+      { original: 'c', majorVersion: 0, config: { i: 3, nest: { iv: 4 } } },
+      { original: 'd', majorVersion: 0, config: { i: 1 } },
+    ],
+  })
 
-  const supermodel = new SuperModel();
-  supermodel.registerModel(thangType);
+  const supermodel = new SuperModel()
+  supermodel.registerModel(thangType)
 
-  const result = level.denormalize(supermodel);
-  const tharinThangComponents = result.thangs[0].components;
+  const result = level.denormalize(supermodel)
+  const tharinThangComponents = result.thangs[0].components
 
-  it('adds default configs to thangs without any config', function() {
-    const aComp = _.find(tharinThangComponents, {original:'a'});
-    return expect(_.isEqual(aComp.config, {i:1})).toBeTruthy();
-  });
+  it('adds default configs to thangs without any config', function () {
+    const aComp = _.find(tharinThangComponents, { original: 'a' })
+    return expect(_.isEqual(aComp.config, { i: 1 })).toBeTruthy()
+  })
 
-  it('leaves alone configs for components the level thang has but the thang type does not', function() {
-    const bComp = _.find(tharinThangComponents, {original:'b'});
-    return expect(_.isEqual(bComp.config, {i:2})).toBeTruthy();
-  });
+  it('leaves alone configs for components the level thang has but the thang type does not', function () {
+    const bComp = _.find(tharinThangComponents, { original: 'b' })
+    return expect(_.isEqual(bComp.config, { i: 2 })).toBeTruthy()
+  })
 
-  it('merges configs where both the level thang and thang type have one, giving priority to the level thang', function() {
-    const cComp = _.find(tharinThangComponents, {original:'c'});
-    return expect(_.isEqual(cComp.config, {i: 1, ii: 2, nest: {iii: 3, iv: 4}})).toBeTruthy();
-  });
+  it('merges configs where both the level thang and thang type have one, giving priority to the level thang', function () {
+    const cComp = _.find(tharinThangComponents, { original: 'c' })
+    return expect(_.isEqual(cComp.config, { i: 1, ii: 2, nest: { iii: 3, iv: 4 } })).toBeTruthy()
+  })
 
-  return it('adds components from the thang type that do not exist in the level thang', function() {
-    const dComp = _.find(tharinThangComponents, {original:'d'});
-    expect(dComp).toBeTruthy();
-    return expect(_.isEqual(dComp != null ? dComp.config : undefined, {i: 1})).toBeTruthy();
-  });
-}));
+  return it('adds components from the thang type that do not exist in the level thang', function () {
+    const dComp = _.find(tharinThangComponents, { original: 'd' })
+    expect(dComp).toBeTruthy()
+    return expect(_.isEqual(dComp != null ? dComp.config : undefined, { i: 1 })).toBeTruthy()
+  })
+}))
+
+describe('Level starter-code comment context', function () {
+  const makeLevel = (i18n) => new Level({
+    type: 'hero',
+    thangs: [
+      {
+        id: 'Hero Placeholder',
+        components: [
+          {
+            original: 'programmable',
+            majorVersion: 0,
+            config: {
+              programmableMethods: {
+                plan: {
+                  source: '// <%= greet %>\n// <%= parens %>\n',
+                  languages: { python: '# <%= greet %>\n# <%= parens %>\n' },
+                  context: { greet: 'Say hi', parens: 'Use parentheses' },
+                  solutions: [{ language: 'python', succeeds: true, source: '# <%= greet %>\n# <%= parens %>\nhero.say("hi")' }],
+                  i18n,
+                },
+              },
+            },
+          },
+        ],
+      },
+    ],
+  })
+
+  let previousLanguage
+  beforeEach(function () {
+    previousLanguage = me.get('preferredLanguage')
+    me.set('preferredLanguage', 'nl')
+  })
+  afterEach(function () {
+    me.set('preferredLanguage', previousLanguage)
+  })
+
+  it('falls back to the English comment for keys the locale context is missing', function () {
+    const level = makeLevel({ nl: { context: { greet: 'Zeg hoi' } } })
+    const code = level.getSampleCodeForLanguage('python')
+    expect(code).toBe('# Zeg hoi\n# Use parentheses\n')
+    expect(code).not.toMatch(/<%=/)
+  })
+
+  it('falls back to English for blank locale translations', function () {
+    const level = makeLevel({ nl: { context: { greet: '   ', parens: 'Gebruik haakjes' } } })
+    expect(level.getSampleCodeForLanguage('python')).toBe('# Say hi\n# Gebruik haakjes\n')
+  })
+
+  it('uses the locale context fully when it is complete, stripping AI markers', function () {
+    const level = makeLevel({ nl: { context: { greet: '[AI_TRANSLATION]Zeg hoi', parens: 'Gebruik haakjes' } } })
+    expect(level.getSampleCodeForLanguage('python')).toBe('# Zeg hoi\n# Gebruik haakjes\n')
+  })
+
+  it('renders English when the locale has no context at all', function () {
+    const level = makeLevel({ nl: { name: 'Naam' } })
+    expect(level.getSampleCodeForLanguage('python')).toBe('# Say hi\n# Use parentheses\n')
+  })
+
+  it('leaves English rendering unchanged', function () {
+    me.set('preferredLanguage', 'en-US')
+    const level = makeLevel({ nl: { context: { greet: 'Zeg hoi' } } })
+    expect(level.getSampleCodeForLanguage('javascript')).toBe('// Say hi\n// Use parentheses\n')
+  })
+
+  it('applies the same merge to solutions', function () {
+    const level = makeLevel({ nl: { context: { greet: 'Zeg hoi' } } })
+    const solution = level.getSolutionForLanguage('python')
+    expect(solution.source).toBe('# Zeg hoi\n# Use parentheses\nhero.say("hi")')
+  })
+})

--- a/test/app/views/play/level/tome/Spell.spec.js
+++ b/test/app/views/play/level/tome/Spell.spec.js
@@ -1,0 +1,40 @@
+const Spell = require('views/play/level/tome/Spell')
+
+describe('Spell.translateCommentContext', function () {
+  const source = '# <%= greet %>\n# <%= parens %>\nhero.moveXY(1, 2)\n'
+  const commentContext = { greet: 'Say hi', parens: 'Use parentheses' }
+  const translate = (args) => Spell.prototype.translateCommentContext(args)
+
+  let previousLanguage
+  beforeEach(function () {
+    previousLanguage = me.get('preferredLanguage')
+    me.set('preferredLanguage', 'nl')
+  })
+  afterEach(function () { me.set('preferredLanguage', previousLanguage) })
+
+  it('falls back to English per key when the locale context is incomplete', function () {
+    const commentI18N = { nl: { context: { greet: 'Zeg hoi' } } }
+    const result = translate({ source, commentContext, commentI18N, codeLanguage: 'python', spokenLanguage: 'nl' })
+    expect(result).toBe('# Zeg hoi\n# Use parentheses\nhero.moveXY(1, 2)\n')
+    expect(result).not.toMatch(/<%=/)
+  })
+
+  it('uses the complete locale context as before', function () {
+    const commentI18N = { nl: { context: { greet: 'Zeg hoi', parens: 'Gebruik haakjes' } } }
+    const result = translate({ source, commentContext, commentI18N, codeLanguage: 'python', spokenLanguage: 'nl' })
+    expect(result).toBe('# Zeg hoi\n# Gebruik haakjes\nhero.moveXY(1, 2)\n')
+  })
+
+  it('keeps the Lua method-call rewrite on English fallback keys', function () {
+    const luaSource = '-- <%= greet %>\n-- <%= parens %>\n'
+    const luaContext = { greet: 'Call hero.say()', parens: 'Use parentheses' }
+    const commentI18N = { nl: { context: { parens: 'Gebruik haakjes' } } }
+    const result = translate({ source: luaSource, commentContext: luaContext, commentI18N, codeLanguage: 'lua', spokenLanguage: 'nl' })
+    expect(result).toBe('-- Call hero:say()\n-- Gebruik haakjes\n')
+  })
+
+  it('renders English when there is no i18n', function () {
+    const result = translate({ source, commentContext, commentI18N: undefined, codeLanguage: 'python', spokenLanguage: 'nl' })
+    expect(result).toBe('# Say hi\n# Use parentheses\nhero.moveXY(1, 2)\n')
+  })
+})


### PR DESCRIPTION
## Problem

Support ticket (2026-09-11): CS3 level 7 "De Tovenaar's Vlakte" (`the-wizards-plane`) showed raw `# <%= secret_number %>` tags instead of comments in the Dutch UI. English was fine.

Starter-code comments are Lodash templates. Every templating path picked the localized `plan.i18n.<lang>.context` object as a whole via `utils.i18n`, with no per-key fallback to English. One missing key made `_.template` throw, and the catch left the whole source raw for that locale. The Dutch context on that level was missing a single key (`use_parens`), skipped by the AI translation pass (ENG-463).

A scan of all 82 CS3 levels found about 60 with an incomplete context in at least one locale (15 for `nl`, 7 more via `nl-NL`), so patching content by hand is not viable.

## Fix

New `utils.i18nCommentContext(plan)` layers the localized context over the English `plan.context` key by key. Blank translations count as missing. Only the absent key falls back to English, the rest stays translated, and no raw tag can appear.

Every place that templated starter code or solutions now goes through it:

- `Spell.translateCommentContext` (the gameplay editor path, Lua rewrite preserved)
- `TeacherCourseSolutionView` (no longer drops to "coming soon" on an incomplete locale)
- Ozaria game store (`game.js`, solution auto-fill in two places)
- `Level.getCodeContext` (`getSampleCode` / `getSolutions`)

Client only. No server, schema, or data changes.

## Tests

- `utils.i18nCommentContext`: partial locale with blank value, complete locale, locale without context, plan without context.
- `Spell.translateCommentContext`: partial locale, complete locale, Lua fallback keys, no i18n.
- `Level.getSampleCode` / `getSolutions`: partial, blank, complete with AI marker stripped, no locale context, English unchanged, solutions path. That spec file also picked up a standard-style lint pass on its old decaffeinated lines because the pre-commit lint runs on staged files.
- Full Karma suite green locally (7399 executed, 0 failed).

## Manual QA fixture

On prod `the-wizards-plane`, the `nl` context has been completed by hand. The `hu` and `id` contexts are intentionally still missing `use_parens`: with Hungarian or Indonesian UI the level shows raw tags before this change, and translated comments plus one English line after it. Please keep those two as-is until this ships.

## Out of scope

Backfilling the missing translations themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved localized starter code, solutions, and code comments by using English text when translations are missing, blank, or incomplete.
  - Combined translated and English context on a per-item basis for more complete localized content.
  - Removed internal translation markers from displayed code comments while preserving existing English rendering.
  - Corrected localized code comment rendering for method calls and ensured translation round trips remain consistent.
  - Improved localized rendering across gameplay and teacher solution views for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->